### PR TITLE
chore(autoHideContainer): Generic implementation

### DIFF
--- a/decorators/__tests__/autoHideContainer-test.js
+++ b/decorators/__tests__/autoHideContainer-test.js
@@ -23,7 +23,7 @@ describe('autoHideContainer', () => {
   });
 
   it('should not render autoHideContainer(<TestComponent />)', () => {
-    var out = render({hasResults: false, hideContainerWhenNoResults: true});
+    var out = render({shouldAutoHideContainer: true});
     expect(out).toEqualJSX(<div />);
   });
 

--- a/decorators/autoHideContainer.js
+++ b/decorators/autoHideContainer.js
@@ -16,16 +16,11 @@ function autoHideContainer(ComposedComponent) {
 
     _hideOrShowContainer(props) {
       var container = ReactDOM.findDOMNode(this).parentNode;
-      if (props.hideContainerWhenNoResults === true && props.hasResults === false) {
-        container.style.display = 'none';
-      } else if (props.hideContainerWhenNoResults === true) {
-        container.style.display = '';
-      }
+      container.style.display = (props.shouldAutoHideContainer === true) ? 'none' : '';
     }
 
     render() {
-      if (this.props.hasResults === false &&
-        this.props.hideContainerWhenNoResults === true) {
+      if (this.props.shouldAutoHideContainer === true) {
         return <div />;
       }
 
@@ -34,8 +29,7 @@ function autoHideContainer(ComposedComponent) {
   }
 
   AutoHide.propTypes = {
-    hasResults: React.PropTypes.bool.isRequired,
-    hideContainerWhenNoResults: React.PropTypes.bool.isRequired
+    shouldAutoHideContainer: React.PropTypes.bool.isRequired
   };
 
   // precise displayName for ease of debugging (react dev tool, react warnings)

--- a/widgets/hierarchical-menu/hierarchical-menu.js
+++ b/widgets/hierarchical-menu/hierarchical-menu.js
@@ -6,7 +6,6 @@ var bem = utils.bemHelper('ais-hierarchical-menu');
 var cx = require('classnames/dedupe');
 var autoHideContainer = require('../../decorators/autoHideContainer');
 var headerFooter = require('../../decorators/headerFooter');
-var RefinementList = autoHideContainer(headerFooter(require('../../components/RefinementList/RefinementList.js')));
 
 var defaultTemplates = require('./defaultTemplates.js');
 
@@ -47,7 +46,12 @@ function hierarchicalMenu({
     transformData
   }) {
   var containerNode = utils.getContainerNode(container);
-  var usage = 'Usage: hierarchicalMenu({container, attributes, [separator, sortBy, limit, cssClasses.{root, list, item}, templates.{header, item, footer}, transformData]})';
+  var usage = 'Usage: hierarchicalMenu({container, attributes, [separator, sortBy, limit, cssClasses.{root, list, item}, templates.{header, item, footer}, transformData, hideContainerWhenNoResults]})';
+
+  var RefinementList = headerFooter(require('../../components/RefinementList/RefinementList.js'));
+  if (hideContainerWhenNoResults === true) {
+    RefinementList = autoHideContainer(RefinementList);
+  }
 
   if (!container || !attributes || !attributes.length) {
     throw new Error(usage);
@@ -68,6 +72,7 @@ function hierarchicalMenu({
     }),
     render: function({results, helper, templatesConfig, createURL, state}) {
       var facetValues = getFacetValues(results, hierarchicalFacetName, sortBy);
+      var hasNoRefinements = facetValues.length === 0;
 
       var templateProps = utils.prepareTemplateProps({
         transformData,
@@ -95,9 +100,8 @@ function hierarchicalMenu({
           cssClasses={cssClasses}
           facetNameKey="path"
           facetValues={facetValues}
-          hasResults={facetValues.length > 0}
-          hideContainerWhenNoResults={hideContainerWhenNoResults}
           limit={limit}
+          shouldAutoHideContainer={hasNoRefinements}
           templateProps={templateProps}
           toggleRefinement={toggleRefinement.bind(null, helper, hierarchicalFacetName)}
         />,

--- a/widgets/hits-per-page-selector/__tests__/hits-per-page-selector-test.js
+++ b/widgets/hits-per-page-selector/__tests__/hits-per-page-selector-test.js
@@ -49,7 +49,8 @@ describe('hitsPerPageSelector()', () => {
       search: sinon.spy()
     };
     results = {
-      hits: []
+      hits: [],
+      nbHits: 0
     };
   });
 
@@ -65,8 +66,7 @@ describe('hitsPerPageSelector()', () => {
         item: 'ais-hits-per-page-selector--item custom-item'
       },
       currentValue: 20,
-      hasResults: false,
-      hideContainerWhenNoResults: false,
+      shouldAutoHideContainer: true,
       options: [
         {value: 10, label: '10 results'},
         {value: 20, label: '20 results'}

--- a/widgets/hits-per-page-selector/hits-per-page-selector.js
+++ b/widgets/hits-per-page-selector/hits-per-page-selector.js
@@ -27,8 +27,13 @@ function hitsPerPageSelector({
     hideContainerWhenNoResults = false
   }) {
   var containerNode = utils.getContainerNode(container);
-
   var usage = 'Usage: hitsPerPageSelector({container, options[, cssClasses.{root,item}, hideContainerWhenNoResults]})';
+
+  var Selector = require('../../components/Selector');
+  if (hideContainerWhenNoResults === true) {
+    Selector = autoHideContainer(Selector);
+  }
+
   if (!container || !options) {
     throw new Error(usage);
   }
@@ -50,9 +55,8 @@ function hitsPerPageSelector({
 
     render: function({helper, state, results}) {
       let currentValue = state.hitsPerPage;
-      let hasResults = results.hits.length > 0;
+      let hasNoResults = results.nbHits === 0;
       let setHitsPerPage = this.setHitsPerPage.bind(this, helper);
-      var Selector = autoHideContainer(require('../../components/Selector'));
 
       cssClasses = {
         root: cx(bem(null), cssClasses.root),
@@ -62,10 +66,9 @@ function hitsPerPageSelector({
         <Selector
           cssClasses={cssClasses}
           currentValue={currentValue}
-          hasResults={hasResults}
-          hideContainerWhenNoResults={hideContainerWhenNoResults}
           options={options}
           setValue={setHitsPerPage}
+          shouldAutoHideContainer={hasNoResults}
         />,
         containerNode
       );

--- a/widgets/index-selector/__tests__/index-selector-test.js
+++ b/widgets/index-selector/__tests__/index-selector-test.js
@@ -47,7 +47,8 @@ describe('indexSelector()', () => {
       search: sinon.spy()
     };
     results = {
-      hits: []
+      hits: [],
+      nbHits: 0
     };
   });
 
@@ -63,8 +64,7 @@ describe('indexSelector()', () => {
         item: 'ais-index-selector--item custom-item'
       },
       currentValue: 'index-a',
-      hasResults: false,
-      hideContainerWhenNoResults: false,
+      shouldAutoHideContainer: true,
       options: [
         {value: 'index-a', label: 'Index A'},
         {value: 'index-b', label: 'Index B'}

--- a/widgets/index-selector/index-selector.js
+++ b/widgets/index-selector/index-selector.js
@@ -27,8 +27,13 @@ function indexSelector({
     hideContainerWhenNoResults = false
   }) {
   var containerNode = utils.getContainerNode(container);
-
   var usage = 'Usage: indexSelector({container, indices[, cssClasses.{root,item}, hideContainerWhenNoResults]})';
+
+  var Selector = require('../../components/Selector');
+  if (hideContainerWhenNoResults === true) {
+    Selector = autoHideContainer(Selector);
+  }
+
   if (!container || !indices) {
     throw new Error(usage);
   }
@@ -53,9 +58,8 @@ function indexSelector({
 
     render: function({helper, results}) {
       let currentIndex = helper.getIndex();
-      let hasResults = results.hits.length > 0;
+      let hasNoResults = results.nbHits === 0;
       let setIndex = this.setIndex.bind(this, helper);
-      var Selector = autoHideContainer(require('../../components/Selector'));
 
       cssClasses = {
         root: cx(bem(null), cssClasses.root),
@@ -65,10 +69,9 @@ function indexSelector({
         <Selector
           cssClasses={cssClasses}
           currentValue={currentIndex}
-          hasResults={hasResults}
-          hideContainerWhenNoResults={hideContainerWhenNoResults}
           options={selectorOptions}
           setValue={setIndex}
+          shouldAutoHideContainer={hasNoResults}
         />,
         containerNode
       );

--- a/widgets/menu/menu.js
+++ b/widgets/menu/menu.js
@@ -6,7 +6,6 @@ var bem = utils.bemHelper('ais-menu');
 var cx = require('classnames/dedupe');
 var autoHideContainer = require('../../decorators/autoHideContainer');
 var headerFooter = require('../../decorators/headerFooter');
-var RefinementList = autoHideContainer(headerFooter(require('../../components/RefinementList/RefinementList.js')));
 
 var defaultTemplates = require('./defaultTemplates.js');
 
@@ -45,7 +44,12 @@ function menu({
     hideContainerWhenNoResults = true
   }) {
   var containerNode = utils.getContainerNode(container);
-  var usage = 'Usage: menu({container, facetName, [sortBy, limit, cssClasses.{root,list,item}, templates.{header,item,footer}, transformData, hideWhenResults]})';
+  var usage = 'Usage: menu({container, facetName, [sortBy, limit, cssClasses.{root,list,item}, templates.{header,item,footer}, transformData, hideContainerWhenNoResults]})';
+
+  var RefinementList = headerFooter(require('../../components/RefinementList/RefinementList.js'));
+  if (hideContainerWhenNoResults === true) {
+    RefinementList = autoHideContainer(RefinementList);
+  }
 
   if (!container || !facetName) {
     throw new Error(usage);
@@ -64,6 +68,7 @@ function menu({
     }),
     render: function({results, helper, templatesConfig, state, createURL}) {
       var facetValues = getFacetValues(results, hierarchicalFacetName, sortBy, limit);
+      var hasNoRefinements = facetValues.length === 0;
 
       var templateProps = utils.prepareTemplateProps({
         transformData,
@@ -89,8 +94,7 @@ function menu({
           createURL={(facetValue) => createURL(state.toggleRefinement(hierarchicalFacetName, facetValue))}
           cssClasses={cssClasses}
           facetValues={facetValues}
-          hasResults={facetValues.length > 0}
-          hideContainerWhenNoResults={hideContainerWhenNoResults}
+          shouldAutoHideContainer={hasNoRefinements}
           templateProps={templateProps}
           toggleRefinement={toggleRefinement.bind(null, helper, hierarchicalFacetName)}
         />,

--- a/widgets/pagination/__tests__/pagination-test.js
+++ b/widgets/pagination/__tests__/pagination-test.js
@@ -91,8 +91,7 @@ describe('pagination()', () => {
     return {
       cssClasses: {},
       currentPage: 0,
-      hasResults: true,
-      hideContainerWhenNoResults: true,
+      shouldAutoHideContainer: false,
       labels: {first: '«', last: '»', next: '›', previous: '‹'},
       nbHits: results.nbHits,
       nbPages: results.nbPages,

--- a/widgets/pagination/pagination.js
+++ b/widgets/pagination/pagination.js
@@ -53,6 +53,11 @@ function pagination({
   var containerNode = utils.getContainerNode(container);
   var scrollToNode = scrollTo !== false ? utils.getContainerNode(scrollTo) : false;
 
+  var Pagination = require('../../components/Pagination/Pagination.js');
+  if (hideContainerWhenNoResults === true) {
+    Pagination = autoHideContainer(Pagination);
+  }
+
   if (!container) {
     throw new Error('Usage: pagination({container[, cssClasses.{root,item,page,previous,next,first,last,active,disabled}, labels.{previous,next,first,last}, maxPages, showFirstLast, hideContainerWhenNoResults]})');
   }
@@ -72,25 +77,23 @@ function pagination({
       var currentPage = results.page;
       var nbPages = results.nbPages;
       var nbHits = results.nbHits;
-      var hasResults = nbHits > 0;
+      var hasNoResults = nbHits === 0;
 
       if (maxPages !== undefined) {
         nbPages = Math.min(maxPages, results.nbPages);
       }
 
-      var Pagination = autoHideContainer(require('../../components/Pagination/Pagination.js'));
       ReactDOM.render(
         <Pagination
           createURL={(page) => createURL(state.setPage(page))}
           cssClasses={cssClasses}
           currentPage={currentPage}
-          hasResults={hasResults}
-          hideContainerWhenNoResults={hideContainerWhenNoResults}
           labels={labels}
           nbHits={nbHits}
           nbPages={nbPages}
           padding={padding}
           setCurrentPage={this.setCurrentPage.bind(this, helper)}
+          shouldAutoHideContainer={hasNoResults}
           showFirstLast={showFirstLast}
         />,
         containerNode

--- a/widgets/price-ranges/__tests__/price-ranges-test.js
+++ b/widgets/price-ranges/__tests__/price-ranges-test.js
@@ -36,6 +36,7 @@ describe('priceRanges()', () => {
     widget = priceRanges({container, facetName: 'aFacetname'});
     results = {
       hits: [1],
+      nbHits: 1,
       getFacetStats: sinon.stub().returns({
         min: 1.99,
         max: 4999.98,
@@ -73,8 +74,7 @@ describe('priceRanges()', () => {
           range: 'ais-price-ranges--range',
           root: 'ais-price-ranges'
         },
-        hasResults: true,
-        hideContainerWhenNoResults: true,
+        shouldAutoHideContainer: false,
         facetValues: generateRanges(results.getFacetStats()),
         labels: {
           currency: '$',

--- a/widgets/price-ranges/price-ranges.js
+++ b/widgets/price-ranges/price-ranges.js
@@ -48,7 +48,12 @@ function priceRanges({
     hideContainerWhenNoResults = true
   }) {
   var containerNode = utils.getContainerNode(container);
-  var usage = 'Usage: priceRanges({container, facetName, [cssClasses, templates, labels]})';
+  var usage = 'Usage: priceRanges({container, facetName, [cssClasses, templates, labels, hideContainerWhenNoResults]})';
+
+  var PriceRanges = headerFooter(require('../../components/PriceRanges'));
+  if (hideContainerWhenNoResults === true) {
+    PriceRanges = autoHideContainer(PriceRanges);
+  }
 
   if (container === null || facetName === null) {
     throw new Error(usage);
@@ -100,7 +105,7 @@ function priceRanges({
     },
 
     render: function({results, helper, templatesConfig, state, createURL}) {
-      var PriceRanges = autoHideContainer(headerFooter(require('../../components/PriceRanges')));
+      var hasNoResults = results.nbHits === 0;
       var facetValues;
 
       if (results.hits.length > 0) {
@@ -147,10 +152,9 @@ function priceRanges({
           }}
           cssClasses={cssClasses}
           facetValues={facetValues}
-          hasResults={results.hits.length > 0}
-          hideContainerWhenNoResults={hideContainerWhenNoResults}
           labels={labels}
           refine={this._refine.bind(this, helper)}
+          shouldAutoHideContainer={hasNoResults}
           templateProps={templateProps}
         />,
         containerNode

--- a/widgets/range-slider/__tests__/range-slider-test.js
+++ b/widgets/range-slider/__tests__/range-slider-test.js
@@ -64,10 +64,9 @@ describe('rangeSlider()', () => {
     expect(ReactDOM.render.firstCall.args[0]).toEqualJSX(
     <Slider
       cssClasses={{body: null, root: null}}
-      hasResults
-      hideContainerWhenNoResults
       onChange={() => {}}
       range={{max: 4999.98, min: 1.99}}
+      shouldAutoHideContainer={false}
       start={[-Infinity, Infinity]}
       templateProps={{
         templates: {footer: '', header: ''},

--- a/widgets/range-slider/range-slider.js
+++ b/widgets/range-slider/range-slider.js
@@ -41,6 +41,11 @@ function rangeSlider({
   }) {
   var containerNode = utils.getContainerNode(container);
 
+  var Slider = headerFooter(require('../../components/Slider/Slider'));
+  if (hideContainerWhenNoResults === true) {
+    Slider = autoHideContainer(Slider);
+  }
+
   return {
     getConfiguration: () => ({
       disjunctiveFacets: [facetName]
@@ -88,20 +93,20 @@ function rangeSlider({
         };
       }
 
+      var hasNoRefinements = stats.min === null && stats.max === null;
+
       var templateProps = utils.prepareTemplateProps({
         defaultTemplates,
         templatesConfig,
         templates
       });
 
-      var Slider = autoHideContainer(headerFooter(require('../../components/Slider/Slider')));
       ReactDOM.render(
         <Slider
           cssClasses={cssClasses}
-          hasResults={stats.min !== null && stats.max !== null}
-          hideContainerWhenNoResults={hideContainerWhenNoResults}
           onChange={this._refine.bind(this, helper, stats)}
           range={{min: stats.min, max: stats.max}}
+          shouldAutoHideContainer={hasNoRefinements}
           start={[currentRefinement.min, currentRefinement.max]}
           templateProps={templateProps}
           tooltips={tooltips}

--- a/widgets/refinement-list/refinement-list.js
+++ b/widgets/refinement-list/refinement-list.js
@@ -7,7 +7,6 @@ var cx = require('classnames/dedupe');
 
 var autoHideContainer = require('../../decorators/autoHideContainer');
 var headerFooter = require('../../decorators/headerFooter');
-var RefinementList = autoHideContainer(headerFooter(require('../../components/RefinementList/RefinementList.js')));
 
 var defaultTemplates = require('./defaultTemplates');
 
@@ -49,7 +48,12 @@ function refinementList({
     hideContainerWhenNoResults = true
   }) {
   var containerNode = utils.getContainerNode(container);
-  var usage = 'Usage: refinementList({container, facetName, [operator, sortBy, limit, cssClasses.{root,header,body,footer,list,item,active,label,checkbox,count}, templates.{header,item,footer}, transformData, hideIfNoResults]})';
+  var usage = 'Usage: refinementList({container, facetName, [operator, sortBy, limit, cssClasses.{root,header,body,footer,list,item,active,label,checkbox,count}, templates.{header,item,footer}, transformData, hideContainerWhenNoResults]})';
+
+  var RefinementList = headerFooter(require('../../components/RefinementList/RefinementList.js'));
+  if (hideContainerWhenNoResults === true) {
+    RefinementList = autoHideContainer(RefinementList);
+  }
 
   if (!container || !facetName) {
     throw new Error(usage);
@@ -86,6 +90,8 @@ function refinementList({
 
       var facetValues = results.getFacetValues(facetName, {sortBy: sortBy}).slice(0, limit);
 
+      var hasNoResults = facetValues.length === 0;
+
       cssClasses = {
         root: cx(bem(null), cssClasses.root),
         header: cx(bem('header'), cssClasses.header),
@@ -104,8 +110,7 @@ function refinementList({
           createURL={(facetValue) => createURL(state.toggleRefinement(facetName, facetValue))}
           cssClasses={cssClasses}
           facetValues={facetValues}
-          hasResults={facetValues.length > 0}
-          hideContainerWhenNoResults={hideContainerWhenNoResults}
+          shouldAutoHideContainer={hasNoResults}
           templateProps={templateProps}
           toggleRefinement={toggleRefinement.bind(null, helper, facetName)}
         />,

--- a/widgets/stats/__tests__/stats-test.js
+++ b/widgets/stats/__tests__/stats-test.js
@@ -61,14 +61,13 @@ describe('stats()', () => {
         root: 'ais-stats',
         time: 'ais-stats--time'
       }}
-      hasResults
-      hideContainerWhenNoResults
       hitsPerPage={2}
       nbHits={20}
       nbPages={10}
       page={0}
       processingTimeMS={42}
       query="a query"
+      shouldAutoHideContainer={false}
       templateProps={ReactDOM.render.firstCall.args[0].props.templateProps}
     />);
     expect(ReactDOM.render.firstCall.args[1]).toEqual(container);

--- a/widgets/stats/stats.js
+++ b/widgets/stats/stats.js
@@ -35,20 +35,24 @@ function stats({
   }) {
   var containerNode = utils.getContainerNode(container);
 
+  var Stats = headerFooter(require('../../components/Stats/Stats.js'));
+  if (hideContainerWhenNoResults === true) {
+    Stats = autoHideContainer(Stats);
+  }
+
   if (!containerNode) {
-    throw new Error('Usage: stats({container[, template, transformData]})');
+    throw new Error('Usage: stats({container[, template, transformData, hideContainerWhenNoResults]})');
   }
 
   return {
     render: function({results, templatesConfig}) {
+      var hasNoResults = results.nbHits === 0;
       var templateProps = utils.prepareTemplateProps({
         transformData,
         defaultTemplates,
         templatesConfig,
         templates
       });
-
-      var Stats = autoHideContainer(headerFooter(require('../../components/Stats/Stats.js')));
 
       cssClasses = {
         body: cx(bem('body'), cssClasses.body),
@@ -61,14 +65,13 @@ function stats({
       ReactDOM.render(
         <Stats
           cssClasses={cssClasses}
-          hasResults={results.hits.length > 0}
-          hideContainerWhenNoResults={hideContainerWhenNoResults}
           hitsPerPage={results.hitsPerPage}
           nbHits={results.nbHits}
           nbPages={results.nbPages}
           page={results.page}
           processingTimeMS={results.processingTimeMS}
           query={results.query}
+          shouldAutoHideContainer={hasNoResults}
           templateProps={templateProps}
         />,
         containerNode

--- a/widgets/toggle/__tests__/toggle-test.js
+++ b/widgets/toggle/__tests__/toggle-test.js
@@ -101,7 +101,6 @@ describe('toggle()', () => {
             checkbox: 'ais-toggle--checkbox',
             count: 'ais-toggle--count'
           },
-          hideContainerWhenNoResults: true,
           templateProps,
           toggleRefinement: function() {},
           createURL: () => '#'
@@ -111,6 +110,7 @@ describe('toggle()', () => {
       it('calls ReactDOM.render', () => {
         results = {
           hits: [{Hello: ', world!'}],
+          nbHits: 1,
           getFacetValues: sinon.stub().returns([{name: 'true', count: 2}, {name: 'false', count: 1}])
         };
         widget = toggle({container, facetName, label});
@@ -122,6 +122,7 @@ describe('toggle()', () => {
       it('with facet values', () => {
         results = {
           hits: [{Hello: ', world!'}],
+          nbHits: 1,
           getFacetValues: sinon.stub().returns([{name: 'true', count: 2}, {name: 'false', count: 1}])
         };
         widget = toggle({container, facetName, label});
@@ -129,7 +130,7 @@ describe('toggle()', () => {
 
         props = {
           facetValues: [{count: 1, isRefined: false, name: label}],
-          hasResults: true,
+          shouldAutoHideContainer: false,
           ...props
         };
 
@@ -139,6 +140,7 @@ describe('toggle()', () => {
       it('without facet values', () => {
         results = {
           hits: [],
+          nbHits: 0,
           getFacetValues: sinon.stub().returns([])
         };
         widget = toggle({container, facetName, label});
@@ -146,7 +148,7 @@ describe('toggle()', () => {
 
         props = {
           facetValues: [{name: label, isRefined: false, count: null}],
-          hasResults: false,
+          shouldAutoHideContainer: true,
           ...props
         };
 
@@ -159,6 +161,7 @@ describe('toggle()', () => {
         };
         results = {
           hits: [{Hello: ', world!'}],
+          nbHits: 1,
           getFacetValues: sinon.stub().returns([{name: 'true', count: 2}, {name: 'false', count: 1}])
         };
         widget = toggle({container, facetName, label});
@@ -166,7 +169,7 @@ describe('toggle()', () => {
 
         props = {
           facetValues: [{count: 2, isRefined: true, name: label}],
-          hasResults: true,
+          shouldAutoHideContainer: false,
           ...props
         };
 
@@ -176,6 +179,7 @@ describe('toggle()', () => {
       it('using props.toggleRefinement', () => {
         results = {
           hits: [{Hello: ', world!'}],
+          nbHits: 1,
           getFacetValues: sinon.stub().returns([{name: 'true', count: 2}, {name: 'false', count: 1}])
         };
         widget = toggle({container, facetName, label});

--- a/widgets/toggle/toggle.js
+++ b/widgets/toggle/toggle.js
@@ -46,9 +46,13 @@ function toggle({
     transformData,
     hideContainerWhenNoResults = true
   } = {}) {
-  var RefinementList = autoHideContainer(headerFooter(require('../../components/RefinementList/RefinementList.js')));
   var containerNode = utils.getContainerNode(container);
   var usage = 'Usage: toggle({container, facetName, label[, cssClasses.{root,header,body,footer,list,item,active,label,checkbox,count}, templates.{header,item,footer}, transformData, hideContainerWhenNoResults]})';
+
+  var RefinementList = headerFooter(require('../../components/RefinementList/RefinementList.js'));
+  if (hideContainerWhenNoResults === true) {
+    RefinementList = autoHideContainer(RefinementList);
+  }
 
   if (!container || !facetName || !label) {
     throw new Error(usage);
@@ -61,6 +65,7 @@ function toggle({
     render: function({helper, results, templatesConfig, state, createURL}) {
       var isRefined = helper.hasRefinements(facetName);
       var values = find(results.getFacetValues(facetName), {name: isRefined.toString()});
+      var hasNoResults = results.nbHits === 0;
 
       var templateProps = utils.prepareTemplateProps({
         transformData,
@@ -93,8 +98,7 @@ function toggle({
           createURL={() => createURL(state.toggleRefinement(facetName, facetValue.isRefined))}
           cssClasses={cssClasses}
           facetValues={[facetValue]}
-          hasResults={results.hits.length > 0}
-          hideContainerWhenNoResults={hideContainerWhenNoResults}
+          shouldAutoHideContainer={hasNoResults}
           templateProps={templateProps}
           toggleRefinement={toggleRefinement.bind(null, helper, facetName, facetValue.isRefined)}
         />,


### PR DESCRIPTION
Removed `hideContainerWhenNoResults` prop from the props passed to all components.

`autoHideContainer` now accepts only one prop: `shouldAutoHideContainer` instead of `hasResults`.

Closes #324