### PR TITLE
fix(doc): ensure the documentation content doesn't overflow

### DIFF
--- a/docs/css/_documentation.sass
+++ b/docs/css/_documentation.sass
@@ -79,6 +79,8 @@
 .documentation-content
   position: absolute
   top: 0
+  left: 0
+  right: 0
   bottom: 0
   padding: 30px
   overflow-y: scroll

--- a/docs/js/doc.js
+++ b/docs/js/doc.js
@@ -84,7 +84,7 @@
         source += '  ';
       }
       source += line + '\n';
-      if (line.indexOf('<') === 0 && line.indexOf('</') !== 0) {
+      if (line.indexOf('<') === 0 && line.indexOf('</') !== 0 && line.indexOf('<input') === -1) {
         ++indent;
       }
     });


### PR DESCRIPTION
I had a hard time finding how to fix this one :skull: 

Fix #444

(includes a fix in the indentation of the HTML code as well)