### PR TITLE
PoweredBy: extract its hiding capabilities

### DIFF
--- a/components/PoweredBy/index.js
+++ b/components/PoweredBy/index.js
@@ -6,12 +6,9 @@ require('style?prepend!raw!./index.css');
 
 class PoweredBy extends React.Component {
   render() {
-    var poweredByDisplay = (this.props.display === true) ? 'block' : 'none';
-
     return (
       <div
         className={bem()}
-        style={{display: poweredByDisplay}}
       >
         Powered by
         <a href="https://www.algolia.com/">
@@ -26,7 +23,6 @@ class PoweredBy extends React.Component {
 }
 
 PoweredBy.propTypes = {
-  display: React.PropTypes.bool
 };
 
 module.exports = PoweredBy;

--- a/widgets/search-box.js
+++ b/widgets/search-box.js
@@ -63,7 +63,7 @@ function searchbox({
         var PoweredBy = require('../components/PoweredBy');
         var poweredByContainer = document.createElement('div');
         input.parentNode.appendChild(poweredByContainer);
-        React.render(<PoweredBy display />, poweredByContainer);
+        React.render(<PoweredBy />, poweredByContainer);
       }
 
       helper.on('change', function(state) {


### PR DESCRIPTION
It must not be the responsability of the PoweredBy component to
show/hide itself. Fix #189