### PR TITLE
feat(menu): first widget version

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,14 +171,17 @@ search.addWidget(
 
 ```js
 /**
- * Instantiate a list of refinement based on a facet
+ * Instantiate a list of refinements based on a facet
  * @param  {String|DOMElement} options.container Valid CSS Selector as a string or DOMElement
  * @param  {String} options.facetName Name of the attribute for faceting
  * @param  {String} options.operator How to apply refinements. Possible values: `or`, `and`
  * @param  {String[]} [options.sortBy=['count:desc']] How to sort refinements. Possible values: `count|isRefined|name:asc|desc`
  * @param  {String} [options.limit=100] How much facet values to get.
- * @param  {String|String[]} [options.cssClass=null] CSS class(es) for the main `<ul>` wrapper.
+ * @param  {String|String[]} [options.rootClass=null] CSS class(es) for the root `<ul>` element
+ * @param  {String|String[]} [options.itemClass=null] CSS class(es) for the item `<li>` element
  * @param  {String|Function} [options.template] Item template, provided with `name`, `count`, `isRefined`
+ * @param  {String|Function} [options.singleRefine=true] Are multiple refinements allowed or only one at the same time. You can use this
+ *                                                       to build radio based refinement lists for example.
  * @return {Object}
  */
 ```
@@ -196,6 +199,40 @@ search.addWidget(
     container: '#brands', 
     facetName: 'brands',
     operator: 'or'
+  })
+);
+```
+
+### menu
+
+#### API
+
+```js
+/**
+ * Create a menu out of a facet
+ * @param  {String|DOMElement} options.container Valid CSS Selector as a string or DOMElement
+ * @param  {String} options.facetName Name of the attribute for faceting
+ * @param  {String[]} [options.sortBy=['count:desc']] How to sort refinements. Possible values: `count|isRefined|name:asc|desc`
+ * @param  {String} [options.limit=100] How much facet values to get.
+ * @param  {String|String[]} [options.rootClass=null] CSS class(es) for the root `<ul>` element
+ * @param  {String|String[]} [options.itemClass=null] CSS class(es) for the item `<li>` element
+ * @param  {String|Function} [options.template] Item template, provided with `name`, `count`, `isRefined`
+ * @return {Object}
+ */
+```
+
+
+#### Usage
+
+```html
+<div id="categories"></div>
+```
+
+```js
+search.addWidget(
+  instantsearch.widgets.menu({
+    container: '#categories', 
+    facetName: 'categories'
   })
 );
 ```

--- a/components/MultipleChoiceList.js
+++ b/components/MultipleChoiceList.js
@@ -5,7 +5,6 @@ var Template = require('./Template');
 class MultipleChoiceList extends React.Component {
   refine(value) {
     this.props.toggleRefine(value);
-    this.props.search();
   }
 
   // Click events on DOM tree like LABEL > INPUT will result in two click events
@@ -46,10 +45,10 @@ class MultipleChoiceList extends React.Component {
     var template = this.props.template;
 
     return (
-      <ul className={this.props.cssClass}>
+      <ul className={this.props.rootClass}>
         {facetValues.map(facetValue => {
           return (
-            <li key={facetValue.name} onClick={this.handleClick.bind(this, facetValue.name)}>
+            <li className={this.props.itemClass} key={facetValue.name} onClick={this.handleClick.bind(this, facetValue.name)}>
               <Template data={facetValue} template={template} />
             </li>
           );
@@ -60,12 +59,15 @@ class MultipleChoiceList extends React.Component {
 }
 
 MultipleChoiceList.propTypes = {
-  cssClass: React.PropTypes.oneOfType([
+  rootClass: React.PropTypes.oneOfType([
     React.PropTypes.string,
-    React.PropTypes.array
+    React.PropTypes.arrayOf(React.PropTypes.string)
+  ]),
+  itemClass: React.PropTypes.oneOfType([
+    React.PropTypes.string,
+    React.PropTypes.arrayOf(React.PropTypes.string)
   ]),
   facetValues: React.PropTypes.array,
-  search: React.PropTypes.func.isRequired,
   template: React.PropTypes.oneOfType([
     React.PropTypes.string,
     React.PropTypes.func

--- a/example/app.js
+++ b/example/app.js
@@ -47,8 +47,18 @@ search.addWidget(
     facetName: 'brand',
     operator: 'or',
     limit: 10,
-    cssClass: 'nav nav-stacked',
+    rootClass: 'nav nav-stacked',
     template: require('./templates/or.html')
+  })
+);
+
+search.addWidget(
+  instantsearch.widgets.menu({
+    container: '#categories',
+    facetName: 'categories',
+    limit: 10,
+    rootClass: 'list-unstyled',
+    template: require('./templates/category.html')
   })
 );
 

--- a/example/index.html
+++ b/example/index.html
@@ -14,10 +14,19 @@
 
     <div class="row">
       <div class="col-md-3">
-        <div id="search-box"></div>
+        <div class="panel">
+          <div class="panel-body" id="search-box"></div>
+        </div>
 
-        <h2>Brands</h1>
-        <div id="brands"></div>
+        <div class="panel panel-default">
+          <div class="panel-heading">Categories</div>
+          <div id="categories" class="list-group"></div>
+        </div>
+
+        <div class="panel panel-default">
+          <div class="panel-heading">Brands</div>
+          <div class="panel-body" id="brands"></div>
+        </div>
       </div>
       <div class="col-md-9">
         <div id="stats"></div>

--- a/example/templates/category.html
+++ b/example/templates/category.html
@@ -1,0 +1,1 @@
+<a href="#" class="list-group-item{{#isRefined}} active{{/isRefined}}">{{name}} <span class="badge">{{count}}</span></a>

--- a/example/templates/or.html
+++ b/example/templates/or.html
@@ -1,3 +1,6 @@
-<label class="checkbox">
-  <input type="checkbox" value="{{name}}" {{#isRefined}}checked{{/isRefined}} />{{name}} <span class="badge pull-right">{{count}}</span>
-</label>
+<div class="checkbox">
+  <label>
+    <input type="checkbox" value="{{name}}" {{#isRefined}}checked{{/isRefined}} />{{name}}
+  </label>
+  <span class="badge pull-right">{{count}}</span>
+</div>

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ module.exports = {
   InstantSearch: require('./lib/InstantSearch'),
   widgets: {
     hits: require('./widgets/hits'),
+    menu: require('./widgets/menu'),
     multipleChoiceList: require('./widgets/multiple-choice-list'),
     pagination: require('./widgets/pagination'),
     searchBox: require('./widgets/search-box'),

--- a/widgets/menu.js
+++ b/widgets/menu.js
@@ -1,0 +1,77 @@
+var React = require('react');
+var cx = require('classnames');
+
+var utils = require('../lib/widget-utils.js');
+
+var defaultTemplate = `<a href="{{href}}">{{name}}</a> {{count}}`;
+
+var hierarchicalCounter = 0;
+
+/**
+ * Instantiate a list of refinements based on a facet
+ * @param  {String|DOMElement} options.container Valid CSS Selector as a string or DOMElement
+ * @param  {String} options.facetName Name of the attribute for faceting
+ * @param  {String[]} [options.sortBy=['count:desc']] How to sort refinements. Possible values: `count|isRefined|name:asc|desc`
+ * @param  {String} [options.limit=100] How much facet values to get.
+ * @param  {String|String[]} [options.rootClass=null] CSS class(es) for the root `<ul>` element
+ * @param  {String|String[]} [options.itemClass=null] CSS class(es) for the item `<li>` element
+ * @param  {String|Function} [options.template] Item template, provided with `name`, `count`, `isRefined`
+ * @return {Object}
+ */
+function menu({
+    container = null,
+    facetName = null,
+    sortBy = ['count:desc'],
+    limit = 100,
+    rootClass = null,
+    itemClass = null,
+    template = defaultTemplate
+  }) {
+  hierarchicalCounter++;
+
+  var MultipleChoiceList = require('../components/MultipleChoiceList');
+
+  var containerNode = utils.getContainerNode(container);
+  var usage = 'Usage: menu({container, facetName, [sortBy, limit, rootClass, itemClass, template]})';
+
+  if (container === null || facetName === null) {
+    throw new Error(usage);
+  }
+
+  var hierarchicalFacetName = 'instantsearch.js' + hierarchicalCounter;
+
+  return {
+    getConfiguration: () => ({
+      hierarchicalFacets: [{
+        name: hierarchicalFacetName,
+        attributes: [facetName]
+      }]
+    }),
+    render: function(results, state, helper) {
+      React.render(
+        <MultipleChoiceList
+          rootClass={cx(rootClass)}
+          itemClass={cx(itemClass)}
+          facetValues={getFacetValues(results, hierarchicalFacetName, sortBy, limit)}
+          template={template}
+          toggleRefine={toggleRefine.bind(null, helper, hierarchicalFacetName)}
+        />,
+        containerNode
+      );
+    }
+  };
+}
+
+function toggleRefine(helper, facetName, facetValue) {
+  helper
+    .toggleRefine(facetName, facetValue)
+    .search();
+}
+
+function getFacetValues(results, hierarchicalFacetName, sortBy, limit) {
+  return results
+    .getFacetValues(hierarchicalFacetName, {sortBy: sortBy})
+    .data.slice(0, limit);
+}
+
+module.exports = menu;


### PR DESCRIPTION
So it works(tm).

![untitled screencast 2](https://cloud.githubusercontent.com/assets/123822/9694558/04653428-535a-11e5-89b3-8a6d94fc8f9c.gif)

After a bit of tuning I was even able to get the bootstrap rendering to be fine. I first thought that we would hit a wall because of the react div wrapping but we are still ok.

As for the APIs: `menu`, `multipleChoiceList` (or `refinementList` is we rename it).
It does seems that they could all be the same widget. We only have three behaviors:
- `menu`: refinementList with only one selectable item at a time
- `refinementList` + multiple selectable items + AND
- `refinementList` + multiple selectable items + AND

We could merge both widgets into a single widget.

But we still need to express the hierarchical menu feature.
So having already a menu widget seems the easiest rather than trying to bend the `multipleChoiceList` API into something understanding the hierarchical menu. cc @redox ?