### PR TITLE
fix(template): transformData checks too strict

### DIFF
--- a/components/Template.js
+++ b/components/Template.js
@@ -67,7 +67,13 @@ function transformData(fn, templateKey, originalData) {
     data = fn(originalData);
   } else if (typeof fn === 'object') {
     // ex: transformData: {hit, empty}
-    data = fn[templateKey] && fn[templateKey](originalData);
+    if (fn[templateKey]) {
+      data = fn[templateKey](originalData);
+    } else {
+      // if the templateKey doesn't exist, just use the
+      // original data
+      data = originalData;
+    }
   } else {
     throw new Error('`transformData` must be a function or an object');
   }

--- a/components/__tests__/Template-test.js
+++ b/components/__tests__/Template-test.js
@@ -127,6 +127,19 @@ describe('Template', () => {
     }).toThrow('`transformData` must return a `object`, got `undefined`.');
   });
 
+  it('doesn\'t throw an error if the transformData is an object without the templateKey', () => {
+    templates = {test: 'it supports {{feature}}'};
+    data = {feature: 'replace me'};
+    templateKey = 'test';
+    transformData = {
+      anotherKey: (d) => { return d; }
+    };
+    let props = getProps();
+    expect(() => {
+      renderer.render(<Template {...props} />);
+    }).toNotThrow();
+  });
+
   it('throws an error if the transformData returns an unexpected type', () => {
     templates = {test: 'it supports {{feature}}'};
     data = {feature: 'replace me'};


### PR DESCRIPTION
The Template component shouldn't throw an error if you define
the transformData for a single templateKey.

Fix #347