### PR TITLE
chore(documentation): add the rendered HTML code as well. Fix #402

### DIFF
--- a/docs/css/_documentation.sass
+++ b/docs/css/_documentation.sass
@@ -171,42 +171,18 @@
       color: $text-color
       font-weight: bold
 
-.toggle-html-button
-  margin-top: 1em
-  margin-right: 50%
-  max-width: 50%
-  margin-bottom: 0.5em
-  text-align: right
-  button
-    border-color: #ccc
-    &:focus
-      box-shadow: none
-      outline: 0
-
 .widget-icon
   margin: 4px 20px 20px 0
 
 .html-container
-  padding: 40px 24px 24px
-  border: solid 1px #E4E4E4
-  border-radius: 5px
-  position: relative
-  overflow-x: hidden
-  max-height: 500px
-  &:after
-    font-size: 11px
-    font-family: $font-family-sans-serif
-    content: "Generated html"
-    top: 0
-    left: 0
-    color: #999
-    padding: 4px 6px
-    line-height: 1em
-    position: absolute
-    background-color: $gray-light
-    border: solid 1px #E4E4E4
-    border-width: 0 1px 1px 0
-    border-radius: 5px 0 3px 0
+  border: none
+  color: #A3B6CB
+  padding: 9.5px
+  margin: 0 0 10px
+  background-color: #0A1724
+  word-wrap: normal
+  white-space: pre
+  overflow-x: scroll
 
 .widget-container
   padding: 50px 40px 40px


### PR DESCRIPTION
I managed to extract the HTML code from the actual widgets and make it look pretty nice (heavyweight regexps however):

![](http://g.recordit.co/MQMVOAvpMD.gif)