### PR TITLE
feat: formatNumber in Stats widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,15 @@ API is unstable. We welcome any idea.
 
 - [Usage](#usage)
 - [Widget API](#widget-api)
+- [Templates](#templates)
+  - [Examples](#examples)
+  - [Template helpers](#template-helpers)
 - [Dev](#dev)
 - [Test](#test)
 - [Available widgets](#available-widgets)
   - [searchBox](#searchbox)
   - [stats](#stats)
+  - [indexSelector](#indexselector)
   - [pagination](#pagination)
   - [hits](#hits)
   - [toggle](#toggle)
@@ -89,7 +93,7 @@ template.
 search.addWidget(
   instantsearch.widgets.stats({
     container: '#stats',
-    template: '<div>You have {{nbHits}} results, fetched in {{processingTimeMS}}ms.</div>
+    template: '<div>You have {{nbHits}} results, fetched in {{processingTimeMS}}ms.</div>'
   })
 );
 // Function template example

--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ API is unstable. We welcome any idea.
 ```js
 var instantsearch = require('instantsearch.js');
 var search = instantsearch({
-  appId: appId,
-  apiKey: apiKey,
-  indexName: indexName
+  appId: appId, // Mandatory
+  apiKey: apiKey, // Mandatory
+  indexName: indexName, // Mandatory
+  numberLocale: 'fr-FR' // Optional, defaults to 'en-EN'
 });
 
 // add a widget
@@ -71,6 +72,52 @@ function mySuperWidget(opts) {
 
 search.addWidget(mySuperWidget());
 ```
+
+## Templates
+
+Most of the widgets accept a `template` or `templates` option that let you
+change the default rendering.
+
+`template` can be defined either as a Mustache (Hogan) string or as a function.
+See the documentation of each widget to see which data is passed to the
+template.
+
+### Examples
+
+```javascript
+// Mustache template example
+search.addWidget(
+  instantsearch.widgets.stats({
+    container: '#stats',
+    template: '<div>You have {{nbHits}} results, fetched in {{processingTimeMS}}ms.</div>
+  })
+);
+// Function template example
+search.addWidget(
+  instantsearch.widgets.stats({
+    container: '#stats',
+    template: function(data) {
+      return '<div>You have ' + data.nbHits + 'results, fetched in ' + data.processingTimMS +'ms.</div>'
+    }
+  })
+);
+```
+
+### Template helpers
+
+In order to help you when defining your templates, `instantsearch.js` exposes
+a few helpers. All helpers are accessible in the Mustache templating through
+`{{#helpers.nameOfTheHelper}}{{valueToFormat}}{{/helpers.nameOfTheHelper}}`. To
+use them in the function templates, you'll have to call
+`search.templateHelpers.nameOfTheHelper` where `search` is your current
+`instantsearch` instance.
+
+Here is the list of the currently available helpers.
+
+- `formatNumber`: Will accept a number as input and returned the formatted
+  version of the number in the locale defined with the `numberLocale` config
+  option (defaults to `en-EN`).
+  eg. `100000` will be formatted as `100 000` with `en-EN`
 
 ## Dev
 

--- a/components/Stats.js
+++ b/components/Stats.js
@@ -5,6 +5,7 @@ var Template = require('./Template');
 class Stats extends React.Component {
   render() {
     var template = this.props.template;
+    var templateHelpers = this.props.templateHelpers;
     var data = {
       nbHits: this.props.nbHits,
       hasNoResults: this.props.nbHits === 0,
@@ -17,6 +18,7 @@ class Stats extends React.Component {
       <Template
         data={data}
         template={template}
+        templateHelpers={templateHelpers}
       />
     );
   }
@@ -28,7 +30,8 @@ Stats.propTypes = {
   template: React.PropTypes.oneOfType([
     React.PropTypes.func,
     React.PropTypes.string
-  ]).isRequired
+  ]).isRequired,
+  templateHelpers: React.PropTypes.object
 };
 
 module.exports = Stats;

--- a/components/Template.js
+++ b/components/Template.js
@@ -4,7 +4,11 @@ var renderTemplate = require('../lib/utils').renderTemplate;
 
 class Template {
   render() {
-    var content = renderTemplate(this.props.template, this.props.data);
+    var content = renderTemplate({
+      template: this.props.template,
+      templateHelpers: this.props.templateHelpers,
+      data: this.props.data
+    });
 
     return <div dangerouslySetInnerHTML={{__html: content}} />;
   }
@@ -15,6 +19,7 @@ Template.propTypes = {
     React.PropTypes.string,
     React.PropTypes.func
   ]).isRequired,
+  templateHelpers: React.PropTypes.object,
   data: React.PropTypes.object
 };
 

--- a/example/app.js
+++ b/example/app.js
@@ -3,7 +3,8 @@ var instantsearch = require('../');
 var search = instantsearch({
   appId: 'latency',
   apiKey: '6be0576ff61c053d5f9a3225e2a90f76',
-  indexName: 'instant_search'
+  indexName: 'instant_search',
+  numberLocale: 'fr-FR'
 });
 
 search.addWidget(

--- a/example/app.js
+++ b/example/app.js
@@ -3,8 +3,7 @@ var instantsearch = require('../');
 var search = instantsearch({
   appId: 'latency',
   apiKey: '6be0576ff61c053d5f9a3225e2a90f76',
-  indexName: 'instant_search',
-  numberLocale: 'fr-FR'
+  indexName: 'instant_search'
 });
 
 search.addWidget(

--- a/lib/InstantSearch.js
+++ b/lib/InstantSearch.js
@@ -10,6 +10,7 @@ class InstantSearch {
     appId = null,
     apiKey = null,
     indexName = null,
+    numberLocale = 'en-EN',
     searchParameters = {}
   }) {
     if (appId === null || apiKey === null || indexName === null) {
@@ -22,7 +23,6 @@ Usage: instantsearch({
       throw new Error(usage);
     }
 
-
     var client = algoliasearch(appId, apiKey);
 
     this.client = client;
@@ -30,6 +30,11 @@ Usage: instantsearch({
     this.indexName = indexName;
     this.searchParameters = searchParameters || {};
     this.widgets = [];
+    this.templateHelpers = {
+      formatNumber(number) {
+        return Number(number).toLocaleString(numberLocale);
+      }
+    };
   }
 
   addWidget(widgetDefinition) {
@@ -67,10 +72,16 @@ Usage: instantsearch({
 
   _render(helper, results, state) {
     forEach(this.widgets, function(widget) {
-      if (widget.render) {
-        widget.render(results, state, helper);
+      if (!widget.render) {
+        return;
       }
-    });
+      widget.render({
+        templateHelpers: this.templateHelpers,
+        results,
+        state,
+        helper
+      });
+    }, this);
   }
 
   _init(state, helper) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -14,16 +14,33 @@ function isDomElement(o) {
   return o instanceof HTMLElement || o && o.nodeType > 0;
 }
 
-function renderTemplate(template, data) {
+function renderTemplate({template, templateHelpers, data}) {
   var hogan = require('hogan.js');
+  var forEach = require('lodash/collection/forEach');
   var content;
 
-  if (typeof template === 'string') {
-    content = hogan.compile(template).render(data);
-  } else if (typeof template === 'function') {
-    content = template(data);
-  } else {
+  if (typeof template !== 'string' && typeof template !== 'function') {
     throw new Error('Template must be `string` or `function`');
+  }
+
+  if (typeof template === 'function') {
+    content = template(data);
+  }
+
+  if (typeof template === 'string') {
+    // We add all our template helper methods to the template as lambdas. Note
+    // that lambdas in Mustache are supposed to accept a second argument of
+    // `render` to get the rendered value, not the literal `{{value}}`. But
+    // this is currently broken (see
+    // https://github.com/twitter/hogan.js/issues/222).
+    forEach(templateHelpers, function(method, name) {
+      data['_' + name] = function() {
+        return function(value) {
+          return method(hogan.compile(value).render(data));
+        };
+      };
+    });
+    content = hogan.compile(this.props.template).render(data);
   }
 
   return content;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -33,6 +33,7 @@ function renderTemplate({template, templateHelpers, data}) {
         };
       };
     });
+    return data;
   }
 
   if (typeof template !== 'string' && typeof template !== 'function') {
@@ -44,13 +45,9 @@ function renderTemplate({template, templateHelpers, data}) {
   }
 
   if (typeof template === 'string') {
-    if (!data.helpers) {
-      data = addTemplateHelpersToData(data);
-    } else {
-      console.warn('TemplateHelpers not included because template data already contained a .helpers key');
-    }
+    data = addTemplateHelpersToData(data);
 
-    content = hogan.compile(this.props.template).render(data);
+    content = hogan.compile(template).render(data);
   }
 
   return content;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -33,14 +33,15 @@ function renderTemplate({template, templateHelpers, data}) {
     // `render` to get the rendered value, not the literal `{{value}}`. But
     // this is currently broken (see
     // https://github.com/twitter/hogan.js/issues/222).
-    forEach(templateHelpers, function(method, name) {
-      data['_' + name] = function() {
-        return function(value) {
+    data.helpers = {};
+    forEach(templateHelpers, (method, name) => {
+      data.helpers[name] = () => {
+        return (value) => {
           return method(hogan.compile(value).render(data));
         };
       };
     });
-    content = hogan.compile(this.props.template).render(data);
+    content = hogan.compile(template).render(data);
   }
 
   return content;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,6 +19,22 @@ function renderTemplate({template, templateHelpers, data}) {
   var forEach = require('lodash/collection/forEach');
   var content;
 
+  // We add all our template helper methods to the template as lambdas. Note
+  // that lambdas in Mustache are supposed to accept a second argument of
+  // `render` to get the rendered value, not the literal `{{value}}`. But
+  // this is currently broken (see
+  // https://github.com/twitter/hogan.js/issues/222).
+  function addTemplateHelpersToData(templateData) {
+    templateData.helpers = {};
+    forEach(templateHelpers, (method, name) => {
+      data.helpers[name] = () => {
+        return (value) => {
+          return method(hogan.compile(value).render(templateData));
+        };
+      };
+    });
+  }
+
   if (typeof template !== 'string' && typeof template !== 'function') {
     throw new Error('Template must be `string` or `function`');
   }
@@ -28,20 +44,13 @@ function renderTemplate({template, templateHelpers, data}) {
   }
 
   if (typeof template === 'string') {
-    // We add all our template helper methods to the template as lambdas. Note
-    // that lambdas in Mustache are supposed to accept a second argument of
-    // `render` to get the rendered value, not the literal `{{value}}`. But
-    // this is currently broken (see
-    // https://github.com/twitter/hogan.js/issues/222).
-    data.helpers = {};
-    forEach(templateHelpers, (method, name) => {
-      data.helpers[name] = () => {
-        return (value) => {
-          return method(hogan.compile(value).render(data));
-        };
-      };
-    });
-    content = hogan.compile(template).render(data);
+    if (!data.helpers) {
+      data = addTemplateHelpersToData(data);
+    } else {
+      console.warn('TemplateHelpers not included because template data already contained a .helpers key');
+    }
+
+    content = hogan.compile(this.props.template).render(data);
   }
 
   return content;

--- a/test/InstantSearch/lifecycle.js
+++ b/test/InstantSearch/lifecycle.js
@@ -89,7 +89,12 @@ test('InstantSearch: lifecycle', function(t) {
   t.ok(widget.render.calledOnce, 'widget.render called');
   t.deepEqual(
     widget.render.args[0],
-    [results, helper.state, helper],
+    [{
+      results: results,
+      state: helper.state,
+      helper: helper,
+      templateHelpers: search.templateHelpers
+    }],
     'widget.render(results, state, helper)'
   );
 

--- a/widgets/hits.js
+++ b/widgets/hits.js
@@ -9,7 +9,7 @@ function hits({container = null, templates = {}, hitsPerPage = 20}) {
 
   return {
     getConfiguration: () => ({hitsPerPage}),
-    render: function(results, state, helper) {
+    render: function({results, helper}) {
       React.render(
         <Hits
           hits={results.hits}

--- a/widgets/index-selector.js
+++ b/widgets/index-selector.js
@@ -32,7 +32,7 @@ function indexSelector({
       }
     },
 
-    render: function(results, state, helper) {
+    render: function({helper}) {
       var containerId = containerNode.id;
       React.render(
         <IndexSelector

--- a/widgets/menu.js
+++ b/widgets/menu.js
@@ -47,7 +47,7 @@ function menu({
         attributes: [facetName]
       }]
     }),
-    render: function(results, state, helper) {
+    render: function({results, helper}) {
       React.render(
         <RefinementList
           rootClass={cx(rootClass)}

--- a/widgets/pagination.js
+++ b/widgets/pagination.js
@@ -8,7 +8,7 @@ function pagination({container, cssClass, labels, maxPages} = {}) {
   var containerNode = utils.getContainerNode(container);
 
   return {
-    render: function(results, state, helper) {
+    render: function({results, helper}) {
       var nbPages = results.nbPages;
       if (maxPages !== undefined) {
         nbPages = Math.min(maxPages, results.nbPages);

--- a/widgets/range-slider.js
+++ b/widgets/range-slider.js
@@ -53,7 +53,7 @@ function rangeSlider({
       helper.addNumericRefinement(facetName, '<=', newValues[1]);
       helper.search();
     },
-    render(results, state, helper) {
+    render({results, helper}) {
       var stats = results.getFacetStats(facetName);
       var currentRefinement = this._getCurrentRefinement(helper);
 

--- a/widgets/refinement-list.js
+++ b/widgets/refinement-list.js
@@ -55,7 +55,7 @@ function refinementList({
     getConfiguration: () => ({
       [operator === 'and' ? 'facets' : 'disjunctiveFacets']: [facetName]
     }),
-    render: function(results, state, helper) {
+    render: function({results, helper}) {
       React.render(
         <RefinementList
           rootClass={cx(rootClass)}

--- a/widgets/stats/index.js
+++ b/widgets/stats/index.js
@@ -12,12 +12,13 @@ function stats({container = null, template = defaultTemplate}) {
   }
 
   return {
-    render: function(results) {
+    render: function({results, templateHelpers}) {
       React.render(
         <Stats
           nbHits={results.nbHits}
           processingTimeMS={results.processingTimeMS}
           template={template}
+          templateHelpers={templateHelpers}
         />,
         containerNode
       );

--- a/widgets/stats/template.html
+++ b/widgets/stats/template.html
@@ -1,6 +1,6 @@
 <div>
   {{#hasNoResults}}No results{{/hasNoResults}}
   {{#hasOneResult}}1 result{{/hasOneResult}}
-  {{#hasManyResults}}{{nbHits}} results{{/hasManyResults}}
+  {{#hasManyResults}}{{#_formatNumber}}{{nbHits}}{{/_formatNumber}} results{{/hasManyResults}}
   <small>found in {{processingTimeMS}}ms</small>
 </div>

--- a/widgets/stats/template.html
+++ b/widgets/stats/template.html
@@ -1,6 +1,6 @@
 <div>
   {{#hasNoResults}}No results{{/hasNoResults}}
   {{#hasOneResult}}1 result{{/hasOneResult}}
-  {{#hasManyResults}}{{#_formatNumber}}{{nbHits}}{{/_formatNumber}} results{{/hasManyResults}}
+  {{#hasManyResults}}{{#helpers.formatNumber}}{{nbHits}}{{/helpers.formatNumber}} results{{/hasManyResults}}
   <small>found in {{processingTimeMS}}ms</small>
 </div>

--- a/widgets/toggle.js
+++ b/widgets/toggle.js
@@ -32,7 +32,7 @@ function toggle({
     getConfiguration: () => ({
       facets: [facetName]
     }),
-    render: function(results, state, helper) {
+    render: function({helper}) {
       var isRefined = helper.hasRefinements(facetName);
 
       function toggleFilter() {


### PR DESCRIPTION
I've added `_formatNumber` to Hogan templates. It is also available through `search.templateHelpers.formatNumber` (`search` being the `instantsearch.js` instance).

I've updated all other widgets to accept the new `widget.render` syntax.

I'll update the other widgets (to use the `formatNumber` in prices and facet counts) after this PR is merged. I currently need to pass the `templateHelper` from instant search to the widget, then to the component, then to the template which is not optimal, though.

Also fixes #82 since the new render API is option object based
