### PR TITLE
doc(jsdoc): Wrap HTML code examples in `quotes`

### DIFF
--- a/docs/_includes/widget-jsdoc/hitsPerPageSelector.md
+++ b/docs/_includes/widget-jsdoc/hitsPerPageSelector.md
@@ -5,8 +5,8 @@
 |  <span class='attr-required'>`options.options[0].value`</span> | number of hits to display per page |
 |  <span class='attr-required'>`options.options[0].label`</span> | Label to display in the option |
 |  <span class='attr-optional'>`options.cssClasses`</span> | CSS classes to be added |
-|  <span class='attr-optional'>`options.cssClasses.root`</span> | CSS classes added to the parent <select> |
-|  <span class='attr-optional'>`options.cssClasses.item`</span> | CSS classes added to each <option> |
+|  <span class='attr-optional'>`options.cssClasses.root`</span> | CSS classes added to the parent `<select>` |
+|  <span class='attr-optional'>`options.cssClasses.item`</span> | CSS classes added to each `<option>` |
 |  <span class='attr-optional'>`options.autoHideContainer`</span> | Hide the container when no results match |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/pagination.md
+++ b/docs/_includes/widget-jsdoc/pagination.md
@@ -2,16 +2,16 @@
 | --- | --- |
 |  <span class='attr-required'>`options.container`</span> | CSS Selector or DOMElement to insert the widget |
 |  <span class='attr-optional'>`options.cssClasses`</span> | CSS classes to be added |
-|  <span class='attr-optional'>`options.cssClasses.root`</span> | CSS classes added to the parent <ul> |
-|  <span class='attr-optional'>`options.cssClasses.item`</span> | CSS classes added to each <li> |
+|  <span class='attr-optional'>`options.cssClasses.root`</span> | CSS classes added to the parent `<ul>` |
+|  <span class='attr-optional'>`options.cssClasses.item`</span> | CSS classes added to each `<li>` |
 |  <span class='attr-optional'>`options.cssClasses.link`</span> | CSS classes added to each link |
-|  <span class='attr-optional'>`options.cssClasses.page`</span> | CSS classes added to page <li> |
-|  <span class='attr-optional'>`options.cssClasses.previous`</span> | CSS classes added to the previous <li> |
-|  <span class='attr-optional'>`options.cssClasses.next`</span> | CSS classes added to the next <li> |
-|  <span class='attr-optional'>`options.cssClasses.first`</span> | CSS classes added to the first <li> |
-|  <span class='attr-optional'>`options.cssClasses.last`</span> | CSS classes added to the last <li> |
-|  <span class='attr-optional'>`options.cssClasses.active`</span> | CSS classes added to the active <li> |
-|  <span class='attr-optional'>`options.cssClasses.disabled`</span> | CSS classes added to the disabled <li> |
+|  <span class='attr-optional'>`options.cssClasses.page`</span> | CSS classes added to page `<li>` |
+|  <span class='attr-optional'>`options.cssClasses.previous`</span> | CSS classes added to the previous `<li>` |
+|  <span class='attr-optional'>`options.cssClasses.next`</span> | CSS classes added to the next `<li>` |
+|  <span class='attr-optional'>`options.cssClasses.first`</span> | CSS classes added to the first `<li>` |
+|  <span class='attr-optional'>`options.cssClasses.last`</span> | CSS classes added to the last `<li>` |
+|  <span class='attr-optional'>`options.cssClasses.active`</span> | CSS classes added to the active `<li>` |
+|  <span class='attr-optional'>`options.cssClasses.disabled`</span> | CSS classes added to the disabled `<li>` |
 |  <span class='attr-optional'>`options.labels`</span> | Text to display in the various links (prev, next, first, last) |
 |  <span class='attr-optional'>`options.labels.previous`</span> | Label for the Previous link |
 |  <span class='attr-optional'>`options.labels.next`</span> | Label for the Next link |

--- a/docs/_includes/widget-jsdoc/priceRanges.md
+++ b/docs/_includes/widget-jsdoc/priceRanges.md
@@ -21,7 +21,7 @@
 |  <span class='attr-optional'>`options.templates.item`</span> | Item template |
 |  <span class='attr-optional'>`options.labels`</span> | Labels to use for the widget |
 |  <span class='attr-optional'>`options.labels.currency`</span> | Currency label |
