### PR TITLE
fix(hits): Fix warning about unique key in iterator

### DIFF
--- a/components/Hits.js
+++ b/components/Hits.js
@@ -7,10 +7,9 @@ class Hits extends React.Component {
   renderWithResults() {
     var renderedHits = map(this.props.results.hits, hit => {
       return (
-        <div className={this.props.cssClasses.item}>
+        <div className={this.props.cssClasses.item} key={hit.objectID}>
           <Template
             data={hit}
-            key={hit.objectID}
             templateKey="item"
             {...this.props.templateProps}
           />


### PR DESCRIPTION
I forgot to move the `key` key to the parent element