### PR TITLE
chore(react): Upgrade to React 0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "classnames": "^2.1.5",
     "hogan.js": "^3.0.2",
     "lodash": "^3.10.1",
-    "react": "^0.13.3",
+    "react": "^0.14.0",
     "react-nouislider": "^1.2.1",
     "to-factory": "^1.0.0"
   },


### PR DESCRIPTION
The major API update is around the findDOMNode API but it seems we're
not using it, so I think there is nothing to update.

Fix #151