### PR TITLE
fix(onClick): do not replace the browser's behavior on special clicks

### DIFF
--- a/components/Pagination/Pagination.js
+++ b/components/Pagination/Pagination.js
@@ -1,6 +1,7 @@
 var React = require('react');
 var forEach = require('lodash/collection/forEach');
 var defaultsDeep = require('lodash/object/defaultsDeep');
+var {isSpecialClick} = require('../../lib/utils.js');
 
 var Paginator = require('./Paginator');
 var PaginationLink = require('./PaginationLink');
@@ -14,6 +15,11 @@ class Pagination extends React.Component {
   }
 
   handleClick(pageNumber, event) {
+    if (isSpecialClick(event)) {
+      // do not alter the default browser behavior
+      // if one special key is down
+      return;
+    }
     event.preventDefault();
     this.props.setCurrentPage(pageNumber);
   }

--- a/components/Pagination/PaginationLink.js
+++ b/components/Pagination/PaginationLink.js
@@ -1,11 +1,6 @@
 var React = require('react');
 
 class PaginationLink extends React.Component {
-  handleClick(page, e) {
-    e.preventDefault();
-    this.props.setCurrentPage(page);
-  }
-
   render() {
     var {className, label, ariaLabel, handleClick, url} = this.props;
 

--- a/components/Pagination/__tests__/Pagination-test.js
+++ b/components/Pagination/__tests__/Pagination-test.js
@@ -105,6 +105,24 @@ describe('Pagination', () => {
       .toEqual(cx(bem('item', 'disabled'), bem('item'), bem('item-last')));
   });
 
+  it('should handle special clicks', () => {
+    var props = {
+      setCurrentPage: sinon.spy()
+    };
+    var preventDefault = sinon.spy();
+    var component = new Pagination(props);
+    ['ctrlKey', 'shiftKey', 'altKey', 'metaKey'].forEach((e) => {
+      var event = {preventDefault};
+      event[e] = true;
+      component.handleClick(42, event);
+      expect(props.setCurrentPage.called).toBe(false, 'setCurrentPage never called');
+      expect(preventDefault.called).toBe(false, 'preventDefault never called');
+    });
+    component.handleClick(42, {preventDefault});
+    expect(props.setCurrentPage.calledOnce).toBe(true, 'setCurrentPage called once');
+    expect(preventDefault.calledOnce).toBe(true, 'preventDefault called once');
+  });
+
   function render(extraProps = {}) {
     var props = {
       cssClasses: {},

--- a/components/Pagination/__tests__/Pagination-test.js
+++ b/components/Pagination/__tests__/Pagination-test.js
@@ -18,93 +18,91 @@ describe('Pagination', () => {
     renderer = createRenderer();
   });
 
-  context('with stats', () => {
-    it('should not display the first/last link by default', () => {
-      var out = render();
+  it('should not display the first/last link by default', () => {
+    var out = render();
 
-      expect(out.props.children.length).toEqual(5);
-      expect(out.props.children[0]).toEqual(null);
-      expect(out.props.children[4]).toEqual(null);
+    expect(out.props.children.length).toEqual(5);
+    expect(out.props.children[0]).toEqual(null);
+    expect(out.props.children[4]).toEqual(null);
+  });
+
+  it('should display the first/last link', () => {
+    var out = render({showFirstLast: true});
+
+    expect(out.props.children.length).toEqual(5);
+    expect(out.props.children[0]).toNotEqual(null);
+    expect(out.props.children[4]).toNotEqual(null);
+  });
+
+  it('should display the right number of pages', () => {
+    var padding = 4;
+    var out = render({padding});
+
+    expect(out.props.children.length).toEqual(5);
+    expect(out.props.children[2].length).toEqual(padding + 1 + padding);
+  });
+
+  it('should flag the current page as active', () => {
+    var out = render({currentPage: 0});
+
+    expect(out.props.children.length).toEqual(5);
+    expect(out.props.children[2][0].props.className)
+      .toEqual(cx(bem('item-page', 'active'), bem('item'), bem('item-page')));
+    expect(out.props.children[2][1].props.className)
+      .toEqual(cx(bem('item'), bem('item-page')));
+  });
+
+  it('should disable the first page if already on it', () => {
+    var out = render({currentPage: 0, showFirstLast: true});
+
+    expect(out.props.children.length).toEqual(5);
+    expect(out.props.children[0].props.className)
+      .toEqual(cx(bem('item', 'disabled'), bem('item'), bem('item-first')));
+  });
+
+  it('should build the associated URL', () => {
+    var createURL = sinon.stub().returns('/page');
+    var out = new Pagination({cssClasses: {}}).pageLink({
+      label: 'test',
+      createURL
     });
 
-    it('should display the first/last link', () => {
-      var out = render({showFirstLast: true});
+    expect(out).toEqualJSX(
+      <PaginationLink
+        ariaLabel={undefined}
+        className="ais-pagination--item"
+        handleClick={() => {}}
+        label="test"
+        url="/page"
+      />);
+    expect(createURL.calledOnce).toBe(true, 'createURL should be called once');
+  });
 
-      expect(out.props.children.length).toEqual(5);
-      expect(out.props.children[0]).toNotEqual(null);
-      expect(out.props.children[4]).toNotEqual(null);
+  it('should not build the URL of disabled page', () => {
+    var createURL = sinon.spy();
+    var out = new Pagination({cssClasses: {}}).pageLink({
+      label: 'test',
+      isDisabled: true,
+      createURL
     });
 
-    it('should display the right number of pages', () => {
-      var padding = 4;
-      var out = render({padding});
+    expect(out).toEqualJSX(
+      <PaginationLink
+        ariaLabel={undefined}
+        className="ais-pagination--item__disabled ais-pagination--item"
+        handleClick={() => {}}
+        label="test"
+        url="#"
+      />);
+    expect(createURL.called).toBe(false, 'createURL should not be called');
+  });
 
-      expect(out.props.children.length).toEqual(5);
-      expect(out.props.children[2].length).toEqual(padding + 1 + padding);
-    });
+  it('should disable last first page if already on it', () => {
+    var out = render({currentPage: 19, showFirstLast: true});
 
-    it('should flag the current page as active', () => {
-      var out = render({currentPage: 0});
-
-      expect(out.props.children.length).toEqual(5);
-      expect(out.props.children[2][0].props.className)
-        .toEqual(cx(bem('item-page', 'active'), bem('item'), bem('item-page')));
-      expect(out.props.children[2][1].props.className)
-        .toEqual(cx(bem('item'), bem('item-page')));
-    });
-
-    it('should disable the first page if already on it', () => {
-      var out = render({currentPage: 0, showFirstLast: true});
-
-      expect(out.props.children.length).toEqual(5);
-      expect(out.props.children[0].props.className)
-        .toEqual(cx(bem('item', 'disabled'), bem('item'), bem('item-first')));
-    });
-
-    it('should build the associated URL', () => {
-      var createURL = sinon.stub().returns('/page');
-      var out = new Pagination({cssClasses: {}}).pageLink({
-        label: 'test',
-        createURL
-      });
-
-      expect(out).toEqualJSX(
-        <PaginationLink
-          ariaLabel={undefined}
-          className="ais-pagination--item"
-          handleClick={() => {}}
-          label="test"
-          url="/page"
-        />);
-      expect(createURL.calledOnce).toBe(true, 'createURL should be called once');
-    });
-
-    it('should not build the URL of disabled page', () => {
-      var createURL = sinon.spy();
-      var out = new Pagination({cssClasses: {}}).pageLink({
-        label: 'test',
-        isDisabled: true,
-        createURL
-      });
-
-      expect(out).toEqualJSX(
-        <PaginationLink
-          ariaLabel={undefined}
-          className="ais-pagination--item__disabled ais-pagination--item"
-          handleClick={() => {}}
-          label="test"
-          url="#"
-        />);
-      expect(createURL.called).toBe(false, 'createURL should not be called');
-    });
-
-    it('should disable last first page if already on it', () => {
-      var out = render({currentPage: 19, showFirstLast: true});
-
-      expect(out.props.children.length).toEqual(5);
-      expect(out.props.children[4].props.className)
-        .toEqual(cx(bem('item', 'disabled'), bem('item'), bem('item-last')));
-    });
+    expect(out.props.children.length).toEqual(5);
+    expect(out.props.children[4].props.className)
+      .toEqual(cx(bem('item', 'disabled'), bem('item'), bem('item-last')));
   });
 
   function render(extraProps = {}) {

--- a/components/RefinementList.js
+++ b/components/RefinementList.js
@@ -4,6 +4,9 @@ var cx = require('classnames');
 
 var Template = require('./Template');
 
+var {isSpecialClick} = require('../lib/utils.js');
+
+
 class RefinementList extends React.Component {
   refine(value) {
     this.props.toggleRefinement(value);
@@ -53,6 +56,12 @@ class RefinementList extends React.Component {
   // Finally, we always stop propagation of the event to avoid multiple levels RefinementLists to fail: click
   // on child would click on parent also
   handleClick(value, e) {
+    if (isSpecialClick(e)) {
+      // do not alter the default browser behavior
+      // if one special key is down
+      return;
+    }
+
     if (e.target.tagName === 'INPUT') {
       this.refine(value);
       return;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,8 @@
 var utils = {
   getContainerNode,
   bemHelper,
-  prepareTemplateProps
+  prepareTemplateProps,
+  isSpecialClick
 };
 
 function getContainerNode(selectorOrHTMLElement) {
@@ -26,6 +27,10 @@ function getContainerNode(selectorOrHTMLElement) {
 
 function isDomElement(o) {
   return o instanceof HTMLElement || o && o.nodeType > 0;
+}
+
+function isSpecialClick(event) {
+  return event.altKey || event.ctrlKey || event.metaKey || event.shiftKey;
 }
 
 function bemHelper(block) {


### PR DESCRIPTION
It seems to be a common practice to not do anything if one of the special (shift, ctrl, alt or meta) keys are down:
https://github.com/search?q=react+metakey+ctrlkey+preventdefault&type=Code&utf8=%E2%9C%93

Fix #278