### PR TITLE
fix(transformData): add an explicit error message

### DIFF
--- a/components/Template.js
+++ b/components/Template.js
@@ -57,14 +57,22 @@ function transformData(fn, templateKey, originalData) {
     return originalData;
   }
 
+  var data;
   if (typeof fn === 'function') {
-    return fn(originalData);
+    data = fn(originalData);
   } else if (typeof fn === 'object') {
     // ex: transformData: {hit, empty}
-    return fn[templateKey] && fn[templateKey](originalData) || originalData;
+    data = fn[templateKey] && fn[templateKey](originalData);
+  } else {
+    throw new Error('`transformData` must be a function or an object');
   }
 
-  throw new Error('`transformData` must be a function or an object');
+  var dataType = typeof data;
+  var expectedType = typeof originalData;
+  if (dataType !== expectedType) {
+    throw new Error(`\`transformData\` must return a \`${expectedType}\`, got \`${dataType}\`.`);
+  }
+  return data;
 }
 
 function renderTemplate({template, compileOptions, helpers, data}) {

--- a/components/__tests__/Template-test.js
+++ b/components/__tests__/Template-test.js
@@ -110,7 +110,7 @@ describe('Template', () => {
     expect(out).toEqual(<div dangerouslySetInnerHTML={{__html: 'it supports transformData'}}></div>);
   });
 
-  it('throws an error if the transformData is not anything', () => {
+  it('throws an error if the transformData is not returning anything', () => {
     templates = {test: 'it supports {{feature}}'};
     data = {feature: 'replace me'};
     templateKey = 'test';

--- a/components/__tests__/Template-test.js
+++ b/components/__tests__/Template-test.js
@@ -110,6 +110,34 @@ describe('Template', () => {
     expect(out).toEqual(<div dangerouslySetInnerHTML={{__html: 'it supports transformData'}}></div>);
   });
 
+  it('throws an error if the transformData is not anything', () => {
+    templates = {test: 'it supports {{feature}}'};
+    data = {feature: 'replace me'};
+    templateKey = 'test';
+    transformData = () => {
+      // return case if missing
+    };
+
+    let props = getProps();
+    expect(() => {
+      renderer.render(<Template {...props} />);
+    }).toThrow('`transformData` must return a `object`, got `undefined`.');
+  });
+
+  it('throws an error if the transformData returns an unexpected type', () => {
+    templates = {test: 'it supports {{feature}}'};
+    data = {feature: 'replace me'};
+    templateKey = 'test';
+    transformData = () => {
+      return true;
+    };
+
+    let props = getProps();
+    expect(() => {
+      renderer.render(<Template {...props} />);
+    }).toThrow('`transformData` must return a `object`, got `boolean`.');
+  });
+
   function getProps() {
     return {templates, data, templateKey, useCustomCompileOptions, templatesConfig, transformData};
   }

--- a/widgets/toggle.js
+++ b/widgets/toggle.js
@@ -104,7 +104,14 @@ function prepareToggleData(transformData) {
       count: data.count
     };
 
-    return transformData && transformData(newData) || newData;
+    if (transformData) {
+      newData = transformData(newData);
+      if (typeof newData !== 'object') {
+        throw new Error('`transformData` must return an object.');
+      }
+    }
+
+    return newData;
   };
 }
 

--- a/widgets/toggle.js
+++ b/widgets/toggle.js
@@ -106,11 +106,7 @@ function prepareToggleData(transformData) {
 
     if (transformData) {
       newData = transformData(newData);
-      if (typeof newData !== 'object') {
-        throw new Error('`transformData` must return an object.');
-      }
     }
-
     return newData;
   };
 }


### PR DESCRIPTION
In case the `transformData` is not returning any value or
the wrong type, we now throw an explicit error.

Fix #212