### PR TITLE
docs(jekyll): set env to production when building gh pages

### DIFF
--- a/scripts/gh-pages.sh
+++ b/scripts/gh-pages.sh
@@ -8,5 +8,5 @@ cd docs
 rm -rf node_modules/gh-pages/.cache
 rm -rf _site
 bundle install
-VERSION=`cat package.json | json version` bundle exec jekyll build
+JEKYLL_ENV=production VERSION=`cat package.json | json version` bundle exec jekyll build
 gh-pages --dist _site --branch gh_pages


### PR DESCRIPTION
Current website for instantsearch is trying to load the local css