### PR TITLE
fix(middle-click): Allow middle click on links

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -50,7 +50,8 @@ function isDomElement(o) {
 }
 
 function isSpecialClick(event) {
-  return event.altKey || event.ctrlKey || event.metaKey || event.shiftKey;
+  let isMiddleClick = (event.button === 1);
+  return isMiddleClick || event.altKey || event.ctrlKey || event.metaKey || event.shiftKey;
 }
 
 /**


### PR DESCRIPTION
We let middle clicks go through

`Array.protoype.find` does not have a large enough support. Let's use
lodash instead.

(Requires https://github.com/algolia/instantsearch.js/pull/480 being merged first)