### PR TITLE
fix(templatesConfig): helpers are now following Mustache spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,21 @@ Here is the list of the currently available helpers:
   option (defaults to `en-EN`).
   eg. `100000` will be formatted as `100 000` with `en-EN`
 
+Here is the syntax of a helper (`render` is using `search.templatesConfig.compileOptions`):
+```js
+search.templatesConfig.helpers.makeTitle = function (text, render) {
+  return '<h1>' + render(text) + '</h1>';
+};
+```
+
+If you know the structure of the object you'll be calling a helper with,
+you can access it with `this`:
+```js
+search.templatesConfig.helpers.discount = function () {
+  return '-' + ((1 - this.promotion_price / this.price) * 100) + '%'; // -10%
+};
+```
+
 You can configure the options passed to `Hogan.compile` by using `search.templatesConfig.compileOptions`. We accept all [compile options](https://github.com/twitter/hogan.js/#compilation-options).
 
 Theses options will be passed to the `Hogan.compile` calls when you pass a custom template.

--- a/lib/InstantSearch.js
+++ b/lib/InstantSearch.js
@@ -32,8 +32,8 @@ Usage: instantsearch({
     this.widgets = [];
     this.templatesConfig = {
       helpers: {
-        formatNumber(number) {
-          return Number(number).toLocaleString(numberLocale);
+        formatNumber(number, render) {
+          return Number(render(number)).toLocaleString(numberLocale);
         }
       },
       compileOptions: {}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -56,9 +56,10 @@ function renderTemplate({template, compileOptions, helpers, data}) {
   function addTemplateHelpersToData(templateData) {
     templateData.helpers = {};
     forOwn(helpers, (method, name) => {
-      data.helpers[name] = () => {
-        return (value) => {
-          return method(hogan.compile(value, compileOptions).render(templateData));
+      templateData.helpers[name] = function() {
+        return (text) => {
+          var render = (value) => hogan.compile(value, compileOptions).render(this);
+          return method.call(this, text, render);
         };
       };
     });


### PR DESCRIPTION
Hogan still hasn't fixed it, so we implemented our own fix, but we weren't following the Mustache(5) spec either.

Changes the helper syntax from:
```js
helpers: function (renderedText) {
  return '<h1>' + renderedText + '</h1>';
};
```
to:
```js
helpers: function (text, render) {
  return '<h1>' + render(text) + '</h1>';
};
```

Also replaced the fat arrow of the wrapping closure by a simple `function` to allow Hogan to bind the currently rendered object. (This is unspecified by the Mustache spec, but is really useful)