-|  <span class='attr-optional'>`options.labels.separator`</span> | Separator labe, between min and max |
+|  <span class='attr-optional'>`options.labels.separator`</span> | Separator label, between min and max |
 |  <span class='attr-optional'>`options.labels.button`</span> | Button label |
 |  <span class='attr-optional'>`options.autoHideContainer`</span> | Hide the container when no refinements available |
 

--- a/docs/_includes/widget-jsdoc/rangeSlider.md
+++ b/docs/_includes/widget-jsdoc/rangeSlider.md
@@ -2,7 +2,7 @@
 | --- | --- |
 |  <span class='attr-required'>`options.container`</span> | CSS Selector or DOMElement to insert the widget |
 |  <span class='attr-required'>`options.attributeName`</span> | Name of the attribute for faceting |
-|  <span class='attr-optional'>`options.tooltips`</span> | Should we show tooltips or not. The default tooltip will show the formatted corresponding value without any other token. You can also provide tooltips: {format: function(formattedValue, rawValue) {return '$' + formattedValue}} So that you can format the tooltip display value as you want |
+|  <span class='attr-optional'>`options.tooltips`</span> | Should we show tooltips or not. The default tooltip will show the formatted corresponding value without any other token. You can also provide `tooltips: {format: function(formattedValue, rawValue) {return '$' + formattedValue}}` So that you can format the tooltip display value as you want |
 |  <span class='attr-optional'>`options.templates`</span> | Templates to use for the widget |
 |  <span class='attr-optional'>`options.templates.header`</span> | Header template |
 |  <span class='attr-optional'>`options.templates.footer`</span> | Footer template |

--- a/docs/_includes/widget-jsdoc/searchBox.md
+++ b/docs/_includes/widget-jsdoc/searchBox.md
@@ -3,12 +3,12 @@
 |  <span class='attr-required'>`options.container`</span> | CSS Selector or DOMElement to insert the widget |
 |  <span class='attr-optional'>`options.placeholder`</span> | Input's placeholder |
 |  <span class='attr-optional'>`options.cssClasses`</span> | CSS classes to add |
-|  <span class='attr-optional'>`options.cssClasses.root`</span> | CSS class to add to the wrapping div (if wrapInput set to `true`) |
+|  <span class='attr-optional'>`options.cssClasses.root`</span> | CSS class to add to the wrapping div (if `wrapInput` set to `true`) |
 |  <span class='attr-optional'>`options.cssClasses.input`</span> | CSS class to add to the input |
 |  <span class='attr-optional'>`options.cssClasses.poweredBy`</span> | CSS class to add to the poweredBy element |
 |  <span class='attr-optional'>`poweredBy`</span> | Show a powered by Algolia link below the input |
-|  <span class='attr-optional'>`wrapInput`</span> | Wrap the input in a div.ais-search-box |
+|  <span class='attr-optional'>`wrapInput`</span> | Wrap the input in a `div.ais-search-box` |
 |  <span class='attr-optional'>`autofocus`</span> | autofocus on the input |
-|  <span class='attr-optional'>`searchOnEnterKeyPressOnly`</span> | If set, trigger the search once <Enter> is pressed only |
+|  <span class='attr-optional'>`searchOnEnterKeyPressOnly`</span> | If set, trigger the search once `<Enter>` is pressed only |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/widgets/hits-per-page-selector/hits-per-page-selector.js
+++ b/widgets/hits-per-page-selector/hits-per-page-selector.js
@@ -14,8 +14,8 @@ let autoHideContainerHOC = require('../../decorators/autoHideContainer');
  * @param  {number} options.options[0].value number of hits to display per page
  * @param  {string} options.options[0].label Label to display in the option
  * @param  {Object} [options.cssClasses] CSS classes to be added
- * @param  {string} [options.cssClasses.root] CSS classes added to the parent <select>
- * @param  {string} [options.cssClasses.item] CSS classes added to each <option>
+ * @param  {string} [options.cssClasses.root] CSS classes added to the parent `<select>`
+ * @param  {string} [options.cssClasses.item] CSS classes added to each `<option>`
  * @param  {boolean} [options.autoHideContainer=false] Hide the container when no results match
  * @return {Object}
  */

