### PR TITLE
documentation(workflow): add npm run dev:docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,16 +3,16 @@ Instantsearch.js website
 
 # Development
 
+You need [ruby](https://www.ruby-lang.org/en/), [bundler](http://bundler.io/).
+
 ```sh
-$ bundle install
-$ bundle exec guard # watch & live-reload
-$ open http://localhost:4000/instantsearch.js/
+npm run dev:docs
 ```
 
 # MacOS
 
 If you are using `brew` and you had `brew install openssl`, you may need to configure the build path of eventmachine with
 
-```
+```sh
 bundle config build.eventmachine --with-cppflags=-I$(brew --prefix openssl)/include
 ```

--- a/docs/_layouts/documentation.html
+++ b/docs/_layouts/documentation.html
@@ -27,14 +27,6 @@ layout: default
 
 {% if site.env == 'development' %}
   <script src="http://localhost:8080/instantsearch.js"></script>
-  <script type="text/javascript">
-    if (!window.instantsearch) {
-      // if the latest/dev version wasn't loaded, use JSDelivr
-      // latest version is required while creating doc of new (non-published) widgets
-      window.console && window.console.log('Dev version of instantsearch.js not found, using published version instead.')
-      document.write('\x3Cscript src="https://cdn.jsdelivr.net/instantsearch.js/0/instantsearch.js">\x3C/script>');
-    }
-  </script>
 {% else %}
   <script src="https://cdn.jsdelivr.net/instantsearch.js/0/instantsearch.js"></script>
 {% endif %}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "./scripts/build.sh",
     "dev": "./scripts/dev.sh",
+    "dev:docs": "./scripts/dev-docs.sh",
     "doctoc": "doctoc --maxlevel 3 README.md",
     "jsdoc:widget": "babel-node ./scripts/doc/gen-widget-doc.js",
     "gh-pages": "./scripts/gh-pages.sh",

--- a/scripts/dev-docs.sh
+++ b/scripts/dev-docs.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -ev # exit when error
+
+npm run dev &
+cd docs && bundle install && bundle exec guard


### PR DESCRIPTION
Added an `npm run dev:docs` task to avoid doing weird hacks to handle both devs running `npm run dev` + `docs/guard`.

Now you just do `npm run dev:docs` when you want to dev on docs.

We might want at some point to have the docs instantsearch watch build running on another port.