### PR TITLE
feat(searchBox): Add `wrapInput` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,9 +321,13 @@ instantsearch({
 /**
  * Instantiate a searchbox
  * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
- * @param  {string} [options.placeholder='Search here'] Input's placeholder
- * @param  {Object} [options.cssClass] CSS classes to add to the input
+ * @param  {string} [options.placeholder] Input's placeholder
+ * @param  {Object} [options.cssClasses] CSS classes to add
+ * @param  {string} [options.cssClasses.root] CSS class to add to the wrapping div (if wrapInput set to `true`)
+ * @param  {string} [options.cssClasses.input] CSS class to add to the input
+ * @param  {string} [options.cssClasses.poweredBy] CSS class to add to the poweredBy element
  * @param  {boolean} [poweredBy=false] Show a powered by Algolia link below the input
+ * @param  {boolean} [wrapInput=true] Wrap the input in a div.ais-search-box
  * @param  {boolean|string} [autofocus='auto'] autofocus on the input
  * @return {Object}
  */
@@ -342,7 +346,6 @@ search.addWidget(
   instantsearch.widgets.searchBox({
     container: '#search-box',
     placeholder: 'Search for products',
-    cssClass: 'form-control',
     poweredBy: true
   })
 );
@@ -351,15 +354,18 @@ search.addWidget(
 #### Styling
 
 ```html
-<input class="ais-search-box--input">
-<!-- With poweredBy: true -->
-<div class="ais-search-box--powered-by">
-  Powered by
-  <a class="ais-search-box--powered-by-link">Algolia</a>
+<div class="ais-search-box">
+  <input class="ais-search-box--input">
+  <div class="ais-search-box--powered-by">
+    Powered by
+    <a class="ais-search-box--powered-by-link">Algolia</a>
+  </div>
 </div>
 ```
 
 ```css
+.ais-search-box {
+}
 .ais-search-box--input {
 }
 .ais-search-box--powered-by {

--- a/themes/default.css
+++ b/themes/default.css
@@ -1,4 +1,6 @@
 /* SEARCH BOX */
+.ais-search-box {
+}
 .ais-search-box--input {
 }
 .ais-search-box--powered-by {

--- a/widgets/search-box/__tests__/search-box-test.js
+++ b/widgets/search-box/__tests__/search-box-test.js
@@ -102,6 +102,52 @@ describe('search-box()', () => {
     });
   });
 
+  context('wraps the input in a div', () => {
+    it('when targeting a div', () => {
+      // Given
+      container = document.createElement('div');
+      widget = searchBox({container});
+
+      // When
+      widget.init(initialState, helper);
+
+      // Then
+      var wrapper = container.querySelectorAll('div.ais-search-box')[0];
+      var input = container.querySelectorAll('input')[0];
+
+      expect(wrapper.contains(input)).toEqual(true);
+      expect(wrapper.getAttribute('class')).toEqual('ais-search-box');
+    });
+
+    it('when targeting an input', () => {
+      // Given
+      container = createHTMLNodeFromString('<input />');
+      widget = searchBox({container});
+
+      // When
+      widget.init(initialState, helper);
+
+      // Then
+      var wrapper = container.parentNode;
+      expect(wrapper.getAttribute('class')).toEqual('ais-search-box');
+    });
+
+    it('can be disabled with wrapInput:false', () => {
+      // Given
+      container = document.createElement('div');
+      widget = searchBox({container, wrapInput: false});
+
+      // When
+      widget.init(initialState, helper);
+
+      // Then
+      var wrapper = container.querySelectorAll('div.ais-search-box');
+      var input = container.querySelectorAll('input')[0];
+      expect(wrapper.length).toEqual(0);
+      expect(container.firstChild).toEqual(input);
+    });
+  });
+
   context('adds a PoweredBy', () => {
     beforeEach(() => {
       container = document.createElement('div');
@@ -124,7 +170,7 @@ describe('search-box()', () => {
     var input;
     beforeEach(() => {
       container = document.createElement('div');
-      input = document.createElement('input');
+      input = createHTMLNodeFromString('<input />');
       input.focus = sinon.spy();
     });
 


### PR DESCRIPTION
BREAKING CHANGE: The `input` used by the search-box widget is now
wrapped in a `<div class="ais-search-box">` by default. This can be
turned off with `wrapInput: false`.

This PR is a bit long, I had to do some minor refactoring to keep the
new code understandable. I simply split the large `init` method into
calls to smaller methods.

There is some vanilla JS DOM manipulation involved to handle all the
possible cases: targeting an `input` or a `div`, adding or not the
`poweredBy`, adding or not the wrapping div.

Note that there is no `targetNode.insertAfter(newNode)` method, so
I had to resort to the old trick of `parentNode.insertBefore(newNode,
targetNode.nextSibling)`.