### PR TITLE
chore(line endings): force lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf


### PR DESCRIPTION
We have some files with windows line feed, dunno why. We can force it from gitattributes. Anyone with git powerskills can check this? :)