### PR TITLE
fix(theme): Revert default spacing into pagination

### DIFF
--- a/css/default/_pagination.scss
+++ b/css/default/_pagination.scss
@@ -4,6 +4,8 @@
 @include block(pagination) {
   @include element(item) {
     /* pagination item */
+    display: inline-block;
+    padding: 3px;
     @include modifier(disabled) {
       /* disabled pagination item */
       visibility: hidden;


### PR DESCRIPTION
This have been reverted in a bad merge, I'm re-adding it.