### PR TITLE
chore(build): Add map file to the build

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,12 +10,12 @@ bundle='instantsearch'
 
 webpack
 
-cat dist/$bundle.js | uglifyjs -c warnings=false -m > dist/$bundle.min.js
-
 cp themes/default.css dist/themes/default.css
 cleancss dist/themes/default.css > dist/themes/default.min.css
 
-printf "$license" | cat - dist/"$bundle".js > /tmp/out && mv /tmp/out dist/"$bundle".js
-printf "$license" | cat - dist/"$bundle".min.js > /tmp/out && mv /tmp/out dist/"$bundle".min.js
+printf "$license" | cat - dist/${bundle}.js > /tmp/out && mv /tmp/out dist/${bundle}.js
+cd dist
+uglifyjs ${bundle}.js --source-map ${bundle}.min.map --preamble "$license" -c warnings=false -m -o ${bundle}.min.js
+cd ..
 
-printf "=> $bundle.min.js gzipped will weight `cat dist/$bundle.min.js | gzip -9 | wc -c | pretty-bytes`\n"
+printf "=> ${bundle}.min.js gzipped will weight `cat dist/${bundle}.min.js | gzip -9 | wc -c | pretty-bytes`\n"


### PR DESCRIPTION
I also took the liberty to remove "useless" double quotes because I hope we'll never consider putting spaces in the filename and added braces for clarity when a variable was followed by a dot (the syntax coloration of vim failed on it, and colored it with the extension).

See #145 .