### PR TITLE
feat:IE8-9 support using a simpler polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,17 +491,16 @@ search.addWidget(
 
 ## Browser support
 
-We support IE10+ and all other modern browsers.
+We natively support IE10+ and all other modern browsers without any dependency need
+on your side.
 
-To get < IE10 support, please insert this in the `<head>`:
+To get < IE10 support, please insert this code in the `<head>`:
 
 ```html
 <meta http-equiv="X-UA-Compatible" content="IE=Edge">
 <!--[if lte IE 9]>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/aight/1.2.2/aight.min.js"></script>
+  <script src="https://cdn.polyfill.io/v1/polyfill.min.js"></script>
 <![endif]-->
 ```
 
-We use the [shawnbot/aight](https://github.com/shawnbot/aight) polyfill.
-
-**Always put the `<script>` after any `jQuery` library**, see https://github.com/shawnbot/aight/issues/42.
+We use the [polyfill.io](https://cdn.polyfill.io/v1/docs/).

--- a/example/index.html
+++ b/example/index.html
@@ -5,6 +5,9 @@
   <title>Instant search demo built with instantsearch.js</title>
   <link rel="stylesheet" href="//cdn.jsdelivr.net/bootstrap/3.3.5/css/bootstrap.min.css">
   <link rel="stylesheet" href="//cdn.jsdelivr.net/bootstrap/3.3.5/css/bootstrap-theme.min.css">
+  <!--[if lte IE 9]>
+  <script src="https://cdn.polyfill.io/v1/polyfill.min.js"></script>
+  <![endif]-->
   <link rel="stylesheet" href="./style.css">
 </head>
 <body>

--- a/widgets/menu.js
+++ b/widgets/menu.js
@@ -11,6 +11,8 @@ var defaultTemplates = {
 
 var hierarchicalCounter = 0;
 
+var defaults = require('lodash/object/defaults');
+
 /**
  * Create a menu out of a facet
  * @param  {String|DOMElement} options.container Valid CSS Selector as a string or DOMElement
@@ -55,7 +57,7 @@ function menu({
   }
 
   if (templates !== defaultTemplates) {
-    templates = Object.assign({}, defaultTemplates, templates);
+    templates = defaults({}, templates, defaultTemplates);
   }
 
   var hierarchicalFacetName = 'instantsearch.js' + hierarchicalCounter;

--- a/widgets/refinement-list.js
+++ b/widgets/refinement-list.js
@@ -10,6 +10,8 @@ var defaultTemplates = {
 </label>`
 };
 
+var defaults = require('lodash/object/defaults');
+
 /**
  * Instantiate a list of refinements based on a facet
  * @param  {String|DOMElement} options.container Valid CSS Selector as a string or DOMElement
@@ -69,7 +71,7 @@ function refinementList({
   }
 
   if (templates !== defaultTemplates) {
-    templates = Object.assign({}, defaultTemplates, templates);
+    templates = defaults({}, templates, defaultTemplates);
   }
 
   return {


### PR DESCRIPTION
https://cdn.polyfill.io/v1/docs/ is a nice small polyfill
+ can't use Object.assign, would require another polyfill for most
browsers

IE8 support currently waiting for https://github.com/Financial-Times/polyfill-service/pull/483 merge, should be ok