### PR TITLE
style(eslint): Add ordering rule on React props

### DIFF
--- a/components/Hits.js
+++ b/components/Hits.js
@@ -5,7 +5,11 @@ class Hits extends React.Component {
   renderWithResults() {
     var renderedHits = map(this.props.results.hits, (hit) => {
       return (
-        <this.props.Template templateKey="hit" data={hit} key={hit.objectID} />
+        <this.props.Template
+          data={hit}
+          key={hit.objectID}
+          templateKey="hit"
+        />
       );
     });
 
@@ -15,7 +19,10 @@ class Hits extends React.Component {
   renderNoResults() {
     return (
       <div>
-        <this.props.Template templateKey="empty" data={this.props.results} />
+        <this.props.Template
+          data={this.props.results}
+          templateKey="empty"
+        />
       </div>
     );
   }

--- a/components/Pagination/PaginationLink.js
+++ b/components/Pagination/PaginationLink.js
@@ -14,9 +14,9 @@ class PaginationLink extends React.Component {
         <a
           ariaLabel={ariaLabel}
           className={className}
+          dangerouslySetInnerHTML={{__html: label}}
           href="#"
           onClick={handleClick}
-          dangerouslySetInnerHTML={{__html: label}}
         ></a>
       </li>
     );
@@ -29,11 +29,11 @@ PaginationLink.propTypes = {
     React.PropTypes.number
   ]).isRequired,
   className: React.PropTypes.string,
+  handleClick: React.PropTypes.func.isRequired,
   label: React.PropTypes.oneOfType([
     React.PropTypes.string,
     React.PropTypes.number
-  ]).isRequired,
-  handleClick: React.PropTypes.func.isRequired
+  ]).isRequired
 };
 
 module.exports = PaginationLink;

--- a/components/RefinementList.js
+++ b/components/RefinementList.js
@@ -72,6 +72,7 @@ class RefinementList extends React.Component {
 }
 
 RefinementList.propTypes = {
+  Template: React.PropTypes.func,
   cssClasses: React.PropTypes.shape({
     item: React.PropTypes.oneOfType([
       React.PropTypes.string,
@@ -82,10 +83,9 @@ RefinementList.propTypes = {
       React.PropTypes.arrayOf(React.PropTypes.string)
     ])
   }),
+  facetNameKey: React.PropTypes.string,
   facetValues: React.PropTypes.array,
-  Template: React.PropTypes.func,
-  toggleRefinement: React.PropTypes.func.isRequired,
-  facetNameKey: React.PropTypes.string
+  toggleRefinement: React.PropTypes.func.isRequired
 };
 
 RefinementList.defaultProps = {

--- a/components/Slider/index.js
+++ b/components/Slider/index.js
@@ -19,11 +19,11 @@ class Slider extends React.Component {
       <div className={cx(this.props.cssClasses.body)}>
         <Nouislider
           {...this.props}
-          onChange={this.handleChange.bind(this)}
           animate={false}
           behaviour={'snap'}
           connect
           cssPrefix={cssPrefix}
+          onChange={this.handleChange.bind(this)}
         />
       </div>
     );
@@ -31,20 +31,20 @@ class Slider extends React.Component {
 }
 
 Slider.propTypes = {
-  onSlide: React.PropTypes.func,
-  onChange: React.PropTypes.func,
-  range: React.PropTypes.object.isRequired,
-  start: React.PropTypes.arrayOf(React.PropTypes.number).isRequired,
-  tooltips: React.PropTypes.oneOfType([
-    React.PropTypes.bool,
-    React.PropTypes.object
-  ]),
   cssClasses: React.PropTypes.shape({
     body: React.PropTypes.oneOfType([
       React.PropTypes.string,
       React.PropTypes.arrayOf(React.PropTypes.string)
     ])
-  })
+  }),
+  onChange: React.PropTypes.func,
+  onSlide: React.PropTypes.func,
+  range: React.PropTypes.object.isRequired,
+  start: React.PropTypes.arrayOf(React.PropTypes.number).isRequired,
+  tooltips: React.PropTypes.oneOfType([
+    React.PropTypes.bool,
+    React.PropTypes.object
+  ])
 };
 
 module.exports = Slider;

--- a/components/Template.js
+++ b/components/Template.js
@@ -22,12 +22,12 @@ class Template extends React.Component {
 }
 
 Template.propTypes = {
+  data: React.PropTypes.object,
+  templateKey: React.PropTypes.string,
   templates: React.PropTypes.objectOf(React.PropTypes.oneOfType([
     React.PropTypes.string,
     React.PropTypes.func
   ])),
-  templateKey: React.PropTypes.string,
-  useCustomCompileOptions: React.PropTypes.objectOf(React.PropTypes.bool),
   templatesConfig: React.PropTypes.shape({
     helpers: React.PropTypes.objectOf(React.PropTypes.func),
     // https://github.com/twitter/hogan.js/#compilation-options
@@ -45,7 +45,7 @@ Template.propTypes = {
     React.PropTypes.func,
     React.PropTypes.objectOf(React.PropTypes.func)
   ]),
-  data: React.PropTypes.object
+  useCustomCompileOptions: React.PropTypes.objectOf(React.PropTypes.bool)
 };
 
 Template.defaultProps = {

--- a/components/__tests__/Hits-test.js
+++ b/components/__tests__/Hits-test.js
@@ -29,8 +29,16 @@ describe('Hits', () => {
 
     expect(out).toEqual(
       <div>
-        <Template templateKey="hit" data={results.hits[0]} key={results.hits[0].objectID} />
-        <Template templateKey="hit" data={results.hits[1]} key={results.hits[1].objectID} />
+        <Template
+          data={results.hits[0]}
+          key={results.hits[0].objectID}
+          templateKey="hit"
+        />
+        <Template
+          data={results.hits[1]}
+          key={results.hits[1].objectID}
+          templateKey="hit"
+        />
       </div>
     );
   });
@@ -42,6 +50,13 @@ describe('Hits', () => {
     renderer.render(<Hits {...props} />);
     let out = renderer.getRenderOutput();
 
-    expect(out).toEqual(<div><Template templateKey="empty" data={results} /></div>);
+    expect(out).toEqual(
+      <div>
+        <Template
+          data={results}
+          templateKey="empty"
+        />
+      </div>
+    );
   });
 });

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "doctoc": "^0.15.0",
     "eslint": "^1.6.0",
     "eslint-config-airbnb": "^0.1.0",
