### PR TITLE
fix(searchBox): do not update input's value if focused

### DIFF
--- a/widgets/search-box.js
+++ b/widgets/search-box.js
@@ -56,7 +56,7 @@ function searchbox(params) {
       }
 
       helper.on('change', function(state) {
-        if (input.value !== state.query) {
+        if (input !== document.activeElement && input.value !== state.query) {
           input.value = state.query;
         }
       });


### PR DESCRIPTION
fixes #163

At some point we said that there was no need to update the input while it's focused since you are typing in it. Wonder if there are some cases where this can be an issue, but since we are using the "change" helper event it should be good.