### PR TITLE
fix: cap the number of page displayed

### DIFF
--- a/widgets/pagination/index.js
+++ b/widgets/pagination/index.js
@@ -2,13 +2,16 @@ var React = require('react');
 
 var utils = require('../../lib/widgetUtils.js');
 
-function hits({container, cssClass, labels, maxPages} = {}) {
+function pagination({container, cssClass, labels, maxPages} = {}) {
   var Pagination = require('../../components/Pagination/');
   var containerNode = utils.getContainerNode(container);
 
   return {
     render: function(results, state, helper) {
-      var nbPages = maxPages !== undefined ? maxPages : results.nbPages;
+      var nbPages = results.nbPages;
+      if (maxPages !== undefined) {
+        nbPages = Math.min(maxPages, results.nbPages);
+      }
 
       React.render(
         <Pagination
@@ -25,4 +28,4 @@ function hits({container, cssClass, labels, maxPages} = {}) {
   };
 }
 
-module.exports = hits;
+module.exports = pagination;


### PR DESCRIPTION
If we passed a `maxPages` attribute to the pagination widget, it used to always display that number of page, even if the `nbPages` returned was lower. No will only display pagination according to what is really returned.