### PR TITLE
fix(website layout): wrap the main content

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -27,11 +27,13 @@
   <body class="{% body_class %}">
     {% include header.html %}
 
-    {{ content }}
+    <div class="site-content">
+      {{ content }}
 
-{%if page.noFooter == null %}
-    {% include footer.html %}
-{% endif %}
+      {%if page.noFooter == null %}
+        {% include footer.html %}
+      {% endif %}
+    </div>
     <script src="//cdn.jsdelivr.net/jquery/1.11.3/jquery.min.js"></script>
     <script src="{{ "/js/bootstrap.min.js" | prepend: site.baseurl }}"></script>
     <script src="//use.fonticons.com/dff9b562.js"></script> <!-- replace font-awesome -->

--- a/docs/_layouts/page.html
+++ b/docs/_layouts/page.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-<div class="container main-content">
+<div class="container">
   <header class="page-header">
     <h1 class="page-title">{{ page.title }}</h1>
   </header>

--- a/docs/css/_documentation.sass
+++ b/docs/css/_documentation.sass
@@ -48,7 +48,6 @@ code
 
 .main-documentation
   height: 100%
-  padding-top: 50px
   .description
     min-height: 84px
 

--- a/docs/css/_header.sass
+++ b/docs/css/_header.sass
@@ -54,6 +54,3 @@ header.over-white-background
   header.over-white-background
     .navbar-nav a
       color: black !important
-
-.main-content
-  margin-top: $navbar-height

--- a/docs/css/_home.sass
+++ b/docs/css/_home.sass
@@ -18,7 +18,6 @@ h2
   header.site-header nav.navbar
     background-color: rgba(black,0)
 
-
 #space
   position: fixed
   top: 0
@@ -53,7 +52,7 @@ h2
   display: block
   color: white
 .hero
-  padding-top: 100px
+  padding-top: 40px
   opacity: 1
 .logo
   svg

--- a/docs/css/_page.sass
+++ b/docs/css/_page.sass
@@ -1,3 +1,11 @@
 .page-content
   font-size: 1.1em
   line-height: 1.5em
+
+.site-content
+  position: absolute
+  top: 60px
+  left: 0
+  bottom: 0
+  right: 0
+  overflow-y: scroll


### PR DESCRIPTION
Ensure the main content of the website doens't go below the site
header.

Fix #520

New behavior:
![current](https://cloud.githubusercontent.com/assets/123822/11115383/75443b38-892b-11e5-9dfa-a733f919d411.gif)
