### PR TITLE
test(decorators): Use TestComponent instead of string

### DIFF
--- a/decorators/__tests__/TestComponent.js
+++ b/decorators/__tests__/TestComponent.js
@@ -1,0 +1,11 @@
+var React = require('react');
+
+// This component is only used in tests, as a placeholder
+class TestComponent extends React.Component {
+  render() {
+    return <div {...this.props} />;
+  }
+}
+
+
+module.exports = TestComponent;

--- a/decorators/__tests__/autoHide-test.js
+++ b/decorators/__tests__/autoHide-test.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import expect from 'expect';
 import TestUtils from 'react-addons-test-utils';
+import TestComponent from './TestComponent';
 import autoHideContainer from '../autoHideContainer';
 
 import expectJSX from 'expect-jsx';
@@ -16,18 +17,18 @@ describe('autoHideContainer', () => {
     renderer = createRenderer();
   });
 
-  it('should render autoHideContainer(<span />)', () => {
+  it('should render autoHideContainer(<TestComponent />)', () => {
     var out = render();
-    expect(out).toEqualJSX(<span />);
+    expect(out).toEqualJSX(<TestComponent />);
   });
 
-  it('should not render autoHideContainer(<span />)', () => {
+  it('should not render autoHideContainer(<TestComponent />)', () => {
     var out = render({hasResults: false, hideContainerWhenNoResults: true});
     expect(out).toEqualJSX(<div />);
   });
 
   function render(props = {}) {
-    var AutoHide = autoHideContainer('span');
+    var AutoHide = autoHideContainer(TestComponent);
     renderer.render(<AutoHide {...props} />);
     return renderer.getRenderOutput();
   }

--- a/decorators/__tests__/headerFooter-test.js
+++ b/decorators/__tests__/headerFooter-test.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import expect from 'expect';
 import TestUtils from 'react-addons-test-utils';
+import TestComponent from './TestComponent';
 import headerFooter from '../headerFooter';
 import Template from '../../components/Template';
 
@@ -29,7 +30,7 @@ describe('headerFooter', () => {
           <Template data={{}} templateKey="header" transformData={null} />
         </div>
         <div className={undefined}>
-          <div cssClasses={{root: 'wrapper'}} />
+          <TestComponent cssClasses={{root: 'wrapper'}} />
         </div>
         <div className={cx(bemFooter(null))}>
           <Template data={{}} templateKey="footer" transformData={null} />
@@ -39,7 +40,7 @@ describe('headerFooter', () => {
   });
 
   function render(props = {}) {
-    var HeaderFooter = headerFooter('div');
+    var HeaderFooter = headerFooter(TestComponent);
     renderer.render(<HeaderFooter {...props} />);
     return renderer.getRenderOutput();
   }


### PR DESCRIPTION
As discussed in #374, I've added the TestComponent to test decorators.