### PR TITLE
fix(jsdoc): use babel-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "./scripts/build.sh",
     "dev": "./scripts/dev.sh",
     "doctoc": "doctoc --maxlevel 3 README.md",
-    "jsdoc:widget": "node ./scripts/doc/gen-widget-doc.js",
+    "jsdoc:widget": "babel-node ./scripts/doc/gen-widget-doc.js",
     "gh-pages": "./scripts/gh-pages.sh",
     "lint": "eslint . --quiet --no-color && sass-lint --verbose",
     "release": "./scripts/release.sh",


### PR DESCRIPTION
Maybe the simplest is to use vanilla JS here :)

```
./scripts/doc/gen-widget-doc.js:3
let jsdoc2md = require('jsdoc-to-markdown');
^^^

SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:413:25)
    at Object.Module._extensions..js (module.js:452:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Function.Module.runMain (module.js:475:10)
    at startup (node.js:117:18)
    at node.js:951:3
``