### PR TITLE
chore(getRefinements): Returns a list of refinements

### DIFF
--- a/lib/__tests__/utils-test.js
+++ b/lib/__tests__/utils-test.js
@@ -1,7 +1,9 @@
 /* eslint-env mocha */
 
+import deepEqual from 'deep-equal';
 import expect from 'expect';
 import jsdom from 'mocha-jsdom';
+import algoliasearchHelper from 'algoliasearch-helper';
 import utils from '../utils';
 
 describe('getContainerNode', () => {
@@ -123,4 +125,319 @@ describe('prepareTemplateProps', function() {
       expect(defaultsPrepared.templatesConfig).toBe(templatesConfig);
     }
   );
+});
+
+describe('getRefinements', function() {
+  let helper;
+  let results;
+
+  beforeEach(function() {
+    helper = algoliasearchHelper({}, 'my_index', {
+      facets: ['facet1', 'facet2', 'numericFacet1'],
+      disjunctiveFacets: ['disjunctiveFacet1', 'disjunctiveFacet2', 'numericDisjunctiveFacet'],
+      hierarchicalFacets: [{
+        name: 'hierarchicalFacet1',
+        attributes: ['hierarchicalFacet1.lvl0', 'hierarchicalFacet1.lvl1'],
+        separator: '>'
+      }, {
+        name: 'hierarchicalFacet2',
+        attributes: ['hierarchicalFacet2.lvl0', 'hierarchicalFacet2.lvl1'],
+        separator: '>'
+      }]
+    });
+    results = {};
+  });
+
+  it('should retrieve one tag', function() {
+    helper.addTag('tag1');
+    const expected = [
+      {attributeName: '_tags', name: 'tag1'}
+    ];
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[0], deepEqual);
+  });
+
+  it('should retrieve multiple tags', function() {
+    helper.addTag('tag1').addTag('tag2');
+    const expected = [
+      {attributeName: '_tags', name: 'tag1'},
+      {attributeName: '_tags', name: 'tag2'}
+    ];
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[0], deepEqual);
+  });
+
+  it('should retrieve one facetRefinement', function() {
+    helper.toggleRefinement('facet1', 'facet1val1');
+    const expected = [
+      {attributeName: 'facet1', name: 'facet1val1'}
+    ];
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[0], deepEqual);
+  });
+
+  it('should retrieve multiple facetsRefinements on one facet', function() {
+    helper
+      .toggleRefinement('facet1', 'facet1val1')
+      .toggleRefinement('facet1', 'facet1val2');
+    const expected = [
+      {attributeName: 'facet1', name: 'facet1val1'},
+      {attributeName: 'facet1', name: 'facet1val2'}
+    ];
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[0], deepEqual);
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[1], deepEqual);
+  });
+
+  it('should retrieve multiple facetsRefinements on multiple facets', function() {
+    helper
+      .toggleRefinement('facet1', 'facet1val1')
+      .toggleRefinement('facet1', 'facet1val2')
+      .toggleRefinement('facet2', 'facet2val1');
+    const expected = [
+      {attributeName: 'facet1', name: 'facet1val1'},
+      {attributeName: 'facet1', name: 'facet1val2'},
+      {attributeName: 'facet2', name: 'facet2val1'}
+    ];
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[0], deepEqual);
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[1], deepEqual);
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[2], deepEqual);
+  });
+
+  it('should have a count for a facetRefinement if available', function() {
+    helper.toggleRefinement('facet1', 'facet1val1');
+    results = {
+      facets: [{
+        name: 'facet1',
+        data: {
+          facet1val1: 4
+        }
+      }]
+    };
+    const expected = [
+      {attributeName: 'facet1', name: 'facet1val1', count: 4}
+    ];
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[0], deepEqual);
+  });
+
+  it('should have exhaustive for a facetRefinement if available', function() {
+    helper.toggleRefinement('facet1', 'facet1val1');
+    results = {
+      facets: [{
+        name: 'facet1',
+        exhaustive: true
+      }]
+    };
+    const expected = [
+      {attributeName: 'facet1', name: 'facet1val1', exhaustive: true}
+    ];
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[0], deepEqual);
+  });
+
+  it('should retrieve one facetExclude', function() {
+    helper.toggleExclude('facet1', 'facet1exclude1');
+    const expected = [
+      {attributeName: 'facet1', name: 'facet1exclude1', exclude: true}
+    ];
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[0], deepEqual);
+  });
+
+  it('should retrieve multiple facetsExcludes on one facet', function() {
+    helper
+      .toggleExclude('facet1', 'facet1exclude1')
+      .toggleExclude('facet1', 'facet1exclude2');
+    const expected = [
+      {attributeName: 'facet1', name: 'facet1exclude1', exclude: true},
+      {attributeName: 'facet1', name: 'facet1exclude2', exclude: true}
+    ];
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[0], deepEqual);
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[1], deepEqual);
+  });
+
+  it('should retrieve multiple facetsExcludes on multiple facets', function() {
+    helper
+      .toggleExclude('facet1', 'facet1exclude1')
+      .toggleExclude('facet1', 'facet1exclude2')
+      .toggleExclude('facet2', 'facet2exclude1');
+    const expected = [
+      {attributeName: 'facet1', name: 'facet1exclude1', exclude: true},
+      {attributeName: 'facet1', name: 'facet1exclude2', exclude: true},
+      {attributeName: 'facet2', name: 'facet2exclude1', exclude: true}
+    ];
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[0], deepEqual);
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[1], deepEqual);
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[2], deepEqual);
+  });
+
+  it('should retrieve one disjunctiveFacetRefinement', function() {
+    helper.addDisjunctiveFacetRefinement('disjunctiveFacet1', 'disjunctiveFacet1val1');
+    const expected = [
+      {attributeName: 'disjunctiveFacet1', name: 'disjunctiveFacet1val1'}
+    ];
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[0], deepEqual);
+  });
+
+  it('should retrieve multiple disjunctiveFacetsRefinements on one facet', function() {
+    helper
+      .addDisjunctiveFacetRefinement('disjunctiveFacet1', 'disjunctiveFacet1val1')
+      .addDisjunctiveFacetRefinement('disjunctiveFacet1', 'disjunctiveFacet1val2');
+    const expected = [
+      {attributeName: 'disjunctiveFacet1', name: 'disjunctiveFacet1val1'},
+      {attributeName: 'disjunctiveFacet1', name: 'disjunctiveFacet1val2'}
+    ];
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[0], deepEqual);
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[1], deepEqual);
+  });
+
+  it('should retrieve multiple disjunctiveFacetsRefinements on multiple facets', function() {
+    helper
+      .toggleRefinement('disjunctiveFacet1', 'disjunctiveFacet1val1')
+      .toggleRefinement('disjunctiveFacet1', 'disjunctiveFacet1val2')
+      .toggleRefinement('disjunctiveFacet2', 'disjunctiveFacet2val1');
+    const expected = [
+      {attributeName: 'disjunctiveFacet1', name: 'disjunctiveFacet1val1'},
+      {attributeName: 'disjunctiveFacet1', name: 'disjunctiveFacet1val2'},
+      {attributeName: 'disjunctiveFacet2', name: 'disjunctiveFacet2val1'}
+    ];
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[0], deepEqual);
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[1], deepEqual);
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[2], deepEqual);
+  });
+
+  it('should have a count for a disjunctiveFacetRefinement if available', function() {
+    helper.toggleRefinement('disjunctiveFacet1', 'disjunctiveFacet1val1');
+    results = {
+      disjunctiveFacets: [{
+        name: 'disjunctiveFacet1',
+        data: {
+          disjunctiveFacet1val1: 4
+        }
+      }]
+    };
+    const expected = [
+      {attributeName: 'disjunctiveFacet1', name: 'disjunctiveFacet1val1', count: 4}
+    ];
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[0], deepEqual);
+  });
+
+  it('should have exhaustive for a disjunctiveFacetRefinement if available', function() {
+    helper.toggleRefinement('disjunctiveFacet1', 'disjunctiveFacet1val1');
+    results = {
+      disjunctiveFacets: [{
+        name: 'disjunctiveFacet1',
+        exhaustive: true
+      }]
+    };
+    const expected = [
+      {attributeName: 'disjunctiveFacet1', name: 'disjunctiveFacet1val1', exhaustive: true}
+    ];
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[0], deepEqual);
+  });
+
+  it('should retrieve one hierarchicalFacetRefinement', function() {
+    helper.toggleRefinement('hierarchicalFacet1', 'hierarchicalFacet1lvl0val1');
+    const expected = [
+      {attributeName: 'hierarchicalFacet1', name: 'hierarchicalFacet1lvl0val1'}
+    ];
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[0], deepEqual);
+  });
+
+  it('should retrieve hierarchicalFacetsRefinements on multiple facets', function() {
+    helper
+      .toggleRefinement('hierarchicalFacet1', 'hierarchicalFacet1lvl0val1')
+      .toggleRefinement('hierarchicalFacet2', 'hierarchicalFacet2lvl0val1');
+    const expected = [
+      {attributeName: 'hierarchicalFacet1', name: 'hierarchicalFacet1lvl0val1'},
+      {attributeName: 'hierarchicalFacet2', name: 'hierarchicalFacet2lvl0val1'}
+    ];
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[0], deepEqual);
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[1], deepEqual);
+  });
+
+  it('should retrieve hierarchicalFacetsRefinements on multiple facets and multiple levels', function() {
+    helper
+      .toggleRefinement('hierarchicalFacet1', 'hierarchicalFacet1lvl0val1')
+      .toggleRefinement('hierarchicalFacet2', 'hierarchicalFacet2lvl0val1 > lvl1val1');
+    const expected = [
+      {attributeName: 'hierarchicalFacet1', name: 'hierarchicalFacet1lvl0val1'},
+      {attributeName: 'hierarchicalFacet2', name: 'hierarchicalFacet2lvl0val1 > lvl1val1'}
+    ];
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[0], deepEqual);
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[1], deepEqual);
+  });
+
+  it('should have a count for a hierarchicalFacetRefinement if available', function() {
+    helper.toggleRefinement('hierarchicalFacet1', 'hierarchicalFacet1val1');
+    results = {
+      hierarchicalFacets: [{
+        name: 'hierarchicalFacet1',
+        data: {
+          hierarchicalFacet1val1: 4
+        }
+      }]
+    };
+    const expected = [
+      {attributeName: 'hierarchicalFacet1', name: 'hierarchicalFacet1val1', count: 4}
+    ];
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[0], deepEqual);
+  });
+
+  it('should have exhaustive for a hierarchicalFacetRefinement if available', function() {
+    helper.toggleRefinement('hierarchicalFacet1', 'hierarchicalFacet1val1');
+    results = {
+      hierarchicalFacets: [{
+        name: 'hierarchicalFacet1',
+        exhaustive: true
+      }]
+    };
+    const expected = [
+      {attributeName: 'hierarchicalFacet1', name: 'hierarchicalFacet1val1', exhaustive: true}
+    ];
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[0], deepEqual);
+  });
+
+  it('should retrieve a numericRefinement on one facet', function() {
+    helper.addNumericRefinement('numericFacet1', '>', '1');
+    const expected = [
+      {attributeName: 'numericFacet1', operator: '>', name: '1'}
+    ];
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[0], deepEqual);
+  });
+
+  it('should retrieve a numericRefinement on one disjunctive facet', function() {
+    helper.addNumericRefinement('numericDisjunctiveFacet1', '>', '1');
+    const expected = [
+      {attributeName: 'numericDisjunctiveFacet1', operator: '>', name: '1'}
+    ];
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[0], deepEqual);
+  });
+
+  it('should retrieve multiple numericRefinements with same operator', function() {
+    helper
+      .addNumericRefinement('numericFacet1', '>', '1')
+      .addNumericRefinement('numericFacet1', '>', '2');
+    const expected = [
+      {attributeName: 'numericFacet1', operator: '>', name: '1'},
+      {attributeName: 'numericFacet1', operator: '>', name: '2'}
+    ];
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[0], deepEqual);
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[1], deepEqual);
+  });
+
+  it('should retrieve multiple conjunctive and numericRefinements', function() {
+    helper
+      .addNumericRefinement('numericFacet1', '>', '1')
+      .addNumericRefinement('numericFacet1', '>', '2')
+      .addNumericRefinement('numericFacet1', '<=', '3')
+      .addNumericRefinement('numericDisjunctiveFacet1', '>', '1')
+      .addNumericRefinement('numericDisjunctiveFacet1', '>', '2');
+    const expected = [
+      {attributeName: 'numericFacet1', operator: '>', name: '1'},
+      {attributeName: 'numericFacet1', operator: '>', name: '2'},
+      {attributeName: 'numericFacet1', operator: '<=', name: '3'},
+      {attributeName: 'numericDisjunctiveFacet1', operator: '>', name: '1'},
+      {attributeName: 'numericDisjunctiveFacet1', operator: '>', name: '2'}
+    ];
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[0], deepEqual);
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[1], deepEqual);
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[2], deepEqual);
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[3], deepEqual);
+    expect(utils.getRefinements(results, helper.state)).toInclude(expected[4], deepEqual);
+  });
 });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,7 @@
 let reduce = require('lodash/collection/reduce');
 let forEach = require('lodash/collection/forEach');
