### PR TITLE
fix(api): rename hideContainerWhenNoResults to autoHideContainer

### DIFF
--- a/docs/_includes/widget-jsdoc/hierarchicalMenu.md
+++ b/docs/_includes/widget-jsdoc/hierarchicalMenu.md
@@ -19,6 +19,6 @@
 |  <span class='attr-optional'>`options.templates.item`</span> | Item template |
 |  <span class='attr-optional'>`options.templates.footer`</span> | Footer template (root level only) |
 |  <span class='attr-optional'>`options.transformData`</span> | Method to change the object passed to the item template |
-|  <span class='attr-optional'>`hideContainerWhenNoResults`</span> | Hide the container when there's no results |
+|  <span class='attr-optional'>`options.autoHideContainer`</span> | Hide the container when there are no items in the menu |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/hitsPerPageSelector.md
+++ b/docs/_includes/widget-jsdoc/hitsPerPageSelector.md
@@ -7,6 +7,6 @@
 |  <span class='attr-optional'>`options.cssClasses`</span> | CSS classes to be added |
 |  <span class='attr-optional'>`options.cssClasses.root`</span> | CSS classes added to the parent <select> |
 |  <span class='attr-optional'>`options.cssClasses.item`</span> | CSS classes added to each <option> |
-|  <span class='attr-optional'>`hideContainerWhenNoResults`</span> | Hide the container when no results match |
+|  <span class='attr-optional'>`options.autoHideContainer`</span> | Hide the container when no results match |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/indexSelector.md
+++ b/docs/_includes/widget-jsdoc/indexSelector.md
@@ -7,6 +7,6 @@
 |  <span class='attr-optional'>`options.cssClasses`</span> | CSS classes to be added |
 |  <span class='attr-optional'>`options.cssClasses.root`</span> | CSS classes added to the parent <select> |
 |  <span class='attr-optional'>`options.cssClasses.item`</span> | CSS classes added to each <option> |
-|  <span class='attr-optional'>`hideContainerWhenNoResults`</span> | Hide the container when no results match |
+|  <span class='attr-optional'>`options.autoHideContainer`</span> | Hide the container when no results match |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/menu.md
+++ b/docs/_includes/widget-jsdoc/menu.md
@@ -19,6 +19,6 @@
 |  <span class='attr-optional'>`options.templates.item`</span> | Item template, provided with `name`, `count`, `isRefined` |
 |  <span class='attr-optional'>`options.templates.footer`</span> | Footer template |
 |  <span class='attr-optional'>`options.transformData`</span> | Method to change the object passed to the item template |
-|  <span class='attr-optional'>`hideContainerWhenNoResults`</span> | Hide the container when there's no results |
+|  <span class='attr-optional'>`options.autoHideContainer`</span> | Hide the container when there are no items in the menu |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/numericRefinementList.md
+++ b/docs/_includes/widget-jsdoc/numericRefinementList.md
@@ -17,6 +17,6 @@
 |  <span class='attr-optional'>`options.templates.item`</span> | Item template, provided with `name`, `count`, `isRefined` |
 |  <span class='attr-optional'>`options.templates.footer`</span> | Footer template |
 |  <span class='attr-optional'>`options.transformData`</span> | Function to change the object passed to the item template |
-|  <span class='attr-optional'>`hideContainerWhenNoResults`</span> | Hide the container when there's no results |
+|  <span class='attr-optional'>`options.autoHideContainer`</span> | Hide the container when no results match |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/pagination.md
+++ b/docs/_includes/widget-jsdoc/pagination.md
@@ -20,6 +20,6 @@
 |  <span class='attr-optional'>`options.padding`</span> | The number of pages to display on each side of the current page |
 |  <span class='attr-optional'>`options.scrollTo`</span> | Where to scroll after a click, set to `false` to disable |
 |  <span class='attr-optional'>`options.showFirstLast`</span> | Define if the First and Last links should be displayed |
-|  <span class='attr-optional'>`options.hideContainerWhenNoResults`</span> | Hide the container when no results match |
+|  <span class='attr-optional'>`options.autoHideContainer`</span> | Hide the container when no results match |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/priceRanges.md
+++ b/docs/_includes/widget-jsdoc/priceRanges.md
@@ -23,6 +23,6 @@
 |  <span class='attr-optional'>`options.labels.currency`</span> | Currency label |
 |  <span class='attr-optional'>`options.labels.separator`</span> | Separator labe, between min and max |
 |  <span class='attr-optional'>`options.labels.button`</span> | Button label |
-|  <span class='attr-optional'>`hideContainerWhenNoResults`</span> | Hide the container when no results match |
+|  <span class='attr-optional'>`options.autoHideContainer`</span> | Hide the container when no refinements available |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/rangeSlider.md
+++ b/docs/_includes/widget-jsdoc/rangeSlider.md
@@ -9,6 +9,6 @@
 |  <span class='attr-optional'>`options.cssClasses`</span> | CSS classes to add to the wrapping elements: root, body |
 |  <span class='attr-optional'>`options.cssClasses.root`</span> | CSS class to add to the root element |
 |  <span class='attr-optional'>`options.cssClasses.body`</span> | CSS class to add to the body element |
-|  <span class='attr-optional'>`hideContainerWhenNoResults`</span> | Hide the container when no results match |
+|  <span class='attr-optional'>`options.autoHideContainer`</span> | Hide the container when no refinements available |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/refinementList.md
+++ b/docs/_includes/widget-jsdoc/refinementList.md
@@ -21,6 +21,6 @@
 |  <span class='attr-optional'>`options.templates.item`</span> | Item template, provided with `name`, `count`, `isRefined` |
 |  <span class='attr-optional'>`options.templates.footer`</span> | Footer template |
 |  <span class='attr-optional'>`options.transformData`</span> | Function to change the object passed to the item template |
