### PR TITLE
fix(range-slider): Use lodash find instead of Array.prototype.find

### DIFF
--- a/widgets/range-slider/range-slider.js
+++ b/widgets/range-slider/range-slider.js
@@ -2,6 +2,7 @@ let React = require('react');
 let ReactDOM = require('react-dom');
 
 let utils = require('../../lib/utils.js');
+let find = require('lodash/collection/find');
 let autoHideContainerHOC = require('../../decorators/autoHideContainer');
 let headerFooterHOC = require('../../decorators/headerFooter');
 
@@ -84,9 +85,7 @@ function rangeSlider({
       helper.search();
     },
     render({results, helper, templatesConfig}) {
-      let facet = results.disjunctiveFacets.find(
-        function(f) { return f.name === attributeName; }
-      );
+      let facet = find(results.disjunctiveFacets, {name: attributeName});
       let stats = facet.stats;
       let currentRefinement = this._getCurrentRefinement(helper);
 


### PR DESCRIPTION
My browser (Chromium Version 44.0.2403.89 Ubuntu 15.04 (64-bit)) does not have Array.prototype.find.

Tests in the console are passing, but everytime I launch the demo I have errors. I'll see to find a way to have eslint preventing us from using Array.prototype.find