### PR TITLE
docs(documentation): Stop loading files from localhost:8080

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -10,7 +10,7 @@
 
     <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
     {% if site.env == 'development' %}
-      <link rel="stylesheet" href="//localhost:8080/instantsearch.css" />
+      <link rel="stylesheet" href="{{ "/css/instantsearch.css" | prepend: site.baseurl }}" />
     {% else %}
       <link rel="stylesheet" href="//cdn.jsdelivr.net/instantsearch.js/0/instantsearch.min.css" />
     {% endif %}

--- a/docs/_layouts/documentation.html
+++ b/docs/_layouts/documentation.html
@@ -26,7 +26,7 @@ layout: default
 {% contentfor site-footer %}
 
 {% if site.env == 'development' %}
-  <script src="//localhost:8080/instantsearch.js"></script>
+  <script src="{{ "/js/instantsearch.js" | prepend: site.baseurl }}"></script>
 {% else %}
   <script src="//cdn.jsdelivr.net/instantsearch.js/0/instantsearch.js"></script>
 {% endif %}

--- a/docs/css/instantsearch.css
+++ b/docs/css/instantsearch.css
@@ -1,0 +1,1 @@
+../../dist/instantsearch.css

--- a/docs/js/instantsearch.js
+++ b/docs/js/instantsearch.js
@@ -1,0 +1,1 @@
+../../dist/instantsearch.js


### PR DESCRIPTION
This will load `instantsearch.css` and `instantsearch.js` from the same host in dev. This only use symlinks to the build files.