### PR TITLE
chore(selector): ability to specify a label

### DIFF
--- a/components/Selector.js
+++ b/components/Selector.js
@@ -1,4 +1,5 @@
 let React = require('react');
+let {nextId} = require('../lib/utils.js');
 
 class Selector extends React.Component {
   handleChange(event) {
@@ -9,11 +10,12 @@ class Selector extends React.Component {
     let {currentValue, options} = this.props;
 
     let handleChange = this.handleChange.bind(this);
-
-    return (
+    const id = nextId('selector');
+    let select = (
       <select
         className={this.props.cssClasses.root}
         defaultValue={currentValue}
+        id={id}
         onChange={handleChange}
       >
         {options.map((option) => {
@@ -21,6 +23,12 @@ class Selector extends React.Component {
         })}
       </select>
     );
+    return this.props.label ? (
+      <span>
+        <label className={this.props.cssClasses.label} htmlFor={id}>{this.props.label}</label>
+        {select}
+      </span>
+    ) : select;
   }
 }
 
@@ -33,12 +41,17 @@ Selector.propTypes = {
     item: React.PropTypes.oneOfType([
       React.PropTypes.string,
       React.PropTypes.arrayOf(React.PropTypes.string)
+    ]),
+    label: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.arrayOf(React.PropTypes.string)
     ])
   }),
   currentValue: React.PropTypes.oneOfType([
     React.PropTypes.string,
     React.PropTypes.number
   ]).isRequired,
