### PR TITLE
feat(toggle): Allow custom on/off values

### DIFF
--- a/docs/_includes/widget-jsdoc/toggle.md
+++ b/docs/_includes/widget-jsdoc/toggle.md
@@ -3,6 +3,9 @@
 |  <span class='attr-required'>`options.container`</span> | CSS Selector or DOMElement to insert the widget |
 |  <span class='attr-required'>`options.facetName`</span> | Name of the attribute for faceting (eg. "free_shipping") |
 |  <span class='attr-required'>`options.label`</span> | Human-readable name of the filter (eg. "Free Shipping") |
+|  <span class='attr-optional'>`options.values`</span> | Lets you define the values to filter on when toggling |
+|  <span class='attr-optional'>`options.values.on`</span> | Value to filter on when checked |
+|  <span class='attr-optional'>`options.values.off`</span> | Value to filter on when unchecked |
 |  <span class='attr-optional'>`options.cssClasses`</span> | CSS classes to add |
 |  <span class='attr-optional'>`options.cssClasses.root`</span> | CSS class to add to the root element |
 |  <span class='attr-optional'>`options.cssClasses.header`</span> | CSS class to add to the header element |

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -589,6 +589,10 @@ search.addWidget(
     container: '#free-shipping',
     facetName: 'free_shipping',
     label: 'Free Shipping',
+    values: {
+      on: true,
+      off: false
+    },
     templates: {
       header: 'Shipping'
     },


### PR DESCRIPTION
Fixes #409

Adds the `values` option to the `toggle` widget. Defaults to `{on:
true, off: undefined}`.

- It does not break previous API, new default value is
  retro-compatible
- If `off` set to `undefined`, it will simply remove all filtering on
  this facet when unchecking
- If `off` set to anything else, it will allow toggling between `on`
  and `off` value when checking/unchecking the checkbox
- If an `off` value is set and the results are not currently filtered
  on the `on` value at startup, then we add filtering on `off`. This
  helps in not creating an undefined state on first load.

To test if a refinement was currently set on a specific value, I had
to use `helper.state.isFacetRefined`, I did not found any method
directly on the helper. Maybe I missed something.