### PR TITLE
docs(examples): Fix e-commerce image display on IE11

### DIFF
--- a/docs/examples/e-commerce/style.scss
+++ b/docs/examples/e-commerce/style.scss
@@ -381,6 +381,7 @@ aside {
   }
   .product-picture-wrapper {
     display: table;
+    table-layout: fixed;
     width: 100%;
     text-align: center;
     margin-bottom: 10px;


### PR DESCRIPTION
### Before:
![image](https://cloud.githubusercontent.com/assets/283419/11212819/843c9c1e-8d38-11e5-9021-d205928665b3.png)
### After:
![image](https://cloud.githubusercontent.com/assets/283419/11212835/98fe21f4-8d38-11e5-9de1-5b299a1776bc.png)

Fix found at: http://www.carsonshold.com/2014/07/css-display-table-cell-child-width-bug-in-firefox-and-ie/
