### PR TITLE
chore(warnings): Remove test warning about `type should not be null`

### DIFF
--- a/decorators/__tests__/autoHide-test.js
+++ b/decorators/__tests__/autoHide-test.js
@@ -27,7 +27,7 @@ describe('autoHideContainer', () => {
   });
 
   function render(props = {}) {
-    var AutoHide = autoHideContainer(<span />);
+    var AutoHide = autoHideContainer('span');
     renderer.render(<AutoHide {...props} />);
     return renderer.getRenderOutput();
   }

--- a/decorators/__tests__/headerFooter-test.js
+++ b/decorators/__tests__/headerFooter-test.js
@@ -39,7 +39,7 @@ describe('headerFooter', () => {
   });
 
   function render(props = {}) {
-    var HeaderFooter = headerFooter(<div />);
+    var HeaderFooter = headerFooter('div');
     renderer.render(<HeaderFooter {...props} />);
     return renderer.getRenderOutput();
   }


### PR DESCRIPTION
The warning `Warning: React.createElement: type should not be null,
undefined, boolean, or number. It should be a string (for DOM
elements) or a ReactClass (for composite components).` was caused by
calling the test decorator on `<div />` instead of `'div'`.

As the message suggest, we should use strings for basic DOM elements.
