### PR TITLE
docs(target): remove target=_blank from links

### DIFF
--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -19,7 +19,7 @@
             </li>
           {% endfor %}
             <li>
-              <a href="http://github.com/algolia/instantsearch.js" title="See more, open issues and get answers in our Github repository" target="_blank">
+              <a href="http://github.com/algolia/instantsearch.js" title="See more, open issues and get answers in our Github repository">
                 <i class="fa fa-github hidden-xs"></i>
                 <span class="visible-xs">View project on github</span>
               </a>

--- a/docs/_includes/newsletter-mc.html
+++ b/docs/_includes/newsletter-mc.html
@@ -1,6 +1,6 @@
 <!-- Begin MailChimp Signup Form -->
 <div id="mc_embed_signup">
-  <form action="//algolia.us3.list-manage.com/subscribe/post?u=f7b8acc6ec97794a08484ca9b&amp;id=285b80e148" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+  <form action="//algolia.us3.list-manage.com/subscribe/post?u=f7b8acc6ec97794a08484ca9b&amp;id=285b80e148" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" novalidate>
     <div id="mc_embed_signup_scroll">
     <h3>Signup for our newsletter</h3>
     <div class="spacer20"></div>

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -19,13 +19,13 @@ noFooter: true
 <div class="sticker sticker-algolia">
 <img src="{{site.baseurl}}/img/logo-algolia-notext.svg" width="26"/>
 </div>
-Built on top of <a href="https://www.algolia.com" target="_blank">Algolia Search API</a>
+Built on top of <a href="https://www.algolia.com">Algolia Search API</a>
 </div>
 <div class="col-md-4 m-b">
 <div class="sticker sticker-open-source">
 <img src="{{site.baseurl}}/img/logo-open-source.svg" width="30"/>
 </div>
-Driven by community and available on  <a href="http://github.com/algolia/instantsearch.js" target="_blank">Github</a>
+Driven by community and available on  <a href="http://github.com/algolia/instantsearch.js">Github</a>
 </div>
 <div class="col-md-4 m-b">
 <div class="sticker sticker-ux">

--- a/docs/examples.haml
+++ b/docs/examples.haml
@@ -20,14 +20,14 @@ permalink: /examples/
     .col-sm-4
       %h3 Youtube
       %img.m-b.img-responsive.img-thumbnail{src: "{{ "/examples/youtube/capture.png" | prepend: site.baseurl }}"}
-      %a.btn.btn-default.primary-btn{href: '{{ "/examples/youtube/" | prepend: site.baseurl }}', target: '_blank'} Live Preview
+      %a.btn.btn-default.primary-btn{href: '{{ "/examples/youtube/" | prepend: site.baseurl }}'} Live Preview
 
     .col-sm-4
       %h3 Amazon
       %img.m-b.img-responsive.img-thumbnail{src:"http://placehold.it/600x400"}
-      %a.btn.btn-default.primary-btn{href: '{{ "/examples/amazon/" | prepend: site.baseurl }}', target: '_blank'} Live Preview
+      %a.btn.btn-default.primary-btn{href: '{{ "/examples/amazon/" | prepend: site.baseurl }}'} Live Preview
 
     .col-sm-4
       %h3 Airbnb
       %img.m-b.img-responsive.img-thumbnail{src: "{{ "/examples/airbnb/capture.png" | prepend: site.baseurl }}"}
-      %a.btn.btn-default.primary-btn{href: '{{ "/examples/airbnb/" | prepend: site.baseurl }}', target: '_blank'} Live Preview
+      %a.btn.btn-default.primary-btn{href: '{{ "/examples/airbnb/" | prepend: site.baseurl }}'} Live Preview

--- a/docs/index.haml
+++ b/docs/index.haml
@@ -9,7 +9,7 @@ layout: default
       .col-sm-6
         .spacer100
         .presented-by
-          %a{href: "https://www.algolia.com", title: "Instant Search as a Service", target: "_blank"}
+          %a{href: "https://www.algolia.com", title: "Instant Search as a Service"}
             %img{src:"img/algolia-logo.svg", width: 100, alt:"Logo Algolia"}
           presents:
         .spacer40


### PR DESCRIPTION
As a dev I hate target=_blank. If I want to open a new tab I
will do it: **trust me** I am an engineer!

I feel we do not need target=_blank, we should not fear people will
"leave" our website and not comeback. They will and they will not be
disapointed because of weird target blank (especially on mobile, its
painful. The navigation flow is stopped).

back button works really well