### PR TITLE
fix(autohide): Rename attribute to `hideContainerWhenNoResults`

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ search.addWidget(
  * @param  {String|Function} [options.templates.body] Body template
  * @param  {String|Function} [options.templates.footer=''] Footer template
  * @param  {Function} [options.transformData] Function to change the object passed to the `body` template
- * @param  {boolean} [hideWhenNoResults=true] Hide the container when there's no results
+ * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when there's no results
  * @return {Object}
  */
 ```
@@ -455,7 +455,7 @@ you'll need several indices. This widget lets you easily change it.
  * @param  {Object} [options.cssClasses] CSS classes to be added
  * @param  {String} [options.cssClasses.root] CSS classes added to the parent <select>
  * @param  {String} [options.cssClasses.item] CSS classes added to each <option>
- * @param  {boolean} [hideWhenNoResults=false] Hide the container when no results match
+ * @param  {boolean} [hideContainerWhenNoResults=false] Hide the container when no results match
  * @return {Object}
  */
 ```
@@ -518,7 +518,7 @@ search.addWidget(
  * @param  {Number} [maxPages=20] The max number of pages to browse
  * @param  {String|DOMElement|boolean} [scrollTo='body'] Where to scroll after a click, set to `false` to disable
  * @param  {boolean} [showFirstLast=true] Define if the First and Last links should be displayed
- * @param  {boolean} [hideWhenNoResults=true] Hide the container when no results match
+ * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when no results match
  * @return {Object}
  */
 ```
@@ -660,7 +660,7 @@ Note that we are not toggling from `true` to `false` here, but from `true` to
  * @param  {String|Function} [options.templates.item] Item template
  * @param  {String|Function} [options.templates.footer=''] Footer template
  * @param  {Function} [options.transformData] Function to change the object passed to the item template
- * @param  {boolean} [hideWhenNoResults=true] Hide the container when there's no results
+ * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when there's no results
  * @return {Object}
  */
 ```
@@ -755,7 +755,7 @@ search.addWidget(
  * @param  {String|Function} [options.templates.item] Item template, provided with `name`, `count`, `isRefined`
  * @param  {String|Function} [options.templates.footer] Footer template
  * @param  {Function} [options.transformData] Function to change the object passed to the item template
- * @param  {boolean} [hideWhenNoResults=true] Hide the container when there's no results
+ * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when there's no results
  * @return {Object}
  */
 ```
@@ -851,7 +851,7 @@ search.addWidget(
  * @param  {String|Function} [options.templates.item] Item template, provided with `name`, `count`, `isRefined`
  * @param  {String|Function} [options.templates.footer=''] Footer template
  * @param  {Function} [options.transformData] Method to change the object passed to the item template
- * @param  {boolean} [hideWhenNoResults=true] Hide the container when there's no results
+ * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when there's no results
  * @return {Object}
  */
 ```
@@ -940,7 +940,7 @@ search.addWidget(
  * @param  {Object} [options.cssClasses] CSS classes to add to the wrapping elements: root, body
  * @param  {String|String[]} [options.cssClasses.root] CSS class to add to the root element
  * @param  {String|String[]} [options.cssClasses.body] CSS class to add to the body element
- * @param  {boolean} [hideWhenNoResults=true] Hide the container when no results match
+ * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when no results match
  * @return {Object}
  */
 ```
@@ -990,7 +990,7 @@ search.addWidget(
  * @param  {String|Function} [options.labels.button] Button label
  * @param  {String|Function} [options.labels.currency] Currency label
  * @param  {String|Function} [options.labels.to] To label
- * @param  {boolean} [hideWhenNoResults=true] Hide the container when no results match
+ * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when no results match
  * @return {Object}
  */
 ```
@@ -1045,7 +1045,7 @@ search.addWidget(
  * @param  {String|Function} [options.templates.item] Item template
  * @param  {String|Function} [options.templates.footer=''] Footer template (root level only)
  * @param  {Function} [options.transformData] Method to change the object passed to the item template
- * @param  {boolean} [hideWhenNoResults=true] Hide the container when there's no results
+ * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when there's no results
  * @return {Object}
  */
 ```

--- a/components/RefinementList/__tests__/RefinementList-test.js
+++ b/components/RefinementList/__tests__/RefinementList-test.js
@@ -55,7 +55,7 @@ describe('RefinementList', () => {
   });
 
   context('sublist', () => {
-    it('uses autoHide() and headerFooter()', () => {
+    it('uses autoHideContainer() and headerFooter()', () => {
       var customProps = {
         cssClasses: {
           depth: 'depth',

--- a/decorators/__tests__/autoHide-test.js
+++ b/decorators/__tests__/autoHide-test.js
@@ -3,12 +3,12 @@
 import React from 'react';
 import expect from 'expect';
 import TestUtils from 'react-addons-test-utils';
-import autoHide from '../autoHide';
+import autoHideContainer from '../autoHideContainer';
 
 import expectJSX from 'expect-jsx';
 expect.extend(expectJSX);
 
-describe('autoHide', () => {
+describe('autoHideContainer', () => {
   var renderer;
 
   beforeEach(() => {
@@ -16,18 +16,18 @@ describe('autoHide', () => {
     renderer = createRenderer();
   });
 
-  it('should render autoHide(<span />)', () => {
+  it('should render autoHideContainer(<span />)', () => {
     var out = render();
     expect(out).toEqualJSX(<span />);
   });
 
-  it('should not render autoHide(<span />)', () => {
-    var out = render({hasResults: false, hideWhenNoResults: true});
+  it('should not render autoHideContainer(<span />)', () => {
+    var out = render({hasResults: false, hideContainerWhenNoResults: true});
     expect(out).toEqualJSX(<div />);
   });
 
   function render(props = {}) {
-    var AutoHide = autoHide(<span />);
+    var AutoHide = autoHideContainer(<span />);
     renderer.render(<AutoHide {...props} />);
     return renderer.getRenderOutput();
   }

--- a/decorators/autoHideContainer.js
+++ b/decorators/autoHideContainer.js
@@ -1,7 +1,7 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
 
-function autoHide(ComposedComponent) {
+function autoHideContainer(ComposedComponent) {
   class AutoHide extends React.Component {
     componentDidMount() {
       this._hideOrShowContainer(this.props);
@@ -13,16 +13,16 @@ function autoHide(ComposedComponent) {
 
     _hideOrShowContainer(props) {
       var container = ReactDOM.findDOMNode(this).parentNode;
-      if (props.hideWhenNoResults === true && props.hasResults === false) {
+      if (props.hideContainerWhenNoResults === true && props.hasResults === false) {
         container.style.display = 'none';
-      } else if (props.hideWhenNoResults === true) {
+      } else if (props.hideContainerWhenNoResults === true) {
         container.style.display = '';
       }
     }
 
     render() {
       if (this.props.hasResults === false &&
-        this.props.hideWhenNoResults === true) {
+        this.props.hideContainerWhenNoResults === true) {
         return <div />;
       }
 
@@ -32,7 +32,7 @@ function autoHide(ComposedComponent) {
 
   AutoHide.propTypes = {
     hasResults: React.PropTypes.bool.isRequired,
-    hideWhenNoResults: React.PropTypes.bool.isRequired
+    hideContainerWhenNoResults: React.PropTypes.bool.isRequired
   };
 
   // precise displayName for ease of debugging (react dev tool, react warnings)
@@ -41,4 +41,4 @@ function autoHide(ComposedComponent) {
   return AutoHide;
 }
 
-module.exports = autoHide;
+module.exports = autoHideContainer;

--- a/widgets/hierarchical-menu/hierarchical-menu.js
+++ b/widgets/hierarchical-menu/hierarchical-menu.js
@@ -4,9 +4,9 @@ var ReactDOM = require('react-dom');
 var utils = require('../../lib/utils.js');
 var bem = utils.bemHelper('ais-hierarchical-menu');
 var cx = require('classnames/dedupe');
-var autoHide = require('../../decorators/autoHide');
+var autoHideContainer = require('../../decorators/autoHideContainer');
 var headerFooter = require('../../decorators/headerFooter');
-var RefinementList = autoHide(headerFooter(require('../../components/RefinementList/RefinementList.js')));
+var RefinementList = autoHideContainer(headerFooter(require('../../components/RefinementList/RefinementList.js')));
 
 var defaultTemplates = require('./defaultTemplates.js');
 
@@ -32,7 +32,7 @@ var defaultTemplates = require('./defaultTemplates.js');
  * @param  {String|Function} [options.templates.item] Item template
  * @param  {String|Function} [options.templates.footer=''] Footer template (root level only)
  * @param  {Function} [options.transformData] Method to change the object passed to the item template
- * @param  {boolean} [hideWhenNoResults=true] Hide the container when there's no results
+ * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when there's no results
  * @return {Object}
  */
 function hierarchicalMenu({
@@ -42,7 +42,7 @@ function hierarchicalMenu({
     limit = 100,
     sortBy = ['name:asc'],
     cssClasses = {},
-    hideWhenNoResults = true,
+    hideContainerWhenNoResults = true,
     templates = defaultTemplates,
     transformData
   }) {
@@ -96,7 +96,7 @@ function hierarchicalMenu({
           facetNameKey="path"
           facetValues={facetValues}
           hasResults={facetValues.length > 0}
-          hideWhenNoResults={hideWhenNoResults}
+          hideContainerWhenNoResults={hideContainerWhenNoResults}
           limit={limit}
           templateProps={templateProps}
           toggleRefinement={toggleRefinement.bind(null, helper, hierarchicalFacetName)}

--- a/widgets/index-selector/__tests__/index-selector-test.js
+++ b/widgets/index-selector/__tests__/index-selector-test.js
@@ -22,14 +22,14 @@ describe('indexSelector()', () => {
   var props;
   var helper;
   var results;
-  var autoHide;
+  var autoHideContainer;
 
   beforeEach(() => {
-    autoHide = sinon.stub().returns(IndexSelector);
+    autoHideContainer = sinon.stub().returns(IndexSelector);
 
     ReactDOM = {render: sinon.spy()};
     indexSelector.__Rewire__('ReactDOM', ReactDOM);
-    indexSelector.__Rewire__('autoHide', autoHide);
+    indexSelector.__Rewire__('autoHideContainer', autoHideContainer);
 
     container = document.createElement('div');
     indices = ['index-a', 'index-b'];
@@ -61,7 +61,7 @@ describe('indexSelector()', () => {
       },
       currentIndex: 'index-a',
       hasResults: false,
-      hideWhenNoResults: false,
+      hideContainerWhenNoResults: false,
       indices: ['index-a', 'index-b'],
       setIndex: () => {}
     };
@@ -85,6 +85,6 @@ describe('indexSelector()', () => {
 
   afterEach(() => {
     indexSelector.__ResetDependency__('ReactDOM');
-    indexSelector.__ResetDependency__('autoHide');
+    indexSelector.__ResetDependency__('autoHideContainer');
   });
 });

--- a/widgets/index-selector/index-selector.js
+++ b/widgets/index-selector/index-selector.js
@@ -5,7 +5,7 @@ var findIndex = require('lodash/array/findIndex');
 var utils = require('../../lib/utils.js');
 var bem = utils.bemHelper('ais-index-selector');
 var cx = require('classnames');
-var autoHide = require('../../decorators/autoHide');
+var autoHideContainer = require('../../decorators/autoHideContainer');
 
 /**
  * Instantiate a dropdown element to choose the current targeted index
@@ -16,18 +16,18 @@ var autoHide = require('../../decorators/autoHide');
  * @param  {Object} [options.cssClasses] CSS classes to be added
  * @param  {String} [options.cssClasses.root] CSS classes added to the parent <select>
  * @param  {String} [options.cssClasses.item] CSS classes added to each <option>
- * @param  {boolean} [hideWhenNoResults=false] Hide the container when no results match
+ * @param  {boolean} [hideContainerWhenNoResults=false] Hide the container when no results match
  * @return {Object}
  */
 function indexSelector({
     container,
     indices,
     cssClasses = {},
-    hideWhenNoResults = false
+    hideContainerWhenNoResults = false
   }) {
   var containerNode = utils.getContainerNode(container);
 
-  var usage = 'Usage: indexSelector({container, indices[, cssClasses.{select,option}, hideWhenNoResults]})';
+  var usage = 'Usage: indexSelector({container, indices[, cssClasses.{select,option}, hideContainerWhenNoResults]})';
   if (!container || !indices) {
     throw new Error(usage);
   }
@@ -50,7 +50,7 @@ function indexSelector({
       let currentIndex = helper.getIndex();
       let hasResults = results.hits.length > 0;
       let setIndex = this.setIndex.bind(this, helper);
-      var IndexSelector = autoHide(require('../../components/IndexSelector'));
+      var IndexSelector = autoHideContainer(require('../../components/IndexSelector'));
 
       cssClasses = {
         root: cx(bem(null), cssClasses.root),
@@ -61,7 +61,7 @@ function indexSelector({
           cssClasses={cssClasses}
           currentIndex={currentIndex}
           hasResults={hasResults}
-          hideWhenNoResults={hideWhenNoResults}
+          hideContainerWhenNoResults={hideContainerWhenNoResults}
           indices={indices}
           setIndex={setIndex}
         />,

--- a/widgets/menu/menu.js
+++ b/widgets/menu/menu.js
@@ -4,9 +4,9 @@ var ReactDOM = require('react-dom');
 var utils = require('../../lib/utils.js');
 var bem = utils.bemHelper('ais-menu');
 var cx = require('classnames/dedupe');
-var autoHide = require('../../decorators/autoHide');
+var autoHideContainer = require('../../decorators/autoHideContainer');
 var headerFooter = require('../../decorators/headerFooter');
-var RefinementList = autoHide(headerFooter(require('../../components/RefinementList/RefinementList.js')));
+var RefinementList = autoHideContainer(headerFooter(require('../../components/RefinementList/RefinementList.js')));
 
 var defaultTemplates = require('./defaultTemplates.js');
 
@@ -31,7 +31,7 @@ var defaultTemplates = require('./defaultTemplates.js');
  * @param  {String|Function} [options.templates.item] Item template, provided with `name`, `count`, `isRefined`
  * @param  {String|Function} [options.templates.footer=''] Footer template
  * @param  {Function} [options.transformData] Method to change the object passed to the item template
- * @param  {boolean} [hideWhenNoResults=true] Hide the container when there's no results
+ * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when there's no results
  * @return {Object}
  */
 function menu({
@@ -42,7 +42,7 @@ function menu({
     cssClasses = {},
     templates = defaultTemplates,
     transformData,
-    hideWhenNoResults = true
+    hideContainerWhenNoResults = true
   }) {
   var containerNode = utils.getContainerNode(container);
   var usage = 'Usage: menu({container, facetName, [sortBy, limit, cssClasses.{root,list,item}, templates.{header,item,footer}, transformData, hideWhenResults]})';
@@ -90,7 +90,7 @@ function menu({
           cssClasses={cssClasses}
           facetValues={facetValues}
           hasResults={facetValues.length > 0}
-          hideWhenNoResults={hideWhenNoResults}
+          hideContainerWhenNoResults={hideContainerWhenNoResults}
           templateProps={templateProps}
           toggleRefinement={toggleRefinement.bind(null, helper, hierarchicalFacetName)}
         />,

--- a/widgets/pagination/__tests__/pagination-test.js
+++ b/widgets/pagination/__tests__/pagination-test.js
@@ -23,7 +23,7 @@ describe('pagination()', () => {
   beforeEach(() => {
     ReactDOM = {render: sinon.spy()};
     pagination.__Rewire__('ReactDOM', ReactDOM);
-    pagination.__Rewire__('autoHide', sinon.stub().returns(Pagination));
+    pagination.__Rewire__('autoHideContainer', sinon.stub().returns(Pagination));
 
     container = document.createElement('div');
     widget = pagination({container, scrollTo: false});
@@ -84,7 +84,7 @@ describe('pagination()', () => {
 
   afterEach(() => {
     pagination.__ResetDependency__('ReactDOM');
-    pagination.__ResetDependency__('autoHide');
+    pagination.__ResetDependency__('autoHideContainer');
   });
 
   function getProps(extraProps = {}) {
@@ -92,7 +92,7 @@ describe('pagination()', () => {
       cssClasses: {},
       currentPage: 0,
       hasResults: true,
-      hideWhenNoResults: true,
+      hideContainerWhenNoResults: true,
       labels: {first: '«', last: '»', next: '›', previous: '‹'},
       nbHits: results.nbHits,
       nbPages: results.nbPages,

--- a/widgets/pagination/pagination.js
+++ b/widgets/pagination/pagination.js
@@ -3,7 +3,7 @@ var ReactDOM = require('react-dom');
 var defaults = require('lodash/object/defaults');
 
 var utils = require('../../lib/utils.js');
-var autoHide = require('../../decorators/autoHide');
+var autoHideContainer = require('../../decorators/autoHideContainer');
 var defaultLabels = {
   previous: '‹',
   next: '›',
@@ -33,7 +33,7 @@ var defaultLabels = {
  * @param  {Number} [options.padding=3] The number of pages to display on each side of the current page
  * @param  {String|DOMElement|boolean} [options.scrollTo='body'] Where to scroll after a click, set to `false` to disable
  * @param  {boolean} [options.showFirstLast=true] Define if the First and Last links should be displayed
- * @param  {boolean} [options.hideWhenNoResults=true] Hide the container when no results match
+ * @param  {boolean} [options.hideContainerWhenNoResults=true] Hide the container when no results match
  * @return {Object}
  */
 function pagination({
@@ -43,7 +43,7 @@ function pagination({
     maxPages = 20,
     padding = 3,
     showFirstLast = true,
-    hideWhenNoResults = true,
+    hideContainerWhenNoResults = true,
     scrollTo = 'body'
   }) {
   if (scrollTo === true) {
@@ -54,7 +54,7 @@ function pagination({
   var scrollToNode = scrollTo !== false ? utils.getContainerNode(scrollTo) : false;
 
   if (!container) {
-    throw new Error('Usage: pagination({container[, cssClasses.{root,item,page,previous,next,first,last,active,disabled}, labels.{previous,next,first,last}, maxPages, showFirstLast, hideWhenNoResults]})');
+    throw new Error('Usage: pagination({container[, cssClasses.{root,item,page,previous,next,first,last,active,disabled}, labels.{previous,next,first,last}, maxPages, showFirstLast, hideContainerWhenNoResults]})');
   }
 
   labels = defaults(labels, defaultLabels);
@@ -78,14 +78,14 @@ function pagination({
         nbPages = Math.min(maxPages, results.nbPages);
       }
 
-      var Pagination = autoHide(require('../../components/Pagination/Pagination.js'));
+      var Pagination = autoHideContainer(require('../../components/Pagination/Pagination.js'));
       ReactDOM.render(
         <Pagination
           createURL={(page) => createURL(state.setPage(page))}
           cssClasses={cssClasses}
           currentPage={currentPage}
           hasResults={hasResults}
-          hideWhenNoResults={hideWhenNoResults}
+          hideContainerWhenNoResults={hideContainerWhenNoResults}
           labels={labels}
           nbHits={nbHits}
           nbPages={nbPages}

--- a/widgets/price-ranges/__tests__/price-ranges-test.js
+++ b/widgets/price-ranges/__tests__/price-ranges-test.js
@@ -18,18 +18,18 @@ describe('priceRanges()', () => {
   var widget;
   var results;
   var helper;
-  var autoHide;
+  var autoHideContainer;
   var headerFooter;
 
   jsdom();
 
   beforeEach(() => {
     ReactDOM = {render: sinon.spy()};
-    autoHide = sinon.stub().returns(PriceRanges);
+    autoHideContainer = sinon.stub().returns(PriceRanges);
     headerFooter = sinon.stub().returns(PriceRanges);
 
     priceRanges.__Rewire__('ReactDOM', ReactDOM);
-    priceRanges.__Rewire__('autoHide', autoHide);
+    priceRanges.__Rewire__('autoHideContainer', autoHideContainer);
     priceRanges.__Rewire__('headerFooter', headerFooter);
 
     container = document.createElement('div');
@@ -72,7 +72,7 @@ describe('priceRanges()', () => {
           root: 'ais-price-ranges'
         },
         hasResults: true,
-        hideWhenNoResults: true,
+        hideContainerWhenNoResults: true,
         facetValues: generateRanges(results.getFacetStats()),
         labels: {
           currency: '$',
@@ -100,7 +100,7 @@ describe('priceRanges()', () => {
     it('calls the decorators', () => {
       widget.render({results, helper});
       expect(headerFooter.calledOnce).toBe(true);
-      expect(autoHide.calledOnce).toBe(true);
+      expect(autoHideContainer.calledOnce).toBe(true);
     });
 
     it('calls getRefinements to check if there are some refinements', () => {
@@ -131,7 +131,7 @@ describe('priceRanges()', () => {
 
   afterEach(() => {
     priceRanges.__ResetDependency__('ReactDOM');
-    priceRanges.__ResetDependency__('autoHide');
+    priceRanges.__ResetDependency__('autoHideContainer');
     priceRanges.__ResetDependency__('headerFooter');
   });
 });

--- a/widgets/price-ranges/price-ranges.js
+++ b/widgets/price-ranges/price-ranges.js
@@ -6,7 +6,7 @@ var utils = require('../../lib/utils.js');
 var generateRanges = require('./generate-ranges.js');
 
 var defaultTemplates = require('./defaultTemplates');
-var autoHide = require('../../decorators/autoHide');
+var autoHideContainer = require('../../decorators/autoHideContainer');
 var headerFooter = require('../../decorators/headerFooter');
 
 var bem = utils.bemHelper('ais-price-ranges');
@@ -30,7 +30,7 @@ var cx = require('classnames/dedupe');
  * @param  {String|Function} [options.labels.button] Button label
  * @param  {String|Function} [options.labels.currency] Currency label
  * @param  {String|Function} [options.labels.to] To label
- * @param  {boolean} [hideWhenNoResults=true] Hide the container when no results match
+ * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when no results match
  * @return {Object}
  */
 function priceRanges({
@@ -43,7 +43,7 @@ function priceRanges({
       button: 'Go',
       to: 'to'
     },
-    hideWhenNoResults = true
+    hideContainerWhenNoResults = true
   }) {
   var containerNode = utils.getContainerNode(container);
   var usage = 'Usage: priceRanges({container, facetName, [cssClasses, templates, labels]})';
@@ -98,7 +98,7 @@ function priceRanges({
     },
 
     render: function({results, helper, templatesConfig}) {
-      var PriceRanges = autoHide(headerFooter(require('../../components/PriceRanges')));
+      var PriceRanges = autoHideContainer(headerFooter(require('../../components/PriceRanges')));
       var facetValues;
 
       if (results.hits.length > 0) {
@@ -133,7 +133,7 @@ function priceRanges({
           cssClasses={cssClasses}
           facetValues={facetValues}
           hasResults={results.hits.length > 0}
-          hideWhenNoResults={hideWhenNoResults}
+          hideContainerWhenNoResults={hideContainerWhenNoResults}
           labels={labels}
           refine={this._refine.bind(this, helper)}
           templateProps={templateProps}

--- a/widgets/range-slider/__tests__/range-slider-test.js
+++ b/widgets/range-slider/__tests__/range-slider-test.js
@@ -17,7 +17,7 @@ describe('rangeSlider()', () => {
   var results;
   var helper;
 
-  var autoHide;
+  var autoHideContainer;
   var headerFooter;
   var Slider;
   var rangeSlider;
@@ -27,8 +27,8 @@ describe('rangeSlider()', () => {
     Slider = require('../../../components/Slider/Slider');
     ReactDOM = {render: sinon.spy()};
     rangeSlider.__Rewire__('ReactDOM', ReactDOM);
-    autoHide = sinon.stub().returns(Slider);
-    rangeSlider.__Rewire__('autoHide', autoHide);
+    autoHideContainer = sinon.stub().returns(Slider);
+    rangeSlider.__Rewire__('autoHideContainer', autoHideContainer);
     headerFooter = sinon.stub().returns(Slider);
     rangeSlider.__Rewire__('headerFooter', headerFooter);
 
@@ -59,13 +59,13 @@ describe('rangeSlider()', () => {
   it('calls ReactDOM.render(<Slider props />, container)', () => {
     widget.render({results, helper});
     expect(ReactDOM.render.calledOnce).toBe(true, 'ReactDOM.render called once');
-    expect(autoHide.calledOnce).toBe(true, 'autoHide called once');
+    expect(autoHideContainer.calledOnce).toBe(true, 'autoHideContainer called once');
     expect(headerFooter.calledOnce).toBe(true, 'headerFooter called once');
     expect(ReactDOM.render.firstCall.args[0]).toEqualJSX(
     <Slider
       cssClasses={{body: null, root: null}}
       hasResults={true}
-      hideWhenNoResults={true}
+      hideContainerWhenNoResults={true}
       onChange={() => {}}
       range={{max: 4999.98, min: 1.99}}
       start={[-Infinity, Infinity]}
@@ -118,7 +118,7 @@ describe('rangeSlider()', () => {
 
   afterEach(() => {
     rangeSlider.__ResetDependency__('ReactDOM');
-    rangeSlider.__ResetDependency__('autoHide');
+    rangeSlider.__ResetDependency__('autoHideContainer');
     rangeSlider.__ResetDependency__('headerFooter');
   });
 });

--- a/widgets/range-slider/range-slider.js
+++ b/widgets/range-slider/range-slider.js
@@ -2,7 +2,7 @@ var React = require('react');
 var ReactDOM = require('react-dom');
 
 var utils = require('../../lib/utils.js');
-var autoHide = require('../../decorators/autoHide');
+var autoHideContainer = require('../../decorators/autoHideContainer');
 var headerFooter = require('../../decorators/headerFooter');
 
 var defaultTemplates = {
@@ -25,7 +25,7 @@ var defaultTemplates = {
  * @param  {Object} [options.cssClasses] CSS classes to add to the wrapping elements: root, body
  * @param  {String|String[]} [options.cssClasses.root] CSS class to add to the root element
  * @param  {String|String[]} [options.cssClasses.body] CSS class to add to the body element
- * @param  {boolean} [hideWhenNoResults=true] Hide the container when no results match
+ * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when no results match
  * @return {Object}
  */
 function rangeSlider({
@@ -37,7 +37,7 @@ function rangeSlider({
       root: null,
       body: null
     },
-    hideWhenNoResults = true
+    hideContainerWhenNoResults = true
   }) {
   var containerNode = utils.getContainerNode(container);
 
@@ -94,12 +94,12 @@ function rangeSlider({
         templates
       });
 
-      var Slider = autoHide(headerFooter(require('../../components/Slider/Slider')));
+      var Slider = autoHideContainer(headerFooter(require('../../components/Slider/Slider')));
       ReactDOM.render(
         <Slider
           cssClasses={cssClasses}
           hasResults={stats.min !== null && stats.max !== null}
-          hideWhenNoResults={hideWhenNoResults}
+          hideContainerWhenNoResults={hideContainerWhenNoResults}
           onChange={this._refine.bind(this, helper, stats)}
           range={{min: stats.min, max: stats.max}}
           start={[currentRefinement.min, currentRefinement.max]}

--- a/widgets/refinement-list/refinement-list.js
+++ b/widgets/refinement-list/refinement-list.js
@@ -5,9 +5,9 @@ var utils = require('../../lib/utils.js');
 var bem = utils.bemHelper('ais-refinement-list');
 var cx = require('classnames/dedupe');
 
-var autoHide = require('../../decorators/autoHide');
+var autoHideContainer = require('../../decorators/autoHideContainer');
 var headerFooter = require('../../decorators/headerFooter');
-var RefinementList = autoHide(headerFooter(require('../../components/RefinementList/RefinementList.js')));
+var RefinementList = autoHideContainer(headerFooter(require('../../components/RefinementList/RefinementList.js')));
 
 var defaultTemplates = require('./defaultTemplates');
 
@@ -34,7 +34,7 @@ var defaultTemplates = require('./defaultTemplates');
  * @param  {String|Function} [options.templates.item] Item template, provided with `name`, `count`, `isRefined`
  * @param  {String|Function} [options.templates.footer] Footer template
  * @param  {Function} [options.transformData] Function to change the object passed to the item template
- * @param  {boolean} [hideWhenNoResults=true] Hide the container when there's no results
+ * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when there's no results
  * @return {Object}
  */
 function refinementList({
@@ -46,7 +46,7 @@ function refinementList({
     cssClasses = {},
     templates = defaultTemplates,
     transformData,
-    hideWhenNoResults = true
+    hideContainerWhenNoResults = true
   }) {
   var containerNode = utils.getContainerNode(container);
   var usage = 'Usage: refinementList({container, facetName, [operator, sortBy, limit, cssClasses.{root,header,body,footer,list,item,active,label,checkbox,count}, templates.{header,item,footer}, transformData, hideIfNoResults]})';
@@ -105,7 +105,7 @@ function refinementList({
           cssClasses={cssClasses}
           facetValues={facetValues}
           hasResults={facetValues.length > 0}
-          hideWhenNoResults={hideWhenNoResults}
+          hideContainerWhenNoResults={hideContainerWhenNoResults}
           templateProps={templateProps}
           toggleRefinement={toggleRefinement.bind(null, helper, facetName)}
         />,

--- a/widgets/stats/__tests__/stats-test.js
+++ b/widgets/stats/__tests__/stats-test.js
@@ -19,14 +19,14 @@ describe('stats()', () => {
   var widget;
   var results;
 
-  var autoHide;
+  var autoHideContainer;
   var headerFooter;
 
   beforeEach(() => {
     ReactDOM = {render: sinon.spy()};
     stats.__Rewire__('ReactDOM', ReactDOM);
-    autoHide = sinon.stub().returns(Stats);
-    stats.__Rewire__('autoHide', autoHide);
+    autoHideContainer = sinon.stub().returns(Stats);
+    stats.__Rewire__('autoHideContainer', autoHideContainer);
     headerFooter = sinon.stub().returns(Stats);
     stats.__Rewire__('headerFooter', headerFooter);
 
@@ -50,7 +50,7 @@ describe('stats()', () => {
   it('calls ReactDOM.render(<Stats props />, container)', () => {
     widget.render({results});
     expect(ReactDOM.render.calledOnce).toBe(true, 'ReactDOM.render called once');
-    expect(autoHide.calledOnce).toBe(true, 'autoHide called once');
+    expect(autoHideContainer.calledOnce).toBe(true, 'autoHideContainer called once');
     expect(headerFooter.calledOnce).toBe(true, 'headerFooter called once');
     expect(ReactDOM.render.firstCall.args[0]).toEqualJSX(
     <Stats
@@ -62,7 +62,7 @@ describe('stats()', () => {
         time: 'ais-stats--time'
       }}
       hasResults={true}
-      hideWhenNoResults={true}
+      hideContainerWhenNoResults={true}
       hitsPerPage={2}
       nbHits={20}
       nbPages={10}
@@ -76,7 +76,7 @@ describe('stats()', () => {
 
   afterEach(() => {
     stats.__ResetDependency__('ReactDOM');
-    stats.__ResetDependency__('autoHide');
+    stats.__ResetDependency__('autoHideContainer');
     stats.__ResetDependency__('headerFooter');
   });
 });

--- a/widgets/stats/stats.js
+++ b/widgets/stats/stats.js
@@ -2,7 +2,7 @@ var React = require('react');
 var ReactDOM = require('react-dom');
 
 var utils = require('../../lib/utils.js');
-var autoHide = require('../../decorators/autoHide');
+var autoHideContainer = require('../../decorators/autoHideContainer');
 var headerFooter = require('../../decorators/headerFooter');
 var bem = require('../../lib/utils').bemHelper('ais-stats');
 var cx = require('classnames/dedupe');
@@ -23,13 +23,13 @@ var defaultTemplates = require('./defaultTemplates.js');
  * @param  {String|Function} [options.templates.body] Body template
  * @param  {String|Function} [options.templates.footer=''] Footer template
  * @param  {Function} [options.transformData] Function to change the object passed to the `body` template
- * @param  {boolean} [hideWhenNoResults=true] Hide the container when there's no results
+ * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when there's no results
  * @return {Object}
  */
 function stats({
     container,
     cssClasses = {},
-    hideWhenNoResults = true,
+    hideContainerWhenNoResults = true,
     templates = defaultTemplates,
     transformData
   }) {
@@ -48,7 +48,7 @@ function stats({
         templates
       });
 
-      var Stats = autoHide(headerFooter(require('../../components/Stats/Stats.js')));
+      var Stats = autoHideContainer(headerFooter(require('../../components/Stats/Stats.js')));
 
       cssClasses = {
         body: cx(bem('body'), cssClasses.body),
@@ -62,7 +62,7 @@ function stats({
         <Stats
           cssClasses={cssClasses}
           hasResults={results.hits.length > 0}
-          hideWhenNoResults={hideWhenNoResults}
+          hideContainerWhenNoResults={hideContainerWhenNoResults}
           hitsPerPage={results.hitsPerPage}
           nbHits={results.nbHits}
           nbPages={results.nbPages}

--- a/widgets/toggle/__tests__/toggle-test.js
+++ b/widgets/toggle/__tests__/toggle-test.js
@@ -36,7 +36,7 @@ describe('toggle()', () => {
 
   context('good usage', () => {
     var ReactDOM;
-    var autoHide;
+    var autoHideContainer;
     var headerFooter;
     var container;
     var widget;
@@ -45,11 +45,11 @@ describe('toggle()', () => {
 
     beforeEach(() => {
       ReactDOM = {render: sinon.spy()};
-      autoHide = sinon.stub().returns(RefinementList);
+      autoHideContainer = sinon.stub().returns(RefinementList);
       headerFooter = sinon.stub().returns(RefinementList);
 
       toggle.__Rewire__('ReactDOM', ReactDOM);
-      toggle.__Rewire__('autoHide', autoHide);
+      toggle.__Rewire__('autoHideContainer', autoHideContainer);
       toggle.__Rewire__('headerFooter', headerFooter);
 
       container = document.createElement('div');
@@ -62,11 +62,11 @@ describe('toggle()', () => {
       expect(widget.getConfiguration()).toEqual({facets: ['world!']});
     });
 
-    it('uses autoHide() and headerFooter()', () => {
+    it('uses autoHideContainer() and headerFooter()', () => {
       widget = toggle({container, facetName, label});
-      expect(autoHide.calledOnce).toBe(true);
+      expect(autoHideContainer.calledOnce).toBe(true);
       expect(headerFooter.calledOnce).toBe(true);
-      expect(headerFooter.calledBefore(autoHide)).toBe(true);
+      expect(headerFooter.calledBefore(autoHideContainer)).toBe(true);
     });
 
     context('render', () => {
@@ -101,7 +101,7 @@ describe('toggle()', () => {
             checkbox: 'ais-toggle--checkbox',
             count: 'ais-toggle--count'
           },
-          hideWhenNoResults: true,
+          hideContainerWhenNoResults: true,
           templateProps,
           toggleRefinement: function() {},
           createURL: () => '#'
@@ -197,7 +197,7 @@ describe('toggle()', () => {
 
     afterEach(() => {
       toggle.__ResetDependency__('ReactDOM');
-      toggle.__ResetDependency__('autoHide');
+      toggle.__ResetDependency__('autoHideContainer');
       toggle.__ResetDependency__('headerFooter');
     });
   });

--- a/widgets/toggle/toggle.js
+++ b/widgets/toggle/toggle.js
@@ -6,7 +6,7 @@ var utils = require('../../lib/utils.js');
 var bem = utils.bemHelper('ais-toggle');
 var cx = require('classnames/dedupe');
 
-var autoHide = require('../../decorators/autoHide');
+var autoHideContainer = require('../../decorators/autoHideContainer');
 var headerFooter = require('../../decorators/headerFooter');
 
 var defaultTemplates = require('./defaultTemplates');
@@ -34,7 +34,7 @@ var defaultTemplates = require('./defaultTemplates');
  * @param  {String|Function} [options.templates.item] Item template
  * @param  {String|Function} [options.templates.footer=''] Footer template
  * @param  {Function} [options.transformData] Function to change the object passed to the item template
- * @param  {boolean} [hideWhenNoResults=true] Hide the container when there's no results
+ * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when there's no results
  * @return {Object}
  */
 function toggle({
@@ -44,11 +44,11 @@ function toggle({
     templates = defaultTemplates,
     cssClasses = {},
     transformData,
-    hideWhenNoResults = true
+    hideContainerWhenNoResults = true
   } = {}) {
-  var RefinementList = autoHide(headerFooter(require('../../components/RefinementList/RefinementList.js')));
+  var RefinementList = autoHideContainer(headerFooter(require('../../components/RefinementList/RefinementList.js')));
   var containerNode = utils.getContainerNode(container);
-  var usage = 'Usage: toggle({container, facetName, label[, cssClasses.{root,header,body,footer,list,item,active,label,checkbox,count}, templates.{header,item,footer}, transformData, hideWhenNoResults]})';
+  var usage = 'Usage: toggle({container, facetName, label[, cssClasses.{root,header,body,footer,list,item,active,label,checkbox,count}, templates.{header,item,footer}, transformData, hideContainerWhenNoResults]})';
 
   if (!container || !facetName || !label) {
     throw new Error(usage);
@@ -94,7 +94,7 @@ function toggle({
           cssClasses={cssClasses}
           facetValues={[facetValue]}
           hasResults={results.hits.length > 0}
-          hideWhenNoResults={hideWhenNoResults}
+          hideContainerWhenNoResults={hideContainerWhenNoResults}
           templateProps={templateProps}
           toggleRefinement={toggleRefinement.bind(null, helper, facetName, facetValue.isRefined)}
         />,


### PR DESCRIPTION
BREAKING CHANGE: Widget attribute is now named
`hideContainerWhenNoResults` instead of `hideWhenNoResults` to be more
explicit on what it is really doing.

Also internally renamed the `autoHide` decorator to
`autoHideContainer`

Fixes #325