### PR TITLE
fix(InstantSearch): throw error when init and render are not defined.…

### DIFF
--- a/lib/InstantSearch.js
+++ b/lib/InstantSearch.js
@@ -51,6 +51,10 @@ Usage: instantsearch({
 
   addWidget(widgetDefinition) {
     // Add the widget to the list of widget
+    if (widgetDefinition.render === undefined && widgetDefinition.init === undefined) {
+      throw new Error('Widget definition missing render or init method');
+    }
+
     this.widgets.push(widgetDefinition);
   }
 

--- a/lib/__tests__/InstantSearch-test.js
+++ b/lib/__tests__/InstantSearch-test.js
@@ -68,6 +68,20 @@ describe('InstantSearch lifecycle', () => {
     expect(algoliasearchHelper.notCalled).toBe(true, 'algoliasearchHelper not yet called');
   });
 
+  context('when adding a widget without render and init', () => {
+    let widget;
+
+    beforeEach(() => {
+      widget = {};
+    });
+
+    it('throw an error', function() {
+      expect(() => {
+        search.addWidget(widget);
+      }).toThrow('Widget definition missing render or init method');
+    });
+  });
+
   context('when adding a widget', () => {
     let widget;
 
@@ -148,6 +162,7 @@ describe('InstantSearch lifecycle', () => {
       widgets = range(5);
       widgets = widgets.map((widget, widgetIndex) => {
         widget = {
+          init: function() {},
           getConfiguration: sinon.stub().returns({values: [widgetIndex]})
         };
 


### PR DESCRIPTION
… Fixes #499 

```
let myImaginaryWidgetThatDoesntExist = {};
search.addWidget(myImaginaryWidgetThatDoesntExist);
```

was possible, now it will throw an error