### PR TITLE
docs(requirements): Add Algolia requirements to the doc

### DIFF
--- a/components/RefinementList/RefinementList.js
+++ b/components/RefinementList/RefinementList.js
@@ -26,7 +26,7 @@ class RefinementList extends React.Component {
     let data = facetValue;
 
     if (this.props.createURL) {
-      data.url = this.props.createURL(facetValue[this.props.facetNameKey]);
+      data.url = this.props.createURL(facetValue[this.props.attributeNameKey]);
     }
 
     let templateData = {...facetValue, cssClasses: this.props.cssClasses};
@@ -35,7 +35,7 @@ class RefinementList extends React.Component {
       [this.props.cssClasses.active]: facetValue.isRefined
     });
 
-    let key = facetValue[this.props.facetNameKey];
+    let key = facetValue[this.props.attributeNameKey];
     if (facetValue.isRefined !== undefined) {
       key += '/' + facetValue.isRefined;
     }
@@ -47,7 +47,7 @@ class RefinementList extends React.Component {
       <div
         className={cssClassItem}
         key={key}
-        onClick={this.handleClick.bind(this, facetValue[this.props.facetNameKey])}
+        onClick={this.handleClick.bind(this, facetValue[this.props.attributeNameKey])}
       >
         <Template data={templateData} templateKey="item" {...this.props.templateProps} />
         {subList}
@@ -120,6 +120,7 @@ class RefinementList extends React.Component {
 
 RefinementList.propTypes = {
   Template: React.PropTypes.func,
+  attributeNameKey: React.PropTypes.string,
   createURL: React.PropTypes.func.isRequired,
   cssClasses: React.PropTypes.shape({
     active: React.PropTypes.string,
@@ -128,7 +129,6 @@ RefinementList.propTypes = {
     list: React.PropTypes.string
   }),
   depth: React.PropTypes.number,
-  facetNameKey: React.PropTypes.string,
   facetValues: React.PropTypes.array,
   templateProps: React.PropTypes.object.isRequired,
   toggleRefinement: React.PropTypes.func.isRequired
@@ -137,7 +137,7 @@ RefinementList.propTypes = {
 RefinementList.defaultProps = {
   cssClasses: {},
   depth: 0,
-  facetNameKey: 'name'
+  attributeNameKey: 'name'
 };
 
 module.exports = RefinementList;

--- a/components/RefinementList/__tests__/RefinementList-test.js
+++ b/components/RefinementList/__tests__/RefinementList-test.js
@@ -127,8 +127,8 @@ describe('RefinementList', () => {
             />
             <RefinementList
               {...templateProps.data}
+              attributeNameKey="name"
               depth={1}
-              facetNameKey="name"
               facetValues={customProps.facetValues[0].data}
               templateProps={{}}
             />

--- a/docs/_includes/widget-jsdoc/menu.md
+++ b/docs/_includes/widget-jsdoc/menu.md
@@ -1,7 +1,7 @@
 | Param | Description |
 | --- | --- |
 | <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
-| <span class='attr-required'>`options.facetName`</span><span class="attr-infos">Type: <code>string</code></span> | Name of the attribute for faceting |
+| <span class='attr-required'>`options.attributeName`</span><span class="attr-infos">Type: <code>string</code></span> | Name of the attribute for faceting |
 | <span class='attr-optional'>`options.sortBy`</span><span class="attr-infos">Default:<code class="attr-default">[&#x27;count:desc&#x27;]</code><br />Type: <code>Array.&lt;string&gt;</code></span> | How to sort refinements. Possible values: `count|isRefined|name:asc|desc` |
 | <span class='attr-optional'>`options.limit`</span><span class="attr-infos">Default:<code class="attr-default">100</code><br />Type: <code>string</code></span> | How many facets values to retrieve |
 | <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add to the wrapping elements: root, list, item |

--- a/docs/_includes/widget-jsdoc/refinementList.md
+++ b/docs/_includes/widget-jsdoc/refinementList.md
@@ -1,7 +1,7 @@
 | Param | Description |
 | --- | --- |
 | <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
-| <span class='attr-required'>`options.facetName`</span><span class="attr-infos">Type: <code>string</code></span> | Name of the attribute for faceting |
+| <span class='attr-required'>`options.attributeName`</span><span class="attr-infos">Type: <code>string</code></span> | Name of the attribute for faceting |
 | <span class='attr-optional'>`options.operator`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;or&#x27;</code><br />Type: <code>string</code></span> | How to apply refinements. Possible values: `or`, `and` |
 | <span class='attr-optional'>`options.sortBy`</span><span class="attr-infos">Default:<code class="attr-default">[&#x27;count:desc&#x27;]</code><br />Type: <code>Array.&lt;string&gt;</code></span> | How to sort refinements. Possible values: `count|isRefined|name:asc|desc` |
 | <span class='attr-optional'>`options.limit`</span><span class="attr-infos">Default:<code class="attr-default">1000</code><br />Type: <code>string</code></span> | How much facet values to get |

--- a/docs/_includes/widget-jsdoc/toggle.md
+++ b/docs/_includes/widget-jsdoc/toggle.md
@@ -1,7 +1,7 @@
 | Param | Description |
 | --- | --- |
 | <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
-| <span class='attr-required'>`options.facetName`</span><span class="attr-infos">Type: <code>string</code></span> | Name of the attribute for faceting (eg. "free_shipping") |
+| <span class='attr-required'>`options.attributeName`</span><span class="attr-infos">Type: <code>string</code></span> | Name of the attribute for faceting (eg. "free_shipping") |
 | <span class='attr-required'>`options.label`</span><span class="attr-infos">Type: <code>string</code></span> | Human-readable name of the filter (eg. "Free Shipping") |
 | <span class='attr-optional'>`options.values`</span><span class="attr-infos">Type: <code>Object</code></span> | Lets you define the values to filter on when toggling |
 | <span class='attr-optional'>`options.values.on`</span><span class="attr-infos">Type: <code>\*</code></span> | Value to filter on when checked |

--- a/docs/css/_documentation.sass
+++ b/docs/css/_documentation.sass
@@ -288,6 +288,19 @@ code
         font-size: 10px
         color: #58d158
 
+  .requirements
+    display: none
+    border: none
+    color: #a3b6cb
+    padding: 9.5px
+    margin: 0 0 10px
+    background-color: #0a1724
+    code
+      font-size: 1em
+      background: none
+      color: #58d158
+    
+
 // Widgets
 #q input
   width: 100%

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -58,7 +58,7 @@ The library is open-source, based on [React.js](http://facebook.github.io/react/
 The fastest way to get started is to use a built version of **instantsearch.js** from a CDN:
 
 <div class="code-box">
-  <div class="code-sample-snippet ignore">
+  <div class="code-sample-snippet js-toggle-snippet ignore">
 {% highlight html %}
 <link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/instantsearch.js/0/instantsearch.min.css">
 <script src="//cdn.jsdelivr.net/instantsearch.js/0/instantsearch.min.js"></script>
@@ -78,14 +78,14 @@ This will expose the global `instantsearch` function.
 If you already have a JavaScript build system, you can use **instantsearch.js** from NPM:
 
 <div class="code-box">
-  <div class="code-sample-snippet ignore">
+  <div class="code-sample-snippet js-toggle-snippet ignore">
 {% highlight sh %}
 npm install instantsearch.js --save
 {% endhighlight %}
   </div>
 </div>
 <div class="code-box">
-  <div class="code-sample-snippet ignore">
+  <div class="code-sample-snippet js-toggle-snippet ignore">
 {% highlight javascript %}
 var instantsearch = require('instantsearch.js');
 // TODO: include the instantsearch.js/dist/instantsearch.css file as well
@@ -99,10 +99,10 @@ var instantsearch = require('instantsearch.js');
 
 <div class="codebox-combo">
 
-To initialize the **instantsearch.js** library you need an Algolia account with a configured & non-empty index. You'll find your Algolia credentials on the [credentials page of your dashboard](https://www.algolia.com/licensing). Use the **APPLICATION\_ID** `appId`, the **search only API\_KEY** `apiKey` and an index name `indexName` to configure the required parameters of the `instantsearch` function.
+To initialize the **instantsearch.js** library you need an Algolia account with a configured & non-empty index. You'll find your Algolia credentials on the [credentials page of your dashboard](https://www.algolia.com/licensing). Use the **APPLICATION\_ID** `appId`, the **search only API\_KEY** `apiKey` and an index name `indexName` as the required parameters of the `instantsearch` function.
 
 <div class="code-box">
-  <div class="code-sample-snippet config">
+  <div class="code-sample-snippet js-toggle-snippet config">
 {% highlight javascript %}
 var search = instantsearch({
   appId: '$appId',
@@ -111,18 +111,22 @@ var search = instantsearch({
 });
 {% endhighlight %}
   </div>
-  <div class="jsdoc" style="display: none">
+  <div class="jsdoc js-toggle-jsdoc" style="display: none">
 {% highlight javascript %}
 instantsearch(options);
 {% endhighlight %}
 
 {% include widget-jsdoc/instantsearch.md %}
   </div>
+  <div class="requirements js-toggle-requirements">
+Make sure you are using the **search-only API key** and that you have created
+the index.
+  </div>
 </div>
 
 </div>
 
-If you don't have any index yet, learn how to push your data with the [Algolia getting started](https://www.algolia.com/getstarted).
+If you don't have any index yet, learn how to push your data with our [getting started guide](https://www.algolia.com/getstarted).
 
 We also expose a few options that can be used to configure the default and initial behavior of the instantsearch instance.
 
@@ -130,14 +134,14 @@ We also expose a few options that can be used to configure the default and initi
 
 <div class="codebox-combo">
 
-The build your search results page, you need to combine widgets together. Widgets are simple objects which hold the handler to part of the instant search lifecycle. Start by adding a `searchBox` widget, a `hits` widget and a `pagination` widget to build a fundamental results page.
+To build your search result page, you need to combine widgets together. Widgets are simple objects which hold the handler to part of the instant search lifecycle. Start by adding a `searchBox` widget, a `hits` widget and a `pagination` widget to build a fundamental results page.
 
 <div class="code-box">
-  <div class="code-sample-snippet ignore">
+  <div class="code-sample-snippet js-toggle-snippet ignore">
 {% highlight html %}
 <div id="search-box"></div>
 
-<script type="text/javascript">
+<script>
   // [...]
   search.addWidget(
     instantsearch.widgets.searchBox({
@@ -148,7 +152,7 @@ The build your search results page, you need to combine widgets together. Widget
 </script>
 {% endhighlight %}
   </div>
-  <div class="jsdoc" style="display: none">
+  <div class="jsdoc js-toggle-jsdoc" style="display: none">
 {% highlight javascript %}
 search.addWidget(widget)
 {% endhighlight %}
@@ -171,7 +175,7 @@ Most widgets requires you to configure the DOM element they will use to display 
 Once all the widgets have been added to the instantsearch instance, just start the rendering calling the `start()` method.
 
 <div class="code-box">
-  <div class="code-sample-snippet start">
+  <div class="code-sample-snippet js-toggle-snippet start">
 {% highlight javascript %}
 search.start();
 {% endhighlight %}
@@ -187,7 +191,7 @@ search.start();
 This example shows you how to create a very simple search results page with a search box, a list of hits and a pagination widget.
 
 <div class="code-box">
-  <div class="code-sample-snippet ignore">
+  <div class="code-sample-snippet js-toggle-snippet ignore">
 {% highlight html %}
 <!doctype html>
 <html>
@@ -248,11 +252,11 @@ This example shows you how to create a very simple search results page with a se
 <div class="codebox-combo">
 
 <img class="widget-icon pull-left" src="../img/icon-widget-searchbox.svg">
-The search box is the widget to use for text input. Underneath, it is based on the Algolia [query parameter](https://www.algolia.com/doc/rest#param-query). It will provide text search on the `attributesToIndex` setting set in your index.
+The search box is the widget to use for text input. Underneath, it will call the [Algolia API](https://www.algolia.com/doc/rest) and return results based on your [configured relevance options](https://www.algolia.com/doc/tutorials/ranking-formula).
 {:.description}
 
 <div class="code-box">
-  <div class="code-sample-snippet">
+  <div class="code-sample-snippet js-toggle-snippet">
 {% highlight javascript %}
 search.addWidget(
   instantsearch.widgets.searchBox({
@@ -269,13 +273,19 @@ search.addWidget(
 );
 {% endhighlight %}
   </div>
-  <div class="jsdoc" style="display: none">
+  <div class="jsdoc js-toggle-jsdoc" style="display: none">
 {% highlight javascript %}
 instantsearch.widgets.searchBox(options)
 {% endhighlight %}
 
 {% include widget-jsdoc/searchBox.md %}
 
+  </div>
+  <div class="requirements js-toggle-requirements">
+For better results, we suggest that you configure at least the
+[attributeToIndex](https://www.algolia.com/doc/rest#param-attributesToIndex) and
+[customRanking](https://www.algolia.com/doc/rest#param-customRanking) of your
+index.
   </div>
 </div>
 
@@ -292,7 +302,7 @@ The hits widget is the main component for displaying results from Algolia. It ac
 {:.description}
 
 <div class="code-box">
-  <div class="code-sample-snippet">
+  <div class="code-sample-snippet js-toggle-snippet">
 {% highlight javascript %}
 {% raw %}
 search.addWidget(
@@ -308,7 +318,7 @@ search.addWidget(
 {% endraw %}
 {% endhighlight %}
   </div>
-  <div class="jsdoc" style='display:none'>
+  <div class="jsdoc js-toggle-jsdoc" style='display:none'>
 {% highlight javascript %}
 {% raw %}
 instantsearch.widgets.hits(options);
@@ -317,6 +327,12 @@ instantsearch.widgets.hits(options);
 
 {% include widget-jsdoc/hits.md %}
 
+  </div>
+  <div class="requirements js-toggle-requirements">
+For better control on what kind of data is returned, we suggest that you configure the
+[attributeToRetrieve](https://www.algolia.com/doc/rest#param-attributesToRetrieve)
+and
+[attributeToHighlight](https://www.algolia.com/doc/rest#param-attributesToHighlight) of your index.
   </div>
 </div>
 
@@ -335,7 +351,7 @@ displayed.
 {:.description}
 
 <div class="code-box">
-  <div class="code-sample-snippet">
+  <div class="code-sample-snippet js-toggle-snippet">
 {% highlight javascript %}
 {% raw %}
 search.addWidget(
@@ -355,7 +371,7 @@ search.addWidget(
 {% endraw %}
 {% endhighlight %}
   </div>
-  <div class="jsdoc" style='display:none'>
+  <div class="jsdoc js-toggle-jsdoc" style='display:none'>
 {% highlight javascript %}
 {% raw %}
 instantsearch.widgets.hitsPerPageSelector(options);
@@ -364,6 +380,10 @@ instantsearch.widgets.hitsPerPageSelector(options);
 
 {% include widget-jsdoc/hitsPerPageSelector.md %}
 
+  </div>
+  <div class="requirements js-toggle-requirements">
+The [hits](#hits) widget lets you define the default number of results
+displayed. This value must also be defined in the `options` parameter.
   </div>
 </div>
 
@@ -383,7 +403,7 @@ pages.
 {:.description}
 
 <div class="code-box">
-  <div class="code-sample-snippet">
+  <div class="code-sample-snippet js-toggle-snippet">
     {% highlight javascript %}
 search.addWidget(
   instantsearch.widgets.pagination({
@@ -394,7 +414,7 @@ search.addWidget(
 );
     {% endhighlight %}
   </div>
-  <div class="jsdoc" style='display:none'>
+  <div class="jsdoc js-toggle-jsdoc" style='display:none'>
 {% highlight javascript %}
 instantsearch.widgets.pagination(options);
 {% endhighlight %}
@@ -418,12 +438,12 @@ of an ecommerce website.
 {:.description}
 
 <div class="code-box">
-  <div class="code-sample-snippet">
+  <div class="code-sample-snippet js-toggle-snippet">
 {% highlight javascript %}
 search.addWidget(
   instantsearch.widgets.menu({
     container: '#categories',
-    facetName: 'categories',
+    attributeName: 'categories',
     limit: 10,
     templates: {
       header: 'Categories'
@@ -445,12 +465,16 @@ search.addWidget(
 {% endhighlight %}
   </div>
 
-  <div class="jsdoc" style='display:none'>
+  <div class="jsdoc js-toggle-jsdoc" style='display:none'>
 {% highlight javascript %}
 instantsearch.widgets.menu(options);
 {% endhighlight %}
 
 {% include widget-jsdoc/menu.md %}
+  </div>
+  <div class="requirements js-toggle-requirements">
+The attribute defined in `attributeName` must also be defined as an
+[attributesForFaceting](https://www.algolia.com/doc/rest#param-attributesForFaceting) in your index configuration.
   </div>
 </div>
 
@@ -470,7 +494,7 @@ From a UX point of view, we suggest to not display more than two levels deep.
 {:.description}
 
 <div class="code-box">
-  <div class="code-sample-snippet">
+  <div class="code-sample-snippet js-toggle-snippet">
 {% highlight javascript %}
 search.addWidget(
   instantsearch.widgets.hierarchicalMenu({
@@ -496,12 +520,30 @@ search.addWidget(
 {% endhighlight %}
   </div>
 
-  <div class="jsdoc" style='display:none'>
+  <div class="jsdoc js-toggle-jsdoc" style='display:none'>
 {% highlight javascript %}
 instantsearch.widgets.hierarchicalMenu(options);
 {% endhighlight %}
 
 {% include widget-jsdoc/hierarchicalMenu.md %}
+  </div>
+  <div class="requirements js-toggle-requirements">
+The attribute used for facetting must be an object that follows a [specific
+convention](https://github.com/algolia/algoliasearch-helper-js#hierarchical-facets). For
+example, to build this example menu, we have data that looks like:
+{% highlight javascript %}
+{
+  "objectID": 4815162342,
+  "hierarchicalCategories": {
+    "lvl0": "Appliances"
+    "lvl1": "Appliances > Air Conditioners"
+    "lvl2": "Appliances > Air Conditioners > Portable Air Conditioners"
+  }
+{% endhighlight %}
+
+The root attribute (here, `hierarchicalCategories`) must also be defined as an
+[attributesForFaceting](https://www.algolia.com/doc/rest#param-attributesForFaceting) in your index configuration.
+
   </div>
 </div>
 </div>
@@ -520,12 +562,12 @@ results that have either the value `a` or `b` will match.
 {:.description}
 
 <div class="code-box">
-  <div class="code-sample-snippet">
+  <div class="code-sample-snippet js-toggle-snippet">
 {% highlight javascript %}
 search.addWidget(
   instantsearch.widgets.refinementList({
     container: '#brands',
-    facetName: 'brand',
+    attributeName: 'brand',
     operator: 'or',
     limit: 10,
     templates: {
@@ -547,12 +589,16 @@ search.addWidget(
 );
 {% endhighlight %}
   </div>
-  <div class="jsdoc" style='display:none'>
+  <div class="jsdoc js-toggle-jsdoc" style='display:none'>
 {% highlight javascript %}
 instantsearch.widgets.refinementList(options);
 {% endhighlight %}
 
 {% include widget-jsdoc/refinementList.md %}
+  </div>
+  <div class="requirements js-toggle-requirements">
+The attribute defined in `attributeName` must also be defined as an
+[attributesForFaceting](https://www.algolia.com/doc/rest#param-attributesForFaceting) in your index configuration.
   </div>
 </div>
 
@@ -569,7 +615,7 @@ This filtering widget lets the user choose one value for a single numeric attrib
 {:.description}
 
 <div class="code-box">
-  <div class="code-sample-snippet">
+  <div class="code-sample-snippet js-toggle-snippet">
 {% highlight javascript %}
 search.addWidget(
   instantsearch.widgets.numericRefinementList({
@@ -598,12 +644,12 @@ search.addWidget(
 );
 {% endhighlight %}
   </div>
-  <div class="jsdoc" style='display:none'>
+  <div class="jsdoc js-toggle-jsdoc" style='display:none'>
 {% highlight javascript %}
 instantsearch.widgets.numericRefinementList(options);
 {% endhighlight %}
 
-{% include widget-jsdoc/refinementList.md %}
+{% include widget-jsdoc/numericRefinementList.md %}
   </div>
 </div>
 
@@ -620,12 +666,12 @@ This filtering widget lets the user choose either or not to filter values to `tr
 {:.description}
 
 <div class="code-box">
-  <div class="code-sample-snippet">
+  <div class="code-sample-snippet js-toggle-snippet">
 {% highlight javascript %}
 search.addWidget(
   instantsearch.widgets.toggle({
     container: '#free-shipping',
-    facetName: 'free_shipping',
+    attributeName: 'free_shipping',
     label: 'Free Shipping',
     values: {
       on: true,
@@ -650,11 +696,15 @@ search.addWidget(
 );
 {% endhighlight %}
   </div>
-  <div class="jsdoc" style='display:none'>
+  <div class="jsdoc js-toggle-jsdoc" style='display:none'>
 {% highlight javascript %}
 instantsearch.widgets.toggle(options);
 {% endhighlight %}
 {% include widget-jsdoc/toggle.md %}
+  </div>
+  <div class="requirements js-toggle-requirements">
+The attribute defined in `attributeName` must also be defined as an
+[attributesForFaceting](https://www.algolia.com/doc/rest#param-attributesForFaceting) in your index configuration.
   </div>
 </div>
 
@@ -671,7 +721,7 @@ The range slider filters values of a single numeric attribute using 2 cursors: t
 {:.description}. The min and max values are automatically computed by Algolia using the data in the index.
 
 <div class="code-box">
-  <div class="code-sample-snippet">
+  <div class="code-sample-snippet js-toggle-snippet">
 {% highlight javascript %}
 search.addWidget(
   instantsearch.widgets.rangeSlider({
@@ -689,11 +739,15 @@ search.addWidget(
 );
 {% endhighlight %}
   </div>
-  <div class="jsdoc" style='display:none'>
+  <div class="jsdoc js-toggle-jsdoc" style='display:none'>
 {% highlight javascript %}
 instantsearch.widgets.rangeSlider(options);
 {% endhighlight %}
 {% include widget-jsdoc/rangeSlider.md %}
+  </div>
+  <div class="requirements js-toggle-requirements">
+The attribute defined in `attributeName` must also be defined as an
+[attributesForFaceting](https://www.algolia.com/doc/rest#param-attributesForFaceting) in your index configuration.
   </div>
 </div>
 
@@ -710,7 +764,7 @@ This filtering widget lets the user choose between ranges of price. Those ranges
 {:.description}
 
 <div class="code-box">
-  <div class="code-sample-snippet">
+  <div class="code-sample-snippet js-toggle-snippet">
 {% highlight javascript %}
 search.addWidget(
   instantsearch.widgets.priceRanges({
@@ -741,12 +795,16 @@ search.addWidget(
 );
 {% endhighlight %}
   </div>
-  <div class="jsdoc" style='display:none'>
+  <div class="jsdoc js-toggle-jsdoc" style='display:none'>
 {% highlight javascript %}
 instantsearch.widgets.priceRanges(options);
 {% endhighlight %}
 
 {% include widget-jsdoc/priceRanges.md %}
+  </div>
+  <div class="requirements js-toggle-requirements">
+The attribute defined in `attributeName` must also be defined as an
+[attributesForFaceting](https://www.algolia.com/doc/rest#param-attributesForFaceting) in your index configuration.
   </div>
 </div>
 
@@ -804,7 +862,7 @@ instantsearch.widgets.numericSelector(options);
 This widget clears all the refinements that are currently applied.
 
 <div class="code-box">
-  <div class="code-sample-snippet">
+  <div class="code-sample-snippet js-toggle-snippet">
 {% highlight javascript %}
 search.addWidget(
   instantsearch.widgets.clearAll({
@@ -824,7 +882,7 @@ search.addWidget(
 );
 {% endhighlight %}
   </div>
-  <div class="jsdoc" style='display:none'>
+  <div class="jsdoc js-toggle-jsdoc" style='display:none'>
 {% highlight javascript %}
 instantsearch.widgets.clearAll(options);
 {% endhighlight %}
@@ -848,7 +906,7 @@ This widget lets you select which index you want to use for the search. Since Al
 {:.description}
 
 <div class="code-box">
-  <div class="code-sample-snippet">
+  <div class="code-sample-snippet js-toggle-snippet">
 {% highlight javascript %}
 search.addWidget(
   instantsearch.widgets.indexSelector({
@@ -866,11 +924,17 @@ search.addWidget(
 );
 {% endhighlight %}
   </div>
-  <div class="jsdoc" style='display:none'>
+  <div class="jsdoc js-toggle-jsdoc" style='display:none'>
 {% highlight javascript %}
 instantsearch.widgets.indexSelector(options);
 {% endhighlight %}
 {% include widget-jsdoc/indexSelector.md %}
+  </div>
+  <div class="requirements js-toggle-requirements">
+You need to create slave indices for every sort order you need, and
+configure their `ranking` to use a custom attribute as the first criterion.
+You can find more information [in our FAQ
+page](https://www.algolia.com/doc/faq/index-configuration/how-to-sort-the-results-with-a-specific-attribute).
   </div>
 </div>
 
@@ -889,7 +953,7 @@ This widget lets you display meta informations of the current search. It helps t
 {:.description}
 
 <div class="code-box">
-  <div class="code-sample-snippet">
+  <div class="code-sample-snippet js-toggle-snippet">
 {% highlight javascript %}
 search.addWidget(
   instantsearch.widgets.stats({
@@ -904,7 +968,7 @@ search.addWidget(
 );
 {% endhighlight %}
   </div>
-  <div class="jsdoc" style='display:none'>
+  <div class="jsdoc js-toggle-jsdoc" style='display:none'>
 {% highlight javascript %}
 instantsearch.widgets.stats(options);
 {% endhighlight %}
@@ -1017,7 +1081,7 @@ for simple widgets such as the searchBox and for the most advanced, we use
 If your code base is relying on an other framework, feel free to use it to create your own widget!
 
 <div class="code-box">
-  <div class="code-sample-snippet ignore">
+  <div class="code-sample-snippet js-toggle-snippet ignore">
 {% highlight javascript %}
 var mySingletonWidget = {
   getConfiguration: function(searchParams) {
@@ -1036,7 +1100,7 @@ search.addWidget(mySingletonWidget);
 {% endhighlight %}
 
 </div>
-<div class="jsdoc" style='display:none'>
+<div class="jsdoc js-toggle-jsdoc" style='display:none'>
 
 {% highlight javascript %}
 search.addWidget(widget)
@@ -1086,23 +1150,23 @@ If you want to build you own theme, we recommend you to start from our default s
 We're providing a few SCSS mixins to help you write BEM rules. Those mixins can be loaded from the `_base.scss` file.
 
 <div class="code-box">
-  <div class="code-sample-snippet ignore">
+  <div class="code-sample-snippet js-toggle-snippet ignore">
 {% highlight scss %}
-// .ais-<component>--<element>
-@include bem(component, element) {
+// .ais-<block>--<element>
+@include bem(block, element) {
   color: red
 }
 
-// .ais-<component>--<element>__<modifier>
-@include bem(component, element, modifier) {
+// .ais-<block>--<element>__<modifier>
+@include bem(block, element, modifier) {
   color: red
 }
 
-// .ais-<component>
-@include component(component) {
-  // .ais-<component>--<element>
+// .ais-<block>
+@include block(block) {
+  // .ais-<block>--<element>
   @include element(element) {
-    // .ais-<component>--<element>__<modifier>
+    // .ais-<block>--<element>__<modifier>
     @include modifier(modifier) {
       color: red
     }
@@ -1124,7 +1188,7 @@ We're providing a few SCSS mixins to help you write BEM rules. Those mixins can 
 If you want to style the **search-box** widget, you can do:
 
 <div class="code-box">
-<div class="code-sample-snippet ignore">
+<div class="code-sample-snippet js-toggle-snippet ignore">
 <div class="row">
 <div class="col-sm-6">
 <strong class="text-white">With SCSS</strong>

--- a/docs/js/doc.js
+++ b/docs/js/doc.js
@@ -35,33 +35,45 @@
     $('.code-box').each(function() {
       var $this = $(this);
       var code = $this.find('.code-sample-snippet');
-      var doc = $this.find('.jsdoc');
-      if (code.length > 0 && doc.length > 0) {
-        $(this).prepend(
-          '<div class="btn-group">' +
-            '<button type="button" class="toggle-doc-button snippet-btn btn btn-default btn-sm active">Snippet</button>' +
-            '<button type="button" class="toggle-doc-button jsdoc-btn btn btn-default btn-sm">All options</button>' +
-          '</div>'
-        );
+      var jsdoc = $this.find('.jsdoc');
+      var requirements = $this.find('.requirements');
+      var hasCode = code.length > 0;
+      var hasJsdoc = jsdoc.length > 0;
+      var hasRequirements = requirements.length > 0;
+
+      var needButtons = (hasCode && (hasJsdoc || hasRequirements));
+      if (!needButtons) {
+        return;
       }
+
+      function getButton(label, target) {
+        var $button = $('<button type="button" class="btn btn-default btn-sm toggle-doc-button">' + label + '</button>');
+        $button.attr('name', target);
+        return $button;
+      }
+      var $btnGroup = $('<div class="btn-group js-doc-toggle"></div>');
+      $btnGroup.append(getButton('Snippet', 'snippet').addClass('active'));
+      if (hasJsdoc) {
+        $btnGroup.append(getButton('All options', 'jsdoc'));
+      }
+      if (hasRequirements) {
+        $btnGroup.append(getButton('Requirements', 'requirements'));
+      }
+
+      $this.prepend($btnGroup);
     });
-    $(document).on('click', '.toggle-doc-button.jsdoc-btn', function() {
-      var $btn = $(this);
-      var $box = $btn.closest('.code-box');
-      $box.find('.toggle-doc-button').removeClass('active');
-      $btn.addClass('active');
-      $box.find('.code-sample-snippet, .html-container').hide();
+    $(document).on('click', '.toggle-doc-button', function() {
+      var $this = $(this);
+      var $codeBox = $this.closest('.code-box');
+      var $btnGroup = $codeBox.find('.btn-group');
+      // Set the current one as active
+      $btnGroup.find('.toggle-doc-button').removeClass('active');
+      $this.addClass('active');
+      // Show the specified target
+      $codeBox.find('.js-toggle-snippet,.js-toggle-jsdoc,.js-toggle-requirements,.js-toggle-html').hide();
+      $codeBox.find('.js-toggle-' + $this.attr('name')).show();
+      // Remove HTML debug if any
       $('.debug-widget').removeClass('debug-widget');
-      $box.find('.jsdoc').show();
-    });
-    $(document).on('click', '.toggle-doc-button.snippet-btn', function() {
-      var $btn = $(this);
-      var $box = $btn.closest('.code-box');
-      $box.find('.toggle-doc-button').removeClass('active');
-      $btn.addClass('active');
-      $box.find('.jsdoc, .html-container').hide();
-      $('.debug-widget').removeClass('debug-widget');
-      $box.find('.code-sample-snippet').show();
     });
   }
 
@@ -96,13 +108,12 @@
     $('.widget-container').each(function() {
       var id = $(this).attr('id');
       var buttons = $('.code-box pre:contains("container: \'#' + id + '\'")').closest('.code-box').find('.btn-group');
-      buttons.append('<button type="button" class="toggle-doc-button html-btn btn btn-default btn-sm" data-widget-container="' + id + '">View HTML</button>');
-      buttons.after('<pre class="html-container highlight" id="html-' + id + '" style="display: none"></pre>');
+      buttons.append('<button type="button" class="toggle-doc-button html-btn btn btn-default btn-sm" name="html" data-widget-container="' + id + '">View HTML</button>');
+      buttons.after('<pre class="html-container highlight js-toggle-html" id="html-' + id + '" style="display: none">kjkjkj</pre>');
     });
     $(document).on('click', '.toggle-doc-button.html-btn', function() {
-      var $btn = $(this);
-      var $box = $btn.closest('.code-box');
-      var id = $(this).data('widget-container');
+      var $this = $(this);
+      var id = $this.data('widget-container');
       var $widget = $('#' + id);
       var source = cleanupAndHighlightMarkup($widget.html());
       var htmlSource = $('<div />').text(source).html();
@@ -111,12 +122,7 @@
         .replace(/(&lt;\/?[a-z]+(&gt;)?)/g, '<span class="nt">$1</span>') // highlight tags
         .replace(/(&gt;)\n/g, '<span class="nt">&gt;</span>\n') // highlight closing chevron
       );
-      $box.find('.toggle-doc-button').removeClass('active');
-      $btn.addClass('active');
-      $box.find('.code-sample-snippet, .jsdoc').hide();
-      $('.debug-widget').removeClass('debug-widget');
       $widget.addClass('debug-widget');
-      $box.find('.html-container').show();
     });
   }
 

--- a/widgets/hierarchical-menu/hierarchical-menu.js
+++ b/widgets/hierarchical-menu/hierarchical-menu.js
@@ -110,9 +110,9 @@ function hierarchicalMenu({
 
       ReactDOM.render(
         <RefinementList
+          attributeNameKey="path"
           createURL={(facetValue) => createURL(state.toggleRefinement(hierarchicalFacetName, facetValue))}
           cssClasses={cssClasses}
-          facetNameKey="path"
           facetValues={facetValues}
           limit={limit}
           shouldAutoHideContainer={hasNoFacetValues}
@@ -125,9 +125,9 @@ function hierarchicalMenu({
   };
 }
 
-function toggleRefinement(helper, facetName, facetValue) {
+function toggleRefinement(helper, attributeName, facetValue) {
   helper
-    .toggleRefinement(facetName, facetValue)
+    .toggleRefinement(attributeName, facetValue)
     .search();
 }
 

--- a/widgets/menu/__tests__/menu-test.js
+++ b/widgets/menu/__tests__/menu-test.js
@@ -8,14 +8,14 @@ import menu from '../menu';
 describe('indexSelector call', () => {
   jsdom({useEach: true});
 
-  it('throws an exception when no facetName', () => {
+  it('throws an exception when no attributeName', () => {
     const container = document.createElement('div');
     expect(menu.bind(null, {container})).toThrow(/^Usage/);
   });
 
   it('throws an exception when no container', () => {
-    const facetName = '';
-    expect(menu.bind(null, {facetName})).toThrow(/^Usage/);
+    const attributeName = '';
+    expect(menu.bind(null, {attributeName})).toThrow(/^Usage/);
   });
 });
 

--- a/widgets/menu/menu.js
+++ b/widgets/menu/menu.js
@@ -13,7 +13,7 @@ let defaultTemplates = require('./defaultTemplates.js');
  * Create a menu out of a facet
  * @function menu
  * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
- * @param  {string} options.facetName Name of the attribute for faceting
+ * @param  {string} options.attributeName Name of the attribute for faceting
  * @param  {string[]} [options.sortBy=['count:desc']] How to sort refinements. Possible values: `count|isRefined|name:asc|desc`
  * @param  {string} [options.limit=100] How many facets values to retrieve
  * @param  {Object} [options.cssClasses] CSS classes to add to the wrapping elements: root, list, item
@@ -37,7 +37,7 @@ let defaultTemplates = require('./defaultTemplates.js');
 const usage = `Usage:
 menu({
   container,
-  facetName,
+  attributeName,
   [sortBy],
   [limit],
   [cssClasses.{root,list,item}],
@@ -47,7 +47,7 @@ menu({
 })`;
 function menu({
     container,
-    facetName,
+    attributeName,
     sortBy = ['count:desc'],
     limit = 100,
     cssClasses: userCssClasses = {},
@@ -55,7 +55,7 @@ function menu({
     transformData,
     autoHideContainer = true
   } = {}) {
-  if (!container || !facetName) {
+  if (!container || !attributeName) {
     throw new Error(usage);
   }
 
@@ -67,13 +67,13 @@ function menu({
 
   // we use a hierarchicalFacet for the menu because that's one of the use cases
   // of hierarchicalFacet: a flat menu
-  let hierarchicalFacetName = facetName;
+  let hierarchicalFacetName = attributeName;
 
   return {
     getConfiguration: () => ({
       hierarchicalFacets: [{
         name: hierarchicalFacetName,
-        attributes: [facetName]
+        attributes: [attributeName]
       }]
     }),
     render: function({results, helper, templatesConfig, state, createURL}) {
@@ -114,9 +114,9 @@ function menu({
   };
 }
 
-function toggleRefinement(helper, facetName, facetValue) {
+function toggleRefinement(helper, attributeName, facetValue) {
   helper
-    .toggleRefinement(facetName, facetValue)
+    .toggleRefinement(attributeName, facetValue)
     .search();
 }
 

--- a/widgets/refinement-list/__tests__/refinement-list-test.js
+++ b/widgets/refinement-list/__tests__/refinement-list-test.js
@@ -37,9 +37,9 @@ describe('refinementList()', () => {
   });
 
   context('instanciated with wrong parameters', () => {
-    it('should fail if no facetName', () => {
+    it('should fail if no attributeName', () => {
       // Given
-      options = {container, facetName: undefined};
+      options = {container, attributeName: undefined};
 
       // Then
       expect(() => {
@@ -49,7 +49,7 @@ describe('refinementList()', () => {
     });
     it('should fail if no container', () => {
       // Given
-      options = {container: undefined, facetName: 'foo'};
+      options = {container: undefined, attributeName: 'foo'};
 
       // Then
       expect(() => {
@@ -61,7 +61,7 @@ describe('refinementList()', () => {
 
   context('autoHideContainer', () => {
     beforeEach(() => {
-      options = {container, facetName: 'facetName'};
+      options = {container, attributeName: 'facetName'};
     });
     it('should be called if autoHideContainer set to true', () => {
       // Given
@@ -87,7 +87,7 @@ describe('refinementList()', () => {
 
   context('operator', () => {
     beforeEach(() => {
-      options = {container, facetName: 'facetName'};
+      options = {container, attributeName: 'facetName'};
     });
     it('should accept [and, or, AND, OR]', () => {
       expect(() => {
@@ -116,7 +116,7 @@ describe('refinementList()', () => {
   context('getConfiguration', () => {
     let configuration;
     beforeEach(() => {
-      options = {container, facetName: 'facetName'};
+      options = {container, attributeName: 'attributeName'};
     });
     it('should add a facet for AND operator', () => {
       // Given
@@ -128,7 +128,7 @@ describe('refinementList()', () => {
       let actual = widget.getConfiguration(configuration);
 
       // Then
-      expect(actual.facets).toInclude('facetName');
+      expect(actual.facets).toInclude('attributeName');
     });
     it('should add disjunctiveFacet for OR operator', () => {
       // Given
@@ -140,7 +140,7 @@ describe('refinementList()', () => {
       let actual = widget.getConfiguration(configuration);
 
       // Then
-      expect(actual.disjunctiveFacets).toInclude('facetName');
+      expect(actual.disjunctiveFacets).toInclude('attributeName');
     });
     it('should set the maxValuePerFacet to the specified limit if higher', () => {
       // Given
@@ -181,7 +181,7 @@ describe('refinementList()', () => {
     }
 
     beforeEach(() => {
-      options = {container, facetName: 'facetName'};
+      options = {container, attributeName: 'facetName'};
       results = {getFacetValues: sinon.stub().returns(['foo', 'bar'])};
       state = {toggleRefinement: sinon.spy()};
       createURL = sinon.spy();
@@ -260,7 +260,7 @@ describe('refinementList()', () => {
   context('toggleRefinement', () => {
     let helper;
     beforeEach(() => {
-      options = {container, facetName: 'facetName'};
+      options = {container, attributeName: 'facetName'};
       helper = {
         toggleRefinement: sinon.stub().returnsThis(),
         search: sinon.spy()
@@ -272,10 +272,10 @@ describe('refinementList()', () => {
       widget = refinementList(options);
 
       // When
-      widget.toggleRefinement(helper, 'facetName', 'facetValue');
+      widget.toggleRefinement(helper, 'attributeName', 'facetValue');
 
       // Then
-      expect(helper.toggleRefinement.calledWith('facetName', 'facetValue'));
+      expect(helper.toggleRefinement.calledWith('attributeName', 'facetValue'));
 
       // Then
     });
@@ -284,7 +284,7 @@ describe('refinementList()', () => {
       widget = refinementList(options);
 
       // When
-      widget.toggleRefinement(helper, 'facetName', 'facetValue');
+      widget.toggleRefinement(helper, 'attributeName', 'facetValue');
 
       // Then
       expect(helper.search.called);

--- a/widgets/refinement-list/refinement-list.js
+++ b/widgets/refinement-list/refinement-list.js
@@ -14,7 +14,7 @@ let defaultTemplates = require('./defaultTemplates');
  * Instantiate a list of refinements based on a facet
  * @function refinementList
  * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
- * @param  {string} options.facetName Name of the attribute for faceting
+ * @param  {string} options.attributeName Name of the attribute for faceting
  * @param  {string} [options.operator='or'] How to apply refinements. Possible values: `or`, `and`
  * @param  {string[]} [options.sortBy=['count:desc']] How to sort refinements. Possible values: `count|isRefined|name:asc|desc`
  * @param  {string} [options.limit=1000] How much facet values to get
@@ -40,7 +40,7 @@ let defaultTemplates = require('./defaultTemplates');
 const usage = `Usage:
 refinementList({
   container,
-  facetName,
+  attributeName,
   [ operator='or' ],
   [ sortBy=['count:desc'] ],
   [ limit=1000 ],
@@ -51,7 +51,7 @@ refinementList({
 })`;
 function refinementList({
     container,
-    facetName,
+    attributeName,
     operator = 'or',
     sortBy = ['count:desc'],
     limit = 1000,
@@ -62,7 +62,7 @@ function refinementList({
   }) {
   let RefinementList = require('../../components/RefinementList/RefinementList.js');
 
-  if (!container || !facetName) {
+  if (!container || !attributeName) {
     throw new Error(usage);
   }
 
@@ -83,7 +83,7 @@ function refinementList({
   return {
     getConfiguration: (configuration) => {
       let widgetConfiguration = {
-        [operator === 'and' ? 'facets' : 'disjunctiveFacets']: [facetName]
+        [operator === 'and' ? 'facets' : 'disjunctiveFacets']: [attributeName]
       };
 
       let currentMaxValuesPerFacet = configuration.maxValuesPerFacet || 0;
@@ -93,7 +93,7 @@ function refinementList({
     },
     toggleRefinement: (helper, facetValue) => {
       helper
-        .toggleRefinement(facetName, facetValue)
+        .toggleRefinement(attributeName, facetValue)
         .search();
     },
     render: function({results, helper, templatesConfig, state, createURL}) {
@@ -104,7 +104,7 @@ function refinementList({
         templates
       });
 
-      let facetValues = results.getFacetValues(facetName, {sortBy: sortBy}).slice(0, limit);
+      let facetValues = results.getFacetValues(attributeName, {sortBy: sortBy}).slice(0, limit);
 
       let hasNoFacetValues = facetValues.length === 0;
 
@@ -125,7 +125,7 @@ function refinementList({
 
       ReactDOM.render(
         <RefinementList
-          createURL={(facetValue) => createURL(state.toggleRefinement(facetName, facetValue))}
+          createURL={(facetValue) => createURL(state.toggleRefinement(attributeName, facetValue))}
           cssClasses={cssClasses}
           facetValues={facetValues}
           shouldAutoHideContainer={hasNoFacetValues}

--- a/widgets/toggle/__tests__/toggle-test.js
+++ b/widgets/toggle/__tests__/toggle-test.js
@@ -27,7 +27,7 @@ describe('toggle()', () => {
       }).toThrow(/Container must be `string` or `HTMLElement`/);
     });
 
-    it('throws when no facetName', () => {
+    it('throws when no attributeName', () => {
       expect(() => {
         toggle({container: document.createElement('div')});
       }).toThrow(/Usage:/);
@@ -35,7 +35,7 @@ describe('toggle()', () => {
 
     it('throws when no label', () => {
       expect(() => {
-        toggle({container: document.createElement('div'), facetName: 'Hello'});
+        toggle({container: document.createElement('div'), attributeName: 'Hello'});
       }).toThrow(/Usage:/);
     });
   });
@@ -46,7 +46,7 @@ describe('toggle()', () => {
     let headerFooter;
     let container;
     let widget;
-    let facetName;
+    let attributeName;
     let label;
 
     beforeEach(() => {
@@ -60,16 +60,16 @@ describe('toggle()', () => {
 
       container = document.createElement('div');
       label = 'Hello, ';
-      facetName = 'world!';
+      attributeName = 'world!';
     });
 
     it('configures hitsPerPage', () => {
-      widget = toggle({container, facetName, label});
+      widget = toggle({container, attributeName, label});
       expect(widget.getConfiguration()).toEqual({facets: ['world!']});
     });
 
     it('uses autoHideContainer() and headerFooter()', () => {
-      widget = toggle({container, facetName, label});
+      widget = toggle({container, attributeName, label});
       expect(autoHideContainer.calledOnce).toBe(true);
       expect(headerFooter.calledOnce).toBe(true);
       expect(headerFooter.calledBefore(autoHideContainer)).toBe(true);
@@ -121,7 +121,7 @@ describe('toggle()', () => {
           nbHits: 1,
           getFacetValues: sinon.stub().returns([{name: 'true', count: 2}, {name: 'false', count: 1}])
         };
-        widget = toggle({container, facetName, label});
+        widget = toggle({container, attributeName, label});
         widget.render({results, helper});
         widget.render({results, helper});
         expect(ReactDOM.render.calledTwice).toBe(true, 'ReactDOM.render called twice');
@@ -142,7 +142,7 @@ describe('toggle()', () => {
           nbHits: 1,
           getFacetValues: sinon.stub().returns([{name: 'true', count: 2}, {name: 'false', count: 1}])
         };
-        widget = toggle({container, facetName, label});
+        widget = toggle({container, attributeName, label});
         widget.render({results, helper});
         widget.render({results, helper});
 
@@ -162,7 +162,7 @@ describe('toggle()', () => {
           nbHits: 0,
           getFacetValues: sinon.stub().returns([])
         };
-        widget = toggle({container, facetName, label});
+        widget = toggle({container, attributeName, label});
         widget.render({results, helper});
         widget.render({results, helper});
 
@@ -187,7 +187,7 @@ describe('toggle()', () => {
           nbHits: 1,
           getFacetValues: sinon.stub().returns([{name: 'true', count: 2}, {name: 'false', count: 1}])
         };
-        widget = toggle({container, facetName, label});
+        widget = toggle({container, attributeName, label});
         widget.render({results, helper});
         widget.render({results, helper});
 
@@ -207,13 +207,13 @@ describe('toggle()', () => {
           nbHits: 1,
           getFacetValues: sinon.stub().returns([{name: 'true', count: 2}, {name: 'false', count: 1}])
         };
-        widget = toggle({container, facetName, label});
+        widget = toggle({container, attributeName, label});
         widget.render({results, helper});
         let toggleRefinement = ReactDOM.render.firstCall.args[0].props.toggleRefinement;
         expect(toggleRefinement).toBeA('function');
         toggleRefinement();
         expect(helper.addFacetRefinement.calledOnce).toBe(true);
-        expect(helper.addFacetRefinement.calledWithExactly(facetName, true));
+        expect(helper.addFacetRefinement.calledWithExactly(attributeName, true));
         helper.hasRefinements = sinon.stub().returns(true);
       });
     });
@@ -240,24 +240,24 @@ describe('toggle()', () => {
       context('default values', () => {
         it('toggle on should add filter to true', () => {
           // Given
-          widget = toggle({container, facetName, label});
+          widget = toggle({container, attributeName, label});
 
           // When
           toggleOn();
 
           // Then
-          expect(helper.addFacetRefinement.calledWith(facetName, true)).toBe(true);
+          expect(helper.addFacetRefinement.calledWith(attributeName, true)).toBe(true);
           expect(helper.removeFacetRefinement.called).toBe(false);
         });
         it('toggle off should remove all filters', () => {
           // Given
-          widget = toggle({container, facetName, label});
+          widget = toggle({container, attributeName, label});
 
           // When
           toggleOff();
 
           // Then
-          expect(helper.removeFacetRefinement.calledWith(facetName, true)).toBe(true);
+          expect(helper.removeFacetRefinement.calledWith(attributeName, true)).toBe(true);
           expect(helper.addFacetRefinement.called).toBe(false);
         });
       });
@@ -265,26 +265,26 @@ describe('toggle()', () => {
         it('toggle on should change the refined value', () => {
           // Given
           values = {on: 'on', off: 'off'};
-          widget = toggle({container, facetName, label, values});
+          widget = toggle({container, attributeName, label, values});
 
           // When
           toggleOn();
 
           // Then
-          expect(helper.removeFacetRefinement.calledWith(facetName, 'off')).toBe(true);
-          expect(helper.addFacetRefinement.calledWith(facetName, 'on')).toBe(true);
+          expect(helper.removeFacetRefinement.calledWith(attributeName, 'off')).toBe(true);
+          expect(helper.addFacetRefinement.calledWith(attributeName, 'on')).toBe(true);
         });
         it('toggle off should change the refined value', () => {
           // Given
           values = {on: 'on', off: 'off'};
-          widget = toggle({container, facetName, label, values});
+          widget = toggle({container, attributeName, label, values});
 
           // When
           toggleOff();
 
           // Then
-          expect(helper.removeFacetRefinement.calledWith(facetName, 'on')).toBe(true);
-          expect(helper.addFacetRefinement.calledWith(facetName, 'off')).toBe(true);
+          expect(helper.removeFacetRefinement.calledWith(attributeName, 'on')).toBe(true);
+          expect(helper.addFacetRefinement.calledWith(attributeName, 'off')).toBe(true);
         });
       });
     });
@@ -293,7 +293,7 @@ describe('toggle()', () => {
       it('should add a refinement for custom off value on init', () => {
         // Given
         let values = {on: 'on', off: 'off'};
-        widget = toggle({container, facetName, label, values});
+        widget = toggle({container, attributeName, label, values});
         let state = {
           isFacetRefined: sinon.stub().returns(false)
         };
@@ -305,12 +305,12 @@ describe('toggle()', () => {
         widget.init(state, helper);
 
         // Then
-        expect(helper.addFacetRefinement.calledWith(facetName, 'off')).toBe(true);
+        expect(helper.addFacetRefinement.calledWith(attributeName, 'off')).toBe(true);
       });
       it('should not add a refinement for custom off value on init if already checked', () => {
         // Given
         let values = {on: 'on', off: 'off'};
-        widget = toggle({container, facetName, label, values});
+        widget = toggle({container, attributeName, label, values});
         let state = {
           isFacetRefined: sinon.stub().returns(true)
         };
@@ -326,7 +326,7 @@ describe('toggle()', () => {
       });
       it('should not add a refinement for no custom off value on init', () => {
         // Given
-        widget = toggle({container, facetName, label});
+        widget = toggle({container, attributeName, label});
         let state = {};
         let helper = {
           addFacetRefinement: sinon.spy()

--- a/widgets/toggle/toggle.js
+++ b/widgets/toggle/toggle.js
@@ -17,7 +17,7 @@ let defaultTemplates = require('./defaultTemplates');
  * and `undefined`.
  * @function toggle
  * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
- * @param  {string} options.facetName Name of the attribute for faceting (eg. "free_shipping")
+ * @param  {string} options.attributeName Name of the attribute for faceting (eg. "free_shipping")
  * @param  {string} options.label Human-readable name of the filter (eg. "Free Shipping")
  * @param  {Object} [options.values] Lets you define the values to filter on when toggling
  * @param  {*} [options.values.on] Value to filter on when checked
@@ -44,7 +44,7 @@ let defaultTemplates = require('./defaultTemplates');
 const usage = `Usage:
 toggle({
   container,
-  facetName,
+  attributeName,
   label,
   [ userValues={on: true, off: undefined} ],
   [ cssClasses.{root,header,body,footer,list,item,active,label,checkbox,count} ],
@@ -54,7 +54,7 @@ toggle({
 })`;
 function toggle({
     container,
-    facetName,
+    attributeName,
     label,
     values: userValues = {on: true, off: undefined},
     templates = defaultTemplates,
@@ -69,7 +69,7 @@ function toggle({
     RefinementList = autoHideContainerHOC(RefinementList);
   }
 
-  if (!container || !facetName || !label) {
+  if (!container || !attributeName || !label) {
     throw new Error(usage);
   }
 
@@ -77,16 +77,16 @@ function toggle({
 
   return {
     getConfiguration: () => ({
-      facets: [facetName]
+      facets: [attributeName]
     }),
     init: (state, helper) => {
       if (userValues.off === undefined) {
         return;
       }
       // Add filtering on the 'off' value if set
-      let isRefined = state.isFacetRefined(facetName, userValues.on);
+      let isRefined = state.isFacetRefined(attributeName, userValues.on);
       if (!isRefined) {
-        helper.addFacetRefinement(facetName, userValues.off);
+        helper.addFacetRefinement(attributeName, userValues.off);
       }
     },
     toggleRefinement: (helper, isRefined) => {
@@ -96,22 +96,22 @@ function toggle({
       // Checking
       if (!isRefined) {
         if (hasAnOffValue) {
-          helper.removeFacetRefinement(facetName, off);
+          helper.removeFacetRefinement(attributeName, off);
         }
-        helper.addFacetRefinement(facetName, on);
+        helper.addFacetRefinement(attributeName, on);
       } else {
         // Unchecking
-        helper.removeFacetRefinement(facetName, on);
+        helper.removeFacetRefinement(attributeName, on);
         if (hasAnOffValue) {
-          helper.addFacetRefinement(facetName, off);
+          helper.addFacetRefinement(attributeName, off);
         }
       }
 
       helper.search();
     },
     render: function({helper, results, templatesConfig, state, createURL}) {
-      let isRefined = helper.state.isFacetRefined(facetName, userValues.on);
-      let values = find(results.getFacetValues(facetName), {name: isRefined.toString()});
+      let isRefined = helper.state.isFacetRefined(attributeName, userValues.on);
+      let values = find(results.getFacetValues(attributeName), {name: isRefined.toString()});
       let hasNoResults = results.nbHits === 0;
 
       let templateProps = utils.prepareTemplateProps({
@@ -144,7 +144,7 @@ function toggle({
 
       ReactDOM.render(
         <RefinementList
-          createURL={() => createURL(state.toggleRefinement(facetName, facetValue.isRefined))}
+          createURL={() => createURL(state.toggleRefinement(attributeName, facetValue.isRefined))}
           cssClasses={cssClasses}
           facetValues={[facetValue]}
           shouldAutoHideContainer={hasNoResults}


### PR DESCRIPTION
Fixes #156 

There are a few unrelated changed in this PR and I apologize for that.

The more controversial change is renaming the `facetName` to `attributeName` everywhere. After discussing with @vvo and @seafoox, we realized that not all widgets needed an `attributesForFacetting` defined. For example, the `numericFacetRefinement` does not need one, but the `rangeSlider` does (to get the min/max values).

In order to make the public API more consistent, we decided that all attributes could be named `attributeName` and that the required facet configuration should be clearly indicated in the docs.

Most of the diff is actually the search/replace part and the regeneration of the markdown doc.

I've also had to refactor the way the button toggling was working to use a more generic method of hide/show. I fixed a few typos/links as well, but another proof-reading will be needed.


