### PR TITLE
feat(hits): allow configuring hitsPerPage

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,22 +6,8 @@
   ],
   "plugins": ["react"],
   "ecmaFeatures": {
-    "arrowFunctions": true,
-    "blockBindings": true,
-    "classes": true,
-    "defaultParams": true,
-    "destructuring": true,
-    "forOf": true,
-    "generators": false,
-    "modules": true,
-    "objectLiteralComputedProperties": true,
-    "objectLiteralDuplicateProperties": false,
-    "objectLiteralShorthandMethods": true,
-    "objectLiteralShorthandProperties": true,
-    "spread": true,
-    "superInFunctions": true,
-    "templateStrings": true,
-    "jsx": true
+    // eslint-config-algolia disables modules because all projects are not ES6
+    "modules": true
   },
   "rules": {
     "strict": [2, "never"], // babel inserts "use strict"; for us

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ instant.addWidget(
   instantsearch.widgets.searchBox({
     container: '#search-box',
     placeholder: 'Search for products',
-    // cssClass: 'form-control'
+    // cssClass
   })
 );
 ```
@@ -109,13 +109,12 @@ instant.addWidget(
 instant.addWidget(
   instantsearch.widgets.pagination({
     container: '#pagination',
-    // cssClass, // no default
+    // cssClass, // add cssClasses to the main wrapper
     // padding: 3, // number of page numbers to show before/after current
     // showFirstLast: true, // show or hide first and last links
-    // hitsPerPage: 20,
     // maxPages, // automatically computed based on the result set
     // labels: {
-    //   previous: '‹', // &lsaquo;
+    //   prev: '‹', // &lsaquo;
     //   next: '›', // &rsaquo;
     //   first: '«', // &laquo;
     //   last: '»' // &raquo;
@@ -135,20 +134,11 @@ instant.addWidget(
   instantsearch.widgets.hits({
     container: '#hits',
     templates: {
-      noResults, // string (mustache format) or function(hit) return string 
+      empty, // string (mustache format) or function(hit) return string 
       hit // string (mustache format) or function(hit) return string
-    }
-    // cssClass, // no default
-    // padding: 3, // number of page numbers to show before/after current
-    // showFirstLast: true, // show or hide first and last links
-    // hitsPerPage: 20,
-    // maxPages, // automatically computed based on the result set
-    // labels: {
-    //   previous: '‹', // &lsaquo;
-    //   next: '›', // &rsaquo;
-    //   first: '«', // &laquo;
-    //   last: '»' // &raquo;
-    // }
+    },
+    hitsPerPage: 20,
+    // cssClass
   })
 );
 ```

--- a/components/Hits/index.js
+++ b/components/Hits/index.js
@@ -7,27 +7,46 @@ var TemplateFn = require('../templates/Function');
 
 class Hits extends React.Component {
   render() {
-    var results = this.props.results;
-    if (!results || !results.hits || results.hits.length === 0) {
-      return this.renderNoResults(results, this.props.noResultsTemplate);
+    if (this.props.hits.length === 0) {
+      return this.renderNoResults();
     }
-    return this.renderWithResults(results.hits, this.props.hitTemplate);
+
+    return this.renderWithResults();
   }
-  renderWithResults(hits, hitTemplate) {
-    var TemplateComponent = isString(hitTemplate) ? Hogan : TemplateFn;
-    var renderedHits = map(hits, function(hit) {
-      return <TemplateComponent data={hit} key={hit.objectID} template={hitTemplate} />;
-    });
-    return <div className="search_list search_results_container row">{renderedHits}</div>;
+
+  renderWithResults() {
+    var TemplateComponent = isString(this.props.hitTemplate) ? Hogan : TemplateFn;
+
+    var renderedHits = map(this.props.hits, function(hit) {
+      return <TemplateComponent data={hit} key={hit.objectID} template={this.props.hitTemplate} />;
+    }, this);
+
+    return <div>{renderedHits}</div>;
   }
-  renderNoResults(results, noResultsTemplate) {
-    var TemplateComponent = isString(noResultsTemplate) ? Hogan : TemplateFn;
+
+  renderNoResults() {
+    var TemplateComponent = isString(this.props.noResultsTemplate) ? Hogan : TemplateFn;
+
     return (
-      <div className="search_list search_results_container row">
-        <TemplateComponent data={results} template={noResultsTemplate} />
-      </div>
+      <div><TemplateComponent template={this.props.noResultsTemplate} /></div>
     );
   }
 }
+
+Hits.propTypes = {
+  hits: React.PropTypes.array,
+  hitTemplate: React.PropTypes.oneOfType([
+    React.PropTypes.string,
+    React.PropTypes.func
+  ]).isRequired,
+  noResultsTemplate: React.PropTypes.oneOfType([
+    React.PropTypes.string,
+    React.PropTypes.func
+  ]).isRequired
+};
+
+Hits.defaultProps = {
+  hits: []
+};
 
 module.exports = Hits;

--- a/components/SearchBox/index.js
+++ b/components/SearchBox/index.js
@@ -20,7 +20,6 @@ var SearchBox = React.createClass({
         placeholder={this.props.placeholder}
         name="algolia-query"
         className={classNames}
-        data-role="autocomplete"
         autoComplete="off"
         autoFocus="autofocus"
         onChange={this.change}

--- a/example/app.js
+++ b/example/app.js
@@ -20,9 +20,10 @@ instant.addWidget(
   instantsearch.widgets.hits({
     container: '#hits',
     templates: {
-      noResults: require('./templates/no-results.html'),
+      empty: require('./templates/no-results.html'),
       hit: require('./templates/hit.html')
-    }
+    },
+    hitsPerPage: 5
   })
 );
 
@@ -30,7 +31,6 @@ instant.addWidget(
   instantsearch.widgets.pagination({
     container: '#pagination',
     cssClass: 'pagination',
-    hitsPerPage: 5,
     maxPages: 20
   })
 );

--- a/package.json
+++ b/package.json
@@ -22,14 +22,14 @@
     "lodash": "lodash-compat"
   },
   "devDependencies": {
-    "babel": "5.8.19",
+    "babel": "5.8.20",
     "babel-loader": "5.3.2",
     "css-loader": "0.15.6",
     "doctoc": "0.14.2",
     "eslint": "1.0.0",
     "eslint-config-airbnb": "0.0.7",
     "eslint-config-algolia": "2.1.2",
-    "eslint-plugin-react": "3.1.0",
+    "eslint-plugin-react": "3.2.0",
     "isparta": "3.0.3",
     "nodemon": "1.4.0",
     "onchange": "1.1.0",
@@ -39,7 +39,7 @@
     "sinon": "1.15.4",
     "style-loader": "0.12.3",
     "tap-spec": "4.0.2",
-    "tape": "4.0.1",
+    "tape": "4.0.2",
     "uglifyjs": "2.4.10",
     "webpack": "1.10.5",
     "webpack-dev-server": "1.10.1"
@@ -49,7 +49,7 @@
     "algoliasearch-helper": "2.2.0",
     "classnames": "2.1.3",
     "hogan.js": "3.0.2",
-    "lodash": "3.10.0",
+    "lodash": "3.10.1",
     "react": "0.13.3"
   },
   "license": "MIT"

--- a/widgets/hits/index.js
+++ b/widgets/hits/index.js
@@ -2,17 +2,18 @@ var React = require('react');
 
 var utils = require('../../lib/widgetUtils.js');
 
-function hits(params) {
+function hits({container=null, templates={}, hitsPerPage=20}) {
   var Hits = require('../../components/Hits');
-  var containerNode = utils.getContainerNode(params.container);
+  var containerNode = utils.getContainerNode(container);
 
   return {
+    getConfiguration: () => ({hitsPerPage}),
     render: function(results, state, helper) {
       React.render(
-        <Hits results={results}
+        <Hits hits={results.hits}
           helper={helper}
-          noResultsTemplate={params.templates.noResults}
-          hitTemplate={params.templates.hit} />,
+          noResultsTemplate={templates.empty}
+          hitTemplate={templates.hit} />,
         containerNode
       );
     }

--- a/widgets/pagination/index.js
+++ b/widgets/pagination/index.js
@@ -2,16 +2,11 @@ var React = require('react');
 
 var utils = require('../../lib/widgetUtils.js');
 
-function hits({container, cssClass, labels, hitsPerPage=20, maxPages}={}) {
+function hits({container, cssClass, labels, maxPages}={}) {
   var Pagination = require('../../components/Pagination/');
   var containerNode = utils.getContainerNode(container);
 
   return {
-    getConfiguration: function() {
-      return {
-        hitsPerPage
-      };
-    },
     render: function(results, state, helper) {
       var nbPages = maxPages !== undefined ? maxPages : results.nbPages;
 


### PR DESCRIPTION
+ allow configuring hitsPerPage on hits widget
+ rewrite a little of the hits widget to only use what we need to use (may have to expose more things in the future, like the query done in the empty template)
+ rename noResults in the widget API to empty (typeahead style)
+ removed hitsPerPage configuration from the pagination template
+ some linting and deps upgrade for free