### PR TITLE
fix(validate-commit): Update the regexp

### DIFF
--- a/scripts/validate-commit-msgs.sh
+++ b/scripts/validate-commit-msgs.sh
@@ -35,7 +35,7 @@ for sha in `git log --format=oneline "$RANGE" | cut '-d ' -f1`; do
     EXIT=2
   elif echo $FIRST_LINE | grep -qE '^Merge (?:pull request|branch)'; then
     echo "OK (merge)"
-  elif echo $FIRST_LINE | grep -qE '^(?:feat|fix|docs|style|refactor|perf|test|chore|revert)\(.+\).*'; then
+  elif echo $FIRST_LINE | grep -qE '^(feat|fix|docs|style|refactor|perf|test|chore|revert)\(.+\): .*'; then
     echo "OK"
   else
     echo "KO (format): $FIRST_LINE"


### PR DESCRIPTION
The current regexp was sometime refusing commit messages that are
valid (see
https://travis-ci.org/algolia/instantsearch.js/builds/85530333)

I've simply removed the `?:` and added a check on the `: `, and this
seems to work better.

I still have no idea why some commits where ok and some not. If anyone
has a guess...?