+let find = require('lodash/collection/find');
+let get = require('lodash/object/get');
 
 let utils = {
   getContainerNode,
@@ -120,12 +122,28 @@ function prepareTemplates(defaultTemplates, templates) {
   }, {templates: {}, useCustomCompileOptions: {}});
 }
 
-function getRefinements(state) {
+function getRefinement(attributeName, name, resultsFacets) {
+  let res = {attributeName, name};
+  let facet = find(resultsFacets, (_facet) => { return _facet.name === attributeName; });
+  if (facet !== undefined) {
+    const count = get(facet, 'data.' + name);
+    const exhaustive = get(facet, 'exhaustive');
+    if (count !== undefined) {
+      res.count = count;
+    }
+    if (exhaustive !== undefined) {
+      res.exhaustive = exhaustive;
+    }
+  }
+  return res;
+}
+
+function getRefinements(results, state) {
   let res = [];
 
   forEach(state.facetsRefinements, (refinements, attributeName) => {
     forEach(refinements, (name) => {
-      res.push({attributeName, name});
+      res.push(getRefinement(attributeName, name, results.facets));
     });
   });
 
@@ -137,13 +155,13 @@ function getRefinements(state) {
 
   forEach(state.disjunctiveFacetsRefinements, (refinements, attributeName) => {
     forEach(refinements, (name) => {
-      res.push({attributeName, name});
+      res.push(getRefinement(attributeName, name, results.disjunctiveFacets));
     });
   });
 
   forEach(state.hierarchicalFacetsRefinements, (refinements, attributeName) => {
     forEach(refinements, (name) => {
-      res.push({attributeName, name});
+      res.push(getRefinement(attributeName, name, results.hierarchicalFacets));
     });
   });
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,11 +1,13 @@
 let reduce = require('lodash/collection/reduce');
+let forEach = require('lodash/collection/forEach');
 
 let utils = {
   getContainerNode,
   bemHelper,
   prepareTemplateProps,
   isSpecialClick,
-  isDomElement
+  isDomElement,
+  getRefinements
 };
 
 /**
@@ -116,6 +118,48 @@ function prepareTemplates(defaultTemplates, templates) {
     }
     return config;
   }, {templates: {}, useCustomCompileOptions: {}});
+}
+
+function getRefinements(state) {
+  let res = [];
+
+  forEach(state.facetsRefinements, (refinements, attributeName) => {
+    forEach(refinements, (name) => {
+      res.push({attributeName, name});
+    });
+  });
+
+  forEach(state.facetsExcludes, (refinements, attributeName) => {
+    forEach(refinements, (name) => {
+      res.push({attributeName, name, exclude: true});
+    });
+  });
+
+  forEach(state.disjunctiveFacetsRefinements, (refinements, attributeName) => {
+    forEach(refinements, (name) => {
+      res.push({attributeName, name});
+    });
+  });
+
+  forEach(state.hierarchicalFacetsRefinements, (refinements, attributeName) => {
+    forEach(refinements, (name) => {
+      res.push({attributeName, name});
+    });
+  });
+
+  forEach(state.numericRefinements, (operators, attributeName) => {
+    forEach(operators, (values, operator) => {
+      forEach(values, (name) => {
+        res.push({attributeName, name, operator});
+      });
+    });
+  });
+
+  forEach(state.tagRefinements, (name) => {
+    res.push({attributeName: '_tags', name});
+  });
+
+  return res;
 }
 
 module.exports = utils;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2004,6 +2004,10 @@
         }
       }
     },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
+    },
     "dmd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/dmd/-/dmd-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "babel-plugin-rewire": "^0.1.22",
     "clean-css": "^3.4.6",
     "conventional-changelog": "^0.5.1",
+    "deep-equal": "^1.0.1",
     "dmd": "^1.2.0",
     "doctoc": "^0.15.0",
     "eslint": "^1.7.3",


### PR DESCRIPTION
Used temporarily before https://github.com/algolia/algoliasearch-helper-js/issues/195 is resolved.

The rationale of why I did it in `lib/utils` instead of the helper is that the helper's `getRefinements` is not sending back tags right now and throws errors on `state.get{Conjunctive,Disjunctive,Numeric}Refinements(facetName)` when `facetName` is `undefined` and I didn't want to mess it up.

Will be used for #404 and #405 .