### PR TITLE
fix: switch back to divs in refinementList, rendering glitch

### DIFF
--- a/components/RefinementList.js
+++ b/components/RefinementList.js
@@ -41,15 +41,15 @@ class RefinementList extends React.Component {
     var template = this.props.template;
 
     return (
-      <ul className={this.props.rootClass}>
+      <div className={this.props.rootClass}>
         {facetValues.map(facetValue => {
           return (
-            <li className={this.props.itemClass} key={facetValue.name} onClick={this.handleClick.bind(this, facetValue.name)}>
+            <div className={this.props.itemClass} key={facetValue.name} onClick={this.handleClick.bind(this, facetValue.name)}>
               <Template data={facetValue} template={template} />
-            </li>
+            </div>
           );
         })}
-      </ul>
+      </div>
     );
   }
 }

--- a/example/index.html
+++ b/example/index.html
@@ -19,15 +19,6 @@
         </div>
 
         <div class="panel panel-default">
-          <div class="panel-heading">Toggle filters</div>
-          <div class="panel-body">
-            <ul class="nav nav-stacked">
-              <li><div id="free_shipping"></div></li>
-            </ul>
-          </div>
-        </div>
-
-        <div class="panel panel-default">
           <div class="panel-heading">Categories</div>
           <div id="categories" class="list-group"></div>
         </div>
@@ -35,6 +26,15 @@
         <div class="panel panel-default">
           <div class="panel-heading">Brands</div>
           <div class="panel-body" id="brands"></div>
+        </div>
+
+        <div class="panel panel-default">
+          <div class="panel-heading">Toggle filters</div>
+          <div class="panel-body">
+            <ul class="nav nav-stacked">
+              <li><div id="free_shipping"></div></li>
+            </ul>
+          </div>
         </div>
 
       </div>

--- a/widgets/refinement-list.js
+++ b/widgets/refinement-list.js
@@ -62,7 +62,7 @@ function refinementList({
           itemClass={cx(itemClass)}
           facetValues={results.getFacetValues(facetName, {sortBy: sortBy}).slice(0, limit)}
           template={template}
-          toggleRefine={toggleRefine.bind(null, helper, singleRefine, facetName)}
+          toggleRefinement={toggleRefinement.bind(null, helper, singleRefine, facetName)}
         />,
         containerNode
       );
@@ -70,7 +70,7 @@ function refinementList({
   };
 }
 
-function toggleRefine(helper, singleRefine, facetName, facetValue) {
+function toggleRefinement(helper, singleRefine, facetName, facetValue) {
   if (singleRefine) {
     helper.clearRefinement(facetName);
   }


### PR DESCRIPTION
To be more precise: `<ul>` has a default margin of 10px bottom in bootstrap. It's not an issue if you precisely follow the bootstrap DOM format but otherwise it does not works.

So `<div>` being unstyled by default will in the end by easier to use for most websites.

Example:

![2015-09-09-100326_293x158_scrot](https://cloud.githubusercontent.com/assets/123822/9756387/0dfc1b7c-56da-11e5-841a-4f59eb16a366.png)