### PR TITLE
doc(examples): Lint scss

### DIFF
--- a/docs/examples/airbnb/scss/_pagination.scss
+++ b/docs/examples/airbnb/scss/_pagination.scss
@@ -3,13 +3,13 @@
 
 @include block(pagination) {
   @include element(item) {
-    @include modifier(disabled)
-    @include modifier(active)
-    @include modifier(first)
-    @include modifier(previous)
-    @include modifier(page)
-    @include modifier(next)
-    @include modifier(last)
+    @include modifier(disabled);
+    @include modifier(active);
+    @include modifier(first);
+    @include modifier(previous);
+    @include modifier(page);
+    @include modifier(next);
+    @include modifier(last);
   }
-  @include element(link)
+  @include element(link);
 }

--- a/docs/examples/youtube/scss/_pagination.scss
+++ b/docs/examples/youtube/scss/_pagination.scss
@@ -3,14 +3,14 @@
 
 @include block(pagination) {
   @include element(item) {
-    @include modifier(disabled)
-    @include modifier(active)
-    @include modifier(first)
-    @include modifier(previous)
-    @include modifier(page)
-    @include modifier(next)
-    @include modifier(last)
+    @include modifier(disabled);
+    @include modifier(active);
+    @include modifier(first);
+    @include modifier(previous);
+    @include modifier(page);
+    @include modifier(next);
+    @include modifier(last);
   }
-  @include element(link)
+  @include element(link);
 }
 


### PR DESCRIPTION
`_pagination.scss` files were not scss compatible, Guard could not
process them. They were missing `;`. My bad.

We'll have to add a lint rule for that.