--- a/widgets/pagination/pagination.js
+++ b/widgets/pagination/pagination.js
@@ -18,16 +18,16 @@ let defaultLabels = {
  * Add a pagination menu to navigate through the results
  * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
  * @param  {Object} [options.cssClasses] CSS classes to be added
- * @param  {string} [options.cssClasses.root] CSS classes added to the parent <ul>
- * @param  {string} [options.cssClasses.item] CSS classes added to each <li>
+ * @param  {string} [options.cssClasses.root] CSS classes added to the parent `<ul>`
+ * @param  {string} [options.cssClasses.item] CSS classes added to each `<li>`
  * @param  {string} [options.cssClasses.link] CSS classes added to each link
- * @param  {string} [options.cssClasses.page] CSS classes added to page <li>
- * @param  {string} [options.cssClasses.previous] CSS classes added to the previous <li>
- * @param  {string} [options.cssClasses.next] CSS classes added to the next <li>
- * @param  {string} [options.cssClasses.first] CSS classes added to the first <li>
- * @param  {string} [options.cssClasses.last] CSS classes added to the last <li>
- * @param  {string} [options.cssClasses.active] CSS classes added to the active <li>
- * @param  {string} [options.cssClasses.disabled] CSS classes added to the disabled <li>
+ * @param  {string} [options.cssClasses.page] CSS classes added to page `<li>`
+ * @param  {string} [options.cssClasses.previous] CSS classes added to the previous `<li>`
+ * @param  {string} [options.cssClasses.next] CSS classes added to the next `<li>`
+ * @param  {string} [options.cssClasses.first] CSS classes added to the first `<li>`
+ * @param  {string} [options.cssClasses.last] CSS classes added to the last `<li>`
+ * @param  {string} [options.cssClasses.active] CSS classes added to the active `<li>`
+ * @param  {string} [options.cssClasses.disabled] CSS classes added to the disabled `<li>`
  * @param  {Object} [options.labels] Text to display in the various links (prev, next, first, last)
  * @param  {string} [options.labels.previous] Label for the Previous link
  * @param  {string} [options.labels.next] Label for the Next link

--- a/widgets/price-ranges/price-ranges.js
+++ b/widgets/price-ranges/price-ranges.js
@@ -35,7 +35,7 @@ let cx = require('classnames');
  * @param  {string|Function} [options.templates.item] Item template
  * @param  {Object} [options.labels] Labels to use for the widget
  * @param  {string|Function} [options.labels.currency] Currency label
- * @param  {string|Function} [options.labels.separator] Separator labe, between min and max
+ * @param  {string|Function} [options.labels.separator] Separator label, between min and max
  * @param  {string|Function} [options.labels.button] Button label
  * @param  {boolean} [options.autoHideContainer=true] Hide the container when no refinements available
  * @return {Object}

--- a/widgets/range-slider/range-slider.js
+++ b/widgets/range-slider/range-slider.js
@@ -18,7 +18,7 @@ let defaultTemplates = {
  * @param  {boolean|Object} [options.tooltips=true] Should we show tooltips or not.
  * The default tooltip will show the formatted corresponding value without any other token.
  * You can also provide
- * tooltips: {format: function(formattedValue, rawValue) {return '$' + formattedValue}}
+ * `tooltips: {format: function(formattedValue, rawValue) {return '$' + formattedValue}}`
  * So that you can format the tooltip display value as you want
  * @param  {Object} [options.templates] Templates to use for the widget
  * @param  {string|Function} [options.templates.header=''] Header template

--- a/widgets/search-box/search-box.js
+++ b/widgets/search-box/search-box.js
@@ -13,13 +13,13 @@ const KEY_SUPPRESS = 8;
  * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
  * @param  {string} [options.placeholder] Input's placeholder
  * @param  {Object} [options.cssClasses] CSS classes to add
- * @param  {string} [options.cssClasses.root] CSS class to add to the wrapping div (if wrapInput set to `true`)
+ * @param  {string} [options.cssClasses.root] CSS class to add to the wrapping div (if `wrapInput` set to `true`)
  * @param  {string} [options.cssClasses.input] CSS class to add to the input
  * @param  {string} [options.cssClasses.poweredBy] CSS class to add to the poweredBy element
  * @param  {boolean} [poweredBy=false] Show a powered by Algolia link below the input
- * @param  {boolean} [wrapInput=true] Wrap the input in a div.ais-search-box
+ * @param  {boolean} [wrapInput=true] Wrap the input in a `div.ais-search-box`
  * @param  {boolean|string} [autofocus='auto'] autofocus on the input
- * @param  {boolean} [searchOnEnterKeyPressOnly=false] If set, trigger the search once <Enter> is pressed only
+ * @param  {boolean} [searchOnEnterKeyPressOnly=false] If set, trigger the search once `<Enter>` is pressed only
  * @return {Object}
  */
 function searchBox({


### PR DESCRIPTION
This was messing the display of some documentations.