### PR TITLE
feat:named parameters when instanciating

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ API is unstable. We welcome any idea.
 
 ```js
 var instantsearch = require('instantsearch.js');
-var search = instantsearch(appId, apiKey, indexName);
+var search = instantsearch({
+  appId: appId,
+  apiKey: apiKey,
+  indexName: indexName
+});
 
 // add a widget
 search.addWidget(

--- a/example/app.js
+++ b/example/app.js
@@ -2,11 +2,11 @@ require('./style.css');
 
 var instantsearch = require('../');
 
-var search = instantsearch(
-  'latency',
-  '6be0576ff61c053d5f9a3225e2a90f76',
-  'instant_search'
-);
+var search = instantsearch({
+  applicationID: 'latency',
+  searchAPIKey: '6be0576ff61c053d5f9a3225e2a90f76',
+  indexName: 'instant_search'
+});
 
 search.addWidget(
   instantsearch.widgets.searchBox({

--- a/example/app.js
+++ b/example/app.js
@@ -3,8 +3,8 @@ require('./style.css');
 var instantsearch = require('../');
 
 var search = instantsearch({
-  applicationID: 'latency',
-  searchAPIKey: '6be0576ff61c053d5f9a3225e2a90f76',
+  appId: 'latency',
+  apiKey: '6be0576ff61c053d5f9a3225e2a90f76',
   indexName: 'instant_search'
 });
 

--- a/lib/InstantSearch.js
+++ b/lib/InstantSearch.js
@@ -6,13 +6,29 @@ var merge = require('lodash/object/merge');
 var union = require('lodash/array/union');
 
 class InstantSearch {
-  constructor(applicationID, searchKey, indexName, searchParameters) {
-    var client = algoliasearch(applicationID, searchKey);
+  constructor({
+    applicationID = null,
+    searchAPIKey = null,
+    indexName = null,
+    defaultSearchParameters = {}
+  }) {
+    if (applicationID === null || searchAPIKey === null || indexName === null) {
+      var usage = `
+Usage: instantsearch({
+  applicationID: 'my_application_id',
+  searchAPIKey: 'my_search_api_key',
+  indexName: 'my_index_name'
+});`;
+      throw new Error(usage);
+    }
+
+
+    var client = algoliasearch(applicationID, searchAPIKey);
 
     this.client = client;
     this.helper = null;
     this.indexName = indexName;
-    this.searchParameters = searchParameters || {};
+    this.searchParameters = defaultSearchParameters || {};
     this.widgets = [];
   }
 

--- a/lib/InstantSearch.js
+++ b/lib/InstantSearch.js
@@ -7,28 +7,28 @@ var union = require('lodash/array/union');
 
 class InstantSearch {
   constructor({
-    applicationID = null,
-    searchAPIKey = null,
+    appId = null,
+    apiKey = null,
     indexName = null,
-    defaultSearchParameters = {}
+    searchParameters = {}
   }) {
-    if (applicationID === null || searchAPIKey === null || indexName === null) {
+    if (appId === null || apiKey === null || indexName === null) {
       var usage = `
 Usage: instantsearch({
-  applicationID: 'my_application_id',
-  searchAPIKey: 'my_search_api_key',
+  appId: 'my_application_id',
+  apiKey: 'my_search_api_key',
   indexName: 'my_index_name'
 });`;
       throw new Error(usage);
     }
 
 
-    var client = algoliasearch(applicationID, searchAPIKey);
+    var client = algoliasearch(appId, apiKey);
 
     this.client = client;
     this.helper = null;
     this.indexName = indexName;
-    this.searchParameters = defaultSearchParameters || {};
+    this.searchParameters = searchParameters || {};
     this.widgets = [];
   }
 

--- a/test/InstantSearch/lifecycle.js
+++ b/test/InstantSearch/lifecycle.js
@@ -33,7 +33,12 @@ test('InstantSearch: lifecycle', function(t) {
     'algoliasearch-helper': algoliasearchHelper
   });
 
-  var search = new InstantSearch(appId, apiKey, indexName, searchParameters);
+  var search = new InstantSearch({
+    applicationID: appId,
+    searchAPIKey: apiKey,
+    indexName: indexName,
+    defaultSearchParameters: searchParameters
+  });
 
   // instantiates a client
   t.ok(algoliasearch.calledOnce, 'algoliasearch called');

--- a/test/InstantSearch/lifecycle.js
+++ b/test/InstantSearch/lifecycle.js
@@ -34,10 +34,10 @@ test('InstantSearch: lifecycle', function(t) {
   });
 
   var search = new InstantSearch({
-    applicationID: appId,
-    searchAPIKey: apiKey,
+    appId: appId,
+    apiKey: apiKey,
     indexName: indexName,
-    defaultSearchParameters: searchParameters
+    searchParameters: searchParameters
   });
 
   // instantiates a client

--- a/test/InstantSearch/recursively-merge-arrays-searchParameters.js
+++ b/test/InstantSearch/recursively-merge-arrays-searchParameters.js
@@ -43,10 +43,10 @@ test('InstantSearch: recursively merge arrays in searchParameters', function(t) 
   });
 
   var search = new InstantSearch({
-    applicationID: 'appId',
-    searchAPIKey: 'apiKey',
+    appId: 'appId',
+    apiKey: 'apiKey',
     indexName: 'recursively',
-    defaultSearchParameters: searchParameters
+    searchParameters: searchParameters
   });
 
   search.addWidget(firstWidget);

--- a/test/InstantSearch/recursively-merge-arrays-searchParameters.js
+++ b/test/InstantSearch/recursively-merge-arrays-searchParameters.js
@@ -42,7 +42,12 @@ test('InstantSearch: recursively merge arrays in searchParameters', function(t) 
     'algoliasearch-helper': algoliasearchHelper
   });
 
-  var search = new InstantSearch('appId', 'apiKey', 'recursively', searchParameters);
+  var search = new InstantSearch({
+    applicationID: 'appId',
+    searchAPIKey: 'apiKey',
+    indexName: 'recursively',
+    defaultSearchParameters: searchParameters
+  });
 
   search.addWidget(firstWidget);
   search.addWidget(secondWidget);


### PR DESCRIPTION
This adds named parameters when instanciating `instantsearch`, instead of having fixed arguments:

```javascript
var search = instantsearch({
  applicationID: 'latency',
  searchAPIKey: '6be0576ff61c053d5f9a3225e2a90f76',
  indexName: 'instant_search'
});
```

This is needed for #77. I used `searchAPIKey` instead of `apiKey` to be explicit that this plugin is used for search only (we often have people on support using the wrong key). Better be explicit.