### PR TITLE
docs(ie11): Fix rendering on IE11

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -10,8 +10,8 @@
 
     <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
     {% if site.env == 'development' %}
-      <script id="dev-build-css">
-        document.write('<link rel="stylesheet" href="http://' + window.location.hostname +':8080/instantsearch.css">');
+      <script>
+        document.write('\x3Clink rel="stylesheet" href="http://' + window.location.hostname +':8080/instantsearch.css">');
       </script>
     {% else %}
       <link rel="stylesheet" href="//cdn.jsdelivr.net/instantsearch.js/0/instantsearch.min.css" />

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -886,8 +886,7 @@ search.addWidget(
       link: '',
       disabledLink: '',
       star: '',
-      emptyStar: '',
-      active: ''
+      emptyStar: ''
     }
   })
 );


### PR DESCRIPTION
`active` class was defined twice and was breaking IE11 strict mode.

Also, it is needed to encode the `<` in the `document.write` hack otherwise the parser gets confused.