+  label: React.PropTypes.string,
   options: React.PropTypes.arrayOf(
     React.PropTypes.shape({
       value: React.PropTypes.oneOfType([

--- a/dev/app.js
+++ b/dev/app.js
@@ -27,6 +27,7 @@ search.addWidget(
 search.addWidget(
   instantsearch.widgets.indexSelector({
     container: '#index-selector',
+    label: 'Sort by',
     indices: [
       {name: 'instant_search', label: 'Most relevant'},
       {name: 'instant_search_price_asc', label: 'Lowest price'},
@@ -41,6 +42,7 @@ search.addWidget(
 search.addWidget(
   instantsearch.widgets.hitsPerPageSelector({
     container: '#hits-per-page-selector',
+    label: 'Hits per page',
     options: [
       {value: 6, label: '6 per page'},
       {value: 12, label: '12 per page'},
@@ -240,6 +242,7 @@ search.addWidget(
   instantsearch.widgets.numericSelector({
     container: '#popularity-selector',
     attributeName: 'popularity',
+    label: 'Popularity',
     options: [
       { label: 'Select a value', value: undefined },
       { label: '1st', value: 1 },

--- a/dev/index.html
+++ b/dev/index.html
@@ -41,26 +41,17 @@
           </div>
           <div class="col-md-3 text-right">
             <div class="form-inline">
-              <div class="form-group">
-                <label for="hits-per-page-select">Show:</label>
-                <span id="hits-per-page-selector"></span>
-              </div>
+              <div class="form-group" id="hits-per-page-selector"></div>
             </div>
           </div>
           <div class="col-md-3 text-right">
             <div class="form-inline">
-              <div class="form-group">
-                <label for="index-selector-select">Popularity:</label>
-                <span id="popularity-selector"></span>
-              </div>
+              <div class="form-group" id="popularity-selector"></div>
             </div>
           </div>
           <div class="col-md-3 text-right">
             <div class="form-inline">
-              <div class="form-group">
-                <label for="index-selector-select">Sort by:</label>
-                <span id="index-selector"></span>
-              </div>
+              <div class="form-group" id="index-selector"></div>
             </div>
           </div>
         </div>

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -135,6 +135,3 @@ DEPENDENCIES
   nokogiri
   rouge
   sass
-
-BUNDLED WITH
-   1.10.6

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,7 +9,8 @@ let utils = {
   prepareTemplateProps,
   isSpecialClick,
   isDomElement,
-  getRefinements
+  getRefinements,
+  nextId
 };
 
 /**
@@ -179,6 +180,11 @@ function getRefinements(results, state) {
   });
 
   return res;
+}
+
+let id = 0;
+function nextId(prefix) {
+  return prefix + '-' + (id++);
 }
 
 module.exports = utils;

--- a/widgets/hits-per-page-selector/hits-per-page-selector.js
+++ b/widgets/hits-per-page-selector/hits-per-page-selector.js
@@ -11,11 +11,13 @@ let autoHideContainerHOC = require('../../decorators/autoHideContainer');
  * Instantiate a dropdown element to choose the number of hits to display per page
  * @function hitsPerPageSelector
  * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
+ * @param  {string} options.label The optional label displayed before the select.
  * @param  {Array} options.options Array of objects defining the different values and labels
  * @param  {number} options.options[0].value number of hits to display per page
  * @param  {string} options.options[0].label Label to display in the option
  * @param  {Object} [options.cssClasses] CSS classes to be added
  * @param  {string} [options.cssClasses.root] CSS classes added to the parent `<select>`
+ * @param  {string} [options.cssClasses.label] CSS classes added to the `<label>`
  * @param  {string} [options.cssClasses.item] CSS classes added to each `<option>`
  * @param  {boolean} [options.autoHideContainer=false] Hide the container when no results match
  * @return {Object}
@@ -24,12 +26,14 @@ let autoHideContainerHOC = require('../../decorators/autoHideContainer');
 const usage = `Usage:
 hitsPerPageSelector({
   container,
+  label,
   options,
-  [ cssClasses.{root,item}={} ],
+  [ cssClasses.{root,item,label}={} ],
   [ autoHideContainer=false ]
 })`;
 function hitsPerPageSelector({
     container,
+    label,
     options,
     cssClasses: userCssClasses = {},
     autoHideContainer = false
@@ -80,12 +84,14 @@ function hitsPerPageSelector({
 
       let cssClasses = {
         root: cx(bem(null), userCssClasses.root),
-        item: cx(bem('item'), userCssClasses.item)
+        item: cx(bem('item'), userCssClasses.item),
+        label: cx(bem('label'), userCssClasses.label)
       };
       ReactDOM.render(
         <Selector
           cssClasses={cssClasses}
           currentValue={currentValue}
+          label={label}
           options={options}
           setValue={setHitsPerPage}
           shouldAutoHideContainer={hasNoResults}

--- a/widgets/index-selector/index-selector.js
+++ b/widgets/index-selector/index-selector.js
@@ -12,12 +12,14 @@ let autoHideContainerHOC = require('../../decorators/autoHideContainer');
  * Instantiate a dropdown element to choose the current targeted index
  * @function indexSelector
  * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
+ * @param  {string} options.label The optional label displayed before the select.
  * @param  {Array} options.indices Array of objects defining the different indices to choose from.
  * @param  {string} options.indices[0].name Name of the index to target
  * @param  {string} options.indices[0].label Label displayed in the dropdown
  * @param  {Object} [options.cssClasses] CSS classes to be added
  * @param  {string} [options.cssClasses.root] CSS classes added to the parent <select>
  * @param  {string} [options.cssClasses.item] CSS classes added to each <option>
+ * @param  {string} [options.cssClasses.label] CSS classes added to the parent <label>
  * @param  {boolean} [options.autoHideContainer=false] Hide the container when no results match
  * @return {Object}
  */
@@ -25,12 +27,14 @@ const usage = `Usage:
 indexSelector({
   container,
   indices,
-  [cssClasses.{root,item}={}],
+  [label],
+  [cssClasses.{root,item,label}={}],
   [autoHideContainer=false]
 })`;
 function indexSelector({
     container,
     indices,
+    label,
     cssClasses: userCssClasses = {},
     autoHideContainer = false
   } = {}) {
@@ -69,12 +73,14 @@ function indexSelector({
 
       let cssClasses = {
         root: cx(bem(null), userCssClasses.root),
-        item: cx(bem('item'), userCssClasses.item)
+        item: cx(bem('item'), userCssClasses.item),
+        label: cx(bem('label'), userCssClasses.label)
       };
       ReactDOM.render(
         <Selector
           cssClasses={cssClasses}
           currentValue={currentIndex}
+          label={label}
           options={selectorOptions}
           setValue={setIndex}
           shouldAutoHideContainer={hasNoResults}

--- a/widgets/numeric-selector/numeric-selector.js
+++ b/widgets/numeric-selector/numeric-selector.js
@@ -11,6 +11,7 @@ let bem = utils.bemHelper('ais-numeric-selector');
 /**
  * Instantiate a dropdown element to choose the number of hits to display per page
  * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
+ * @param  {string} options.label The optional label displayed before the select.
  * @param  {string} options.attributeName Name of the numeric attribute to use
  * @param  {Array} options.options Array of objects defining the different values and labels
  * @param  {number} options.options[i].value The numerical value to refine with
@@ -19,6 +20,7 @@ let bem = utils.bemHelper('ais-numeric-selector');
  * @param  {Object} [options.cssClasses] CSS classes to be added
  * @param  {string} [options.cssClasses.root] CSS classes added to the parent `<select>`
  * @param  {string} [options.cssClasses.item] CSS classes added to each `<option>`
+ * @param  {string} [options.cssClasses.label] CSS classes added to the `<label>`
  * @param  {boolean} [options.autoHideContainer=false] Hide the container when no results match
  * @return {Object}
  */
@@ -26,13 +28,14 @@ let bem = utils.bemHelper('ais-numeric-selector');
 function numericSelector({
     container,
     operator = '=',
+    label,
     attributeName,
     options,
     cssClasses: userCssClasses = {},
     autoHideContainer = false
   }) {
   let containerNode = utils.getContainerNode(container);
-  let usage = 'Usage: numericSelector({container, attributeName, options[, cssClasses.{root,item}, autoHideContainer]})';
+  let usage = 'Usage: numericSelector({container, attributeName, options[, cssClasses.{root,item,label}, label, autoHideContainer]})';
 
   let Selector = require('../../components/Selector');
   if (autoHideContainer === true) {
@@ -57,12 +60,14 @@ function numericSelector({
 
       const cssClasses = {
         root: cx(bem(null), userCssClasses.root),
-        item: cx(bem('item'), userCssClasses.item)
+        item: cx(bem('item'), userCssClasses.item),
+        label: cx(bem('label'), userCssClasses.label)
       };
       ReactDOM.render(
         <Selector
           cssClasses={cssClasses}
           currentValue={currentValue}
+          label={label}
           options={options}
           setValue={this._refine.bind(this, helper)}
           shouldAutoHideContainer={hasNoResults}


### PR DESCRIPTION
This allows the user to put add a label in front of the `select`.

Open questions:
 - I didn't want to use templates for the `label` to keep it simple, but maybe we should; thoughts?
 - if we want to put the label on the right, how do we do?
 - what do you think about the way I generate the ID?

Fix #582 
