### PR TITLE
docs(widgets): Use primitive types instead of wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,8 +320,8 @@ instantsearch({
 ```js
 /**
  * Instantiate a searchbox
- * @param  {String|DOMElement} options.container CSS Selector or DOMElement to insert the widget
- * @param  {String} [options.placeholder='Search here'] Input's placeholder
+ * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
+ * @param  {string} [options.placeholder='Search here'] Input's placeholder
  * @param  {Object} [options.cssClass] CSS classes to add to the input
  * @param  {boolean} [poweredBy=false] Show a powered by Algolia link below the input
  * @param  {boolean|string} [autofocus='auto'] autofocus on the input
@@ -376,17 +376,17 @@ search.addWidget(
 ```js
 /**
  * Display various stats about the current search state
- * @param  {String|DOMElement} options.container CSS Selector or DOMElement to insert the widget
+ * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
  * @param  {Object} [options.cssClasses] CSS classes to add
- * @param  {String} [options.cssClasses.root] CSS class to add to the root element
- * @param  {String} [options.cssClasses.header] CSS class to add to the header element
- * @param  {String} [options.cssClasses.body] CSS class to add to the body element
- * @param  {String} [options.cssClasses.footer] CSS class to add to the footer element
- * @param  {String} [options.cssClasses.time] CSS class to add to the element wrapping the time processingTimeMs
+ * @param  {string} [options.cssClasses.root] CSS class to add to the root element
+ * @param  {string} [options.cssClasses.header] CSS class to add to the header element
+ * @param  {string} [options.cssClasses.body] CSS class to add to the body element
+ * @param  {string} [options.cssClasses.footer] CSS class to add to the footer element
+ * @param  {string} [options.cssClasses.time] CSS class to add to the element wrapping the time processingTimeMs
  * @param  {Object} [options.templates] Templates to use for the widget
- * @param  {String|Function} [options.templates.header=''] Header template
- * @param  {String|Function} [options.templates.body] Body template
- * @param  {String|Function} [options.templates.footer=''] Footer template
+ * @param  {string|Function} [options.templates.header=''] Header template
+ * @param  {string|Function} [options.templates.body] Body template
+ * @param  {string|Function} [options.templates.footer=''] Footer template
  * @param  {Function} [options.transformData] Function to change the object passed to the `body` template
  * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when there's no results
  * @return {Object}
@@ -450,13 +450,13 @@ you'll need several indices. This widget lets you easily change it.
 ```js
 /**
  * Instantiate a dropdown element to choose the current targeted index
- * @param  {String|DOMElement} options.container CSS Selector or DOMElement to insert the widget
+ * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
  * @param  {Array} options.indices Array of objects defining the different indices to choose from.
- * @param  {String} options.indices[0].name Name of the index to target
- * @param  {String} options.indices[0].label Label displayed in the dropdown
+ * @param  {string} options.indices[0].name Name of the index to target
+ * @param  {string} options.indices[0].label Label displayed in the dropdown
  * @param  {Object} [options.cssClasses] CSS classes to be added
- * @param  {String} [options.cssClasses.root] CSS classes added to the parent <select>
- * @param  {String} [options.cssClasses.item] CSS classes added to each <option>
+ * @param  {string} [options.cssClasses.root] CSS classes added to the parent <select>
+ * @param  {string} [options.cssClasses.item] CSS classes added to each <option>
  * @param  {boolean} [hideContainerWhenNoResults=false] Hide the container when no results match
  * @return {Object}
  */
@@ -513,13 +513,13 @@ displayed per page.
 ```js
 /**
  * Instantiate a dropdown element to choose the number of hits to display per page
- * @param  {String|DOMElement} options.container CSS Selector or DOMElement to insert the widget
+ * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
  * @param  {Array} options.options Array of objects defining the different values and labels
- * @param  {Number} options.options[0].value Number of hits to display per page
- * @param  {String} options.options[0].label Label to display in the option
+ * @param  {number} options.options[0].value number of hits to display per page
+ * @param  {string} options.options[0].label Label to display in the option
  * @param  {Object} [options.cssClasses] CSS classes to be added
- * @param  {String} [options.cssClasses.root] CSS classes added to the parent <select>
- * @param  {String} [options.cssClasses.item] CSS classes added to each <option>
+ * @param  {string} [options.cssClasses.root] CSS classes added to the parent <select>
+ * @param  {string} [options.cssClasses.item] CSS classes added to each <option>
  * @param  {boolean} [hideContainerWhenNoResults=false] Hide the container when no results match
  * @return {Object}
  */
@@ -573,15 +573,15 @@ search.addWidget(
 ```js
 /**
  * Add a pagination menu to navigate through the results
- * @param  {String|DOMElement} options.container CSS Selector or DOMElement to insert the widget
- * @param  {String|String[]} [options.cssClass] CSS class to be added to the wrapper element
+ * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
+ * @param  {string|string[]} [options.cssClass] CSS class to be added to the wrapper element
  * @param  {Object} [options.labels] Text to display in the various links (prev, next, first, last)
- * @param  {String} [options.labels.prev] Label for the Previous link
- * @param  {String} [options.labels.next] Label for the Next link
- * @param  {String} [options.labels.first] Label for the First link
- * @param  {String} [options.labels.last] Label for the Last link
- * @param  {Number} [maxPages=20] The max number of pages to browse
- * @param  {String|DOMElement|boolean} [scrollTo='body'] Where to scroll after a click, set to `false` to disable
+ * @param  {string} [options.labels.prev] Label for the Previous link
+ * @param  {string} [options.labels.next] Label for the Next link
+ * @param  {string} [options.labels.first] Label for the First link
+ * @param  {string} [options.labels.last] Label for the Last link
+ * @param  {number} [maxPages=20] The max number of pages to browse
+ * @param  {string|DOMElement|boolean} [scrollTo='body'] Where to scroll after a click, set to `false` to disable
  * @param  {boolean} [showFirstLast=true] Define if the First and Last links should be displayed
  * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when no results match
  * @return {Object}
@@ -620,18 +620,18 @@ search.addWidget(
 ```js
 /**
  * Display the list of results (hits) from the current search
- * @param  {String|DOMElement} options.container CSS Selector or DOMElement to insert the widget
+ * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
  * @param  {Object} [options.cssClasses] CSS classes to add
- * @param  {String} [options.cssClasses.root] CSS class to add to the wrapping element
- * @param  {String} [options.cssClasses.empty] CSS class to add to the wrapping element when no results
- * @param  {String} [options.cssClasses.item] CSS class to add to each result
+ * @param  {string} [options.cssClasses.root] CSS class to add to the wrapping element
+ * @param  {string} [options.cssClasses.empty] CSS class to add to the wrapping element when no results
+ * @param  {string} [options.cssClasses.item] CSS class to add to each result
  * @param  {Object} [options.templates] Templates to use for the widget
- * @param  {String|Function} [options.templates.empty=''] Template to use when there are no results.
- * @param  {String|Function} [options.templates.item=''] Template to use for each result.
+ * @param  {string|Function} [options.templates.empty=''] Template to use when there are no results.
+ * @param  {string|Function} [options.templates.item=''] Template to use for each result.
  * @param  {Object} [options.transformData] Method to change the object passed to the templates
  * @param  {Function} [options.transformData.empty=''] Method used to change the object passed to the empty template
  * @param  {Function} [options.transformData.item=''] Method used to change the object passed to the item template
- * @param  {Number} [hitsPerPage=20] The number of hits to display per page
+ * @param  {number} [hitsPerPage=20] The number of hits to display per page
  * @return {Object}
  */
 ```
@@ -706,24 +706,24 @@ Note that we are not toggling from `true` to `false` here, but from `true` to
  * Instantiate the toggling of a boolean facet filter on and off.
  * Note that it will not toggle between `true` and `false, but between `true`
  * and `undefined`.
- * @param  {String|DOMElement} options.container CSS Selector or DOMElement to insert the widget
- * @param  {String} options.facetName Name of the attribute for faceting (eg. "free_shipping")
- * @param  {String} options.label Human-readable name of the filter (eg. "Free Shipping")
+ * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
+ * @param  {string} options.facetName Name of the attribute for faceting (eg. "free_shipping")
+ * @param  {string} options.label Human-readable name of the filter (eg. "Free Shipping")
  * @param  {Object} [options.cssClasses] CSS classes to add
- * @param  {String|String[]} [options.cssClasses.root] CSS class to add to the root element
- * @param  {String|String[]} [options.cssClasses.header] CSS class to add to the header element
- * @param  {String|String[]} [options.cssClasses.body] CSS class to add to the body element
- * @param  {String|String[]} [options.cssClasses.footer] CSS class to add to the footer element
- * @param  {String|String[]} [options.cssClasses.list] CSS class to add to the list element
- * @param  {String|String[]} [options.cssClasses.item] CSS class to add to each item element
- * @param  {String|String[]} [options.cssClasses.active] CSS class to add to each active element
- * @param  {String|String[]} [options.cssClasses.label] CSS class to add to each label element (when using the default template)
- * @param  {String|String[]} [options.cssClasses.checkbox] CSS class to add to each checkbox element (when using the default template)
- * @param  {String|String[]} [options.cssClasses.count] CSS class to add to each count element (when using the default template)
+ * @param  {string|string[]} [options.cssClasses.root] CSS class to add to the root element
+ * @param  {string|string[]} [options.cssClasses.header] CSS class to add to the header element
+ * @param  {string|string[]} [options.cssClasses.body] CSS class to add to the body element
+ * @param  {string|string[]} [options.cssClasses.footer] CSS class to add to the footer element
+ * @param  {string|string[]} [options.cssClasses.list] CSS class to add to the list element
+ * @param  {string|string[]} [options.cssClasses.item] CSS class to add to each item element
+ * @param  {string|string[]} [options.cssClasses.active] CSS class to add to each active element
+ * @param  {string|string[]} [options.cssClasses.label] CSS class to add to each label element (when using the default template)
+ * @param  {string|string[]} [options.cssClasses.checkbox] CSS class to add to each checkbox element (when using the default template)
+ * @param  {string|string[]} [options.cssClasses.count] CSS class to add to each count element (when using the default template)
  * @param  {Object} [options.templates] Templates to use for the widget
- * @param  {String|Function} [options.templates.header=''] Header template
- * @param  {String|Function} [options.templates.item] Item template
- * @param  {String|Function} [options.templates.footer=''] Footer template
+ * @param  {string|Function} [options.templates.header=''] Header template
+ * @param  {string|Function} [options.templates.item] Item template
+ * @param  {string|Function} [options.templates.footer=''] Footer template
  * @param  {Function} [options.transformData] Function to change the object passed to the item template
  * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when there's no results
  * @return {Object}
@@ -799,26 +799,26 @@ search.addWidget(
 ```js
 /**
  * Instantiate a list of refinements based on a facet
- * @param  {String|DOMElement} options.container CSS Selector or DOMElement to insert the widget
- * @param  {String} options.facetName Name of the attribute for faceting
- * @param  {String} [options.operator='or'] How to apply refinements. Possible values: `or`, `and`
- * @param  {String[]} [options.sortBy=['count:desc']] How to sort refinements. Possible values: `count|isRefined|name:asc|desc`
- * @param  {String} [options.limit=1000] How much facet values to get
+ * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
+ * @param  {string} options.facetName Name of the attribute for faceting
+ * @param  {string} [options.operator='or'] How to apply refinements. Possible values: `or`, `and`
+ * @param  {string[]} [options.sortBy=['count:desc']] How to sort refinements. Possible values: `count|isRefined|name:asc|desc`
+ * @param  {string} [options.limit=1000] How much facet values to get
  * @param  {Object} [options.cssClasses] CSS classes to add
- * @param  {String|String[]} [options.cssClasses.root] CSS class to add to the root element
- * @param  {String|String[]} [options.cssClasses.header] CSS class to add to the header element
- * @param  {String|String[]} [options.cssClasses.body] CSS class to add to the body element
- * @param  {String|String[]} [options.cssClasses.footer] CSS class to add to the footer element
- * @param  {String|String[]} [options.cssClasses.list] CSS class to add to the list element
- * @param  {String|String[]} [options.cssClasses.item] CSS class to add to each item element
- * @param  {String|String[]} [options.cssClasses.active] CSS class to add to each active element
- * @param  {String|String[]} [options.cssClasses.label] CSS class to add to each label element (when using the default template)
- * @param  {String|String[]} [options.cssClasses.checkbox] CSS class to add to each checkbox element (when using the default template)
- * @param  {String|String[]} [options.cssClasses.count] CSS class to add to each count element (when using the default template)
+ * @param  {string|string[]} [options.cssClasses.root] CSS class to add to the root element
+ * @param  {string|string[]} [options.cssClasses.header] CSS class to add to the header element
+ * @param  {string|string[]} [options.cssClasses.body] CSS class to add to the body element
+ * @param  {string|string[]} [options.cssClasses.footer] CSS class to add to the footer element
+ * @param  {string|string[]} [options.cssClasses.list] CSS class to add to the list element
+ * @param  {string|string[]} [options.cssClasses.item] CSS class to add to each item element
+ * @param  {string|string[]} [options.cssClasses.active] CSS class to add to each active element
+ * @param  {string|string[]} [options.cssClasses.label] CSS class to add to each label element (when using the default template)
+ * @param  {string|string[]} [options.cssClasses.checkbox] CSS class to add to each checkbox element (when using the default template)
+ * @param  {string|string[]} [options.cssClasses.count] CSS class to add to each count element (when using the default template)
  * @param  {Object} [options.templates] Templates to use for the widget
- * @param  {String|Function} [options.templates.header] Header template
- * @param  {String|Function} [options.templates.item] Item template, provided with `name`, `count`, `isRefined`
- * @param  {String|Function} [options.templates.footer] Footer template
+ * @param  {string|Function} [options.templates.header] Header template
+ * @param  {string|Function} [options.templates.item] Item template, provided with `name`, `count`, `isRefined`
+ * @param  {string|Function} [options.templates.footer] Footer template
  * @param  {Function} [options.transformData] Function to change the object passed to the item template
  * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when there's no results
  * @return {Object}
@@ -897,24 +897,24 @@ search.addWidget(
 ```js
 /**
  * Create a menu out of a facet
- * @param  {String|DOMElement} options.container CSS Selector or DOMElement to insert the widget
- * @param  {String} options.facetName Name of the attribute for faceting
- * @param  {String[]} [options.sortBy=['count:desc']] How to sort refinements. Possible values: `count|isRefined|name:asc|desc`
- * @param  {String} [options.limit=100] How many facets values to retrieve
+ * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
+ * @param  {string} options.facetName Name of the attribute for faceting
+ * @param  {string[]} [options.sortBy=['count:desc']] How to sort refinements. Possible values: `count|isRefined|name:asc|desc`
+ * @param  {string} [options.limit=100] How many facets values to retrieve
  * @param  {Object} [options.cssClasses] CSS classes to add to the wrapping elements: root, list, item
- * @param  {String|String[]} [options.cssClasses.root] CSS class to add to the root element
- * @param  {String|String[]} [options.cssClasses.header] CSS class to add to the header element
- * @param  {String|String[]} [options.cssClasses.body] CSS class to add to the body element
- * @param  {String|String[]} [options.cssClasses.footer] CSS class to add to the footer element
- * @param  {String|String[]} [options.cssClasses.list] CSS class to add to the list element
- * @param  {String|String[]} [options.cssClasses.item] CSS class to add to each item element
- * @param  {String|String[]} [options.cssClasses.active] CSS class to add to each active element
- * @param  {String|String[]} [options.cssClasses.link] CSS class to add to each link (when using the default template)
- * @param  {String|String[]} [options.cssClasses.count] CSS class to add to each count element (when using the default template)
+ * @param  {string|string[]} [options.cssClasses.root] CSS class to add to the root element
+ * @param  {string|string[]} [options.cssClasses.header] CSS class to add to the header element
+ * @param  {string|string[]} [options.cssClasses.body] CSS class to add to the body element
+ * @param  {string|string[]} [options.cssClasses.footer] CSS class to add to the footer element
+ * @param  {string|string[]} [options.cssClasses.list] CSS class to add to the list element
+ * @param  {string|string[]} [options.cssClasses.item] CSS class to add to each item element
+ * @param  {string|string[]} [options.cssClasses.active] CSS class to add to each active element
+ * @param  {string|string[]} [options.cssClasses.link] CSS class to add to each link (when using the default template)
+ * @param  {string|string[]} [options.cssClasses.count] CSS class to add to each count element (when using the default template)
  * @param  {Object} [options.templates] Templates to use for the widget
- * @param  {String|Function} [options.templates.header=''] Header template
- * @param  {String|Function} [options.templates.item] Item template, provided with `name`, `count`, `isRefined`
- * @param  {String|Function} [options.templates.footer=''] Footer template
+ * @param  {string|Function} [options.templates.header=''] Header template
+ * @param  {string|Function} [options.templates.item] Item template, provided with `name`, `count`, `isRefined`
+ * @param  {string|Function} [options.templates.footer=''] Footer template
  * @param  {Function} [options.transformData] Method to change the object passed to the item template
  * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when there's no results
  * @return {Object}
@@ -992,19 +992,19 @@ search.addWidget(
 ```js
 /**
  * Instantiate a slider based on a numeric attribute
- * @param  {String|DOMElement} options.container CSS Selector or DOMElement to insert the widget
- * @param  {String} options.facetName Name of the attribute for faceting
- * @param  {Boolean|Object} [options.tooltips=true] Should we show tooltips or not.
+ * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
+ * @param  {string} options.facetName Name of the attribute for faceting
+ * @param  {boolean|Object} [options.tooltips=true] Should we show tooltips or not.
  * The default tooltip will show the formatted corresponding value without any other token.
  * You can also provide
  * tooltips: {format: function(formattedValue, rawValue) {return '$' + formattedValue}}
  * So that you can format the tooltip display value as you want
  * @param  {Object} [options.templates] Templates to use for the widget
- * @param  {String|Function} [options.templates.header=''] Header template
- * @param  {String|Function} [options.templates.footer=''] Footer template
+ * @param  {string|Function} [options.templates.header=''] Header template
+ * @param  {string|Function} [options.templates.footer=''] Footer template
  * @param  {Object} [options.cssClasses] CSS classes to add to the wrapping elements: root, body
- * @param  {String|String[]} [options.cssClasses.root] CSS class to add to the root element
- * @param  {String|String[]} [options.cssClasses.body] CSS class to add to the body element
+ * @param  {string|string[]} [options.cssClasses.root] CSS class to add to the root element
+ * @param  {string|string[]} [options.cssClasses.body] CSS class to add to the body element
  * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when no results match
  * @return {Object}
  */
@@ -1039,22 +1039,22 @@ search.addWidget(
 ```js
 /**
  * Instantiate a price ranges on a numerical facet
- * @param  {String|DOMElement} options.container Valid CSS Selector as a string or DOMElement
- * @param  {String} options.facetName Name of the attribute for faceting
+ * @param  {string|DOMElement} options.container Valid CSS Selector as a string or DOMElement
+ * @param  {string} options.facetName Name of the attribute for faceting
  * @param  {Object} [options.cssClasses] CSS classes to add to the wrapping elements: root, range
- * @param  {String|String[]} [options.cssClasses.root] CSS class to add to the root element
- * @param  {String|String[]} [options.cssClasses.header] CSS class to add to the header element
- * @param  {String|String[]} [options.cssClasses.body] CSS class to add to the body element
- * @param  {String|String[]} [options.cssClasses.footer] CSS class to add to the footer element
- * @param  {String|String[]} [options.cssClasses.range] CSS class to add to the range element
- * @param  {String|String[]} [options.cssClasses.input] CSS class to add to the min/max input elements
- * @param  {String|String[]} [options.cssClasses.button] CSS class to add to the button element
+ * @param  {string|string[]} [options.cssClasses.root] CSS class to add to the root element
+ * @param  {string|string[]} [options.cssClasses.header] CSS class to add to the header element
+ * @param  {string|string[]} [options.cssClasses.body] CSS class to add to the body element
+ * @param  {string|string[]} [options.cssClasses.footer] CSS class to add to the footer element
+ * @param  {string|string[]} [options.cssClasses.range] CSS class to add to the range element
+ * @param  {string|string[]} [options.cssClasses.input] CSS class to add to the min/max input elements
+ * @param  {string|string[]} [options.cssClasses.button] CSS class to add to the button element
  * @param  {Object} [options.templates] Templates to use for the widget
- * @param  {String|Function} [options.templates.range] Range template
+ * @param  {string|Function} [options.templates.range] Range template
  * @param  {Object} [options.labels] Labels to use for the widget
- * @param  {String|Function} [options.labels.button] Button label
- * @param  {String|Function} [options.labels.currency] Currency label
- * @param  {String|Function} [options.labels.to] To label
+ * @param  {string|Function} [options.labels.button] Button label
+ * @param  {string|Function} [options.labels.currency] Currency label
+ * @param  {string|Function} [options.labels.to] To label
  * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when no results match
  * @return {Object}
  */
@@ -1090,25 +1090,25 @@ search.addWidget(
 ```js
 /**
  * Create a hierarchical menu using multiple attributes
- * @param  {String|DOMElement} options.container CSS Selector or DOMElement to insert the widget
- * @param  {String[]} options.attributes Array of attributes to use to generate the hierarchy of the menu.
+ * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
+ * @param  {string[]} options.attributes Array of attributes to use to generate the hierarchy of the menu.
  * You need to follow some conventions:
- * @param  {String[]} [options.sortBy=['count:desc']] How to sort refinements. Possible values: `count|isRefined|name:asc|desc`
- * @param  {Number} [options.limit=100] How much facet values to get
+ * @param  {string[]} [options.sortBy=['count:desc']] How to sort refinements. Possible values: `count|isRefined|name:asc|desc`
+ * @param  {number} [options.limit=100] How much facet values to get
  * @param  {Object} [options.cssClasses] CSS classes to add to the wrapping elements: root, list, item
- * @param  {String|String[]} [options.cssClasses.root] CSS class to add to the root element
- * @param  {String|String[]} [options.cssClasses.header] CSS class to add to the header element
- * @param  {String|String[]} [options.cssClasses.body] CSS class to add to the body element
- * @param  {String|String[]} [options.cssClasses.footer] CSS class to add to the footer element
- * @param  {String|String[]} [options.cssClasses.list] CSS class to add to the list element
- * @param  {String|String[]} [options.cssClasses.item] CSS class to add to each item element
- * @param  {String|String[]} [options.cssClasses.active] CSS class to add to each active element
- * @param  {String|String[]} [options.cssClasses.link] CSS class to add to each link (when using the default template)
- * @param  {String|String[]} [options.cssClasses.count] CSS class to add to each count element (when using the default template)
+ * @param  {string|string[]} [options.cssClasses.root] CSS class to add to the root element
+ * @param  {string|string[]} [options.cssClasses.header] CSS class to add to the header element
+ * @param  {string|string[]} [options.cssClasses.body] CSS class to add to the body element
+ * @param  {string|string[]} [options.cssClasses.footer] CSS class to add to the footer element
+ * @param  {string|string[]} [options.cssClasses.list] CSS class to add to the list element
+ * @param  {string|string[]} [options.cssClasses.item] CSS class to add to each item element
+ * @param  {string|string[]} [options.cssClasses.active] CSS class to add to each active element
+ * @param  {string|string[]} [options.cssClasses.link] CSS class to add to each link (when using the default template)
+ * @param  {string|string[]} [options.cssClasses.count] CSS class to add to each count element (when using the default template)
  * @param  {Object} [options.templates] Templates to use for the widget
- * @param  {String|Function} [options.templates.header=''] Header template (root level only)
- * @param  {String|Function} [options.templates.item] Item template
- * @param  {String|Function} [options.templates.footer=''] Footer template (root level only)
+ * @param  {string|Function} [options.templates.header=''] Header template (root level only)
+ * @param  {string|Function} [options.templates.item] Item template
+ * @param  {string|Function} [options.templates.footer=''] Footer template (root level only)
  * @param  {Function} [options.transformData] Method to change the object passed to the item template
  * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when there's no results
  * @return {Object}

--- a/widgets/hierarchical-menu/hierarchical-menu.js
+++ b/widgets/hierarchical-menu/hierarchical-menu.js
@@ -12,25 +12,25 @@ var defaultTemplates = require('./defaultTemplates.js');
 
 /**
  * Create a hierarchical menu using multiple attributes
- * @param  {String|DOMElement} options.container CSS Selector or DOMElement to insert the widget
- * @param  {String[]} options.attributes Array of attributes to use to generate the hierarchy of the menu.
+ * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
+ * @param  {string[]} options.attributes Array of attributes to use to generate the hierarchy of the menu.
  * You need to follow some conventions:
- * @param  {String[]} [options.sortBy=['count:desc']] How to sort refinements. Possible values: `count|isRefined|name:asc|desc`
- * @param  {Number} [options.limit=100] How much facet values to get
+ * @param  {string[]} [options.sortBy=['count:desc']] How to sort refinements. Possible values: `count|isRefined|name:asc|desc`
+ * @param  {number} [options.limit=100] How much facet values to get
  * @param  {Object} [options.cssClasses] CSS classes to add to the wrapping elements: root, list, item
- * @param  {String|String[]} [options.cssClasses.root] CSS class to add to the root element
- * @param  {String|String[]} [options.cssClasses.header] CSS class to add to the header element
- * @param  {String|String[]} [options.cssClasses.body] CSS class to add to the body element
- * @param  {String|String[]} [options.cssClasses.footer] CSS class to add to the footer element
- * @param  {String|String[]} [options.cssClasses.list] CSS class to add to the list element
- * @param  {String|String[]} [options.cssClasses.item] CSS class to add to each item element
- * @param  {String|String[]} [options.cssClasses.active] CSS class to add to each active element
- * @param  {String|String[]} [options.cssClasses.link] CSS class to add to each link (when using the default template)
- * @param  {String|String[]} [options.cssClasses.count] CSS class to add to each count element (when using the default template)
+ * @param  {string|string[]} [options.cssClasses.root] CSS class to add to the root element
+ * @param  {string|string[]} [options.cssClasses.header] CSS class to add to the header element
+ * @param  {string|string[]} [options.cssClasses.body] CSS class to add to the body element
+ * @param  {string|string[]} [options.cssClasses.footer] CSS class to add to the footer element
+ * @param  {string|string[]} [options.cssClasses.list] CSS class to add to the list element
+ * @param  {string|string[]} [options.cssClasses.item] CSS class to add to each item element
+ * @param  {string|string[]} [options.cssClasses.active] CSS class to add to each active element
+ * @param  {string|string[]} [options.cssClasses.link] CSS class to add to each link (when using the default template)
+ * @param  {string|string[]} [options.cssClasses.count] CSS class to add to each count element (when using the default template)
  * @param  {Object} [options.templates] Templates to use for the widget
- * @param  {String|Function} [options.templates.header=''] Header template (root level only)
- * @param  {String|Function} [options.templates.item] Item template
- * @param  {String|Function} [options.templates.footer=''] Footer template (root level only)
+ * @param  {string|Function} [options.templates.header=''] Header template (root level only)
+ * @param  {string|Function} [options.templates.item] Item template
+ * @param  {string|Function} [options.templates.footer=''] Footer template (root level only)
  * @param  {Function} [options.transformData] Method to change the object passed to the item template
  * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when there's no results
  * @return {Object}

--- a/widgets/hits-per-page-selector/hits-per-page-selector.js
+++ b/widgets/hits-per-page-selector/hits-per-page-selector.js
@@ -9,13 +9,13 @@ var autoHideContainer = require('../../decorators/autoHideContainer');
 
 /**
  * Instantiate a dropdown element to choose the number of hits to display per page
- * @param  {String|DOMElement} options.container CSS Selector or DOMElement to insert the widget
+ * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
  * @param  {Array} options.options Array of objects defining the different values and labels
- * @param  {Number} options.options[0].value Number of hits to display per page
- * @param  {String} options.options[0].label Label to display in the option
+ * @param  {number} options.options[0].value number of hits to display per page
+ * @param  {string} options.options[0].label Label to display in the option
  * @param  {Object} [options.cssClasses] CSS classes to be added
- * @param  {String} [options.cssClasses.root] CSS classes added to the parent <select>
- * @param  {String} [options.cssClasses.item] CSS classes added to each <option>
+ * @param  {string} [options.cssClasses.root] CSS classes added to the parent <select>
+ * @param  {string} [options.cssClasses.item] CSS classes added to each <option>
  * @param  {boolean} [hideContainerWhenNoResults=false] Hide the container when no results match
  * @return {Object}
  */

--- a/widgets/hits/hits.js
+++ b/widgets/hits/hits.js
@@ -10,18 +10,18 @@ var defaultTemplates = require('./defaultTemplates');
 
 /**
  * Display the list of results (hits) from the current search
- * @param  {String|DOMElement} options.container CSS Selector or DOMElement to insert the widget
+ * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
  * @param  {Object} [options.cssClasses] CSS classes to add
- * @param  {String} [options.cssClasses.root] CSS class to add to the wrapping element
- * @param  {String} [options.cssClasses.empty] CSS class to add to the wrapping element when no results
- * @param  {String} [options.cssClasses.item] CSS class to add to each result
+ * @param  {string} [options.cssClasses.root] CSS class to add to the wrapping element
+ * @param  {string} [options.cssClasses.empty] CSS class to add to the wrapping element when no results
+ * @param  {string} [options.cssClasses.item] CSS class to add to each result
  * @param  {Object} [options.templates] Templates to use for the widget
- * @param  {String|Function} [options.templates.empty=''] Template to use when there are no results.
- * @param  {String|Function} [options.templates.item=''] Template to use for each result.
+ * @param  {string|Function} [options.templates.empty=''] Template to use when there are no results.
+ * @param  {string|Function} [options.templates.item=''] Template to use for each result.
  * @param  {Object} [options.transformData] Method to change the object passed to the templates
  * @param  {Function} [options.transformData.empty=''] Method used to change the object passed to the empty template
  * @param  {Function} [options.transformData.item=''] Method used to change the object passed to the item template
- * @param  {Number} [hitsPerPage=20] The number of hits to display per page
+ * @param  {number} [hitsPerPage=20] The number of hits to display per page
  * @return {Object}
  */
 function hits({

--- a/widgets/index-selector/index-selector.js
+++ b/widgets/index-selector/index-selector.js
@@ -10,13 +10,13 @@ var autoHideContainer = require('../../decorators/autoHideContainer');
 
 /**
  * Instantiate a dropdown element to choose the current targeted index
- * @param  {String|DOMElement} options.container CSS Selector or DOMElement to insert the widget
+ * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
  * @param  {Array} options.indices Array of objects defining the different indices to choose from.
- * @param  {String} options.indices[0].name Name of the index to target
- * @param  {String} options.indices[0].label Label displayed in the dropdown
+ * @param  {string} options.indices[0].name Name of the index to target
+ * @param  {string} options.indices[0].label Label displayed in the dropdown
  * @param  {Object} [options.cssClasses] CSS classes to be added
- * @param  {String} [options.cssClasses.root] CSS classes added to the parent <select>
- * @param  {String} [options.cssClasses.item] CSS classes added to each <option>
+ * @param  {string} [options.cssClasses.root] CSS classes added to the parent <select>
+ * @param  {string} [options.cssClasses.item] CSS classes added to each <option>
  * @param  {boolean} [hideContainerWhenNoResults=false] Hide the container when no results match
  * @return {Object}
  */

--- a/widgets/menu/menu.js
+++ b/widgets/menu/menu.js
@@ -12,24 +12,24 @@ var defaultTemplates = require('./defaultTemplates.js');
 
 /**
  * Create a menu out of a facet
- * @param  {String|DOMElement} options.container CSS Selector or DOMElement to insert the widget
- * @param  {String} options.facetName Name of the attribute for faceting
- * @param  {String[]} [options.sortBy=['count:desc']] How to sort refinements. Possible values: `count|isRefined|name:asc|desc`
- * @param  {String} [options.limit=100] How many facets values to retrieve
+ * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
+ * @param  {string} options.facetName Name of the attribute for faceting
+ * @param  {string[]} [options.sortBy=['count:desc']] How to sort refinements. Possible values: `count|isRefined|name:asc|desc`
+ * @param  {string} [options.limit=100] How many facets values to retrieve
  * @param  {Object} [options.cssClasses] CSS classes to add to the wrapping elements: root, list, item
- * @param  {String|String[]} [options.cssClasses.root] CSS class to add to the root element
- * @param  {String|String[]} [options.cssClasses.header] CSS class to add to the header element
- * @param  {String|String[]} [options.cssClasses.body] CSS class to add to the body element
- * @param  {String|String[]} [options.cssClasses.footer] CSS class to add to the footer element
- * @param  {String|String[]} [options.cssClasses.list] CSS class to add to the list element
- * @param  {String|String[]} [options.cssClasses.item] CSS class to add to each item element
- * @param  {String|String[]} [options.cssClasses.active] CSS class to add to each active element
- * @param  {String|String[]} [options.cssClasses.link] CSS class to add to each link (when using the default template)
- * @param  {String|String[]} [options.cssClasses.count] CSS class to add to each count element (when using the default template)
+ * @param  {string|string[]} [options.cssClasses.root] CSS class to add to the root element
+ * @param  {string|string[]} [options.cssClasses.header] CSS class to add to the header element
+ * @param  {string|string[]} [options.cssClasses.body] CSS class to add to the body element
+ * @param  {string|string[]} [options.cssClasses.footer] CSS class to add to the footer element
+ * @param  {string|string[]} [options.cssClasses.list] CSS class to add to the list element
+ * @param  {string|string[]} [options.cssClasses.item] CSS class to add to each item element
+ * @param  {string|string[]} [options.cssClasses.active] CSS class to add to each active element
+ * @param  {string|string[]} [options.cssClasses.link] CSS class to add to each link (when using the default template)
+ * @param  {string|string[]} [options.cssClasses.count] CSS class to add to each count element (when using the default template)
  * @param  {Object} [options.templates] Templates to use for the widget
- * @param  {String|Function} [options.templates.header=''] Header template
- * @param  {String|Function} [options.templates.item] Item template, provided with `name`, `count`, `isRefined`
- * @param  {String|Function} [options.templates.footer=''] Footer template
+ * @param  {string|Function} [options.templates.header=''] Header template
+ * @param  {string|Function} [options.templates.item] Item template, provided with `name`, `count`, `isRefined`
+ * @param  {string|Function} [options.templates.footer=''] Footer template
  * @param  {Function} [options.transformData] Method to change the object passed to the item template
  * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when there's no results
  * @return {Object}

--- a/widgets/pagination/pagination.js
+++ b/widgets/pagination/pagination.js
@@ -13,25 +13,25 @@ var defaultLabels = {
 
 /**
  * Add a pagination menu to navigate through the results
- * @param  {String|DOMElement} options.container CSS Selector or DOMElement to insert the widget
+ * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
  * @param  {Object} [options.cssClasses] CSS classes to be added
- * @param  {String} [options.cssClasses.root] CSS classes added to the parent <ul>
- * @param  {String} [options.cssClasses.item] CSS classes added to each <li>
- * @param  {String} [options.cssClasses.page] CSS classes added to page <li>
- * @param  {String} [options.cssClasses.previous] CSS classes added to the previous <li>
- * @param  {String} [options.cssClasses.next] CSS classes added to the next <li>
- * @param  {String} [options.cssClasses.first] CSS classes added to the first <li>
- * @param  {String} [options.cssClasses.last] CSS classes added to the last <li>
- * @param  {String} [options.cssClasses.active] CSS classes added to the active <li>
- * @param  {String} [options.cssClasses.disabled] CSS classes added to the disabled <li>
+ * @param  {string} [options.cssClasses.root] CSS classes added to the parent <ul>
+ * @param  {string} [options.cssClasses.item] CSS classes added to each <li>
+ * @param  {string} [options.cssClasses.page] CSS classes added to page <li>
+ * @param  {string} [options.cssClasses.previous] CSS classes added to the previous <li>
+ * @param  {string} [options.cssClasses.next] CSS classes added to the next <li>
+ * @param  {string} [options.cssClasses.first] CSS classes added to the first <li>
+ * @param  {string} [options.cssClasses.last] CSS classes added to the last <li>
+ * @param  {string} [options.cssClasses.active] CSS classes added to the active <li>
+ * @param  {string} [options.cssClasses.disabled] CSS classes added to the disabled <li>
  * @param  {Object} [options.labels] Text to display in the various links (prev, next, first, last)
- * @param  {String} [options.labels.previous] Label for the Previous link
- * @param  {String} [options.labels.next] Label for the Next link
- * @param  {String} [options.labels.first] Label for the First link
- * @param  {String} [options.labels.last] Label for the Last link
- * @param  {Number} [options.maxPages=20] The max number of pages to browse
- * @param  {Number} [options.padding=3] The number of pages to display on each side of the current page
- * @param  {String|DOMElement|boolean} [options.scrollTo='body'] Where to scroll after a click, set to `false` to disable
+ * @param  {string} [options.labels.previous] Label for the Previous link
+ * @param  {string} [options.labels.next] Label for the Next link
+ * @param  {string} [options.labels.first] Label for the First link
+ * @param  {string} [options.labels.last] Label for the Last link
+ * @param  {number} [options.maxPages=20] The max number of pages to browse
+ * @param  {number} [options.padding=3] The number of pages to display on each side of the current page
+ * @param  {string|DOMElement|boolean} [options.scrollTo='body'] Where to scroll after a click, set to `false` to disable
  * @param  {boolean} [options.showFirstLast=true] Define if the First and Last links should be displayed
  * @param  {boolean} [options.hideContainerWhenNoResults=true] Hide the container when no results match
  * @return {Object}

--- a/widgets/price-ranges/price-ranges.js
+++ b/widgets/price-ranges/price-ranges.js
@@ -14,24 +14,24 @@ var cx = require('classnames/dedupe');
 
 /**
  * Instantiate a price ranges on a numerical facet
- * @param  {String|DOMElement} options.container Valid CSS Selector as a string or DOMElement
- * @param  {String} options.facetName Name of the attribute for faceting
+ * @param  {string|DOMElement} options.container Valid CSS Selector as a string or DOMElement
+ * @param  {string} options.facetName Name of the attribute for faceting
  * @param  {Object} [options.cssClasses] CSS classes to add to the wrapping elements: root, range
- * @param  {String|String[]} [options.cssClasses.root] CSS class to add to the root element
- * @param  {String|String[]} [options.cssClasses.header] CSS class to add to the header element
- * @param  {String|String[]} [options.cssClasses.body] CSS class to add to the body element
- * @param  {String|String[]} [options.cssClasses.footer] CSS class to add to the footer element
- * @param  {String|String[]} [options.cssClasses.form] CSS class to add to the form element
- * @param  {String|String[]} [options.cssClasses.range] CSS class to add to the range element
- * @param  {String|String[]} [options.cssClasses.active] CSS class to add to the active range element
- * @param  {String|String[]} [options.cssClasses.input] CSS class to add to the min/max input elements
- * @param  {String|String[]} [options.cssClasses.button] CSS class to add to the button element
+ * @param  {string|string[]} [options.cssClasses.root] CSS class to add to the root element
+ * @param  {string|string[]} [options.cssClasses.header] CSS class to add to the header element
+ * @param  {string|string[]} [options.cssClasses.body] CSS class to add to the body element
+ * @param  {string|string[]} [options.cssClasses.footer] CSS class to add to the footer element
+ * @param  {string|string[]} [options.cssClasses.form] CSS class to add to the form element
+ * @param  {string|string[]} [options.cssClasses.range] CSS class to add to the range element
+ * @param  {string|string[]} [options.cssClasses.active] CSS class to add to the active range element
+ * @param  {string|string[]} [options.cssClasses.input] CSS class to add to the min/max input elements
+ * @param  {string|string[]} [options.cssClasses.button] CSS class to add to the button element
  * @param  {Object} [options.templates] Templates to use for the widget
- * @param  {String|Function} [options.templates.range] Range template
+ * @param  {string|Function} [options.templates.range] Range template
  * @param  {Object} [options.labels] Labels to use for the widget
- * @param  {String|Function} [options.labels.button] Button label
- * @param  {String|Function} [options.labels.currency] Currency label
- * @param  {String|Function} [options.labels.to] To label
+ * @param  {string|Function} [options.labels.button] Button label
+ * @param  {string|Function} [options.labels.currency] Currency label
+ * @param  {string|Function} [options.labels.to] To label
  * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when no results match
  * @return {Object}
  */

--- a/widgets/range-slider/range-slider.js
+++ b/widgets/range-slider/range-slider.js
@@ -12,19 +12,19 @@ var defaultTemplates = {
 
 /**
  * Instantiate a slider based on a numeric attribute
- * @param  {String|DOMElement} options.container CSS Selector or DOMElement to insert the widget
- * @param  {String} options.facetName Name of the attribute for faceting
- * @param  {Boolean|Object} [options.tooltips=true] Should we show tooltips or not.
+ * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
+ * @param  {string} options.facetName Name of the attribute for faceting
+ * @param  {boolean|Object} [options.tooltips=true] Should we show tooltips or not.
  * The default tooltip will show the formatted corresponding value without any other token.
  * You can also provide
  * tooltips: {format: function(formattedValue, rawValue) {return '$' + formattedValue}}
  * So that you can format the tooltip display value as you want
  * @param  {Object} [options.templates] Templates to use for the widget
- * @param  {String|Function} [options.templates.header=''] Header template
- * @param  {String|Function} [options.templates.footer=''] Footer template
+ * @param  {string|Function} [options.templates.header=''] Header template
+ * @param  {string|Function} [options.templates.footer=''] Footer template
  * @param  {Object} [options.cssClasses] CSS classes to add to the wrapping elements: root, body
- * @param  {String|String[]} [options.cssClasses.root] CSS class to add to the root element
- * @param  {String|String[]} [options.cssClasses.body] CSS class to add to the body element
+ * @param  {string|string[]} [options.cssClasses.root] CSS class to add to the root element
+ * @param  {string|string[]} [options.cssClasses.body] CSS class to add to the body element
  * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when no results match
  * @return {Object}
  */

--- a/widgets/refinement-list/refinement-list.js
+++ b/widgets/refinement-list/refinement-list.js
@@ -13,26 +13,26 @@ var defaultTemplates = require('./defaultTemplates');
 
 /**
  * Instantiate a list of refinements based on a facet
- * @param  {String|DOMElement} options.container CSS Selector or DOMElement to insert the widget
- * @param  {String} options.facetName Name of the attribute for faceting
- * @param  {String} [options.operator='or'] How to apply refinements. Possible values: `or`, `and`
- * @param  {String[]} [options.sortBy=['count:desc']] How to sort refinements. Possible values: `count|isRefined|name:asc|desc`
- * @param  {String} [options.limit=1000] How much facet values to get
+ * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
+ * @param  {string} options.facetName Name of the attribute for faceting
+ * @param  {string} [options.operator='or'] How to apply refinements. Possible values: `or`, `and`
+ * @param  {string[]} [options.sortBy=['count:desc']] How to sort refinements. Possible values: `count|isRefined|name:asc|desc`
+ * @param  {string} [options.limit=1000] How much facet values to get
  * @param  {Object} [options.cssClasses] CSS classes to add to the wrapping elements: root, list, item
- * @param  {String|String[]} [options.cssClasses.root] CSS class to add to the root element
- * @param  {String|String[]} [options.cssClasses.header] CSS class to add to the header element
- * @param  {String|String[]} [options.cssClasses.body] CSS class to add to the body element
- * @param  {String|String[]} [options.cssClasses.footer] CSS class to add to the footer element
- * @param  {String|String[]} [options.cssClasses.list] CSS class to add to the list element
- * @param  {String|String[]} [options.cssClasses.item] CSS class to add to each item element
- * @param  {String|String[]} [options.cssClasses.active] CSS class to add to each active element
- * @param  {String|String[]} [options.cssClasses.label] CSS class to add to each label element (when using the default template)
- * @param  {String|String[]} [options.cssClasses.checkbox] CSS class to add to each checkbox element (when using the default template)
- * @param  {String|String[]} [options.cssClasses.count] CSS class to add to each count element (when using the default template)
+ * @param  {string|string[]} [options.cssClasses.root] CSS class to add to the root element
+ * @param  {string|string[]} [options.cssClasses.header] CSS class to add to the header element
+ * @param  {string|string[]} [options.cssClasses.body] CSS class to add to the body element
+ * @param  {string|string[]} [options.cssClasses.footer] CSS class to add to the footer element
+ * @param  {string|string[]} [options.cssClasses.list] CSS class to add to the list element
+ * @param  {string|string[]} [options.cssClasses.item] CSS class to add to each item element
+ * @param  {string|string[]} [options.cssClasses.active] CSS class to add to each active element
+ * @param  {string|string[]} [options.cssClasses.label] CSS class to add to each label element (when using the default template)
+ * @param  {string|string[]} [options.cssClasses.checkbox] CSS class to add to each checkbox element (when using the default template)
+ * @param  {string|string[]} [options.cssClasses.count] CSS class to add to each count element (when using the default template)
  * @param  {Object} [options.templates] Templates to use for the widget
- * @param  {String|Function} [options.templates.header] Header template
- * @param  {String|Function} [options.templates.item] Item template, provided with `name`, `count`, `isRefined`
- * @param  {String|Function} [options.templates.footer] Footer template
+ * @param  {string|Function} [options.templates.header] Header template
+ * @param  {string|Function} [options.templates.item] Item template, provided with `name`, `count`, `isRefined`
+ * @param  {string|Function} [options.templates.footer] Footer template
  * @param  {Function} [options.transformData] Function to change the object passed to the item template
  * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when there's no results
  * @return {Object}

--- a/widgets/search-box/search-box.js
+++ b/widgets/search-box/search-box.js
@@ -7,11 +7,11 @@ var cx = require('classnames');
 
 /**
  * Instantiate a searchbox
- * @param  {String|DOMElement} options.container CSS Selector or DOMElement to insert the widget
- * @param  {String} [options.placeholder] Input's placeholder
+ * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
+ * @param  {string} [options.placeholder] Input's placeholder
  * @param  {Object} [options.cssClasses] CSS classes to add
- * @param  {String} [options.cssClasses.input] CSS class to add to the input
- * @param  {String} [options.cssClasses.poweredBy] CSS class to add to the poweredBy element
+ * @param  {string} [options.cssClasses.input] CSS class to add to the input
+ * @param  {string} [options.cssClasses.poweredBy] CSS class to add to the poweredBy element
  * @param  {boolean} [poweredBy=false] Show a powered by Algolia link below the input
  * @param  {boolean|string} [autofocus='auto'] autofocus on the input
  * @return {Object}

--- a/widgets/stats/stats.js
+++ b/widgets/stats/stats.js
@@ -11,17 +11,17 @@ var defaultTemplates = require('./defaultTemplates.js');
 
 /**
  * Display various stats about the current search state
- * @param  {String|DOMElement} options.container CSS Selector or DOMElement to insert the widget
+ * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
  * @param  {Object} [options.cssClasses] CSS classes to add
- * @param  {String} [options.cssClasses.root] CSS class to add to the root element
- * @param  {String} [options.cssClasses.header] CSS class to add to the header element
- * @param  {String} [options.cssClasses.body] CSS class to add to the body element
- * @param  {String} [options.cssClasses.footer] CSS class to add to the footer element
- * @param  {String} [options.cssClasses.time] CSS class to add to the element wrapping the time processingTimeMs
+ * @param  {string} [options.cssClasses.root] CSS class to add to the root element
+ * @param  {string} [options.cssClasses.header] CSS class to add to the header element
+ * @param  {string} [options.cssClasses.body] CSS class to add to the body element
+ * @param  {string} [options.cssClasses.footer] CSS class to add to the footer element
+ * @param  {string} [options.cssClasses.time] CSS class to add to the element wrapping the time processingTimeMs
  * @param  {Object} [options.templates] Templates to use for the widget
- * @param  {String|Function} [options.templates.header=''] Header template
- * @param  {String|Function} [options.templates.body] Body template
- * @param  {String|Function} [options.templates.footer=''] Footer template
+ * @param  {string|Function} [options.templates.header=''] Header template
+ * @param  {string|Function} [options.templates.body] Body template
+ * @param  {string|Function} [options.templates.footer=''] Footer template
  * @param  {Function} [options.transformData] Function to change the object passed to the `body` template
  * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when there's no results
  * @return {Object}

--- a/widgets/toggle/toggle.js
+++ b/widgets/toggle/toggle.js
@@ -15,24 +15,24 @@ var defaultTemplates = require('./defaultTemplates');
  * Instantiate the toggling of a boolean facet filter on and off.
  * Note that it will not toggle between `true` and `false, but between `true`
  * and `undefined`.
- * @param  {String|DOMElement} options.container CSS Selector or DOMElement to insert the widget
- * @param  {String} options.facetName Name of the attribute for faceting (eg. "free_shipping")
- * @param  {String} options.label Human-readable name of the filter (eg. "Free Shipping")
+ * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
+ * @param  {string} options.facetName Name of the attribute for faceting (eg. "free_shipping")
+ * @param  {string} options.label Human-readable name of the filter (eg. "Free Shipping")
  * @param  {Object} [options.cssClasses] CSS classes to add
- * @param  {String|String[]} [options.cssClasses.root] CSS class to add to the root element
- * @param  {String|String[]} [options.cssClasses.header] CSS class to add to the header element
- * @param  {String|String[]} [options.cssClasses.body] CSS class to add to the body element
- * @param  {String|String[]} [options.cssClasses.footer] CSS class to add to the footer element
- * @param  {String|String[]} [options.cssClasses.list] CSS class to add to the list element
- * @param  {String|String[]} [options.cssClasses.item] CSS class to add to each item element
- * @param  {String|String[]} [options.cssClasses.active] CSS class to add to each active element
- * @param  {String|String[]} [options.cssClasses.label] CSS class to add to each label element (when using the default template)
- * @param  {String|String[]} [options.cssClasses.checkbox] CSS class to add to each checkbox element (when using the default template)
- * @param  {String|String[]} [options.cssClasses.count] CSS class to add to each count element (when using the default template)
+ * @param  {string|string[]} [options.cssClasses.root] CSS class to add to the root element
+ * @param  {string|string[]} [options.cssClasses.header] CSS class to add to the header element
+ * @param  {string|string[]} [options.cssClasses.body] CSS class to add to the body element
+ * @param  {string|string[]} [options.cssClasses.footer] CSS class to add to the footer element
+ * @param  {string|string[]} [options.cssClasses.list] CSS class to add to the list element
+ * @param  {string|string[]} [options.cssClasses.item] CSS class to add to each item element
+ * @param  {string|string[]} [options.cssClasses.active] CSS class to add to each active element
+ * @param  {string|string[]} [options.cssClasses.label] CSS class to add to each label element (when using the default template)
+ * @param  {string|string[]} [options.cssClasses.checkbox] CSS class to add to each checkbox element (when using the default template)
+ * @param  {string|string[]} [options.cssClasses.count] CSS class to add to each count element (when using the default template)
  * @param  {Object} [options.templates] Templates to use for the widget
- * @param  {String|Function} [options.templates.header=''] Header template
- * @param  {String|Function} [options.templates.item] Item template
- * @param  {String|Function} [options.templates.footer=''] Footer template
+ * @param  {string|Function} [options.templates.header=''] Header template
+ * @param  {string|Function} [options.templates.item] Item template
+ * @param  {string|Function} [options.templates.footer=''] Footer template
  * @param  {Function} [options.transformData] Function to change the object passed to the item template
  * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when there's no results
  * @return {Object}


### PR DESCRIPTION
Used this script to automatically do it:

```sh
#! /usr/bin/bash

for wrapper in String Number Boolean; do
  prim=`echo $wrapper | tr '[:upper:]' '[:lower:]'`
  for file in `echo README.md widgets/*/*.js`; do
    for i in `seq 3`; do
      sed -i -r "s/(@param.*)(${wrapper})/\1${prim}/g" $file
    done
  done
done
```

I think it should have gotten all of them. Maybe you can think of some other places than on the `@param` lines where we should replace them?