### PR TITLE
feat(es7): Enable `es7.objectRestSpread`

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "plugins": ["babel-plugin-rewire"]
+  "plugins": ["babel-plugin-rewire"],
+  "stage": 2
 }


### PR DESCRIPTION
This will enable us writing this like:

```js
let { x, y, ...z } = { x: 1, y: 2, a: 3, b: 4 };
```

or

```js
var defaults = { first: 'John', last: 'Doe', age: 42 };
var trainer  = { last: 'Smith', age: 35 };
trainer      = { ...defaults, ...trainer, age: 36 }
// => { first: 'John', last: 'Smith', age: 36 }
```

More info: https://github.com/sebmarkbage/ecmascript-rest-spread

Babeljs should have this enabled by default, but it seems than for it
to work when using the babel plugin for webpack, we need to explicitly
enable it.