### PR TITLE
feat(pagination): add pagination widget

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,9 +1,9 @@
 {
   "extends": [
+    "eslint:recommended",
     "airbnb",
     "algolia"
   ],
-  "parser": "babel-eslint",
   "plugins": ["react"],
   "ecmaFeatures": {
     "arrowFunctions": true,
@@ -24,7 +24,7 @@
     "jsx": true
   },
   "rules": {
-    "strict": 0,
-    "react/jsx-curly-spacing": [2, never]
+    "strict": [2, "never"], // babel inserts "use strict"; for us
+    "react/jsx-curly-spacing": [2, "never"]
   }
 }

--- a/README.md
+++ b/README.md
@@ -4,6 +4,21 @@ Instant search for everyone, even for your cat 😸.
 
 API is unstable. We welcome any idea.
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+
+- [Usage](#usage)
+- [Widget API](#widget-api)
+- [Dev](#dev)
+- [Test](#test)
+- [Available widgets](#available-widgets)
+  - [searchBox](#searchbox)
+  - [pagination](#pagination)
+  - [hits](#hits)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ## Usage
 
 ```js
@@ -71,41 +86,70 @@ npm run test:coverage
 ### searchBox
 
 ```html
-  <div id="search-box"></div>
+<div id="search-box"></div>
 ```
 
 ```js
-  instant.addWidget(
-    instantsearch.widgets.searchBox({
-      container: '#search-box',
-      placeholder: 'Search for products',
-      // cssClass: 'form-control'
-    })
-  );
+instant.addWidget(
+  instantsearch.widgets.searchBox({
+    container: '#search-box',
+    placeholder: 'Search for products',
+    // cssClass: 'form-control'
+  })
+);
 ```
 
-## pagination
+### pagination
 
 ```html
-  <div id="pagination"></div>
+<div id="pagination"></div>
 ```
 
 ```js
-  instant.addWidget(
-    instantsearch.widgets.pagination({
-      container: '#pagination',
-      // cssClass, // no default
-      // padding: 3, // number of page numbers to show before/after current
-      // showFirstLast: true, // show or hide first and last links
-      // hitsPerPage: 20,
-      // maxPages, // automatically computed based on the result set
-      // labels: {
-      //   previous: '‹', // &lsaquo;
-      //   next: '›', // &rsaquo;
-      //   first: '«', // &laquo;
-      //   last: '»' // &raquo;
-      // }
-    })
-  );
+instant.addWidget(
+  instantsearch.widgets.pagination({
+    container: '#pagination',
+    // cssClass, // no default
+    // padding: 3, // number of page numbers to show before/after current
+    // showFirstLast: true, // show or hide first and last links
+    // hitsPerPage: 20,
+    // maxPages, // automatically computed based on the result set
+    // labels: {
+    //   previous: '‹', // &lsaquo;
+    //   next: '›', // &rsaquo;
+    //   first: '«', // &laquo;
+    //   last: '»' // &raquo;
+    // }
+  })
+);
+```
+
+### hits
+
+```html
+<div id="hits"></div>
+```
+
+```js
+instant.addWidget(
+  instantsearch.widgets.hits({
+    container: '#hits',
+    templates: {
+      noResults, // string (mustache format) or function(hit) return string 
+      hit // string (mustache format) or function(hit) return string
+    }
+    // cssClass, // no default
+    // padding: 3, // number of page numbers to show before/after current
+    // showFirstLast: true, // show or hide first and last links
+    // hitsPerPage: 20,
+    // maxPages, // automatically computed based on the result set
+    // labels: {
+    //   previous: '‹', // &lsaquo;
+    //   next: '›', // &rsaquo;
+    //   first: '«', // &laquo;
+    //   last: '»' // &raquo;
+    // }
+  })
+);
 ```
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ npm run test:coverage
   instant.addWidget(
     instantsearch.widgets.pagination({
       container: '#pagination',
-      // cssClass: 'pagination', // no default
+      // cssClass, // no default
       // padding: 3, // number of page numbers to show before/after current
       // showFirstLast: true, // show or hide first and last links
       // hitsPerPage: 20,

--- a/README.md
+++ b/README.md
@@ -83,3 +83,27 @@ npm run test:coverage
     })
   );
 ```
+
+## pagination
+
+```html
+  <div id="pagination"></div>
+```
+
+```js
+  instant.addWidget(
+    instantsearch.widgets.pagination({
+      container: '#pagination',
+      // cssClass: 'pagination', // no default
+      // padding: 3, // number of page numbers to show before/after current
+      // showFirstLast: true, // show or hide first and last links
+      // labels: {
+      //   previous: '‹', // &lsaquo;
+      //   next: '›', // &rsaquo;
+      //   first: '«', // &laquo;
+      //   last: '»' // &raquo;
+      // }
+    })
+  );
+```
+

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ npm run test:coverage
       // cssClass: 'pagination', // no default
       // padding: 3, // number of page numbers to show before/after current
       // showFirstLast: true, // show or hide first and last links
+      // hitsPerPage: 20,
+      // maxPages, // automatically computed based on the result set
       // labels: {
       //   previous: '‹', // &lsaquo;
       //   next: '›', // &rsaquo;

--- a/components/BemHelper/index.js
+++ b/components/BemHelper/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 function BemHelper(block) {
   return function(element, modifier) {
     if (!element) {

--- a/components/Hits/index.js
+++ b/components/Hits/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 var React = require('react');
 var map = require('lodash/collection/map');
 var isString = require('lodash/lang/isString');
@@ -7,7 +5,7 @@ var isString = require('lodash/lang/isString');
 var Hogan = require('../templates/Hogan');
 var TemplateFn = require('../templates/Function');
 
-class Results extends React.Component {
+class Hits extends React.Component {
   render() {
     var results = this.props.results;
     if (!results || !results.hits || results.hits.length === 0) {
@@ -32,4 +30,4 @@ class Results extends React.Component {
   }
 }
 
-module.exports = Results;
+module.exports = Hits;

--- a/components/Pagination/PaginationLink/index.js
+++ b/components/Pagination/PaginationLink/index.js
@@ -1,8 +1,6 @@
-'use strict';
-
 var React = require('react');
 
-class PaginationLink extends React . Component {
+class PaginationLink extends React.Component {
   render() {
     var label = this.props.label;
     var ariaLabel = this.props.ariaLabel;

--- a/components/Pagination/PaginationLink/index.js
+++ b/components/Pagination/PaginationLink/index.js
@@ -1,0 +1,47 @@
+'use strict';
+
+var React = require('react');
+
+class PaginationLink extends React . Component {
+  render() {
+    var label = this.props.label;
+    var ariaLabel = this.props.ariaLabel;
+    var href = this.props.href;
+    var page = this.props.page;
+    var className = this.props.className;
+
+    return (
+      <li className={className}>
+        <a href={href} aria-label={ariaLabel} onClick={this.click.bind(this, page)}>
+          {label}
+        </a>
+      </li>
+    );
+  }
+
+  clickDisabled(e) {
+    e.preventDefault();
+  }
+
+  click(page, e) {
+    e.preventDefault();
+    this.props.setCurrentPage(page).search();
+  }
+}
+
+PaginationLink.propTypes = {
+  ariaLabel: React.PropTypes.oneOfType([
+    React.PropTypes.string,
+    React.PropTypes.number
+  ]).isRequired,
+  className: React.PropTypes.string,
+  href: React.PropTypes.string.isRequired,
+  label: React.PropTypes.oneOfType([
+    React.PropTypes.string,
+    React.PropTypes.number
+  ]).isRequired,
+  page: React.PropTypes.number.isRequired,
+  setCurrentPage: React.PropTypes.func.isRequired
+};
+
+module.exports = PaginationLink;

--- a/components/Pagination/Paginator/index.js
+++ b/components/Pagination/Paginator/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 var range = require('lodash/utility/range');
 
 class Paginator {

--- a/components/Pagination/Paginator/index.js
+++ b/components/Pagination/Paginator/index.js
@@ -1,0 +1,43 @@
+'use strict';
+
+var range = require('lodash/utility/range');
+
+class Paginator {
+  constructor(params) {
+    this.currentPage = params.currentPage;
+    this.total = params.total;
+    this.padding = params.padding;
+  }
+
+  pages() {
+    var current = this.currentPage;
+    var padding = this.padding;
+    var paddingLeft = this.calculatePaddingLeft(current, padding, this.total);
+    var paddingRight = Math.min(2 * padding + 1, this.total) - paddingLeft;
+    var first = current - paddingLeft;
+    var last = current + paddingRight;
+    return range(first, last);
+  }
+
+  calculatePaddingLeft(current, padding, total) {
+    if (current <= padding) {
+      return current;
+    }
+
+    if (current >= (total - padding)) {
+      return 2 * padding + 1 - (total - current);
+    }
+
+    return padding;
+  }
+
+  isLastPage() {
+    return this.currentPage === this.total - 1;
+  }
+
+  isFirstPage() {
+    return this.currentPage === 0;
+  }
+}
+
+module.exports = Paginator;

--- a/components/Pagination/index.js
+++ b/components/Pagination/index.js
@@ -1,0 +1,147 @@
+'use strict';
+
+var React = require('react');
+var forEach = require('lodash/collection/forEach');
+var defaultsDeep = require('lodash/object/defaultsDeep');
+
+var Paginator = require('./Paginator');
+var PaginationLink = require('./PaginationLink');
+
+var bem = require('../BemHelper')('as-pagination');
+var cx = require('classnames');
+
+class Pagination extends React.Component {
+  constructor(props) {
+    super(defaultsDeep(props, Pagination.defaultProps));
+  }
+
+  render() {
+    if (this.props.nbHits === 0) {
+      return null;
+    }
+
+    var pager = new Paginator({
+      currentPage: this.props.currentPage,
+      total: this.props.nbPages,
+      padding: this.props.padding
+    });
+
+    var classNames = cx(bem('ul'), this.props.cssClass);
+
+    return (
+      <ul className={classNames}>
+        {this.props.showFirstLast ? this.firstPageLink(pager) : null}
+        {this.previousPageLink(pager)}
+        {this.pages(pager)}
+        {this.nextPageLink(pager)}
+        {this.props.showFirstLast ? this.lastPageLink(pager) : null}
+      </ul>
+    );
+  }
+
+  previousPageLink(pager) {
+    if (pager.isFirstPage()) return null;
+
+    return (
+      <PaginationLink
+        href="#"
+        label={this.props.labels.prev} ariaLabel="Previous"
+        setCurrentPage={this.props.setCurrentPage}
+        page={pager.currentPage - 1} />
+    );
+  }
+
+  nextPageLink(pager) {
+    if (pager.isLastPage()) return null;
+
+    return (
+      <PaginationLink
+        href="#"
+        label={this.props.labels.next} ariaLabel="Next"
+        setCurrentPage={this.props.setCurrentPage}
+        page={pager.currentPage + 1} />
+    );
+  }
+
+  firstPageLink(pager) {
+    if (pager.isFirstPage()) return null;
+
+    return (
+      <PaginationLink
+        href="#"
+        label={this.props.labels.first}
+        ariaLabel="First"
+        setCurrentPage={this.props.setCurrentPage}
+        page={0} />
+    );
+  }
+
+  lastPageLink(pager) {
+    if (pager.isLastPage()) return null;
+
+    return (
+      <PaginationLink
+        href="#"
+        label={this.props.labels.last}
+        ariaLabel="Last"
+        setCurrentPage={this.props.setCurrentPage}
+        page={pager.total - 1} />
+    );
+  }
+
+  pages(pager) {
+    var elements = [];
+
+    forEach(pager.pages(), function(pageNumber) {
+      var className = pageNumber === pager.currentPage ? 'active' : '';
+
+      elements.push(
+        <PaginationLink
+          href="#"
+          label={pageNumber + 1}
+          ariaLabel={pageNumber + 1}
+          setCurrentPage={this.props.setCurrentPage}
+          page={pageNumber}
+          key={pageNumber}
+          className={className} />
+      );
+    }, this);
+
+    return elements;
+  }
+}
+
+Pagination.propTypes = {
+  nbHits: React.PropTypes.number,
+  currentPage: React.PropTypes.number,
+  nbPages: React.PropTypes.number,
+  labels: React.PropTypes.shape({
+    prev: React.PropTypes.string,
+    next: React.PropTypes.string,
+    first: React.PropTypes.string,
+    last: React.PropTypes.string
+  }),
+  showFirstLast: React.PropTypes.bool,
+  padding: React.PropTypes.number,
+  setCurrentPage: React.PropTypes.func.isRequired,
+  cssClass: React.PropTypes.oneOfType([
+    React.PropTypes.string,
+    React.PropTypes.array
+  ])
+};
+
+Pagination.defaultProps = {
+  nbHits: 0,
+  currentPage: 0,
+  nbPages: 0,
+  labels: {
+    prev: '‹', // &lsaquo;
+    next: '›', // &rsaquo;
+    first: '«', // &laquo;
+    last: '»' // &raquo;
+  },
+  showFirstLast: true,
+  padding: 3
+};
+
+module.exports = Pagination;

--- a/components/Pagination/index.js
+++ b/components/Pagination/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 var React = require('react');
 var forEach = require('lodash/collection/forEach');
 var defaultsDeep = require('lodash/object/defaultsDeep');

--- a/components/SearchBox/index.js
+++ b/components/SearchBox/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 var React = require('react');
 var bem = require('../BemHelper')('as-search-box');
 var cx = require('classnames');
@@ -19,14 +17,14 @@ var SearchBox = React.createClass({
 
     return (
       <input type="text"
-      placeholder={this.props.placeholder}
-      name="algolia-query"
-      className={classNames}
-      data-role="autocomplete"
-      autoComplete="off"
-      autoFocus="autofocus"
-      onChange={this.change}
-      role="textbox" />
+        placeholder={this.props.placeholder}
+        name="algolia-query"
+        className={classNames}
+        data-role="autocomplete"
+        autoComplete="off"
+        autoFocus="autofocus"
+        onChange={this.change}
+        role="textbox" />
     );
   },
   change: function(e) {

--- a/components/templates/Function/index.js
+++ b/components/templates/Function/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 var React = require('react');
 
 var TemplateFn = React.createClass({

--- a/components/templates/Hogan/index.js
+++ b/components/templates/Hogan/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 var hogan = require('hogan.js');
 var React = require('react');
 

--- a/example/app.js
+++ b/example/app.js
@@ -17,8 +17,8 @@ instant.addWidget(
 );
 
 instant.addWidget(
-  instantsearch.widgets.results({
-  container: '#hits',
+  instantsearch.widgets.hits({
+    container: '#hits',
     templates: {
       noResults: require('./templates/no-results.html'),
       hit: require('./templates/hit.html')

--- a/example/app.js
+++ b/example/app.js
@@ -26,4 +26,11 @@ instant.addWidget(
   })
 );
 
+instant.addWidget(
+  instantsearch.widgets.pagination({
+    container: '#pagination',
+    cssClass: 'pagination'
+  })
+);
+
 instant.start();

--- a/example/app.js
+++ b/example/app.js
@@ -29,7 +29,9 @@ instant.addWidget(
 instant.addWidget(
   instantsearch.widgets.pagination({
     container: '#pagination',
-    cssClass: 'pagination'
+    cssClass: 'pagination',
+    hitsPerPage: 5,
+    maxPages: 20
   })
 );
 

--- a/example/index.html
+++ b/example/index.html
@@ -19,6 +19,7 @@
       </div>
       <div class="col-md-9">
         <div id="hits"></div>
+        <div id="pagination" class="text-center"></div>
       </div>
     </div>
   </div>

--- a/example/style.css
+++ b/example/style.css
@@ -1,7 +1,14 @@
+html {
+  /* force vertical scrollbar no matter the content,
+  avoid container center position changes */
+  overflow-y: scroll;
+}
+
 body {
   padding: 2em 0;
 }
 
+/* Hits widget */
 .hit + .hit {
   margin-top: 1em;
   padding-top: 1em;
@@ -11,4 +18,20 @@ body {
 .hit em {
   font-style: normal;
   background-color: lightcyan;
+}
+
+/* Force widths and heights to avoid vertical size changes.
+  So that pagination clicks will not jump */
+.hit img {
+  max-height: 100px;
+  max-width: 100px;
+}
+
+.hit p {
+  max-height: 50px;
+  text-overflow: ellipsis;
+}
+
+.hit {
+  height: 125px;
 }

--- a/example/templates/no-results.html
+++ b/example/templates/no-results.html
@@ -1,1 +1,1 @@
-Sorry no results
+No matching products, try another search.

--- a/index.js
+++ b/index.js
@@ -1,10 +1,8 @@
-'use strict';
-
 module.exports = {
   InstantSearch: require('./lib/InstantSearch'),
   widgets: {
     searchBox: require('./widgets/search-box/'),
-    results: require('./widgets/hits/'),
+    hits: require('./widgets/hits/'),
     pagination: require('./widgets/pagination/')
   }
 };

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ module.exports = {
   InstantSearch: require('./lib/InstantSearch'),
   widgets: {
     searchBox: require('./widgets/search-box/'),
-    results: require('./widgets/hits/')
+    results: require('./widgets/hits/'),
+    pagination: require('./widgets/pagination/')
   }
 };

--- a/lib/InstantSearch.js
+++ b/lib/InstantSearch.js
@@ -1,5 +1,3 @@
-'use strict';
-
 var algoliasearch = require('algoliasearch');
 var algoliasearchHelper = require('algoliasearch-helper');
 

--- a/lib/widgetUtils.js
+++ b/lib/widgetUtils.js
@@ -1,5 +1,3 @@
-'use strict';
-
 var isString = require('lodash/lang/isString');
 
 function getContainerNode(value) {

--- a/package.json
+++ b/package.json
@@ -8,11 +8,10 @@
     "lint": "./scripts/lint.sh",
     "build": "./scripts/build.sh",
     "dev": "./scripts/dev.sh",
-    "checkstyle": "jsfmt --diff",
-    "jsfmt": "jsfmt",
     "test": "babel-node test/*.js && npm run lint",
     "test:watch": "nodemon -i node_modules/ -i coverage/ -i .git/ -i dist/ -q --exec 'babel-node test/*.js | tap-spec'",
-    "test:coverage": "babel-node node_modules/.bin/isparta cover test/*.js"
+    "test:coverage": "babel-node node_modules/.bin/isparta cover test/*.js",
+    "doctoc": "doctoc --maxlevel 3 README.md"
   },
   "browserify": {
     "transform": [
@@ -23,12 +22,11 @@
     "lodash": "lodash-compat"
   },
   "devDependencies": {
-    "@algolia/jsfmt": "1.3.0",
     "babel": "5.8.19",
-    "babel-eslint": "4.0.5",
     "babel-loader": "5.3.2",
     "css-loader": "0.15.6",
-    "eslint": "0.24.1",
+    "doctoc": "0.14.2",
+    "eslint": "1.0.0",
     "eslint-config-airbnb": "0.0.7",
     "eslint-config-algolia": "2.1.2",
     "eslint-plugin-react": "3.1.0",
@@ -39,9 +37,9 @@
     "proxyquire": "1.6.0",
     "raw-loader": "0.5.1",
     "sinon": "1.15.4",
+    "style-loader": "0.12.3",
     "tap-spec": "4.0.2",
     "tape": "4.0.1",
-    "style-loader": "0.12.3",
     "uglifyjs": "2.4.10",
     "webpack": "1.10.5",
     "webpack-dev-server": "1.10.1"

--- a/widgets/hits/index.js
+++ b/widgets/hits/index.js
@@ -1,21 +1,20 @@
-'use strict';
-
 var React = require('react');
 
-var utils = require('../../lib/widgetUtils');
+var utils = require('../../lib/widgetUtils.js');
 
-function hits(parameters) {
-  var Results = require('../../components/Results');
-  var containerNode = utils.getContainerNode(parameters.container);
+function hits(params) {
+  var Hits = require('../../components/Hits');
+  var containerNode = utils.getContainerNode(params.container);
 
   return {
     render: function(results, state, helper) {
-      React.render(<Results results={results}
-      searchState={state}
-      helper={helper}
-      noResultsTemplate={parameters.templates.noResults}
-      hitTemplate={parameters.templates.hit} />,
-        containerNode);
+      React.render(
+        <Hits results={results}
+          helper={helper}
+          noResultsTemplate={params.templates.noResults}
+          hitTemplate={params.templates.hit} />,
+        containerNode
+      );
     }
   };
 }

--- a/widgets/pagination/index.js
+++ b/widgets/pagination/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 var React = require('react');
 
 var utils = require('../../lib/widgetUtils.js');

--- a/widgets/pagination/index.js
+++ b/widgets/pagination/index.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var React = require('react');
+
+var utils = require('../../lib/widgetUtils.js');
+
+function hits(params) {
+  var Pagination = require('../../components/Pagination/');
+  var containerNode = utils.getContainerNode(params.container);
+
+  return {
+    render: function(results, state, helper) {
+      React.render(
+        <Pagination
+          nbHits={results.nbHits}
+          currentPage={results.page}
+          nbPages={results.nbPages}
+          setCurrentPage={helper.setCurrentPage.bind(helper)}
+          cssClass={params.cssClass}
+          labels={params.labels} />,
+        containerNode
+      );
+    }
+  };
+}
+
+module.exports = hits;

--- a/widgets/pagination/index.js
+++ b/widgets/pagination/index.js
@@ -4,20 +4,27 @@ var React = require('react');
 
 var utils = require('../../lib/widgetUtils.js');
 
-function hits(params) {
+function hits({container, cssClass, labels, hitsPerPage=20, maxPages}={}) {
   var Pagination = require('../../components/Pagination/');
-  var containerNode = utils.getContainerNode(params.container);
+  var containerNode = utils.getContainerNode(container);
 
   return {
+    getConfiguration: function() {
+      return {
+        hitsPerPage
+      };
+    },
     render: function(results, state, helper) {
+      var nbPages = maxPages !== undefined ? maxPages : results.nbPages;
+
       React.render(
         <Pagination
           nbHits={results.nbHits}
           currentPage={results.page}
-          nbPages={results.nbPages}
+          nbPages={nbPages}
           setCurrentPage={helper.setCurrentPage.bind(helper)}
-          cssClass={params.cssClass}
-          labels={params.labels} />,
+          cssClass={cssClass}
+          labels={labels} />,
         containerNode
       );
     }

--- a/widgets/search-box/index.js
+++ b/widgets/search-box/index.js
@@ -1,8 +1,6 @@
-'use strict';
-
 var React = require('react');
 
-var utils = require('../../lib/widgetUtils');
+var utils = require('../../lib/widgetUtils.js');
 var bind = require('lodash/function/bind');
 
 function searchbox(params) {
@@ -16,7 +14,8 @@ function searchbox(params) {
           setQuery={bind(helper.setQuery, helper)}
           search={bind(helper.search, helper)}
           placeholder={params.placeholder}
-          inputClass={params.cssClass} />, container
+          inputClass={params.cssClass} />,
+        container
       );
     }
   };


### PR DESCRIPTION
Mostly based on the work in ui-kit.

## Differences with ui-kit implementation

- default padding is 3 not 5
- labels are strings and merged with the default ones
- there is no wrapping `<nav>` around, only the `<ul>`
- `<, <<, >, >>` are hidden if not available instead of disabled.
Showing a no-click sign felt frustrating. If not available, not shown,
not needed

## Documentation

```html
  <div id="pagination"></div>
```

```js
  instant.addWidget(
    instantsearch.widgets.pagination({
      container: '#pagination',
      // cssClass, // no default
      // padding: 3, // number of page numbers to show before/after current
      // showFirstLast: true, // show or hide first and last links
      // hitsPerPage: 20,
      // maxPages, // automatically computed based on the result set
      // labels: {
      //   previous: '‹', // &lsaquo;
      //   next: '›', // &rsaquo;
      //   first: '«', // &laquo;
      //   last: '»' // &raquo;
      // }
    })
  );
```





