### PR TITLE
chore(doc): add default values & parameter types

### DIFF
--- a/docs/_includes/widget-jsdoc/addWidget.md
+++ b/docs/_includes/widget-jsdoc/addWidget.md
@@ -1,0 +1,7 @@
+| Param | Description |
+| --- | --- |
+| <span class='attr-optional'>`widget.render`</span><span class="attr-infos">Type: <code>function</code></span> | Called after each search response has been received |
+| <span class='attr-optional'>`widget.getConfiguration`</span><span class="attr-infos">Type: <code>function</code></span> | Let the widget update the configuration of the search with new parameters |
+| <span class='attr-optional'>`widget.init`</span><span class="attr-infos">Type: <code>function</code></span> | Called once before the first search |
+
+<p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/hierarchicalMenu.md
+++ b/docs/_includes/widget-jsdoc/hierarchicalMenu.md
@@ -1,24 +1,24 @@
 | Param | Description |
 | --- | --- |
-|  <span class='attr-required'>`options.container`</span> | CSS Selector or DOMElement to insert the widget |
-|  <span class='attr-required'>`options.attributes`</span> | Array of attributes to use to generate the hierarchy of the menu. Refer to [the readme](https://github.com/algolia/algoliasearch-helper-js#hierarchical-facets) for the convention to follow. |
-|  <span class='attr-optional'>`options.sortBy`</span> | How to sort refinements. Possible values: `count|isRefined|name:asc|desc` |
-|  <span class='attr-optional'>`options.limit`</span> | How much facet values to get |
-|  <span class='attr-optional'>`options.cssClasses`</span> | CSS classes to add to the wrapping elements: root, list, item |
-|  <span class='attr-optional'>`options.cssClasses.root`</span> | CSS class to add to the root element |
-|  <span class='attr-optional'>`options.cssClasses.header`</span> | CSS class to add to the header element |
-|  <span class='attr-optional'>`options.cssClasses.body`</span> | CSS class to add to the body element |
-|  <span class='attr-optional'>`options.cssClasses.footer`</span> | CSS class to add to the footer element |
-|  <span class='attr-optional'>`options.cssClasses.list`</span> | CSS class to add to the list element |
-|  <span class='attr-optional'>`options.cssClasses.item`</span> | CSS class to add to each item element |
-|  <span class='attr-optional'>`options.cssClasses.active`</span> | CSS class to add to each active element |
-|  <span class='attr-optional'>`options.cssClasses.link`</span> | CSS class to add to each link (when using the default template) |
-|  <span class='attr-optional'>`options.cssClasses.count`</span> | CSS class to add to each count element (when using the default template) |
-|  <span class='attr-optional'>`options.templates`</span> | Templates to use for the widget |
-|  <span class='attr-optional'>`options.templates.header`</span> | Header template (root level only) |
-|  <span class='attr-optional'>`options.templates.item`</span> | Item template |
-|  <span class='attr-optional'>`options.templates.footer`</span> | Footer template (root level only) |
-|  <span class='attr-optional'>`options.transformData`</span> | Method to change the object passed to the item template |
-|  <span class='attr-optional'>`options.autoHideContainer`</span> | Hide the container when there are no items in the menu |
+| <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
+| <span class='attr-required'>`options.attributes`</span><span class="attr-infos">Type: <code>Array.&lt;string&gt;</code></span> | Array of attributes to use to generate the hierarchy of the menu. Refer to [the readme](https://github.com/algolia/algoliasearch-helper-js#hierarchical-facets) for the convention to follow. |
+| <span class='attr-optional'>`options.sortBy`</span><span class="attr-infos">Default:<code class="attr-default">[&#x27;count:desc&#x27;]</code><br />Type: <code>Array.&lt;string&gt;</code></span> | How to sort refinements. Possible values: `count|isRefined|name:asc|desc` |
+| <span class='attr-optional'>`options.limit`</span><span class="attr-infos">Default:<code class="attr-default">100</code><br />Type: <code>number</code></span> | How much facet values to get |
+| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add to the wrapping elements: root, list, item |
+| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the root element |
+| <span class='attr-optional'>`options.cssClasses.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the header element |
+| <span class='attr-optional'>`options.cssClasses.body`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the body element |
+| <span class='attr-optional'>`options.cssClasses.footer`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the footer element |
+| <span class='attr-optional'>`options.cssClasses.list`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the list element |
+| <span class='attr-optional'>`options.cssClasses.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each item element |
+| <span class='attr-optional'>`options.cssClasses.active`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each active element |
+| <span class='attr-optional'>`options.cssClasses.link`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each link (when using the default template) |
+| <span class='attr-optional'>`options.cssClasses.count`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each count element (when using the default template) |
+| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
+| <span class='attr-optional'>`options.templates.header`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Header template (root level only) |
+| <span class='attr-optional'>`options.templates.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Item template |
+| <span class='attr-optional'>`options.templates.footer`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Footer template (root level only) |
+| <span class='attr-optional'>`options.transformData`</span><span class="attr-infos">Type: <code>function</code></span> | Method to change the object passed to the item template |
+| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when there are no items in the menu |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/hits.md
+++ b/docs/_includes/widget-jsdoc/hits.md
@@ -1,16 +1,16 @@
 | Param | Description |
 | --- | --- |
-|  <span class='attr-required'>`options.container`</span> | CSS Selector or DOMElement to insert the widget |
-|  <span class='attr-optional'>`options.cssClasses`</span> | CSS classes to add |
-|  <span class='attr-optional'>`options.cssClasses.root`</span> | CSS class to add to the wrapping element |
-|  <span class='attr-optional'>`options.cssClasses.empty`</span> | CSS class to add to the wrapping element when no results |
-|  <span class='attr-optional'>`options.cssClasses.item`</span> | CSS class to add to each result |
-|  <span class='attr-optional'>`options.templates`</span> | Templates to use for the widget |
-|  <span class='attr-optional'>`options.templates.empty`</span> | Template to use when there are no results. |
-|  <span class='attr-optional'>`options.templates.item`</span> | Template to use for each result. |
-|  <span class='attr-optional'>`options.transformData`</span> | Method to change the object passed to the templates |
-|  <span class='attr-optional'>`options.transformData.empty`</span> | Method used to change the object passed to the empty template |
-|  <span class='attr-optional'>`options.transformData.item`</span> | Method used to change the object passed to the item template |
-|  <span class='attr-optional'>`hitsPerPage`</span> | The number of hits to display per page |
+| <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
+| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add |
+| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the wrapping element |
+| <span class='attr-optional'>`options.cssClasses.empty`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the wrapping element when no results |
+| <span class='attr-optional'>`options.cssClasses.item`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to each result |
+| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
+| <span class='attr-optional'>`options.templates.empty`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Template to use when there are no results. |
+| <span class='attr-optional'>`options.templates.item`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Template to use for each result. |
+| <span class='attr-optional'>`options.transformData`</span><span class="attr-infos">Type: <code>Object</code></span> | Method to change the object passed to the templates |
+| <span class='attr-optional'>`options.transformData.empty`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>function</code></span> | Method used to change the object passed to the empty template |
+| <span class='attr-optional'>`options.transformData.item`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>function</code></span> | Method used to change the object passed to the item template |
+| <span class='attr-optional'>`hitsPerPage`</span><span class="attr-infos">Default:<code class="attr-default">20</code><br />Type: <code>number</code></span> | The number of hits to display per page |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/hitsPerPageSelector.md
+++ b/docs/_includes/widget-jsdoc/hitsPerPageSelector.md
@@ -1,12 +1,12 @@
 | Param | Description |
 | --- | --- |
-|  <span class='attr-required'>`options.container`</span> | CSS Selector or DOMElement to insert the widget |
-|  <span class='attr-required'>`options.options`</span> | Array of objects defining the different values and labels |
-|  <span class='attr-required'>`options.options[0].value`</span> | number of hits to display per page |
-|  <span class='attr-required'>`options.options[0].label`</span> | Label to display in the option |
-|  <span class='attr-optional'>`options.cssClasses`</span> | CSS classes to be added |
-|  <span class='attr-optional'>`options.cssClasses.root`</span> | CSS classes added to the parent `<select>` |
-|  <span class='attr-optional'>`options.cssClasses.item`</span> | CSS classes added to each `<option>` |
-|  <span class='attr-optional'>`options.autoHideContainer`</span> | Hide the container when no results match |
+| <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
+| <span class='attr-required'>`options.options`</span><span class="attr-infos">Type: <code>Array</code></span> | Array of objects defining the different values and labels |
+| <span class='attr-required'>`options.options[0].value`</span><span class="attr-infos">Type: <code>number</code></span> | number of hits to display per page |
+| <span class='attr-required'>`options.options[0].label`</span><span class="attr-infos">Type: <code>string</code></span> | Label to display in the option |
+| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to be added |
+| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code></span> | CSS classes added to the parent `<select>` |
+| <span class='attr-optional'>`options.cssClasses.item`</span><span class="attr-infos">Type: <code>string</code></span> | CSS classes added to each `<option>` |
+| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">false</code><br />Type: <code>boolean</code></span> | Hide the container when no results match |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/indexSelector.md
+++ b/docs/_includes/widget-jsdoc/indexSelector.md
@@ -1,12 +1,12 @@
 | Param | Description |
 | --- | --- |
-|  <span class='attr-required'>`options.container`</span> | CSS Selector or DOMElement to insert the widget |
-|  <span class='attr-required'>`options.indices`</span> | Array of objects defining the different indices to choose from. |
-|  <span class='attr-required'>`options.indices[0].name`</span> | Name of the index to target |
-|  <span class='attr-required'>`options.indices[0].label`</span> | Label displayed in the dropdown |
-|  <span class='attr-optional'>`options.cssClasses`</span> | CSS classes to be added |
-|  <span class='attr-optional'>`options.cssClasses.root`</span> | CSS classes added to the parent <select> |
-|  <span class='attr-optional'>`options.cssClasses.item`</span> | CSS classes added to each <option> |
-|  <span class='attr-optional'>`options.autoHideContainer`</span> | Hide the container when no results match |
+| <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
+| <span class='attr-required'>`options.indices`</span><span class="attr-infos">Type: <code>Array</code></span> | Array of objects defining the different indices to choose from. |
+| <span class='attr-required'>`options.indices[0].name`</span><span class="attr-infos">Type: <code>string</code></span> | Name of the index to target |
+| <span class='attr-required'>`options.indices[0].label`</span><span class="attr-infos">Type: <code>string</code></span> | Label displayed in the dropdown |
+| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to be added |
+| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code></span> | CSS classes added to the parent <select> |
+| <span class='attr-optional'>`options.cssClasses.item`</span><span class="attr-infos">Type: <code>string</code></span> | CSS classes added to each <option> |
+| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">false</code><br />Type: <code>boolean</code></span> | Hide the container when no results match |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/instantsearch.md
+++ b/docs/_includes/widget-jsdoc/instantsearch.md
@@ -1,0 +1,13 @@
+| Param | Description |
+| --- | --- |
+| <span class='attr-required'>`options.appId`</span><span class="attr-infos">Type: <code>string</code></span> | The Algolia application ID |
+| <span class='attr-required'>`options.apiKey`</span><span class="attr-infos">Type: <code>string</code></span> | The Algolia search-only API key |
+| <span class='attr-required'>`options.index`</span><span class="attr-infos">Type: <code>string</code></span> | The name of the main index |
+| <span class='attr-optional'>`options.numberLocale`</span><span class="attr-infos">Type: <code>string</code></span> | The locale used to display numbers. |
+| <span class='attr-optional'>`options.searchParameters`</span><span class="attr-infos">Type: <code>string</code></span> | Initial search configuration. |
+| <span class='attr-optional'>`options.urlSync`</span><span class="attr-infos">Type: <code>string</code></span> | Url synchronization configuration. |
+| <span class='attr-optional'>`options.urlSync.trackedParameters`</span><span class="attr-infos">Type: <code>string</code></span> | Parameters that will be synchronized in the URL. By default, it will track the query, all the refinable attribute (facets and numeric filters), the index and the page. |
+| <span class='attr-optional'>`options.urlSync.useHash`</span><span class="attr-infos">Type: <code>string</code></span> | If set to true, the url will be hash based. Otherwise, it'll use the query parameters using the modern history API. |
+| <span class='attr-optional'>`options.urlSync.threshold`</span><span class="attr-infos">Type: <code>string</code></span> | Time in ms after which a new state is created in the browser history. The default value is 700. |
+
+<p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/menu.md
+++ b/docs/_includes/widget-jsdoc/menu.md
@@ -1,24 +1,24 @@
 | Param | Description |
 | --- | --- |
-|  <span class='attr-required'>`options.container`</span> | CSS Selector or DOMElement to insert the widget |
-|  <span class='attr-required'>`options.facetName`</span> | Name of the attribute for faceting |
-|  <span class='attr-optional'>`options.sortBy`</span> | How to sort refinements. Possible values: `count|isRefined|name:asc|desc` |
-|  <span class='attr-optional'>`options.limit`</span> | How many facets values to retrieve |
-|  <span class='attr-optional'>`options.cssClasses`</span> | CSS classes to add to the wrapping elements: root, list, item |
-|  <span class='attr-optional'>`options.cssClasses.root`</span> | CSS class to add to the root element |
-|  <span class='attr-optional'>`options.cssClasses.header`</span> | CSS class to add to the header element |
-|  <span class='attr-optional'>`options.cssClasses.body`</span> | CSS class to add to the body element |
-|  <span class='attr-optional'>`options.cssClasses.footer`</span> | CSS class to add to the footer element |
-|  <span class='attr-optional'>`options.cssClasses.list`</span> | CSS class to add to the list element |
-|  <span class='attr-optional'>`options.cssClasses.item`</span> | CSS class to add to each item element |
-|  <span class='attr-optional'>`options.cssClasses.active`</span> | CSS class to add to each active element |
-|  <span class='attr-optional'>`options.cssClasses.link`</span> | CSS class to add to each link (when using the default template) |
-|  <span class='attr-optional'>`options.cssClasses.count`</span> | CSS class to add to each count element (when using the default template) |
-|  <span class='attr-optional'>`options.templates`</span> | Templates to use for the widget |
-|  <span class='attr-optional'>`options.templates.header`</span> | Header template |
-|  <span class='attr-optional'>`options.templates.item`</span> | Item template, provided with `name`, `count`, `isRefined` |
-|  <span class='attr-optional'>`options.templates.footer`</span> | Footer template |
-|  <span class='attr-optional'>`options.transformData`</span> | Method to change the object passed to the item template |
-|  <span class='attr-optional'>`options.autoHideContainer`</span> | Hide the container when there are no items in the menu |
+| <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
+| <span class='attr-required'>`options.facetName`</span><span class="attr-infos">Type: <code>string</code></span> | Name of the attribute for faceting |
+| <span class='attr-optional'>`options.sortBy`</span><span class="attr-infos">Default:<code class="attr-default">[&#x27;count:desc&#x27;]</code><br />Type: <code>Array.&lt;string&gt;</code></span> | How to sort refinements. Possible values: `count|isRefined|name:asc|desc` |
+| <span class='attr-optional'>`options.limit`</span><span class="attr-infos">Default:<code class="attr-default">100</code><br />Type: <code>string</code></span> | How many facets values to retrieve |
+| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add to the wrapping elements: root, list, item |
+| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the root element |
+| <span class='attr-optional'>`options.cssClasses.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the header element |
+| <span class='attr-optional'>`options.cssClasses.body`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the body element |
+| <span class='attr-optional'>`options.cssClasses.footer`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the footer element |
+| <span class='attr-optional'>`options.cssClasses.list`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the list element |
+| <span class='attr-optional'>`options.cssClasses.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each item element |
+| <span class='attr-optional'>`options.cssClasses.active`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each active element |
+| <span class='attr-optional'>`options.cssClasses.link`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each link (when using the default template) |
+| <span class='attr-optional'>`options.cssClasses.count`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each count element (when using the default template) |
+| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
+| <span class='attr-optional'>`options.templates.header`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Header template |
+| <span class='attr-optional'>`options.templates.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Item template, provided with `name`, `count`, `isRefined` |
+| <span class='attr-optional'>`options.templates.footer`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Footer template |
+| <span class='attr-optional'>`options.transformData`</span><span class="attr-infos">Type: <code>function</code></span> | Method to change the object passed to the item template |
+| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when there are no items in the menu |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/numericRefinementList.md
+++ b/docs/_includes/widget-jsdoc/numericRefinementList.md
@@ -1,22 +1,22 @@
 | Param | Description |
 | --- | --- |
-|  <span class='attr-required'>`options.container`</span> | CSS Selector or DOMElement to insert the widget |
-|  <span class='attr-required'>`options.attributeName`</span> | Name of the attribute for filtering |
-|  <span class='attr-optional'>`options.cssClasses`</span> | CSS classes to add to the wrapping elements: root, list, item |
-|  <span class='attr-optional'>`options.cssClasses.root`</span> | CSS class to add to the root element |
-|  <span class='attr-optional'>`options.cssClasses.header`</span> | CSS class to add to the header element |
-|  <span class='attr-optional'>`options.cssClasses.body`</span> | CSS class to add to the body element |
-|  <span class='attr-optional'>`options.cssClasses.footer`</span> | CSS class to add to the footer element |
-|  <span class='attr-optional'>`options.cssClasses.list`</span> | CSS class to add to the list element |
-|  <span class='attr-optional'>`options.cssClasses.label`</span> | CSS class to add to each link element |
-|  <span class='attr-optional'>`options.cssClasses.item`</span> | CSS class to add to each item element |
-|  <span class='attr-optional'>`options.cssClasses.radio`</span> | CSS class to add to each radio element (when using the default template) |
-|  <span class='attr-optional'>`options.cssClasses.active`</span> | CSS class to add to each active element |
-|  <span class='attr-optional'>`options.templates`</span> | Templates to use for the widget |
-|  <span class='attr-optional'>`options.templates.header`</span> | Header template |
-|  <span class='attr-optional'>`options.templates.item`</span> | Item template, provided with `name`, `count`, `isRefined` |
-|  <span class='attr-optional'>`options.templates.footer`</span> | Footer template |
-|  <span class='attr-optional'>`options.transformData`</span> | Function to change the object passed to the item template |
-|  <span class='attr-optional'>`options.autoHideContainer`</span> | Hide the container when no results match |
+| <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
+| <span class='attr-required'>`options.attributeName`</span><span class="attr-infos">Type: <code>string</code></span> | Name of the attribute for filtering |
+| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add to the wrapping elements: root, list, item |
+| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the root element |
+| <span class='attr-optional'>`options.cssClasses.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the header element |
+| <span class='attr-optional'>`options.cssClasses.body`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the body element |
+| <span class='attr-optional'>`options.cssClasses.footer`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the footer element |
+| <span class='attr-optional'>`options.cssClasses.list`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the list element |
+| <span class='attr-optional'>`options.cssClasses.label`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each link element |
+| <span class='attr-optional'>`options.cssClasses.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each item element |
+| <span class='attr-optional'>`options.cssClasses.radio`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each radio element (when using the default template) |
+| <span class='attr-optional'>`options.cssClasses.active`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each active element |
+| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
+| <span class='attr-optional'>`options.templates.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Header template |
+| <span class='attr-optional'>`options.templates.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Item template, provided with `name`, `count`, `isRefined` |
+| <span class='attr-optional'>`options.templates.footer`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Footer template |
+| <span class='attr-optional'>`options.transformData`</span><span class="attr-infos">Type: <code>function</code></span> | Function to change the object passed to the item template |
+| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when no results match |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/pagination.md
+++ b/docs/_includes/widget-jsdoc/pagination.md
@@ -1,26 +1,26 @@
 | Param | Description |
 | --- | --- |
-|  <span class='attr-required'>`options.container`</span> | CSS Selector or DOMElement to insert the widget |
-|  <span class='attr-optional'>`options.cssClasses`</span> | CSS classes to be added |
-|  <span class='attr-optional'>`options.cssClasses.root`</span> | CSS classes added to the parent `<ul>` |
-|  <span class='attr-optional'>`options.cssClasses.item`</span> | CSS classes added to each `<li>` |
-|  <span class='attr-optional'>`options.cssClasses.link`</span> | CSS classes added to each link |
-|  <span class='attr-optional'>`options.cssClasses.page`</span> | CSS classes added to page `<li>` |
-|  <span class='attr-optional'>`options.cssClasses.previous`</span> | CSS classes added to the previous `<li>` |
-|  <span class='attr-optional'>`options.cssClasses.next`</span> | CSS classes added to the next `<li>` |
-|  <span class='attr-optional'>`options.cssClasses.first`</span> | CSS classes added to the first `<li>` |
-|  <span class='attr-optional'>`options.cssClasses.last`</span> | CSS classes added to the last `<li>` |
-|  <span class='attr-optional'>`options.cssClasses.active`</span> | CSS classes added to the active `<li>` |
-|  <span class='attr-optional'>`options.cssClasses.disabled`</span> | CSS classes added to the disabled `<li>` |
-|  <span class='attr-optional'>`options.labels`</span> | Text to display in the various links (prev, next, first, last) |
-|  <span class='attr-optional'>`options.labels.previous`</span> | Label for the Previous link |
-|  <span class='attr-optional'>`options.labels.next`</span> | Label for the Next link |
-|  <span class='attr-optional'>`options.labels.first`</span> | Label for the First link |
-|  <span class='attr-optional'>`options.labels.last`</span> | Label for the Last link |
-|  <span class='attr-optional'>`options.maxPages`</span> | The max number of pages to browse |
-|  <span class='attr-optional'>`options.padding`</span> | The number of pages to display on each side of the current page |
-|  <span class='attr-optional'>`options.scrollTo`</span> | Where to scroll after a click, set to `false` to disable |
-|  <span class='attr-optional'>`options.showFirstLast`</span> | Define if the First and Last links should be displayed |
-|  <span class='attr-optional'>`options.autoHideContainer`</span> | Hide the container when no results match |
+| <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
+| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to be added |
+| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code></span> | CSS classes added to the parent `<ul>` |
+| <span class='attr-optional'>`options.cssClasses.item`</span><span class="attr-infos">Type: <code>string</code></span> | CSS classes added to each `<li>` |
+| <span class='attr-optional'>`options.cssClasses.link`</span><span class="attr-infos">Type: <code>string</code></span> | CSS classes added to each link |
+| <span class='attr-optional'>`options.cssClasses.page`</span><span class="attr-infos">Type: <code>string</code></span> | CSS classes added to page `<li>` |
+| <span class='attr-optional'>`options.cssClasses.previous`</span><span class="attr-infos">Type: <code>string</code></span> | CSS classes added to the previous `<li>` |
+| <span class='attr-optional'>`options.cssClasses.next`</span><span class="attr-infos">Type: <code>string</code></span> | CSS classes added to the next `<li>` |
+| <span class='attr-optional'>`options.cssClasses.first`</span><span class="attr-infos">Type: <code>string</code></span> | CSS classes added to the first `<li>` |
+| <span class='attr-optional'>`options.cssClasses.last`</span><span class="attr-infos">Type: <code>string</code></span> | CSS classes added to the last `<li>` |
+| <span class='attr-optional'>`options.cssClasses.active`</span><span class="attr-infos">Type: <code>string</code></span> | CSS classes added to the active `<li>` |
+| <span class='attr-optional'>`options.cssClasses.disabled`</span><span class="attr-infos">Type: <code>string</code></span> | CSS classes added to the disabled `<li>` |
+| <span class='attr-optional'>`options.labels`</span><span class="attr-infos">Type: <code>Object</code></span> | Text to display in the various links (prev, next, first, last) |
+| <span class='attr-optional'>`options.labels.previous`</span><span class="attr-infos">Type: <code>string</code></span> | Label for the Previous link |
+| <span class='attr-optional'>`options.labels.next`</span><span class="attr-infos">Type: <code>string</code></span> | Label for the Next link |
+| <span class='attr-optional'>`options.labels.first`</span><span class="attr-infos">Type: <code>string</code></span> | Label for the First link |
+| <span class='attr-optional'>`options.labels.last`</span><span class="attr-infos">Type: <code>string</code></span> | Label for the Last link |
+| <span class='attr-optional'>`options.maxPages`</span><span class="attr-infos">Default:<code class="attr-default">20</code><br />Type: <code>number</code></span> | The max number of pages to browse |
+| <span class='attr-optional'>`options.padding`</span><span class="attr-infos">Default:<code class="attr-default">3</code><br />Type: <code>number</code></span> | The number of pages to display on each side of the current page |
+| <span class='attr-optional'>`options.scrollTo`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;body&#x27;</code><br />Type: <code>string</code> &#124; <code>DOMElement</code> &#124; <code>boolean</code></span> | Where to scroll after a click, set to `false` to disable |
+| <span class='attr-optional'>`options.showFirstLast`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Define if the First and Last links should be displayed |
+| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when no results match |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/priceRanges.md
+++ b/docs/_includes/widget-jsdoc/priceRanges.md
@@ -1,28 +1,28 @@
 | Param | Description |
 | --- | --- |
-|  <span class='attr-required'>`options.container`</span> | Valid CSS Selector as a string or DOMElement |
-|  <span class='attr-required'>`options.attributeName`</span> | Name of the attribute for faceting |
-|  <span class='attr-optional'>`options.cssClasses`</span> | CSS classes to add |
-|  <span class='attr-optional'>`options.cssClasses.root`</span> | CSS class to add to the root element |
-|  <span class='attr-optional'>`options.cssClasses.header`</span> | CSS class to add to the header element |
-|  <span class='attr-optional'>`options.cssClasses.body`</span> | CSS class to add to the body element |
-|  <span class='attr-optional'>`options.cssClasses.list`</span> | CSS class to add to the wrapping list element |
-|  <span class='attr-optional'>`options.cssClasses.item`</span> | CSS class to add to each item element |
-|  <span class='attr-optional'>`options.cssClasses.active`</span> | CSS class to add to the active item element |
-|  <span class='attr-optional'>`options.cssClasses.link`</span> | CSS class to add to each link element |
-|  <span class='attr-optional'>`options.cssClasses.form`</span> | CSS class to add to the form element |
-|  <span class='attr-optional'>`options.cssClasses.label`</span> | CSS class to add to each wrapping label of the form |
-|  <span class='attr-optional'>`options.cssClasses.input`</span> | CSS class to add to each input of the form |
-|  <span class='attr-optional'>`options.cssClasses.currency`</span> | CSS class to add to each currency element of the form |
-|  <span class='attr-optional'>`options.cssClasses.separator`</span> | CSS class to add to the separator of the form |
-|  <span class='attr-optional'>`options.cssClasses.button`</span> | CSS class to add to the submit button of the form |
-|  <span class='attr-optional'>`options.cssClasses.footer`</span> | CSS class to add to the footer element |
-|  <span class='attr-optional'>`options.templates`</span> | Templates to use for the widget |
-|  <span class='attr-optional'>`options.templates.item`</span> | Item template |
-|  <span class='attr-optional'>`options.labels`</span> | Labels to use for the widget |
-|  <span class='attr-optional'>`options.labels.currency`</span> | Currency label |
-|  <span class='attr-optional'>`options.labels.separator`</span> | Separator label, between min and max |
-|  <span class='attr-optional'>`options.labels.button`</span> | Button label |
-|  <span class='attr-optional'>`options.autoHideContainer`</span> | Hide the container when no refinements available |
+| <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | Valid CSS Selector as a string or DOMElement |
+| <span class='attr-required'>`options.attributeName`</span><span class="attr-infos">Type: <code>string</code></span> | Name of the attribute for faceting |
+| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add |
+| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the root element |
+| <span class='attr-optional'>`options.cssClasses.header`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the header element |
+| <span class='attr-optional'>`options.cssClasses.body`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the body element |
+| <span class='attr-optional'>`options.cssClasses.list`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the wrapping list element |
+| <span class='attr-optional'>`options.cssClasses.item`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to each item element |
+| <span class='attr-optional'>`options.cssClasses.active`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the active item element |
+| <span class='attr-optional'>`options.cssClasses.link`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to each link element |
+| <span class='attr-optional'>`options.cssClasses.form`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the form element |
+| <span class='attr-optional'>`options.cssClasses.label`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to each wrapping label of the form |
+| <span class='attr-optional'>`options.cssClasses.input`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to each input of the form |
+| <span class='attr-optional'>`options.cssClasses.currency`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to each currency element of the form |
+| <span class='attr-optional'>`options.cssClasses.separator`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the separator of the form |
+| <span class='attr-optional'>`options.cssClasses.button`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the submit button of the form |
+| <span class='attr-optional'>`options.cssClasses.footer`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the footer element |
+| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
+| <span class='attr-optional'>`options.templates.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Item template |
+| <span class='attr-optional'>`options.labels`</span><span class="attr-infos">Type: <code>Object</code></span> | Labels to use for the widget |
+| <span class='attr-optional'>`options.labels.currency`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Currency label |
+| <span class='attr-optional'>`options.labels.separator`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Separator label, between min and max |
+| <span class='attr-optional'>`options.labels.button`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Button label |
+| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when no refinements available |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/rangeSlider.md
+++ b/docs/_includes/widget-jsdoc/rangeSlider.md
@@ -1,14 +1,14 @@
 | Param | Description |
 | --- | --- |
-|  <span class='attr-required'>`options.container`</span> | CSS Selector or DOMElement to insert the widget |
-|  <span class='attr-required'>`options.attributeName`</span> | Name of the attribute for faceting |
-|  <span class='attr-optional'>`options.tooltips`</span> | Should we show tooltips or not. The default tooltip will show the formatted corresponding value without any other token. You can also provide `tooltips: {format: function(formattedValue, rawValue) {return '$' + formattedValue}}` So that you can format the tooltip display value as you want |
-|  <span class='attr-optional'>`options.templates`</span> | Templates to use for the widget |
-|  <span class='attr-optional'>`options.templates.header`</span> | Header template |
-|  <span class='attr-optional'>`options.templates.footer`</span> | Footer template |
-|  <span class='attr-optional'>`options.cssClasses`</span> | CSS classes to add to the wrapping elements: root, body |
-|  <span class='attr-optional'>`options.cssClasses.root`</span> | CSS class to add to the root element |
-|  <span class='attr-optional'>`options.cssClasses.body`</span> | CSS class to add to the body element |
-|  <span class='attr-optional'>`options.autoHideContainer`</span> | Hide the container when no refinements available |
+| <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
+| <span class='attr-required'>`options.attributeName`</span><span class="attr-infos">Type: <code>string</code></span> | Name of the attribute for faceting |
+| <span class='attr-optional'>`options.tooltips`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code> &#124; <code>Object</code></span> | Should we show tooltips or not. The default tooltip will show the formatted corresponding value without any other token. You can also provide `tooltips: {format: function(formattedValue, rawValue) {return '$' + formattedValue}}` So that you can format the tooltip display value as you want |
+| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
+| <span class='attr-optional'>`options.templates.header`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Header template |
+| <span class='attr-optional'>`options.templates.footer`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Footer template |
+| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add to the wrapping elements: root, body |
+| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the root element |
+| <span class='attr-optional'>`options.cssClasses.body`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the body element |
+| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when no refinements available |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/refinementList.md
+++ b/docs/_includes/widget-jsdoc/refinementList.md
@@ -1,26 +1,26 @@
 | Param | Description |
 | --- | --- |
-|  <span class='attr-required'>`options.container`</span> | CSS Selector or DOMElement to insert the widget |
-|  <span class='attr-required'>`options.facetName`</span> | Name of the attribute for faceting |
-|  <span class='attr-optional'>`options.operator`</span> | How to apply refinements. Possible values: `or`, `and` |
-|  <span class='attr-optional'>`options.sortBy`</span> | How to sort refinements. Possible values: `count|isRefined|name:asc|desc` |
-|  <span class='attr-optional'>`options.limit`</span> | How much facet values to get |
-|  <span class='attr-optional'>`options.cssClasses`</span> | CSS classes to add to the wrapping elements: root, list, item |
-|  <span class='attr-optional'>`options.cssClasses.root`</span> | CSS class to add to the root element |
-|  <span class='attr-optional'>`options.cssClasses.header`</span> | CSS class to add to the header element |
-|  <span class='attr-optional'>`options.cssClasses.body`</span> | CSS class to add to the body element |
-|  <span class='attr-optional'>`options.cssClasses.footer`</span> | CSS class to add to the footer element |
-|  <span class='attr-optional'>`options.cssClasses.list`</span> | CSS class to add to the list element |
-|  <span class='attr-optional'>`options.cssClasses.item`</span> | CSS class to add to each item element |
-|  <span class='attr-optional'>`options.cssClasses.active`</span> | CSS class to add to each active element |
-|  <span class='attr-optional'>`options.cssClasses.label`</span> | CSS class to add to each label element (when using the default template) |
-|  <span class='attr-optional'>`options.cssClasses.checkbox`</span> | CSS class to add to each checkbox element (when using the default template) |
-|  <span class='attr-optional'>`options.cssClasses.count`</span> | CSS class to add to each count element (when using the default template) |
-|  <span class='attr-optional'>`options.templates`</span> | Templates to use for the widget |
-|  <span class='attr-optional'>`options.templates.header`</span> | Header template |
-|  <span class='attr-optional'>`options.templates.item`</span> | Item template, provided with `name`, `count`, `isRefined` |
-|  <span class='attr-optional'>`options.templates.footer`</span> | Footer template |
-|  <span class='attr-optional'>`options.transformData`</span> | Function to change the object passed to the item template |
-|  <span class='attr-optional'>`options.autoHideContainer`</span> | Hide the container when no items in the refinement list |
+| <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
+| <span class='attr-required'>`options.facetName`</span><span class="attr-infos">Type: <code>string</code></span> | Name of the attribute for faceting |
+| <span class='attr-optional'>`options.operator`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;or&#x27;</code><br />Type: <code>string</code></span> | How to apply refinements. Possible values: `or`, `and` |
+| <span class='attr-optional'>`options.sortBy`</span><span class="attr-infos">Default:<code class="attr-default">[&#x27;count:desc&#x27;]</code><br />Type: <code>Array.&lt;string&gt;</code></span> | How to sort refinements. Possible values: `count|isRefined|name:asc|desc` |
+| <span class='attr-optional'>`options.limit`</span><span class="attr-infos">Default:<code class="attr-default">1000</code><br />Type: <code>string</code></span> | How much facet values to get |
+| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add to the wrapping elements: root, list, item |
+| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the root element |
+| <span class='attr-optional'>`options.cssClasses.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the header element |
+| <span class='attr-optional'>`options.cssClasses.body`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the body element |
+| <span class='attr-optional'>`options.cssClasses.footer`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the footer element |
+| <span class='attr-optional'>`options.cssClasses.list`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the list element |
+| <span class='attr-optional'>`options.cssClasses.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each item element |
+| <span class='attr-optional'>`options.cssClasses.active`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each active element |
+| <span class='attr-optional'>`options.cssClasses.label`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each label element (when using the default template) |
+| <span class='attr-optional'>`options.cssClasses.checkbox`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each checkbox element (when using the default template) |
+| <span class='attr-optional'>`options.cssClasses.count`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each count element (when using the default template) |
+| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
+| <span class='attr-optional'>`options.templates.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Header template |
+| <span class='attr-optional'>`options.templates.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Item template, provided with `name`, `count`, `isRefined` |
+| <span class='attr-optional'>`options.templates.footer`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Footer template |
+| <span class='attr-optional'>`options.transformData`</span><span class="attr-infos">Type: <code>function</code></span> | Function to change the object passed to the item template |
+| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when no items in the refinement list |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/searchBox.md
+++ b/docs/_includes/widget-jsdoc/searchBox.md
@@ -1,14 +1,14 @@
 | Param | Description |
 | --- | --- |
-|  <span class='attr-required'>`options.container`</span> | CSS Selector or DOMElement to insert the widget |
-|  <span class='attr-optional'>`options.placeholder`</span> | Input's placeholder |
-|  <span class='attr-optional'>`options.cssClasses`</span> | CSS classes to add |
-|  <span class='attr-optional'>`options.cssClasses.root`</span> | CSS class to add to the wrapping div (if `wrapInput` set to `true`) |
-|  <span class='attr-optional'>`options.cssClasses.input`</span> | CSS class to add to the input |
-|  <span class='attr-optional'>`options.cssClasses.poweredBy`</span> | CSS class to add to the poweredBy element |
-|  <span class='attr-optional'>`poweredBy`</span> | Show a powered by Algolia link below the input |
-|  <span class='attr-optional'>`wrapInput`</span> | Wrap the input in a `div.ais-search-box` |
-|  <span class='attr-optional'>`autofocus`</span> | autofocus on the input |
-|  <span class='attr-optional'>`searchOnEnterKeyPressOnly`</span> | If set, trigger the search once `<Enter>` is pressed only |
+| <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
+| <span class='attr-optional'>`options.placeholder`</span><span class="attr-infos">Type: <code>string</code></span> | Input's placeholder |
+| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add |
+| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the wrapping div (if `wrapInput` set to `true`) |
+| <span class='attr-optional'>`options.cssClasses.input`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the input |
+| <span class='attr-optional'>`options.cssClasses.poweredBy`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the poweredBy element |
+| <span class='attr-optional'>`poweredBy`</span><span class="attr-infos">Default:<code class="attr-default">false</code><br />Type: <code>boolean</code></span> | Show a powered by Algolia link below the input |
+| <span class='attr-optional'>`wrapInput`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Wrap the input in a `div.ais-search-box` |
+| <span class='attr-optional'>`autofocus`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;auto&#x27;</code><br />Type: <code>boolean</code> &#124; <code>string</code></span> | autofocus on the input |
+| <span class='attr-optional'>`searchOnEnterKeyPressOnly`</span><span class="attr-infos">Default:<code class="attr-default">false</code><br />Type: <code>boolean</code></span> | If set, trigger the search once `<Enter>` is pressed only |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/stats.md
+++ b/docs/_includes/widget-jsdoc/stats.md
@@ -1,17 +1,17 @@
 | Param | Description |
 | --- | --- |
-|  <span class='attr-required'>`options.container`</span> | CSS Selector or DOMElement to insert the widget |
-|  <span class='attr-optional'>`options.cssClasses`</span> | CSS classes to add |
-|  <span class='attr-optional'>`options.cssClasses.root`</span> | CSS class to add to the root element |
-|  <span class='attr-optional'>`options.cssClasses.header`</span> | CSS class to add to the header element |
-|  <span class='attr-optional'>`options.cssClasses.body`</span> | CSS class to add to the body element |
-|  <span class='attr-optional'>`options.cssClasses.footer`</span> | CSS class to add to the footer element |
-|  <span class='attr-optional'>`options.cssClasses.time`</span> | CSS class to add to the element wrapping the time processingTimeMs |
-|  <span class='attr-optional'>`options.templates`</span> | Templates to use for the widget |
-|  <span class='attr-optional'>`options.templates.header`</span> | Header template |
-|  <span class='attr-optional'>`options.templates.body`</span> | Body template |
-|  <span class='attr-optional'>`options.templates.footer`</span> | Footer template |
-|  <span class='attr-optional'>`options.transformData`</span> | Function to change the object passed to the `body` template |
-|  <span class='attr-optional'>`options.autoHideContainer`</span> | Hide the container when no results match |
+| <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
+| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add |
+| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the root element |
+| <span class='attr-optional'>`options.cssClasses.header`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the header element |
+| <span class='attr-optional'>`options.cssClasses.body`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the body element |
+| <span class='attr-optional'>`options.cssClasses.footer`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the footer element |
+| <span class='attr-optional'>`options.cssClasses.time`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the element wrapping the time processingTimeMs |
+| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
+| <span class='attr-optional'>`options.templates.header`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Header template |
+| <span class='attr-optional'>`options.templates.body`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Body template |
+| <span class='attr-optional'>`options.templates.footer`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Footer template |
+| <span class='attr-optional'>`options.transformData`</span><span class="attr-infos">Type: <code>function</code></span> | Function to change the object passed to the `body` template |
+| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when no results match |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/toggle.md
+++ b/docs/_includes/widget-jsdoc/toggle.md
@@ -1,27 +1,27 @@
 | Param | Description |
 | --- | --- |
-|  <span class='attr-required'>`options.container`</span> | CSS Selector or DOMElement to insert the widget |
-|  <span class='attr-required'>`options.facetName`</span> | Name of the attribute for faceting (eg. "free_shipping") |
-|  <span class='attr-required'>`options.label`</span> | Human-readable name of the filter (eg. "Free Shipping") |
-|  <span class='attr-optional'>`options.values`</span> | Lets you define the values to filter on when toggling |
-|  <span class='attr-optional'>`options.values.on`</span> | Value to filter on when checked |
-|  <span class='attr-optional'>`options.values.off`</span> | Value to filter on when unchecked |
-|  <span class='attr-optional'>`options.cssClasses`</span> | CSS classes to add |
-|  <span class='attr-optional'>`options.cssClasses.root`</span> | CSS class to add to the root element |
-|  <span class='attr-optional'>`options.cssClasses.header`</span> | CSS class to add to the header element |
-|  <span class='attr-optional'>`options.cssClasses.body`</span> | CSS class to add to the body element |
-|  <span class='attr-optional'>`options.cssClasses.footer`</span> | CSS class to add to the footer element |
-|  <span class='attr-optional'>`options.cssClasses.list`</span> | CSS class to add to the list element |
-|  <span class='attr-optional'>`options.cssClasses.item`</span> | CSS class to add to each item element |
-|  <span class='attr-optional'>`options.cssClasses.active`</span> | CSS class to add to each active element |
-|  <span class='attr-optional'>`options.cssClasses.label`</span> | CSS class to add to each label element (when using the default template) |
-|  <span class='attr-optional'>`options.cssClasses.checkbox`</span> | CSS class to add to each checkbox element (when using the default template) |
-|  <span class='attr-optional'>`options.cssClasses.count`</span> | CSS class to add to each count element (when using the default template) |
-|  <span class='attr-optional'>`options.templates`</span> | Templates to use for the widget |
-|  <span class='attr-optional'>`options.templates.header`</span> | Header template |
-|  <span class='attr-optional'>`options.templates.item`</span> | Item template |
-|  <span class='attr-optional'>`options.templates.footer`</span> | Footer template |
-|  <span class='attr-optional'>`options.transformData`</span> | Function to change the object passed to the item template |
-|  <span class='attr-optional'>`options.autoHideContainer`</span> | Hide the container when there's no results |
+| <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
+| <span class='attr-required'>`options.facetName`</span><span class="attr-infos">Type: <code>string</code></span> | Name of the attribute for faceting (eg. "free_shipping") |
+| <span class='attr-required'>`options.label`</span><span class="attr-infos">Type: <code>string</code></span> | Human-readable name of the filter (eg. "Free Shipping") |
+| <span class='attr-optional'>`options.values`</span><span class="attr-infos">Type: <code>Object</code></span> | Lets you define the values to filter on when toggling |
+| <span class='attr-optional'>`options.values.on`</span><span class="attr-infos">Type: <code>\*</code></span> | Value to filter on when checked |
+| <span class='attr-optional'>`options.values.off`</span><span class="attr-infos">Type: <code>\*</code></span> | Value to filter on when unchecked |
+| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add |
+| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the root element |
+| <span class='attr-optional'>`options.cssClasses.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the header element |
+| <span class='attr-optional'>`options.cssClasses.body`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the body element |
+| <span class='attr-optional'>`options.cssClasses.footer`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the footer element |
+| <span class='attr-optional'>`options.cssClasses.list`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the list element |
+| <span class='attr-optional'>`options.cssClasses.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each item element |
+| <span class='attr-optional'>`options.cssClasses.active`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each active element |
+| <span class='attr-optional'>`options.cssClasses.label`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each label element (when using the default template) |
+| <span class='attr-optional'>`options.cssClasses.checkbox`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each checkbox element (when using the default template) |
+| <span class='attr-optional'>`options.cssClasses.count`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each count element (when using the default template) |
+| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
+| <span class='attr-optional'>`options.templates.header`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Header template |
+| <span class='attr-optional'>`options.templates.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Item template |
+| <span class='attr-optional'>`options.templates.footer`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Footer template |
+| <span class='attr-optional'>`options.transformData`</span><span class="attr-infos">Type: <code>function</code></span> | Function to change the object passed to the item template |
+| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when there's no results |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/css/_documentation.sass
+++ b/docs/css/_documentation.sass
@@ -253,6 +253,10 @@ code
       color: #46aeda
     .attr-required code
       color: $success-color
+    .attr-infos
+      display: block
+      font-size: .8em
+      margin-left: 10px
     h5
       text-decoration: underline
       color: #dddddd

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -116,19 +116,7 @@ var search = instantsearch({
 instantsearch(options);
 {% endhighlight %}
 
-| Option | Description |
-| <span class="attr-required">`options.appId`</span>* | The application ID |
-| <span class="attr-required">`options.apiKey`</span>* | The search key to access algolia |
-| <span class="attr-required">`options.index`</span>* | The name of the main index |
-| <span class="attr-optional">`options.numberLocale`</span> | The locale used to display numbers. By default, `'en-EN'` |
-| <span class="attr-optional">`options.searchParameters`</span> | Initial search configuration. By default, `{}` |
-| <span class="attr-optional">`options.urlSync`</span> | Url synchronisation configuration. By default, `null` |
-| <span class="attr-optional">`options.urlSync.trackedParameters`</span> | Parameters that will be synchronized in the URL. By default, it will track the query, all the refinable attribute (facets and numeric filters), the index and the page. |
-| <span class="attr-optional">`options.urlSync.useHash`</span> | If set to true, the url will be hash based. Otherwise, it'll use the query parameters using the modern history API. |
-| <span class="attr-optional">`options.urlSync.threshold`</span> | Time in ms after which a new state is created in the browser history. The default value is 700. |
-
-  <p class="attr-legend">* <span>Required</span></p>
-  </div>
+{% include widget-jsdoc/instantsearch.md %}
 </div>
 </div>
 
@@ -164,10 +152,7 @@ The build your search results page, you need to combine widgets together. Widget
 search.addWidget(widget)
 {% endhighlight %}
 
-| Option | Description |
-| <span class="attr-optional">`widget.render`</span> | Called after each search response has been received |
-| <span class="attr-optional">`widget.getConfiguration`</span> | Let the widget update the configuration of the search with new parameters |
-| <span class="attr-optional">`widget.init`</span> | Called once before the first search |
+{% include widget-jsdoc/addWidget.md %}
 
   </div>
 </div>
@@ -189,13 +174,6 @@ Once all the widgets have been added to the instantsearch instance, just start t
 {% highlight javascript %}
 search.start();
 {% endhighlight %}
-  </div>
-  <div class="jsdoc" style="display: none">
-{% highlight javascript %}
-search.start();
-{% endhighlight %}
-
-  *No parameters*
   </div>
 </div>
 

--- a/lib/InstantSearch.js
+++ b/lib/InstantSearch.js
@@ -12,6 +12,19 @@ let urlSyncWidget = require('./url-sync');
 function defaultCreateURL() { return '#'; }
 
 class InstantSearch extends EventEmitter {
+  /**
+   * Add a widget test
+   * @param  {string} options.appId The Algolia application ID
+   * @param  {string} options.apiKey The Algolia search-only API key
+   * @param  {string} options.index The name of the main index
+   * @param  {string} [options.numberLocale] The locale used to display numbers.
+   * @param  {string} [options.searchParameters] Initial search configuration.
+   * @param  {string} [options.urlSync] Url synchronization configuration.
+   * @param  {string} [options.urlSync.trackedParameters] Parameters that will be synchronized in the URL. By default, it will track the query, all the refinable attribute (facets and numeric filters), the index and the page.
+   * @param  {string} [options.urlSync.useHash] If set to true, the url will be hash based. Otherwise, it'll use the query parameters using the modern history API.
+   * @param  {string} [options.urlSync.threshold] Time in ms after which a new state is created in the browser history. The default value is 700.
+   * @return {Object} the instantsearch instance
+   */
   constructor({
     appId = null,
     apiKey = null,
@@ -49,13 +62,21 @@ Usage: instantsearch({
     this.urlSync = urlSync;
   }
 
-  addWidget(widgetDefinition) {
+  /**
+   * Add a widget
+   * @param  {Object} [widget] The widget to add
+   * @param  {function} [widget.render] Called after each search response has been received
+   * @param  {function} [widget.getConfiguration] Let the widget update the configuration of the search with new parameters
+   * @param  {function} [widget.init] Called once before the first search
+   * @return {Object} the added widget
+   */
+  addWidget(widget) {
     // Add the widget to the list of widget
-    if (widgetDefinition.render === undefined && widgetDefinition.init === undefined) {
+    if (widget.render === undefined && widget.init === undefined) {
       throw new Error('Widget definition missing render or init method');
     }
 
-    this.widgets.push(widgetDefinition);
+    this.widgets.push(widget);
   }
 
   start() {

--- a/scripts/doc/widgetTemplate.hbs
+++ b/scripts/doc/widgetTemplate.hbs
@@ -1,8 +1,7 @@
 {{#function name="%s"}}
 {{tableHead params "name|Param" "description|Description" ~}}
 {{#tableRow params "name" "type" "defaultvalue" "description" ~}}
-| {{#if @col1}} {{#if optional}}<span class='attr-optional'>{{else}}<span class='attr-required'>{{/if}}`{{name}}`</span> | {{/if~}}
-{{#if @col3}}{{{stripNewlines (inlineLinks description)}}} |{{/if}}
+| {{#if optional}}<span class='attr-optional'>{{else}}<span class='attr-required'>{{/if}}`{{name}}`</span><span class="attr-infos">{{#unless (equal defaultvalue undefined)}}Default:<code class="attr-default">{{defaultvalue}}</code><br />{{/unless}}Type: {{>linked-type-list types=type.names delimiter=" &#124; " }}</span> | {{{stripNewlines (inlineLinks description)}}} |
 {{/tableRow}}
 {{/function}}
 


### PR DESCRIPTION
 - use the jsdoc2md tool to generate the `instantsearch()` and
   `addWidget` documentation as well
 - update the default template to display the default value & type

Fix #473