### PR TITLE
fix(hitsPerPageSelector): Be more tolerant in options

### DIFF
--- a/widgets/hits-per-page-selector/__tests__/hits-per-page-selector-test.js
+++ b/widgets/hits-per-page-selector/__tests__/hits-per-page-selector-test.js
@@ -23,6 +23,7 @@ describe('hitsPerPageSelector()', () => {
   let helper;
   let results;
   let autoHideContainer;
+  let consoleLog;
 
   beforeEach(() => {
     autoHideContainer = sinon.stub().returns(Selector);
@@ -30,6 +31,7 @@ describe('hitsPerPageSelector()', () => {
 
     hitsPerPageSelector.__Rewire__('ReactDOM', ReactDOM);
     hitsPerPageSelector.__Rewire__('autoHideContainer', autoHideContainer);
+    consoleLog = sinon.spy(window.console, 'log');
 
     container = document.createElement('div');
     options = [
@@ -90,16 +92,16 @@ describe('hitsPerPageSelector()', () => {
   it('should throw if there is no name attribute in a passed object', () => {
     options.length = 0;
     options.push({label: 'Label without a value'});
-    expect(() => {
-      widget.init(helper.state, helper);
-    }).toThrow(/No option in `options` with `value: 20`/);
+    widget.init(helper.state, helper);
+    expect(consoleLog.calledOnce).toBe(true, 'console.log called once');
+    expect(consoleLog.firstCall.args[0]).toMatch(/No option in `options` with `value: hitsPerPage` \(hitsPerPage: 20\)/);
   });
 
   it('must include the current hitsPerPage at initialization time', () => {
     helper.state.hitsPerPage = -1;
-    expect(() => {
-      widget.init(helper.state, helper);
-    }).toThrow(/No option in `options` with `value: -1`/);
+    widget.init(helper.state, helper);
+    expect(consoleLog.calledOnce).toBe(true, 'console.log called once');
+    expect(consoleLog.firstCall.args[0]).toMatch(/No option in `options` with `value: hitsPerPage` \(hitsPerPage: -1\)/);
   });
 
   it('should not throw an error if state does not have a `hitsPerPage`', () => {
@@ -112,5 +114,6 @@ describe('hitsPerPageSelector()', () => {
   afterEach(() => {
     hitsPerPageSelector.__ResetDependency__('ReactDOM');
     hitsPerPageSelector.__ResetDependency__('autoHideContainer');
+    consoleLog.restore();
   });
 });

--- a/widgets/hits-per-page-selector/hits-per-page-selector.js
+++ b/widgets/hits-per-page-selector/hits-per-page-selector.js
@@ -41,14 +41,14 @@ function hitsPerPageSelector({
   return {
     init: function(state) {
       let isCurrentInOptions = reduce(options, function(res, option) {
-        if (state.hitsPerPage === undefined) {
-          return true;
-        }
         return res || +state.hitsPerPage === +option.value;
       }, false);
 
       if (!isCurrentInOptions) {
-        throw new Error('[hitsPerPageSelector]: No option in `options` with `value: ' + state.hitsPerPage + '`');
+        options = [{value: undefined, label: ''}].concat(options);
+        if (window.console) {
+          window.console.log('[Warning][hitsPerPageSelector] No option in `options` with `value: hitsPerPage` (hitsPerPage: ' + state.hitsPerPage + ')');
+        }
       }
     },
 


### PR DESCRIPTION
Removes the dependency on hitsPerPage.
Follow-up of #450.

Basically, the issue this solves is mostly linked to the fact that the user can have an impact on the `hitsPerPage` through the URL.
It can happen in two ways:
- Either the end-user modifies the `hPP` in the URL
- Or the developer changes the options and a user uses an old URL with `hPP` not available in the options.

@ElPicador Would this work for you?