### PR TITLE
chore: hide useless info log, only show error log (build errors)

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -5,4 +5,4 @@ set -e # exit when error
 printf "\nDev\n"
 
 webpack-dev-server --config webpack.example.config.js\
-  --hot --inline
+  --hot --inline --no-info


### PR DESCRIPTION
We had some very long log when doing:

```sh
npm run dev
```

Now hidden but you still get important messages: build errors