### PR TITLE
docs(dev): Expose all internal webservers to the same ip

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,6 +4,7 @@ description: instantsearch.js is a library of widgets to build high performance 
 baseurl: "/instantsearch.js" # the subpath of your site, e.g. /blog/
 twitter_username: algolia
 github_username: algolia
+host: 0.0.0.0
 
 # Navigation
 navigation:

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -10,7 +10,9 @@
 
     <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
     {% if site.env == 'development' %}
-      <link rel="stylesheet" href="//localhost:8080/instantsearch.css" />
+      <script id="dev-build-css">
+        document.write('<link rel="stylesheet" href="http://' + window.location.hostname +':8080/instantsearch.css">');
+      </script>
     {% else %}
       <link rel="stylesheet" href="//cdn.jsdelivr.net/instantsearch.js/0/instantsearch.min.css" />
     {% endif %}
@@ -48,7 +50,9 @@
 
 {% if site.env == 'development' %}
     <!-- <script src="//cdn.jsdelivr.net/scrollmagic/2.0.5/plugins/debug.addIndicators.min.js"></script> -->
-    <script src="//localhost:35730/livereload.js"></script>
+    <script>
+      document.write('\x3Cscript src="http://' + window.location.hostname +':35730/livereload.js">\x3C/script>');
+    </script>
 {% endif %}
 
   {% include marketing.html %}

--- a/docs/_layouts/documentation.html
+++ b/docs/_layouts/documentation.html
@@ -26,7 +26,9 @@ layout: default
 {% contentfor site-footer %}
 
 {% if site.env == 'development' %}
-  <script src="//localhost:8080/instantsearch.js"></script>
+  <script id="dev-build-js">
+  document.write('\x3Cscript src="http://' + window.location.hostname +':8080/instantsearch.js">\x3C/script>');
+  </script>
 {% else %}
   <script src="//cdn.jsdelivr.net/instantsearch.js/0/instantsearch.js"></script>
 {% endif %}


### PR DESCRIPTION
Jekyll now is exposed on 0.0.0.0, which means that you can connect to
it through your machine ip. Webpack-dev-server was already doing it,
as well as the guard livereload.

All the instantsearch css, js and livereload are now loaded through
ugly `document.write` calls in dev mode, to be able to know which is
the current ip that is used to access the website.

This works both when testing locally on desktop, on mobile through the
same wifi network, and through an ngrok tunnel.