### PR TITLE
Fixes various update problems in numerics widgets

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5,8 +5,8 @@
   "node-version": "v4.1.1",
   "dependencies": {
     "algoliasearch": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-3.9.0.tgz",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-3.9.1.tgz",
       "dependencies": {
         "agentkeepalive": {
           "version": "2.0.3",
@@ -89,8 +89,8 @@
       }
     },
     "algoliasearch-helper": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-2.6.5.tgz",
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-2.6.6.tgz",
       "dependencies": {
         "lodash-compat": {
           "version": "3.10.1",
@@ -10796,8 +10796,8 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.14.1.tgz"
     },
     "react-nouislider": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/react-nouislider/-/react-nouislider-1.5.1.tgz",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/react-nouislider/-/react-nouislider-1.5.2.tgz",
       "dependencies": {
         "nouislider-algolia-fork": {
           "version": "8.1.1",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "lodash": "^3.10.1",
     "react": "^0.14.0",
     "react-dom": "^0.14.0",
-    "react-nouislider": "^1.5.1",
+    "react-nouislider": "^1.5.2",
     "to-factory": "^1.0.0"
   },
   "license": "MIT"

--- a/widgets/price-ranges/price-ranges.js
+++ b/widgets/price-ranges/price-ranges.js
@@ -152,10 +152,10 @@ function priceRanges({
             let newState = state.clearRefinements(attributeName);
             if (!isRefined) {
               if (typeof from !== 'undefined') {
-                newState = newState.addNumericRefinement(attributeName, '>', from - 1);
+                newState = newState.addNumericRefinement(attributeName, '>=', Math.floor(from));
               }
               if (typeof to !== 'undefined') {
-                newState = newState.addNumericRefinement(attributeName, '<', to + 1);
+                newState = newState.addNumericRefinement(attributeName, '<=', Math.ceil(to));
               }
             }
             return createURL(newState);

--- a/widgets/price-ranges/price-ranges.js
+++ b/widgets/price-ranges/price-ranges.js
@@ -85,9 +85,9 @@ function priceRanges({
 
       refinements.forEach(v => {
         if (v.operator.indexOf('>') !== -1) {
-          from = v.value[0] + 1;
+          from = Math.floor(v.value[0]);
         } else if (v.operator.indexOf('<') !== -1) {
-          to = v.value[0] - 1;
+          to = Math.ceil(v.value[0]);
         }
       });
       return [{from, to, isRefined: true}];
@@ -99,10 +99,10 @@ function priceRanges({
       helper.clearRefinements(attributeName);
       if (facetValues.length === 0 || facetValues[0].from !== from || facetValues[0].to !== to) {
         if (typeof from !== 'undefined') {
-          helper.addNumericRefinement(attributeName, '>', from - 1);
+          helper.addNumericRefinement(attributeName, '>=', Math.floor(from));
         }
         if (typeof to !== 'undefined') {
-          helper.addNumericRefinement(attributeName, '<', to + 1);
+          helper.addNumericRefinement(attributeName, '<=', Math.ceil(to));
         }
       }
 

--- a/widgets/range-slider/range-slider.js
+++ b/widgets/range-slider/range-slider.js
@@ -83,9 +83,16 @@ function rangeSlider({
       }
       helper.search();
     },
+    getDisjunctiveFacetPosition(results, facetName) {
+      let facets = results.disjunctiveFacets;
+      for (let i = 0; facets.length; i++) {
+        if (facets[i].name === facetName) return i;
+      }
+      return -1;
+    },
     render({results, helper, templatesConfig}) {
-      let stats = results.getFacetStats(attributeName);
-
+      let facetPosition = this.getDisjunctiveFacetPosition(results, attributeName);
+      let stats = results.disjunctiveFacets[facetPosition].stats;
       let currentRefinement = this._getCurrentRefinement(helper);
 
       if (stats === undefined) {

--- a/widgets/range-slider/range-slider.js
+++ b/widgets/range-slider/range-slider.js
@@ -76,23 +76,18 @@ function rangeSlider({
     _refine(helper, stats, newValues) {
       helper.clearRefinements(attributeName);
       if (newValues[0] > stats.min) {
-        helper.addNumericRefinement(attributeName, '>=', newValues[0]);
+        helper.addNumericRefinement(attributeName, '>=', Math.round(newValues[0]));
       }
       if (newValues[1] < stats.max) {
-        helper.addNumericRefinement(attributeName, '<=', newValues[1]);
+        helper.addNumericRefinement(attributeName, '<=', Math.round(newValues[1]));
       }
       helper.search();
     },
-    getDisjunctiveFacetPosition(results, facetName) {
-      let facets = results.disjunctiveFacets;
-      for (let i = 0; facets.length; i++) {
-        if (facets[i].name === facetName) return i;
-      }
-      return -1;
-    },
     render({results, helper, templatesConfig}) {
-      let facetPosition = this.getDisjunctiveFacetPosition(results, attributeName);
-      let stats = results.disjunctiveFacets[facetPosition].stats;
+      let facet = results.disjunctiveFacets.find(
+        function(f) { return f.name === attributeName; }
+      );
+      let stats = facet.stats;
       let currentRefinement = this._getCurrentRefinement(helper);
 
       if (stats === undefined) {


### PR DESCRIPTION
Previously : 
![original-numerics](https://cloud.githubusercontent.com/assets/393765/10976949/42aeb1a4-83a3-11e5-80b2-ff4c71bbd7d9.gif)

Now : 
![fix-numerics](https://cloud.githubusercontent.com/assets/393765/10976957/4757634a-83a3-11e5-8843-b04496a650ea.gif)

FAQ : 

I can still see the outer bounds changing when you click on the first prices ranges ?

This is because the first widgets is based on different attribute. So even though, the slider uses a disjunctive facet, the outer bounds will be modified.