### PR TITLE
Refinement list limit improvement

### DIFF
--- a/components/RefinementList.js
+++ b/components/RefinementList.js
@@ -65,9 +65,7 @@ class RefinementList extends React.Component {
   render() {
     return (
       <div className={cx(this.props.cssClasses.list)}>
-      {this.props.facetValues
-        .slice(0, this.props.limit)
-        .map(this._generateFacetItem, this)}
+      {this.props.facetValues.map(this._generateFacetItem, this)}
       </div>
     );
   }
@@ -84,7 +82,6 @@ RefinementList.propTypes = {
       React.PropTypes.arrayOf(React.PropTypes.string)
     ])
   }),
-  limit: React.PropTypes.number,
   facetValues: React.PropTypes.array,
   Template: React.PropTypes.func,
   toggleRefinement: React.PropTypes.func.isRequired,
@@ -96,7 +93,6 @@ RefinementList.defaultProps = {
     item: null,
     list: null
   },
-  limit: 1000,
   facetNameKey: 'name'
 };
 

--- a/widgets/refinement-list.js
+++ b/widgets/refinement-list.js
@@ -22,7 +22,7 @@ var defaultTemplates = {
  * @param  {String} options.facetName Name of the attribute for faceting
  * @param  {String} options.operator How to apply refinements. Possible values: `or`, `and`
  * @param  {String[]} [options.sortBy=['count:desc']] How to sort refinements. Possible values: `count|isRefined|name:asc|desc`
- * @param  {String} [options.limit=100] How much facet values to get
+ * @param  {String} [options.limit=1000] How much facet values to get
  * @param  {Object} [options.cssClasses] CSS classes to add to the wrapping elements: root, list, item
  * @param  {String|String[]} [options.cssClasses.root] CSS class to add to the root element
  * @param  {String|String[]} [options.cssClasses.list] CSS class to add to the list element
@@ -44,7 +44,7 @@ function refinementList({
     facetName = null,
     operator = null,
     sortBy = ['count:desc'],
-    limit = 100,
+    limit = 1000,
     cssClasses = {
       root: null,
       list: null,
@@ -75,6 +75,13 @@ function refinementList({
   }
 
   return {
+    init: (state, helper) => {
+      // set the maxValuesPerFacet to max(limit, currentValue)
+      var maxValuesPerFacet = helper.getQueryParameter('maxValuesPerFacet');
+      if (!maxValuesPerFacet || limit > maxValuesPerFacet) {
+        helper.setQueryParameter('maxValuesPerFacet', limit);
+      }
+    },
     getConfiguration: () => ({
       [operator === 'and' ? 'facets' : 'disjunctiveFacets']: [facetName]
     }),

--- a/widgets/refinement-list.js
+++ b/widgets/refinement-list.js
@@ -75,16 +75,19 @@ function refinementList({
   }
 
   return {
-    init: (state, helper) => {
+    getConfiguration: (configuration) => {
+      var widgetConfiguration = {
+        [operator === 'and' ? 'facets' : 'disjunctiveFacets']: [facetName]
+      };
+
       // set the maxValuesPerFacet to max(limit, currentValue)
-      var maxValuesPerFacet = helper.getQueryParameter('maxValuesPerFacet');
-      if (!maxValuesPerFacet || limit > maxValuesPerFacet) {
-        helper.setQueryParameter('maxValuesPerFacet', limit);
+      if (!configuration.maxValuesPerFacet || limit > configuration.maxValuesPerFacet) {
+        widgetConfiguration.maxValuesPerFacet = limit;
       }
+
+      return widgetConfiguration;
     },
-    getConfiguration: () => ({
-      [operator === 'and' ? 'facets' : 'disjunctiveFacets']: [facetName]
-    }),
+
     render: function({results, helper, templatesConfig}) {
       var templateProps = utils.prepareTemplateProps({
         transformData,


### PR DESCRIPTION
The default limit should be 1000 to fit the API's default configuration.
Remove the limit option from the component itself, it's enough to have it in the
widget.
Set the maxValuesPerFacet if not set to optimize the JSON answer
payload.

Fix #155 