### PR TITLE
feat(refinement-list): Move default template to its own file

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ instantsearch.widgets = {
   hits: require('./widgets/hits/hits'),
   indexSelector: require('./widgets/index-selector'),
   menu: require('./widgets/menu'),
-  refinementList: require('./widgets/refinement-list'),
+  refinementList: require('./widgets/refinement-list/refinement-list.js'),
   pagination: require('./widgets/pagination'),
   searchBox: require('./widgets/search-box'),
   rangeSlider: require('./widgets/range-slider'),

--- a/widgets/refinement-list/defaultTemplates.js
+++ b/widgets/refinement-list/defaultTemplates.js
@@ -1,0 +1,8 @@
+module.exports = {
+  header: '',
+  item: `<label>
+  <input type="checkbox" value="{{name}}" {{#isRefined}}checked{{/isRefined}} />{{name}}
+  <span>{{count}}</span>
+</label>`,
+  footer: ''
+};

--- a/widgets/refinement-list/refinement-list.js
+++ b/widgets/refinement-list/refinement-list.js
@@ -1,21 +1,15 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
 
-var utils = require('../lib/utils.js');
+var utils = require('../../lib/utils.js');
 
-var autoHide = require('../decorators/autoHide');
-var bindProps = require('../decorators/bindProps');
-var headerFooter = require('../decorators/headerFooter');
-var RefinementList = autoHide(headerFooter(require('../components/RefinementList')));
-var Template = require('../components/Template');
+var autoHide = require('../../decorators/autoHide');
+var bindProps = require('../../decorators/bindProps');
+var headerFooter = require('../../decorators/headerFooter');
+var RefinementList = autoHide(headerFooter(require('../../components/RefinementList')));
+var Template = require('../../components/Template');
 
-var defaultTemplates = {
-  header: '',
-  item: `<label>
-<input type="checkbox" value="{{name}}" {{#isRefined}}checked{{/isRefined}} />{{name}} <span>{{count}}</span>
-</label>`,
-  footer: ''
-};
+var defaultTemplates = require('./defaultTemplates');
 
 /**
  * Instantiate a list of refinements based on a facet


### PR DESCRIPTION
I've moved the default template from inline inside the widget to its
own file.

This will make my work adding the CSS classes much easier as I will
now have separate js, html and css files. As a bonus I gain syntax
highlighting and linters in vim as well.

I also think this will make generating the documentation (with HTML
code examples of the default templates) easier.

@vvo pointed out that `require`-ing html files was more or less
a webpack-specific feature and would be hard to port to other build
system. I feel that it's still worth it; what are your thoughts?