-|  <span class='attr-optional'>`hideContainerWhenNoResults`</span> | Hide the container when there's no results |
+|  <span class='attr-optional'>`options.autoHideContainer`</span> | Hide the container when no items in the refinement list |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/searchBox.md
+++ b/docs/_includes/widget-jsdoc/searchBox.md
@@ -9,6 +9,6 @@
 |  <span class='attr-optional'>`poweredBy`</span> | Show a powered by Algolia link below the input |
 |  <span class='attr-optional'>`wrapInput`</span> | Wrap the input in a div.ais-search-box |
 |  <span class='attr-optional'>`autofocus`</span> | autofocus on the input |
-|  <span class='attr-optional'>`searchOnEnterKeyPressOnly`</span> | If false, trigger the search once <Enter> is pressed only |
+|  <span class='attr-optional'>`searchOnEnterKeyPressOnly`</span> | If set, trigger the search once <Enter> is pressed only |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/stats.md
+++ b/docs/_includes/widget-jsdoc/stats.md
@@ -12,6 +12,6 @@
 |  <span class='attr-optional'>`options.templates.body`</span> | Body template |
 |  <span class='attr-optional'>`options.templates.footer`</span> | Footer template |
 |  <span class='attr-optional'>`options.transformData`</span> | Function to change the object passed to the `body` template |
-|  <span class='attr-optional'>`hideContainerWhenNoResults`</span> | Hide the container when there's no results |
+|  <span class='attr-optional'>`options.autoHideContainer`</span> | Hide the container when no results match |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/toggle.md
+++ b/docs/_includes/widget-jsdoc/toggle.md
@@ -19,6 +19,6 @@
 |  <span class='attr-optional'>`options.templates.item`</span> | Item template |
 |  <span class='attr-optional'>`options.templates.footer`</span> | Footer template |
 |  <span class='attr-optional'>`options.transformData`</span> | Function to change the object passed to the item template |
-|  <span class='attr-optional'>`hideContainerWhenNoResults`</span> | Hide the container when there's no results |
+|  <span class='attr-optional'>`options.autoHideContainer`</span> | Hide the container when there's no results |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/widgets/hierarchical-menu/hierarchical-menu.js
+++ b/widgets/hierarchical-menu/hierarchical-menu.js
@@ -4,8 +4,8 @@ let ReactDOM = require('react-dom');
 let utils = require('../../lib/utils.js');
 let bem = utils.bemHelper('ais-hierarchical-menu');
 let cx = require('classnames');
-let autoHideContainer = require('../../decorators/autoHideContainer');
-let headerFooter = require('../../decorators/headerFooter');
+let autoHideContainerHOC = require('../../decorators/autoHideContainer');
+let headerFooterHOC = require('../../decorators/headerFooter');
 
 let defaultTemplates = require('./defaultTemplates.js');
 
@@ -31,7 +31,7 @@ let defaultTemplates = require('./defaultTemplates.js');
  * @param  {string|Function} [options.templates.item] Item template
  * @param  {string|Function} [options.templates.footer=''] Footer template (root level only)
  * @param  {Function} [options.transformData] Method to change the object passed to the item template
- * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when there's no results
+ * @param  {boolean} [options.autoHideContainer=true] Hide the container when there are no items in the menu
  * @return {Object}
  */
 function hierarchicalMenu({
@@ -41,16 +41,16 @@ function hierarchicalMenu({
     limit = 100,
     sortBy = ['name:asc'],
     cssClasses: userCssClasses = {},
-    hideContainerWhenNoResults = true,
+    autoHideContainer = true,
     templates = defaultTemplates,
     transformData
   }) {
   let containerNode = utils.getContainerNode(container);
-  let usage = 'Usage: hierarchicalMenu({container, attributes, [separator, sortBy, limit, cssClasses.{root, list, item}, templates.{header, item, footer}, transformData, hideContainerWhenNoResults]})';
+  let usage = 'Usage: hierarchicalMenu({container, attributes, [separator, sortBy, limit, cssClasses.{root, list, item}, templates.{header, item, footer}, transformData, autoHideContainer]})';
 
-  let RefinementList = headerFooter(require('../../components/RefinementList/RefinementList.js'));
-  if (hideContainerWhenNoResults === true) {
-    RefinementList = autoHideContainer(RefinementList);
+  let RefinementList = headerFooterHOC(require('../../components/RefinementList/RefinementList.js'));
+  if (autoHideContainer === true) {
+    RefinementList = autoHideContainerHOC(RefinementList);
   }
 
   if (!container || !attributes || !attributes.length) {
@@ -72,7 +72,7 @@ function hierarchicalMenu({
     }),
     render: function({results, helper, templatesConfig, createURL, state}) {
       let facetValues = getFacetValues(results, hierarchicalFacetName, sortBy);
-      let hasNoRefinements = facetValues.length === 0;
+      let hasNoFacetValues = facetValues.length === 0;
 
       let templateProps = utils.prepareTemplateProps({
         transformData,
@@ -101,7 +101,7 @@ function hierarchicalMenu({
           facetNameKey="path"
           facetValues={facetValues}
           limit={limit}
-          shouldAutoHideContainer={hasNoRefinements}
+          shouldAutoHideContainer={hasNoFacetValues}
           templateProps={templateProps}
           toggleRefinement={toggleRefinement.bind(null, helper, hierarchicalFacetName)}
         />,

--- a/widgets/hits-per-page-selector/__tests__/hits-per-page-selector-test.js
+++ b/widgets/hits-per-page-selector/__tests__/hits-per-page-selector-test.js
@@ -30,7 +30,7 @@ describe('hitsPerPageSelector()', () => {
     ReactDOM = {render: sinon.spy()};
 
     hitsPerPageSelector.__Rewire__('ReactDOM', ReactDOM);
-    hitsPerPageSelector.__Rewire__('autoHideContainer', autoHideContainer);
+    hitsPerPageSelector.__Rewire__('autoHideContainerHOC', autoHideContainer);
     consoleLog = sinon.spy(window.console, 'log');
 
     container = document.createElement('div');
@@ -113,7 +113,7 @@ describe('hitsPerPageSelector()', () => {
 
   afterEach(() => {
     hitsPerPageSelector.__ResetDependency__('ReactDOM');
-    hitsPerPageSelector.__ResetDependency__('autoHideContainer');
+    hitsPerPageSelector.__ResetDependency__('autoHideContainerHOC');
     consoleLog.restore();
   });
 });

--- a/widgets/hits-per-page-selector/hits-per-page-selector.js
+++ b/widgets/hits-per-page-selector/hits-per-page-selector.js
@@ -5,7 +5,7 @@ let utils = require('../../lib/utils.js');
 let any = require('lodash/collection/any');
 let bem = utils.bemHelper('ais-hits-per-page-selector');
 let cx = require('classnames');
-let autoHideContainer = require('../../decorators/autoHideContainer');
+let autoHideContainerHOC = require('../../decorators/autoHideContainer');
 
 /**
  * Instantiate a dropdown element to choose the number of hits to display per page
@@ -16,7 +16,7 @@ let autoHideContainer = require('../../decorators/autoHideContainer');
  * @param  {Object} [options.cssClasses] CSS classes to be added
  * @param  {string} [options.cssClasses.root] CSS classes added to the parent <select>
  * @param  {string} [options.cssClasses.item] CSS classes added to each <option>
- * @param  {boolean} [hideContainerWhenNoResults=false] Hide the container when no results match
+ * @param  {boolean} [options.autoHideContainer=false] Hide the container when no results match
  * @return {Object}
  */
 
@@ -24,14 +24,14 @@ function hitsPerPageSelector({
     container,
     options,
     cssClasses: userCssClasses = {},
-    hideContainerWhenNoResults = false
+    autoHideContainer = false
   }) {
   let containerNode = utils.getContainerNode(container);
-  let usage = 'Usage: hitsPerPageSelector({container, options[, cssClasses.{root,item}, hideContainerWhenNoResults]})';
+  let usage = 'Usage: hitsPerPageSelector({container, options[, cssClasses.{root,item}, autoHideContainer]})';
 
   let Selector = require('../../components/Selector');
-  if (hideContainerWhenNoResults === true) {
-    Selector = autoHideContainer(Selector);
+  if (autoHideContainer === true) {
+    Selector = autoHideContainerHOC(Selector);
   }
 
   if (!container || !options) {

--- a/widgets/index-selector/__tests__/index-selector-test.js
+++ b/widgets/index-selector/__tests__/index-selector-test.js
@@ -29,7 +29,7 @@ describe('indexSelector()', () => {
     ReactDOM = {render: sinon.spy()};
 
     indexSelector.__Rewire__('ReactDOM', ReactDOM);
-    indexSelector.__Rewire__('autoHideContainer', autoHideContainer);
+    indexSelector.__Rewire__('autoHideContainerHOC', autoHideContainer);
 
     container = document.createElement('div');
     indices = [
@@ -102,6 +102,6 @@ describe('indexSelector()', () => {
 
   afterEach(() => {
     indexSelector.__ResetDependency__('ReactDOM');
-    indexSelector.__ResetDependency__('autoHideContainer');
+    indexSelector.__ResetDependency__('autoHideContainerHOC');
   });
 });

--- a/widgets/index-selector/index-selector.js
+++ b/widgets/index-selector/index-selector.js
@@ -6,7 +6,7 @@ let map = require('lodash/collection/map');
 let utils = require('../../lib/utils.js');
 let bem = utils.bemHelper('ais-index-selector');
 let cx = require('classnames');
-let autoHideContainer = require('../../decorators/autoHideContainer');
+let autoHideContainerHOC = require('../../decorators/autoHideContainer');
 
 /**
  * Instantiate a dropdown element to choose the current targeted index
@@ -17,21 +17,21 @@ let autoHideContainer = require('../../decorators/autoHideContainer');
  * @param  {Object} [options.cssClasses] CSS classes to be added
  * @param  {string} [options.cssClasses.root] CSS classes added to the parent <select>
  * @param  {string} [options.cssClasses.item] CSS classes added to each <option>
- * @param  {boolean} [hideContainerWhenNoResults=false] Hide the container when no results match
+ * @param  {boolean} [options.autoHideContainer=false] Hide the container when no results match
  * @return {Object}
  */
 function indexSelector({
     container,
     indices,
     cssClasses: userCssClasses = {},
-    hideContainerWhenNoResults = false
+    autoHideContainer = false
   }) {
   let containerNode = utils.getContainerNode(container);
-  let usage = 'Usage: indexSelector({container, indices[, cssClasses.{root,item}, hideContainerWhenNoResults]})';
+  let usage = 'Usage: indexSelector({container, indices[, cssClasses.{root,item}, autoHideContainer]})';
 
   let Selector = require('../../components/Selector');
-  if (hideContainerWhenNoResults === true) {
-    Selector = autoHideContainer(Selector);
+  if (autoHideContainer === true) {
+    Selector = autoHideContainerHOC(Selector);
   }
 
   if (!container || !indices) {

--- a/widgets/menu/menu.js
+++ b/widgets/menu/menu.js
@@ -4,8 +4,8 @@ let ReactDOM = require('react-dom');
 let utils = require('../../lib/utils.js');
 let bem = utils.bemHelper('ais-menu');
 let cx = require('classnames');
-let autoHideContainer = require('../../decorators/autoHideContainer');
-let headerFooter = require('../../decorators/headerFooter');
+let autoHideContainerHOC = require('../../decorators/autoHideContainer');
+let headerFooterHOC = require('../../decorators/headerFooter');
 
 let defaultTemplates = require('./defaultTemplates.js');
 
@@ -30,7 +30,7 @@ let defaultTemplates = require('./defaultTemplates.js');
  * @param  {string|Function} [options.templates.item] Item template, provided with `name`, `count`, `isRefined`
  * @param  {string|Function} [options.templates.footer=''] Footer template
  * @param  {Function} [options.transformData] Method to change the object passed to the item template
- * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when there's no results
+ * @param  {boolean} [options.autoHideContainer=true] Hide the container when there are no items in the menu
  * @return {Object}
  */
 function menu({
@@ -41,14 +41,14 @@ function menu({
     cssClasses: userCssClasses = {},
     templates = defaultTemplates,
     transformData,
-    hideContainerWhenNoResults = true
+    autoHideContainer = true
   }) {
   let containerNode = utils.getContainerNode(container);
-  let usage = 'Usage: menu({container, facetName, [sortBy, limit, cssClasses.{root,list,item}, templates.{header,item,footer}, transformData, hideContainerWhenNoResults]})';
+  let usage = 'Usage: menu({container, facetName, [sortBy, limit, cssClasses.{root,list,item}, templates.{header,item,footer}, transformData, autoHideContainer]})';
 
-  let RefinementList = headerFooter(require('../../components/RefinementList/RefinementList.js'));
-  if (hideContainerWhenNoResults === true) {
-    RefinementList = autoHideContainer(RefinementList);
+  let RefinementList = headerFooterHOC(require('../../components/RefinementList/RefinementList.js'));
+  if (autoHideContainer === true) {
+    RefinementList = autoHideContainerHOC(RefinementList);
   }
 
   if (!container || !facetName) {
@@ -68,7 +68,7 @@ function menu({
     }),
     render: function({results, helper, templatesConfig, state, createURL}) {
       let facetValues = getFacetValues(results, hierarchicalFacetName, sortBy, limit);
-      let hasNoRefinements = facetValues.length === 0;
+      let hasNoFacetValues = facetValues.length === 0;
 
       let templateProps = utils.prepareTemplateProps({
         transformData,
@@ -94,7 +94,7 @@ function menu({
           createURL={(facetValue) => createURL(state.toggleRefinement(hierarchicalFacetName, facetValue))}
           cssClasses={cssClasses}
           facetValues={facetValues}
-          shouldAutoHideContainer={hasNoRefinements}
+          shouldAutoHideContainer={hasNoFacetValues}
           templateProps={templateProps}
           toggleRefinement={toggleRefinement.bind(null, helper, hierarchicalFacetName)}
         />,

--- a/widgets/numeric-refinement-list/__tests__/numeric-refinement-list-test.js
+++ b/widgets/numeric-refinement-list/__tests__/numeric-refinement-list-test.js
@@ -21,6 +21,7 @@ describe('numericRefinementList()', () => {
   let RefinementList;
   let numericRefinementList;
   let options;
+  let results;
 
   beforeEach(() => {
     numericRefinementList = require('../numeric-refinement-list');
@@ -28,9 +29,9 @@ describe('numericRefinementList()', () => {
     ReactDOM = {render: sinon.spy()};
     numericRefinementList.__Rewire__('ReactDOM', ReactDOM);
     autoHideContainer = sinon.stub().returns(RefinementList);
-    numericRefinementList.__Rewire__('autoHideContainer', autoHideContainer);
+    numericRefinementList.__Rewire__('autoHideContainerHOC', autoHideContainer);
     headerFooter = sinon.stub().returns(RefinementList);
-    numericRefinementList.__Rewire__('headerFooter', headerFooter);
+    numericRefinementList.__Rewire__('headerFooterHOC', headerFooter);
 
     options = [
       {name: 'All'},
@@ -50,14 +51,17 @@ describe('numericRefinementList()', () => {
       search: sinon.spy(),
       setState: sinon.spy()
     };
+    results = {
+      hits: []
+    };
 
     helper.state.clearRefinements = sinon.stub().returns(helper.state);
     helper.state.addNumericRefinement = sinon.stub().returns(helper.state);
   });
 
   it('calls twice ReactDOM.render(<RefinementList props />, container)', () => {
-    widget.render({helper});
-    widget.render({helper});
+    widget.render({helper, results});
+    widget.render({helper, results});
 
     let props = {
       cssClasses: {
@@ -103,7 +107,7 @@ describe('numericRefinementList()', () => {
   });
 
   it('doesn\'t call the refinement functions if not refined', () => {
-    widget.render({helper});
+    widget.render({helper, results});
     expect(helper.state.clearRefinements.called).toBe(false, 'clearRefinements called one');
     expect(helper.state.addNumericRefinement.called).toBe(false, 'addNumericRefinement never called');
     expect(helper.search.called).toBe(false, 'search never called');
@@ -144,7 +148,7 @@ describe('numericRefinementList()', () => {
 
   afterEach(() => {
     numericRefinementList.__ResetDependency__('ReactDOM');
-    numericRefinementList.__ResetDependency__('autoHideContainer');
-    numericRefinementList.__ResetDependency__('headerFooter');
+    numericRefinementList.__ResetDependency__('autoHideContainerHOC');
+    numericRefinementList.__ResetDependency__('headerFooterHOC');
   });
 });

--- a/widgets/numeric-refinement-list/numeric-refinement-list.js
+++ b/widgets/numeric-refinement-list/numeric-refinement-list.js
@@ -5,8 +5,8 @@ let utils = require('../../lib/utils.js');
 let bem = utils.bemHelper('ais-refinement-list');
 let cx = require('classnames');
 
-let autoHideContainer = require('../../decorators/autoHideContainer');
-let headerFooter = require('../../decorators/headerFooter');
+let autoHideContainerHOC = require('../../decorators/autoHideContainer');
+let headerFooterHOC = require('../../decorators/headerFooter');
 
 let defaultTemplates = require('./defaultTemplates');
 
@@ -29,7 +29,7 @@ let defaultTemplates = require('./defaultTemplates');
  * @param  {string|Function} [options.templates.item] Item template, provided with `name`, `count`, `isRefined`
  * @param  {string|Function} [options.templates.footer] Footer template
  * @param  {Function} [options.transformData] Function to change the object passed to the item template
- * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when there's no results
+ * @param  {boolean} [options.autoHideContainer=true] Hide the container when no results match
  * @return {Object}
  */
 function numericRefinementList({
@@ -39,14 +39,14 @@ function numericRefinementList({
   cssClasses: userCssClasses = {},
   templates = defaultTemplates,
   transformData,
-  hideContainerWhenNoResults = true
+  autoHideContainer = true
   }) {
   let containerNode = utils.getContainerNode(container);
-  let usage = 'Usage: numericRefinementList({container, attributeName, options, [sortBy, limit, cssClasses.{root,header,body,footer,list,item,active,label,checkbox,count}, templates.{header,item,footer}, transformData, hideContainerWhenNoResults]})';
+  let usage = 'Usage: numericRefinementList({container, attributeName, options, [sortBy, limit, cssClasses.{root,header,body,footer,list,item,active,label,checkbox,count}, templates.{header,item,footer}, transformData, autoHideContainer]})';
 
-  let RefinementList = headerFooter(require('../../components/RefinementList/RefinementList.js'));
-  if (hideContainerWhenNoResults === true) {
-    RefinementList = autoHideContainer(RefinementList);
+  let RefinementList = headerFooterHOC(require('../../components/RefinementList/RefinementList.js'));
+  if (autoHideContainer === true) {
+    RefinementList = autoHideContainerHOC(RefinementList);
   }
 
   if (!container || !attributeName) {
@@ -58,7 +58,7 @@ function numericRefinementList({
       return {};
     },
 
-    render: function({helper, templatesConfig, state, createURL}) {
+    render: function({helper, results, templatesConfig, state, createURL}) {
       let templateProps = utils.prepareTemplateProps({
         transformData,
         defaultTemplates,
@@ -72,7 +72,7 @@ function numericRefinementList({
         return option;
       });
 
-      let hasNoResults = facetValues.length === 0;
+      let hasNoResults = results.nbHits === 0;
 
       let cssClasses = {
         root: cx(bem(null), userCssClasses.root),

--- a/widgets/pagination/__tests__/pagination-test.js
+++ b/widgets/pagination/__tests__/pagination-test.js
@@ -24,7 +24,7 @@ describe('pagination()', () => {
   beforeEach(() => {
     ReactDOM = {render: sinon.spy()};
     pagination.__Rewire__('ReactDOM', ReactDOM);
-    pagination.__Rewire__('autoHideContainer', sinon.stub().returns(Pagination));
+    pagination.__Rewire__('autoHideContainerHOC', sinon.stub().returns(Pagination));
 
     container = document.createElement('div');
     cssClasses = {
@@ -99,7 +99,7 @@ describe('pagination()', () => {
 
   afterEach(() => {
     pagination.__ResetDependency__('ReactDOM');
-    pagination.__ResetDependency__('autoHideContainer');
+    pagination.__ResetDependency__('autoHideContainerHOC');
   });
 
   function getProps() {

--- a/widgets/pagination/pagination.js
+++ b/widgets/pagination/pagination.js
@@ -6,7 +6,7 @@ let cx = require('classnames');
 let utils = require('../../lib/utils.js');
 let bem = utils.bemHelper('ais-pagination');
 
-let autoHideContainer = require('../../decorators/autoHideContainer');
+let autoHideContainerHOC = require('../../decorators/autoHideContainer');
 let defaultLabels = {
   previous: '‹',
   next: '›',
@@ -36,7 +36,7 @@ let defaultLabels = {
  * @param  {number} [options.padding=3] The number of pages to display on each side of the current page
  * @param  {string|DOMElement|boolean} [options.scrollTo='body'] Where to scroll after a click, set to `false` to disable
  * @param  {boolean} [options.showFirstLast=true] Define if the First and Last links should be displayed
- * @param  {boolean} [options.hideContainerWhenNoResults=true] Hide the container when no results match
+ * @param  {boolean} [options.autoHideContainer=true] Hide the container when no results match
  * @return {Object}
  */
 function pagination({
@@ -46,7 +46,7 @@ function pagination({
     maxPages = 20,
     padding = 3,
     showFirstLast = true,
-    hideContainerWhenNoResults = true,
+    autoHideContainer = true,
     scrollTo = 'body'
   }) {
   if (scrollTo === true) {
@@ -57,12 +57,12 @@ function pagination({
   let scrollToNode = scrollTo !== false ? utils.getContainerNode(scrollTo) : false;
 
   let Pagination = require('../../components/Pagination/Pagination.js');
-  if (hideContainerWhenNoResults === true) {
-    Pagination = autoHideContainer(Pagination);
+  if (autoHideContainer === true) {
+    Pagination = autoHideContainerHOC(Pagination);
   }
 
   if (!container) {
-    throw new Error('Usage: pagination({container[, cssClasses.{root,item,page,previous,next,first,last,active,disabled}, labels.{previous,next,first,last}, maxPages, showFirstLast, hideContainerWhenNoResults]})');
+    throw new Error('Usage: pagination({container[, cssClasses.{root,item,page,previous,next,first,last,active,disabled}, labels.{previous,next,first,last}, maxPages, showFirstLast, autoHideContainer]})');
   }
 
   labels = defaults(labels, defaultLabels);

--- a/widgets/price-ranges/__tests__/price-ranges-test.js
+++ b/widgets/price-ranges/__tests__/price-ranges-test.js
@@ -29,8 +29,8 @@ describe('priceRanges()', () => {
     headerFooter = sinon.stub().returns(PriceRanges);
 
     priceRanges.__Rewire__('ReactDOM', ReactDOM);
-    priceRanges.__Rewire__('autoHideContainer', autoHideContainer);
-    priceRanges.__Rewire__('headerFooter', headerFooter);
+    priceRanges.__Rewire__('autoHideContainerHOC', autoHideContainer);
+    priceRanges.__Rewire__('headerFooterHOC', headerFooter);
 
     container = document.createElement('div');
     widget = priceRanges({container, attributeName: 'aNumAttr'});
@@ -141,7 +141,7 @@ describe('priceRanges()', () => {
 
   afterEach(() => {
     priceRanges.__ResetDependency__('ReactDOM');
-    priceRanges.__ResetDependency__('autoHideContainer');
-    priceRanges.__ResetDependency__('headerFooter');
+    priceRanges.__ResetDependency__('autoHideContainerHOC');
+    priceRanges.__ResetDependency__('headerFooterHOC');
   });
 });

--- a/widgets/price-ranges/price-ranges.js
+++ b/widgets/price-ranges/price-ranges.js
@@ -6,8 +6,8 @@ let utils = require('../../lib/utils.js');
 let generateRanges = require('./generate-ranges.js');
 
 let defaultTemplates = require('./defaultTemplates');
-let autoHideContainer = require('../../decorators/autoHideContainer');
-let headerFooter = require('../../decorators/headerFooter');
+let autoHideContainerHOC = require('../../decorators/autoHideContainer');
+let headerFooterHOC = require('../../decorators/headerFooter');
 
 let bem = utils.bemHelper('ais-price-ranges');
 let cx = require('classnames');
@@ -37,7 +37,7 @@ let cx = require('classnames');
  * @param  {string|Function} [options.labels.currency] Currency label
  * @param  {string|Function} [options.labels.separator] Separator labe, between min and max
  * @param  {string|Function} [options.labels.button] Button label
- * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when no results match
+ * @param  {boolean} [options.autoHideContainer=true] Hide the container when no refinements available
  * @return {Object}
  */
 function priceRanges({
@@ -50,14 +50,14 @@ function priceRanges({
       button: 'Go',
       separator: 'to'
     },
-    hideContainerWhenNoResults = true
+    autoHideContainer = true
   }) {
   let containerNode = utils.getContainerNode(container);
-  let usage = 'Usage: priceRanges({container, attributeName, [cssClasses.{root,header,body,list,item,active,link,form,label,input,currency,separator,button,footer}, templates.{header,item,footer}, labels.{currency,separator,button}, hideContainerWhenNoResults]})';
+  let usage = 'Usage: priceRanges({container, attributeName, [cssClasses.{root,header,body,list,item,active,link,form,label,input,currency,separator,button,footer}, templates.{header,item,footer}, labels.{currency,separator,button}, autoHideContainer]})';
 
-  let PriceRanges = headerFooter(require('../../components/PriceRanges/PriceRanges'));
-  if (hideContainerWhenNoResults === true) {
-    PriceRanges = autoHideContainer(PriceRanges);
+  let PriceRanges = headerFooterHOC(require('../../components/PriceRanges/PriceRanges'));
+  if (autoHideContainer === true) {
+    PriceRanges = autoHideContainerHOC(PriceRanges);
   }
 
   if (!container || !attributeName) {
@@ -110,7 +110,6 @@ function priceRanges({
     },
 
     render: function({results, helper, templatesConfig, state, createURL}) {
-      let hasNoResults = results.nbHits === 0;
       let facetValues;
 
       if (results.hits.length > 0) {
@@ -128,6 +127,8 @@ function priceRanges({
         templatesConfig,
         templates
       });
+
+      let hasNoRefinements = facetValues.length === 0;
 
       let cssClasses = {
         root: cx(bem(null), userCssClasses.root),
@@ -164,7 +165,7 @@ function priceRanges({
           facetValues={facetValues}
           labels={labels}
           refine={this._refine.bind(this, helper)}
-          shouldAutoHideContainer={hasNoResults}
+          shouldAutoHideContainer={hasNoRefinements}
           templateProps={templateProps}
         />,
         containerNode

--- a/widgets/range-slider/__tests__/range-slider-test.js
+++ b/widgets/range-slider/__tests__/range-slider-test.js
@@ -28,9 +28,9 @@ describe('rangeSlider()', () => {
     ReactDOM = {render: sinon.spy()};
     rangeSlider.__Rewire__('ReactDOM', ReactDOM);
     autoHideContainer = sinon.stub().returns(Slider);
-    rangeSlider.__Rewire__('autoHideContainer', autoHideContainer);
+    rangeSlider.__Rewire__('autoHideContainerHOC', autoHideContainer);
     headerFooter = sinon.stub().returns(Slider);
-    rangeSlider.__Rewire__('headerFooter', headerFooter);
+    rangeSlider.__Rewire__('headerFooterHOC', headerFooter);
 
     container = document.createElement('div');
     widget = rangeSlider({container, attributeName: 'aNumAttr'});
@@ -124,7 +124,7 @@ describe('rangeSlider()', () => {
 
   afterEach(() => {
     rangeSlider.__ResetDependency__('ReactDOM');
-    rangeSlider.__ResetDependency__('autoHideContainer');
-    rangeSlider.__ResetDependency__('headerFooter');
+    rangeSlider.__ResetDependency__('autoHideContainerHOC');
+    rangeSlider.__ResetDependency__('headerFooterHOC');
   });
 });

--- a/widgets/range-slider/range-slider.js
+++ b/widgets/range-slider/range-slider.js
@@ -2,8 +2,8 @@ let React = require('react');
 let ReactDOM = require('react-dom');
 
 let utils = require('../../lib/utils.js');
-let autoHideContainer = require('../../decorators/autoHideContainer');
-let headerFooter = require('../../decorators/headerFooter');
+let autoHideContainerHOC = require('../../decorators/autoHideContainer');
+let headerFooterHOC = require('../../decorators/headerFooter');
 
 let defaultTemplates = {
   header: '',
@@ -25,7 +25,7 @@ let defaultTemplates = {
  * @param  {Object} [options.cssClasses] CSS classes to add to the wrapping elements: root, body
  * @param  {string|string[]} [options.cssClasses.root] CSS class to add to the root element
  * @param  {string|string[]} [options.cssClasses.body] CSS class to add to the body element
- * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when no results match
+ * @param  {boolean} [options.autoHideContainer=true] Hide the container when no refinements available
  * @return {Object}
  */
 function rangeSlider({
@@ -39,13 +39,13 @@ function rangeSlider({
     },
     step = 1,
     pips = true,
-    hideContainerWhenNoResults = true
+    autoHideContainer = true
   }) {
   let containerNode = utils.getContainerNode(container);
 
-  let Slider = headerFooter(require('../../components/Slider/Slider'));
-  if (hideContainerWhenNoResults === true) {
-    Slider = autoHideContainer(Slider);
+  let Slider = headerFooterHOC(require('../../components/Slider/Slider'));
+  if (autoHideContainer === true) {
+    Slider = autoHideContainerHOC(Slider);
   }
 
   return {

--- a/widgets/refinement-list/refinement-list.js
+++ b/widgets/refinement-list/refinement-list.js
@@ -5,8 +5,8 @@ let utils = require('../../lib/utils.js');
 let bem = utils.bemHelper('ais-refinement-list');
 let cx = require('classnames');
 
-let autoHideContainer = require('../../decorators/autoHideContainer');
-let headerFooter = require('../../decorators/headerFooter');
+let autoHideContainerHOC = require('../../decorators/autoHideContainer');
+let headerFooterHOC = require('../../decorators/headerFooter');
 
 let defaultTemplates = require('./defaultTemplates');
 
@@ -33,7 +33,7 @@ let defaultTemplates = require('./defaultTemplates');
  * @param  {string|Function} [options.templates.item] Item template, provided with `name`, `count`, `isRefined`
  * @param  {string|Function} [options.templates.footer] Footer template
  * @param  {Function} [options.transformData] Function to change the object passed to the item template
- * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when there's no results
+ * @param  {boolean} [options.autoHideContainer=true] Hide the container when no items in the refinement list
  * @return {Object}
  */
 function refinementList({
@@ -45,14 +45,14 @@ function refinementList({
     cssClasses: userCssClasses = {},
     templates = defaultTemplates,
     transformData,
-    hideContainerWhenNoResults = true
+    autoHideContainer = true
   }) {
   let containerNode = utils.getContainerNode(container);
-  let usage = 'Usage: refinementList({container, facetName, [operator, sortBy, limit, cssClasses.{root,header,body,footer,list,item,active,label,checkbox,count}, templates.{header,item,footer}, transformData, hideContainerWhenNoResults]})';
+  let usage = 'Usage: refinementList({container, facetName, [operator, sortBy, limit, cssClasses.{root,header,body,footer,list,item,active,label,checkbox,count}, templates.{header,item,footer}, transformData, autoHideContainer]})';
 
-  let RefinementList = headerFooter(require('../../components/RefinementList/RefinementList.js'));
-  if (hideContainerWhenNoResults === true) {
-    RefinementList = autoHideContainer(RefinementList);
+  let RefinementList = headerFooterHOC(require('../../components/RefinementList/RefinementList.js'));
+  if (autoHideContainer === true) {
+    RefinementList = autoHideContainerHOC(RefinementList);
   }
 
   if (!container || !facetName) {
@@ -90,7 +90,7 @@ function refinementList({
 
       let facetValues = results.getFacetValues(facetName, {sortBy: sortBy}).slice(0, limit);
 
-      let hasNoResults = facetValues.length === 0;
+      let hasNoFacetValues = facetValues.length === 0;
 
       let cssClasses = {
         root: cx(bem(null), userCssClasses.root),
@@ -110,7 +110,7 @@ function refinementList({
           createURL={(facetValue) => createURL(state.toggleRefinement(facetName, facetValue))}
           cssClasses={cssClasses}
           facetValues={facetValues}
-          shouldAutoHideContainer={hasNoResults}
+          shouldAutoHideContainer={hasNoFacetValues}
           templateProps={templateProps}
           toggleRefinement={toggleRefinement.bind(null, helper, facetName)}
         />,

--- a/widgets/stats/__tests__/stats-test.js
+++ b/widgets/stats/__tests__/stats-test.js
@@ -26,9 +26,9 @@ describe('stats()', () => {
     ReactDOM = {render: sinon.spy()};
     stats.__Rewire__('ReactDOM', ReactDOM);
     autoHideContainer = sinon.stub().returns(Stats);
-    stats.__Rewire__('autoHideContainer', autoHideContainer);
+    stats.__Rewire__('autoHideContainerHOC', autoHideContainer);
     headerFooter = sinon.stub().returns(Stats);
-    stats.__Rewire__('headerFooter', headerFooter);
+    stats.__Rewire__('headerFooterHOC', headerFooter);
 
     container = document.createElement('div');
     widget = stats({container});
@@ -78,7 +78,7 @@ describe('stats()', () => {
 
   afterEach(() => {
     stats.__ResetDependency__('ReactDOM');
-    stats.__ResetDependency__('autoHideContainer');
-    stats.__ResetDependency__('headerFooter');
+    stats.__ResetDependency__('autoHideContainerHOC');
+    stats.__ResetDependency__('headerFooterHOC');
   });
 });

--- a/widgets/stats/stats.js
+++ b/widgets/stats/stats.js
@@ -2,8 +2,8 @@ let React = require('react');
 let ReactDOM = require('react-dom');
 
 let utils = require('../../lib/utils.js');
-let autoHideContainer = require('../../decorators/autoHideContainer');
-let headerFooter = require('../../decorators/headerFooter');
+let autoHideContainerHOC = require('../../decorators/autoHideContainer');
+let headerFooterHOC = require('../../decorators/headerFooter');
 let bem = require('../../lib/utils').bemHelper('ais-stats');
 let cx = require('classnames');
 
@@ -23,25 +23,25 @@ let defaultTemplates = require('./defaultTemplates.js');
  * @param  {string|Function} [options.templates.body] Body template
  * @param  {string|Function} [options.templates.footer=''] Footer template
  * @param  {Function} [options.transformData] Function to change the object passed to the `body` template
- * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when there's no results
+ * @param  {boolean} [options.autoHideContainer=true] Hide the container when no results match
  * @return {Object}
  */
 function stats({
     container,
     cssClasses: userCssClasses = {},
-    hideContainerWhenNoResults = true,
+    autoHideContainer = true,
     templates = defaultTemplates,
     transformData
   }) {
   let containerNode = utils.getContainerNode(container);
 
-  let Stats = headerFooter(require('../../components/Stats/Stats.js'));
-  if (hideContainerWhenNoResults === true) {
-    Stats = autoHideContainer(Stats);
+  let Stats = headerFooterHOC(require('../../components/Stats/Stats.js'));
+  if (autoHideContainer === true) {
+    Stats = autoHideContainerHOC(Stats);
   }
 
   if (!containerNode) {
-    throw new Error('Usage: stats({container[, template, transformData, hideContainerWhenNoResults]})');
+    throw new Error('Usage: stats({container[, template, transformData, autoHideContainer]})');
   }
 
   return {

--- a/widgets/toggle/__tests__/toggle-test.js
+++ b/widgets/toggle/__tests__/toggle-test.js
@@ -49,8 +49,8 @@ describe('toggle()', () => {
       headerFooter = sinon.stub().returns(RefinementList);
 
       toggle.__Rewire__('ReactDOM', ReactDOM);
-      toggle.__Rewire__('autoHideContainer', autoHideContainer);
-      toggle.__Rewire__('headerFooter', headerFooter);
+      toggle.__Rewire__('autoHideContainerHOC', autoHideContainer);
+      toggle.__Rewire__('headerFooterHOC', headerFooter);
 
       container = document.createElement('div');
       label = 'Hello, ';
@@ -209,8 +209,8 @@ describe('toggle()', () => {
 
     afterEach(() => {
       toggle.__ResetDependency__('ReactDOM');
-      toggle.__ResetDependency__('autoHideContainer');
-      toggle.__ResetDependency__('headerFooter');
+      toggle.__ResetDependency__('autoHideContainerHOC');
+      toggle.__ResetDependency__('headerFooterHOC');
     });
   });
 });

--- a/widgets/toggle/toggle.js
+++ b/widgets/toggle/toggle.js
@@ -6,8 +6,8 @@ let utils = require('../../lib/utils.js');
 let bem = utils.bemHelper('ais-toggle');
 let cx = require('classnames');
 
-let autoHideContainer = require('../../decorators/autoHideContainer');
-let headerFooter = require('../../decorators/headerFooter');
+let autoHideContainerHOC = require('../../decorators/autoHideContainer');
+let headerFooterHOC = require('../../decorators/headerFooter');
 
 let defaultTemplates = require('./defaultTemplates');
 
@@ -34,7 +34,7 @@ let defaultTemplates = require('./defaultTemplates');
  * @param  {string|Function} [options.templates.item] Item template
  * @param  {string|Function} [options.templates.footer=''] Footer template
  * @param  {Function} [options.transformData] Function to change the object passed to the item template
- * @param  {boolean} [hideContainerWhenNoResults=true] Hide the container when there's no results
+ * @param  {boolean} [options.autoHideContainer=true] Hide the container when there's no results
  * @return {Object}
  */
 function toggle({
@@ -44,14 +44,14 @@ function toggle({
     templates = defaultTemplates,
     cssClasses: userCssClasses = {},
     transformData,
-    hideContainerWhenNoResults = true
+    autoHideContainer = true
   } = {}) {
   let containerNode = utils.getContainerNode(container);
-  let usage = 'Usage: toggle({container, facetName, label[, cssClasses.{root,header,body,footer,list,item,active,label,checkbox,count}, templates.{header,item,footer}, transformData, hideContainerWhenNoResults]})';
+  let usage = 'Usage: toggle({container, facetName, label[, cssClasses.{root,header,body,footer,list,item,active,label,checkbox,count}, templates.{header,item,footer}, transformData, autoHideContainer]})';
 
-  let RefinementList = headerFooter(require('../../components/RefinementList/RefinementList.js'));
-  if (hideContainerWhenNoResults === true) {
-    RefinementList = autoHideContainer(RefinementList);
+  let RefinementList = headerFooterHOC(require('../../components/RefinementList/RefinementList.js'));
+  if (autoHideContainer === true) {
+    RefinementList = autoHideContainerHOC(RefinementList);
   }
 
   if (!container || !facetName || !label) {


### PR DESCRIPTION
Mostly copy pasting

+ updated jsdoc
+ updated some widgets algorithm to hide/show (numeric widgets)
+ had to rename the decorators require to $decoratorHOC (High Order
Component, the pattern we use).

fixes #407

BREAKING CHANGE: use autoHideContainer instead of
hideContainerWhenNoResults