-    "eslint-config-algolia": "^4.0.0",
+    "eslint-config-algolia": "^4.1.0",
     "eslint-plugin-react": "^3.5.1",
     "expect": "^1.12.0",
     "file-loader": "^0.8.4",

--- a/widgets/hierarchicalMenu.js
+++ b/widgets/hierarchicalMenu.js
@@ -80,13 +80,13 @@ function hierarchicalMenu({
 
       ReactDOM.render(
         <RefinementList
-          cssClasses={cssClasses}
-          facetValues={facetValues}
-          limit={limit}
           Template={bindProps(Template, templateProps)}
-          hideWhenNoResults={hideWhenNoResults}
-          hasResults={facetValues.length > 0}
+          cssClasses={cssClasses}
           facetNameKey="path"
+          facetValues={facetValues}
+          hasResults={facetValues.length > 0}
+          hideWhenNoResults={hideWhenNoResults}
+          limit={limit}
           toggleRefinement={toggleRefinement.bind(null, helper, hierarchicalFacetName)}
         />,
         containerNode

--- a/widgets/menu.js
+++ b/widgets/menu.js
@@ -76,11 +76,11 @@ function menu({
 
       ReactDOM.render(
         <RefinementList
+          Template={bindProps(Template, templateProps)}
           cssClasses={cssClasses}
           facetValues={facetValues}
-          Template={bindProps(Template, templateProps)}
-          hideWhenNoResults={hideWhenNoResults}
           hasResults={facetValues.length > 0}
+          hideWhenNoResults={hideWhenNoResults}
           toggleRefinement={toggleRefinement.bind(null, helper, hierarchicalFacetName)}
         />,
         containerNode

--- a/widgets/range-slider.js
+++ b/widgets/range-slider.js
@@ -100,13 +100,13 @@ function rangeSlider({
 
       ReactDOM.render(
         <Slider
-          start={[currentRefinement.min, currentRefinement.max]}
-          range={{min: stats.min, max: stats.max}}
-          cssClasses={cssClasses}
           Template={bindProps(Template, templateProps)}
-          hideWhenNoResults={hideWhenNoResults}
+          cssClasses={cssClasses}
           hasResults={stats.min !== null && stats.max !== null}
+          hideWhenNoResults={hideWhenNoResults}
           onChange={this._refine.bind(this, helper, stats)}
+          range={{min: stats.min, max: stats.max}}
+          start={[currentRefinement.min, currentRefinement.max]}
           tooltips={tooltips}
         />,
         containerNode

--- a/widgets/refinement-list.js
+++ b/widgets/refinement-list.js
@@ -101,11 +101,11 @@ function refinementList({
 
       ReactDOM.render(
         <RefinementList
+          Template={bindProps(Template, templateProps)}
           cssClasses={cssClasses}
           facetValues={facetValues}
-          hideWhenNoResults={hideWhenNoResults}
           hasResults={facetValues.length > 0}
-          Template={bindProps(Template, templateProps)}
+          hideWhenNoResults={hideWhenNoResults}
           toggleRefinement={toggleRefinement.bind(null, helper, singleRefine, facetName)}
         />,
         containerNode

--- a/widgets/stats/index.js
+++ b/widgets/stats/index.js
@@ -58,16 +58,16 @@ function stats({
 
       ReactDOM.render(
         <Stats
+          Template={bindProps(Template, templateProps)}
+          cssClasses={cssClasses}
           hasResults={results.hits.length > 0}
           hideWhenNoResults={hideWhenNoResults}
           hitsPerPage={results.hitsPerPage}
-          cssClasses={cssClasses}
           nbHits={results.nbHits}
           nbPages={results.nbPages}
           page={results.page}
           processingTimeMS={results.processingTimeMS}
           query={results.query}
-          Template={bindProps(Template, templateProps)}
         />,
         containerNode
       );

--- a/widgets/toggle.js
+++ b/widgets/toggle.js
@@ -83,11 +83,11 @@ function toggle({
 
       ReactDOM.render(
         <RefinementList
-          facetValues={[facetValue]}
           Template={bindProps(Template, templateProps)}
           cssClasses={cssClasses}
-          hideWhenNoResults={hideWhenNoResults}
+          facetValues={[facetValue]}
           hasResults={results.hits.length > 0}
+          hideWhenNoResults={hideWhenNoResults}
           toggleRefinement={toggleRefinement.bind(null, helper, facetName, facetValue.isRefined)}
         />,
         containerNode


### PR DESCRIPTION
React props and propTypes should now be set in alphabetical order.
This will help in the diffs and overall visual parsing of props.

Fixes #154 

For vim users, you can add `vnoremap s :!sort -V<CR>` to be able to
sort the current visual selection.