### PR TITLE
fix(live-doc): move scrollbars, removes useless ones #412

### DIFF
--- a/docs/css/_documentation.sass
+++ b/docs/css/_documentation.sass
@@ -3,6 +3,9 @@
 // Navigation
 
 .widget-nav
+  padding: 0
+  padding-left: 15px
+  font-weight: lighter
   background-color: $gray-light
 
 .documentation-menu
@@ -35,6 +38,10 @@
       list-style: none
 
 // Main Content
+
+// Left panel
+.widget-description
+  padding-right: 0
 
 .main-documentation
   height: 100%
@@ -72,8 +79,6 @@
 .documentation-content
   position: absolute
   top: 0
-  left: 15px
-  right: 15px
   bottom: 0
   padding: 30px
   overflow-y: scroll

--- a/docs/css/_documentation.sass
+++ b/docs/css/_documentation.sass
@@ -10,7 +10,7 @@
 
 .documentation-menu
   height: 100%
-  overflow-y: scroll
+  overflow-y: auto
   padding: 0
   font-size: 1.3em
   > ul


### PR DESCRIPTION
Move the scrollbars around, remove some useless scrollbars on the body. (also change the font-weight of the menu to make it lighter)