### PR TITLE
docs(cssClasses): Put them after other options in the JSDoc

### DIFF
--- a/docs/_includes/widget-jsdoc/clearAll.md
+++ b/docs/_includes/widget-jsdoc/clearAll.md
@@ -1,16 +1,16 @@
 | Param | Description |
 | --- | --- |
 | <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
+| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
+| <span class='attr-optional'>`options.templates.header`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Header template |
+| <span class='attr-optional'>`options.templates.link`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Link template |
+| <span class='attr-optional'>`options.templates.footer`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Footer template |
+| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when there's no refinement to clear |
 | <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to be added |
 | <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the root element |
 | <span class='attr-optional'>`options.cssClasses.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the header element |
 | <span class='attr-optional'>`options.cssClasses.body`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the body element |
 | <span class='attr-optional'>`options.cssClasses.footer`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the footer element |
 | <span class='attr-optional'>`options.cssClasses.link`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the link element |
-| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
-| <span class='attr-optional'>`options.templates.header`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Header template |
-| <span class='attr-optional'>`options.templates.link`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Link template |
-| <span class='attr-optional'>`options.templates.footer`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Footer template |
-| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when there's no refinement to clear |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/hierarchicalMenu.md
+++ b/docs/_includes/widget-jsdoc/hierarchicalMenu.md
@@ -5,6 +5,12 @@
 | <span class='attr-optional'>`options.separator`</span><span class="attr-infos">Default:<code class="attr-default">&#x27; &gt; &#x27;</code><br />Type: <code>string</code></span> | Separator used in the attributes to separate level values. |
 | <span class='attr-optional'>`options.limit`</span><span class="attr-infos">Default:<code class="attr-default">100</code><br />Type: <code>number</code></span> | How much facet values to get |
 | <span class='attr-optional'>`options.sortBy`</span><span class="attr-infos">Default:<code class="attr-default">[&#x27;name:asc&#x27;]</code><br />Type: <code>Array.&lt;string&gt;</code></span> | How to sort refinements. Possible values: `count|isRefined|name:asc|desc` |
+| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
+| <span class='attr-optional'>`options.templates.header`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Header template (root level only) |
+| <span class='attr-optional'>`options.templates.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Item template |
+| <span class='attr-optional'>`options.templates.footer`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Footer template (root level only) |
+| <span class='attr-optional'>`options.transformData`</span><span class="attr-infos">Type: <code>function</code></span> | Method to change the object passed to the item template |
+| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when there are no items in the menu |
 | <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add to the wrapping elements: root, list, item |
 | <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the root element |
 | <span class='attr-optional'>`options.cssClasses.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the header element |
@@ -16,11 +22,5 @@
 | <span class='attr-optional'>`options.cssClasses.active`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each active element |
 | <span class='attr-optional'>`options.cssClasses.link`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each link (when using the default template) |
 | <span class='attr-optional'>`options.cssClasses.count`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each count element (when using the default template) |
-| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
-| <span class='attr-optional'>`options.templates.header`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Header template (root level only) |
-| <span class='attr-optional'>`options.templates.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Item template |
-| <span class='attr-optional'>`options.templates.footer`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Footer template (root level only) |
-| <span class='attr-optional'>`options.transformData`</span><span class="attr-infos">Type: <code>function</code></span> | Method to change the object passed to the item template |
-| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when there are no items in the menu |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/hits.md
+++ b/docs/_includes/widget-jsdoc/hits.md
@@ -1,10 +1,6 @@
 | Param | Description |
 | --- | --- |
 | <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
-| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add |
-| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the wrapping element |
-| <span class='attr-optional'>`options.cssClasses.empty`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the wrapping element when no results |
-| <span class='attr-optional'>`options.cssClasses.item`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to each result |
 | <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
 | <span class='attr-optional'>`options.templates.empty`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Template to use when there are no results. |
 | <span class='attr-optional'>`options.templates.item`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Template to use for each result. |
@@ -12,5 +8,9 @@
 | <span class='attr-optional'>`options.transformData.empty`</span><span class="attr-infos">Default:<code class="attr-default">identity</code><br />Type: <code>function</code></span> | Method used to change the object passed to the empty template |
 | <span class='attr-optional'>`options.transformData.item`</span><span class="attr-infos">Default:<code class="attr-default">identity</code><br />Type: <code>function</code></span> | Method used to change the object passed to the item template |
 | <span class='attr-optional'>`hitsPerPage`</span><span class="attr-infos">Default:<code class="attr-default">20</code><br />Type: <code>number</code></span> | The number of hits to display per page |
+| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add |
+| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the wrapping element |
+| <span class='attr-optional'>`options.cssClasses.empty`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the wrapping element when no results |
+| <span class='attr-optional'>`options.cssClasses.item`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to each result |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/hitsPerPageSelector.md
+++ b/docs/_includes/widget-jsdoc/hitsPerPageSelector.md
@@ -4,9 +4,9 @@
 | <span class='attr-required'>`options.options`</span><span class="attr-infos">Type: <code>Array</code></span> | Array of objects defining the different values and labels |
 | <span class='attr-required'>`options.options[0].value`</span><span class="attr-infos">Type: <code>number</code></span> | number of hits to display per page |
 | <span class='attr-required'>`options.options[0].label`</span><span class="attr-infos">Type: <code>string</code></span> | Label to display in the option |
+| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">false</code><br />Type: <code>boolean</code></span> | Hide the container when no results match |
 | <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to be added |
 | <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code></span> | CSS classes added to the parent `<select>` |
 | <span class='attr-optional'>`options.cssClasses.item`</span><span class="attr-infos">Type: <code>string</code></span> | CSS classes added to each `<option>` |
-| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">false</code><br />Type: <code>boolean</code></span> | Hide the container when no results match |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/menu.md
+++ b/docs/_includes/widget-jsdoc/menu.md
@@ -4,6 +4,12 @@
 | <span class='attr-required'>`options.attributeName`</span><span class="attr-infos">Type: <code>string</code></span> | Name of the attribute for faceting |
 | <span class='attr-optional'>`options.sortBy`</span><span class="attr-infos">Default:<code class="attr-default">[&#x27;count:desc&#x27;]</code><br />Type: <code>Array.&lt;string&gt;</code></span> | How to sort refinements. Possible values: `count|isRefined|name:asc|desc` |
 | <span class='attr-optional'>`options.limit`</span><span class="attr-infos">Default:<code class="attr-default">100</code><br />Type: <code>string</code></span> | How many facets values to retrieve |
+| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
+| <span class='attr-optional'>`options.templates.header`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Header template |
+| <span class='attr-optional'>`options.templates.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Item template, provided with `name`, `count`, `isRefined` |
+| <span class='attr-optional'>`options.templates.footer`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Footer template |
+| <span class='attr-optional'>`options.transformData`</span><span class="attr-infos">Type: <code>function</code></span> | Method to change the object passed to the item template |
+| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when there are no items in the menu |
 | <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add to the wrapping elements: root, list, item |
 | <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the root element |
 | <span class='attr-optional'>`options.cssClasses.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the header element |
@@ -14,11 +20,5 @@
 | <span class='attr-optional'>`options.cssClasses.active`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each active element |
 | <span class='attr-optional'>`options.cssClasses.link`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each link (when using the default template) |
 | <span class='attr-optional'>`options.cssClasses.count`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each count element (when using the default template) |
-| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
-| <span class='attr-optional'>`options.templates.header`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Header template |
-| <span class='attr-optional'>`options.templates.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Item template, provided with `name`, `count`, `isRefined` |
-| <span class='attr-optional'>`options.templates.footer`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Footer template |
-| <span class='attr-optional'>`options.transformData`</span><span class="attr-infos">Type: <code>function</code></span> | Method to change the object passed to the item template |
-| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when there are no items in the menu |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/numericRefinementList.md
+++ b/docs/_includes/widget-jsdoc/numericRefinementList.md
@@ -3,6 +3,12 @@
 | <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
 | <span class='attr-required'>`options.attributeName`</span><span class="attr-infos">Type: <code>string</code></span> | Name of the attribute for filtering |
 | <span class='attr-required'>`options.options`</span><span class="attr-infos">Type: <code>Array.&lt;Object&gt;</code></span> | List of all the options |
+| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
+| <span class='attr-optional'>`options.templates.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Header template |
+| <span class='attr-optional'>`options.templates.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Item template, provided with `name`, `count`, `isRefined` |
+| <span class='attr-optional'>`options.templates.footer`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Footer template |
+| <span class='attr-optional'>`options.transformData`</span><span class="attr-infos">Type: <code>function</code></span> | Function to change the object passed to the item template |
+| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when no results match |
 | <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add to the wrapping elements: root, list, item |
 | <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the root element |
 | <span class='attr-optional'>`options.cssClasses.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the header element |
@@ -13,11 +19,5 @@
 | <span class='attr-optional'>`options.cssClasses.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each item element |
 | <span class='attr-optional'>`options.cssClasses.radio`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each radio element (when using the default template) |
 | <span class='attr-optional'>`options.cssClasses.active`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each active element |
-| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
-| <span class='attr-optional'>`options.templates.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Header template |
-| <span class='attr-optional'>`options.templates.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Item template, provided with `name`, `count`, `isRefined` |
-| <span class='attr-optional'>`options.templates.footer`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Footer template |
-| <span class='attr-optional'>`options.transformData`</span><span class="attr-infos">Type: <code>function</code></span> | Function to change the object passed to the item template |
-| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when no results match |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/numericSelector.md
+++ b/docs/_includes/widget-jsdoc/numericSelector.md
@@ -6,9 +6,9 @@
 | <span class='attr-required'>`options.options[i].value`</span><span class="attr-infos">Type: <code>number</code></span> | The numerical value to refine with |
 | <span class='attr-required'>`options.options[i].label`</span><span class="attr-infos">Type: <code>string</code></span> | Label to display in the option |
 | <span class='attr-optional'>`options.operator`</span><span class="attr-infos">Type: <code>string</code></span> | The operator to use to refine |
+| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">false</code><br />Type: <code>boolean</code></span> | Hide the container when no results match |
 | <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to be added |
 | <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code></span> | CSS classes added to the parent `<select>` |
 | <span class='attr-optional'>`options.cssClasses.item`</span><span class="attr-infos">Type: <code>string</code></span> | CSS classes added to each `<option>` |
-| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">false</code><br />Type: <code>boolean</code></span> | Hide the container when no results match |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/pagination.md
+++ b/docs/_includes/widget-jsdoc/pagination.md
@@ -1,6 +1,16 @@
 | Param | Description |
 | --- | --- |
 | <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
+| <span class='attr-optional'>`options.labels`</span><span class="attr-infos">Type: <code>Object</code></span> | Text to display in the various links (prev, next, first, last) |
+| <span class='attr-optional'>`options.labels.previous`</span><span class="attr-infos">Type: <code>string</code></span> | Label for the Previous link |
+| <span class='attr-optional'>`options.labels.next`</span><span class="attr-infos">Type: <code>string</code></span> | Label for the Next link |
+| <span class='attr-optional'>`options.labels.first`</span><span class="attr-infos">Type: <code>string</code></span> | Label for the First link |
+| <span class='attr-optional'>`options.labels.last`</span><span class="attr-infos">Type: <code>string</code></span> | Label for the Last link |
+| <span class='attr-optional'>`options.maxPages`</span><span class="attr-infos">Default:<code class="attr-default">20</code><br />Type: <code>number</code></span> | The max number of pages to browse |
+| <span class='attr-optional'>`options.padding`</span><span class="attr-infos">Default:<code class="attr-default">3</code><br />Type: <code>number</code></span> | The number of pages to display on each side of the current page |
+| <span class='attr-optional'>`options.scrollTo`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;body&#x27;</code><br />Type: <code>string</code> &#124; <code>DOMElement</code> &#124; <code>boolean</code></span> | Where to scroll after a click, set to `false` to disable |
+| <span class='attr-optional'>`options.showFirstLast`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Define if the First and Last links should be displayed |
+| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when no results match |
 | <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to be added |
 | <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code></span> | CSS classes added to the parent `<ul>` |
 | <span class='attr-optional'>`options.cssClasses.item`</span><span class="attr-infos">Type: <code>string</code></span> | CSS classes added to each `<li>` |
@@ -12,15 +22,5 @@
 | <span class='attr-optional'>`options.cssClasses.last`</span><span class="attr-infos">Type: <code>string</code></span> | CSS classes added to the last `<li>` |
 | <span class='attr-optional'>`options.cssClasses.active`</span><span class="attr-infos">Type: <code>string</code></span> | CSS classes added to the active `<li>` |
 | <span class='attr-optional'>`options.cssClasses.disabled`</span><span class="attr-infos">Type: <code>string</code></span> | CSS classes added to the disabled `<li>` |
-| <span class='attr-optional'>`options.labels`</span><span class="attr-infos">Type: <code>Object</code></span> | Text to display in the various links (prev, next, first, last) |
-| <span class='attr-optional'>`options.labels.previous`</span><span class="attr-infos">Type: <code>string</code></span> | Label for the Previous link |
-| <span class='attr-optional'>`options.labels.next`</span><span class="attr-infos">Type: <code>string</code></span> | Label for the Next link |
-| <span class='attr-optional'>`options.labels.first`</span><span class="attr-infos">Type: <code>string</code></span> | Label for the First link |
-| <span class='attr-optional'>`options.labels.last`</span><span class="attr-infos">Type: <code>string</code></span> | Label for the Last link |
-| <span class='attr-optional'>`options.maxPages`</span><span class="attr-infos">Default:<code class="attr-default">20</code><br />Type: <code>number</code></span> | The max number of pages to browse |
-| <span class='attr-optional'>`options.padding`</span><span class="attr-infos">Default:<code class="attr-default">3</code><br />Type: <code>number</code></span> | The number of pages to display on each side of the current page |
-| <span class='attr-optional'>`options.scrollTo`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;body&#x27;</code><br />Type: <code>string</code> &#124; <code>DOMElement</code> &#124; <code>boolean</code></span> | Where to scroll after a click, set to `false` to disable |
-| <span class='attr-optional'>`options.showFirstLast`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Define if the First and Last links should be displayed |
-| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when no results match |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/priceRanges.md
+++ b/docs/_includes/widget-jsdoc/priceRanges.md
@@ -2,6 +2,13 @@
 | --- | --- |
 | <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | Valid CSS Selector as a string or DOMElement |
 | <span class='attr-required'>`options.attributeName`</span><span class="attr-infos">Type: <code>string</code></span> | Name of the attribute for faceting |
+| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
+| <span class='attr-optional'>`options.templates.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Item template |
+| <span class='attr-optional'>`options.labels`</span><span class="attr-infos">Type: <code>Object</code></span> | Labels to use for the widget |
+| <span class='attr-optional'>`options.labels.currency`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Currency label |
+| <span class='attr-optional'>`options.labels.separator`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Separator label, between min and max |
+| <span class='attr-optional'>`options.labels.button`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Button label |
+| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when no refinements available |
 | <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add |
 | <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the root element |
 | <span class='attr-optional'>`options.cssClasses.header`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the header element |
@@ -17,12 +24,5 @@
 | <span class='attr-optional'>`options.cssClasses.separator`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the separator of the form |
 | <span class='attr-optional'>`options.cssClasses.button`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the submit button of the form |
 | <span class='attr-optional'>`options.cssClasses.footer`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the footer element |
-| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
-| <span class='attr-optional'>`options.templates.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Item template |
-| <span class='attr-optional'>`options.labels`</span><span class="attr-infos">Type: <code>Object</code></span> | Labels to use for the widget |
-| <span class='attr-optional'>`options.labels.currency`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Currency label |
-| <span class='attr-optional'>`options.labels.separator`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Separator label, between min and max |
-| <span class='attr-optional'>`options.labels.button`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Button label |
-| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when no refinements available |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/rangeSlider.md
+++ b/docs/_includes/widget-jsdoc/rangeSlider.md
@@ -6,9 +6,9 @@
 | <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
 | <span class='attr-optional'>`options.templates.header`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Header template |
 | <span class='attr-optional'>`options.templates.footer`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Footer template |
+| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when no refinements available |
 | <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add to the wrapping elements: root, body |
 | <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the root element |
 | <span class='attr-optional'>`options.cssClasses.body`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the body element |
-| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when no refinements available |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/refinementList.md
+++ b/docs/_includes/widget-jsdoc/refinementList.md
@@ -5,6 +5,12 @@
 | <span class='attr-optional'>`options.operator`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;or&#x27;</code><br />Type: <code>string</code></span> | How to apply refinements. Possible values: `or`, `and` |
 | <span class='attr-optional'>`options.sortBy`</span><span class="attr-infos">Default:<code class="attr-default">[&#x27;count:desc&#x27;]</code><br />Type: <code>Array.&lt;string&gt;</code></span> | How to sort refinements. Possible values: `count|isRefined|name:asc|desc` |
 | <span class='attr-optional'>`options.limit`</span><span class="attr-infos">Default:<code class="attr-default">1000</code><br />Type: <code>string</code></span> | How much facet values to get |
+| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
+| <span class='attr-optional'>`options.templates.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Header template |
+| <span class='attr-optional'>`options.templates.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Item template, provided with `name`, `count`, `isRefined` |
+| <span class='attr-optional'>`options.templates.footer`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Footer template |
+| <span class='attr-optional'>`options.transformData`</span><span class="attr-infos">Type: <code>function</code></span> | Function to change the object passed to the item template |
+| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when no items in the refinement list |
 | <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add to the wrapping elements: root, list, item |
 | <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the root element |
 | <span class='attr-optional'>`options.cssClasses.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the header element |
@@ -16,11 +22,5 @@
 | <span class='attr-optional'>`options.cssClasses.label`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each label element (when using the default template) |
 | <span class='attr-optional'>`options.cssClasses.checkbox`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each checkbox element (when using the default template) |
 | <span class='attr-optional'>`options.cssClasses.count`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each count element (when using the default template) |
-| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
-| <span class='attr-optional'>`options.templates.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Header template |
-| <span class='attr-optional'>`options.templates.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Item template, provided with `name`, `count`, `isRefined` |
-| <span class='attr-optional'>`options.templates.footer`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Footer template |
-| <span class='attr-optional'>`options.transformData`</span><span class="attr-infos">Type: <code>function</code></span> | Function to change the object passed to the item template |
-| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when no items in the refinement list |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/searchBox.md
+++ b/docs/_includes/widget-jsdoc/searchBox.md
@@ -2,13 +2,13 @@
 | --- | --- |
 | <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
 | <span class='attr-optional'>`options.placeholder`</span><span class="attr-infos">Type: <code>string</code></span> | Input's placeholder |
-| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add |
-| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the wrapping div (if `wrapInput` set to `true`) |
-| <span class='attr-optional'>`options.cssClasses.input`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the input |
-| <span class='attr-optional'>`options.cssClasses.poweredBy`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the poweredBy element |
 | <span class='attr-optional'>`poweredBy`</span><span class="attr-infos">Default:<code class="attr-default">false</code><br />Type: <code>boolean</code></span> | Show a powered by Algolia link below the input |
 | <span class='attr-optional'>`wrapInput`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Wrap the input in a `div.ais-search-box` |
 | <span class='attr-optional'>`autofocus`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;auto&#x27;</code><br />Type: <code>boolean</code> &#124; <code>string</code></span> | autofocus on the input |
 | <span class='attr-optional'>`searchOnEnterKeyPressOnly`</span><span class="attr-infos">Default:<code class="attr-default">false</code><br />Type: <code>boolean</code></span> | If set, trigger the search once `<Enter>` is pressed only |
+| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add |
+| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the wrapping div (if `wrapInput` set to `true`) |
+| <span class='attr-optional'>`options.cssClasses.input`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the input |
+| <span class='attr-optional'>`options.cssClasses.poweredBy`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the poweredBy element |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/sortBySelector.md
+++ b/docs/_includes/widget-jsdoc/sortBySelector.md
@@ -4,9 +4,9 @@
 | <span class='attr-required'>`options.indices`</span><span class="attr-infos">Type: <code>Array</code></span> | Array of objects defining the different indices to choose from. |
 | <span class='attr-required'>`options.indices[0].name`</span><span class="attr-infos">Type: <code>string</code></span> | Name of the index to target |
 | <span class='attr-required'>`options.indices[0].label`</span><span class="attr-infos">Type: <code>string</code></span> | Label displayed in the dropdown |
+| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">false</code><br />Type: <code>boolean</code></span> | Hide the container when no results match |
 | <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to be added |
 | <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code></span> | CSS classes added to the parent <select> |
 | <span class='attr-optional'>`options.cssClasses.item`</span><span class="attr-infos">Type: <code>string</code></span> | CSS classes added to each <option> |
-| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">false</code><br />Type: <code>boolean</code></span> | Hide the container when no results match |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/starRating.md
+++ b/docs/_includes/widget-jsdoc/starRating.md
@@ -3,6 +3,14 @@
 | <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
 | <span class='attr-required'>`options.attributeName`</span><span class="attr-infos">Type: <code>string</code></span> | Name of the attribute for filtering |
 | <span class='attr-optional'>`options.max`</span><span class="attr-infos">Type: <code>number</code></span> | The maximum rating value |
+| <span class='attr-optional'>`options.labels`</span><span class="attr-infos">Type: <code>Object</code></span> | Labels used by the default template |
+| <span class='attr-optional'>`options.labels.andUp`</span><span class="attr-infos">Type: <code>string</code></span> | The label suffixed after each line |
+| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
+| <span class='attr-optional'>`options.templates.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Header template |
+| <span class='attr-optional'>`options.templates.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Item template, provided with `name`, `count`, `isRefined` |
+| <span class='attr-optional'>`options.templates.footer`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Footer template |
+| <span class='attr-optional'>`options.transformData`</span><span class="attr-infos">Type: <code>function</code></span> | Function to change the object passed to the item template |
+| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when no results match |
 | <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add to the wrapping elements: root, list, item |
 | <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the root element |
 | <span class='attr-optional'>`options.cssClasses.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the header element |
@@ -15,13 +23,5 @@
 | <span class='attr-optional'>`options.cssClasses.star`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each star element (when using the default template) |
 | <span class='attr-optional'>`options.cssClasses.emptyStar`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each empty star element (when using the default template) |
 | <span class='attr-optional'>`options.cssClasses.active`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each active element |
-| <span class='attr-optional'>`options.labels`</span><span class="attr-infos">Type: <code>Object</code></span> | Labels used by the default template |
-| <span class='attr-optional'>`options.labels.andUp`</span><span class="attr-infos">Type: <code>string</code></span> | The label suffixed after each line |
-| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
-| <span class='attr-optional'>`options.templates.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Header template |
-| <span class='attr-optional'>`options.templates.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Item template, provided with `name`, `count`, `isRefined` |
-| <span class='attr-optional'>`options.templates.footer`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Footer template |
-| <span class='attr-optional'>`options.transformData`</span><span class="attr-infos">Type: <code>function</code></span> | Function to change the object passed to the item template |
-| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when no results match |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/stats.md
+++ b/docs/_includes/widget-jsdoc/stats.md
@@ -1,17 +1,17 @@
 | Param | Description |
 | --- | --- |
 | <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
-| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add |
-| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the root element |
-| <span class='attr-optional'>`options.cssClasses.header`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the header element |
-| <span class='attr-optional'>`options.cssClasses.body`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the body element |
-| <span class='attr-optional'>`options.cssClasses.footer`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the footer element |
-| <span class='attr-optional'>`options.cssClasses.time`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the element wrapping the time processingTimeMs |
 | <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
 | <span class='attr-optional'>`options.templates.header`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Header template |
 | <span class='attr-optional'>`options.templates.body`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Body template |
 | <span class='attr-optional'>`options.templates.footer`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Footer template |
 | <span class='attr-optional'>`options.transformData`</span><span class="attr-infos">Type: <code>function</code></span> | Function to change the object passed to the `body` template |
 | <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when no results match |
+| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add |
+| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the root element |
+| <span class='attr-optional'>`options.cssClasses.header`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the header element |
+| <span class='attr-optional'>`options.cssClasses.body`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the body element |
+| <span class='attr-optional'>`options.cssClasses.footer`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the footer element |
+| <span class='attr-optional'>`options.cssClasses.time`</span><span class="attr-infos">Type: <code>string</code></span> | CSS class to add to the element wrapping the time processingTimeMs |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/toggle.md
+++ b/docs/_includes/widget-jsdoc/toggle.md
@@ -5,7 +5,13 @@
 | <span class='attr-required'>`options.label`</span><span class="attr-infos">Type: <code>string</code></span> | Human-readable name of the filter (eg. "Free Shipping") |
 | <span class='attr-optional'>`options.values`</span><span class="attr-infos">Type: <code>Object</code></span> | Lets you define the values to filter on when toggling |
 | <span class='attr-optional'>`options.values.on`</span><span class="attr-infos">Type: <code>\*</code></span> | Value to filter on when checked |
-| <span class='attr-optional'>`options.values.off`</span><span class="attr-infos">Type: <code>\*</code></span> | Value to filter on when unchecked |
+| <span class='attr-optional'>`options.values.off`</span><span class="attr-infos">Type: <code>\*</code></span> | Value to filter on when unchecked element (when using the default template) |
+| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
+| <span class='attr-optional'>`options.templates.header`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Header template |
+| <span class='attr-optional'>`options.templates.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Item template |
+| <span class='attr-optional'>`options.templates.footer`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Footer template |
+| <span class='attr-optional'>`options.transformData`</span><span class="attr-infos">Type: <code>function</code></span> | Function to change the object passed to the item template |
+| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when there's no results |
 | <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add |
 | <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the root element |
 | <span class='attr-optional'>`options.cssClasses.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the header element |
@@ -16,12 +22,6 @@
 | <span class='attr-optional'>`options.cssClasses.active`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each active element |
 | <span class='attr-optional'>`options.cssClasses.label`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each label element (when using the default template) |
 | <span class='attr-optional'>`options.cssClasses.checkbox`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each checkbox element (when using the default template) |
-| <span class='attr-optional'>`options.cssClasses.count`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each count element (when using the default template) |
-| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
-| <span class='attr-optional'>`options.templates.header`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Header template |
-| <span class='attr-optional'>`options.templates.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Item template |
-| <span class='attr-optional'>`options.templates.footer`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Footer template |
-| <span class='attr-optional'>`options.transformData`</span><span class="attr-infos">Type: <code>function</code></span> | Function to change the object passed to the item template |
-| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when there's no results |
+| <span class='attr-optional'>`options.cssClasses.count`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each count |
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/widgets/clear-all/clear-all.js
+++ b/widgets/clear-all/clear-all.js
@@ -14,17 +14,17 @@ let defaultTemplates = require('./defaultTemplates');
  * Allows to clear all refinements at once
  * @function clearAll
  * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
+ * @param  {Object} [options.templates] Templates to use for the widget
+ * @param  {string|Function} [options.templates.header=''] Header template
+ * @param  {string|Function} [options.templates.link] Link template
+ * @param  {string|Function} [options.templates.footer=''] Footer template
+ * @param  {boolean} [options.autoHideContainer=true] Hide the container when there's no refinement to clear
  * @param  {Object} [options.cssClasses] CSS classes to be added
  * @param  {string|string[]} [options.cssClasses.root] CSS class to add to the root element
  * @param  {string|string[]} [options.cssClasses.header] CSS class to add to the header element
  * @param  {string|string[]} [options.cssClasses.body] CSS class to add to the body element
  * @param  {string|string[]} [options.cssClasses.footer] CSS class to add to the footer element
  * @param  {string|string[]} [options.cssClasses.link] CSS class to add to the link element
- * @param  {Object} [options.templates] Templates to use for the widget
- * @param  {string|Function} [options.templates.header=''] Header template
- * @param  {string|Function} [options.templates.link] Link template
- * @param  {string|Function} [options.templates.footer=''] Footer template
- * @param  {boolean} [options.autoHideContainer=true] Hide the container when there's no refinement to clear
  * @return {Object}
  */
 const usage = `Usage:

--- a/widgets/hierarchical-menu/hierarchical-menu.js
+++ b/widgets/hierarchical-menu/hierarchical-menu.js
@@ -18,6 +18,12 @@ let defaultTemplates = require('./defaultTemplates.js');
  * @param  {string} [options.separator=' > '] Separator used in the attributes to separate level values.
  * @param  {number} [options.limit=100] How much facet values to get
  * @param  {string[]} [options.sortBy=['name:asc']] How to sort refinements. Possible values: `count|isRefined|name:asc|desc`
+ * @param  {Object} [options.templates] Templates to use for the widget
+ * @param  {string|Function} [options.templates.header=''] Header template (root level only)
+ * @param  {string|Function} [options.templates.item] Item template
+ * @param  {string|Function} [options.templates.footer=''] Footer template (root level only)
+ * @param  {Function} [options.transformData] Method to change the object passed to the item template
+ * @param  {boolean} [options.autoHideContainer=true] Hide the container when there are no items in the menu
  * @param  {Object} [options.cssClasses] CSS classes to add to the wrapping elements: root, list, item
  * @param  {string|string[]} [options.cssClasses.root] CSS class to add to the root element
  * @param  {string|string[]} [options.cssClasses.header] CSS class to add to the header element
@@ -29,12 +35,6 @@ let defaultTemplates = require('./defaultTemplates.js');
  * @param  {string|string[]} [options.cssClasses.active] CSS class to add to each active element
  * @param  {string|string[]} [options.cssClasses.link] CSS class to add to each link (when using the default template)
  * @param  {string|string[]} [options.cssClasses.count] CSS class to add to each count element (when using the default template)
- * @param  {Object} [options.templates] Templates to use for the widget
- * @param  {string|Function} [options.templates.header=''] Header template (root level only)
- * @param  {string|Function} [options.templates.item] Item template
- * @param  {string|Function} [options.templates.footer=''] Footer template (root level only)
- * @param  {Function} [options.transformData] Method to change the object passed to the item template
- * @param  {boolean} [options.autoHideContainer=true] Hide the container when there are no items in the menu
  * @return {Object}
  */
 const usage = `Usage:

--- a/widgets/hits-per-page-selector/hits-per-page-selector.js
+++ b/widgets/hits-per-page-selector/hits-per-page-selector.js
@@ -14,10 +14,10 @@ let autoHideContainerHOC = require('../../decorators/autoHideContainer');
  * @param  {Array} options.options Array of objects defining the different values and labels
  * @param  {number} options.options[0].value number of hits to display per page
  * @param  {string} options.options[0].label Label to display in the option
+ * @param  {boolean} [options.autoHideContainer=false] Hide the container when no results match
  * @param  {Object} [options.cssClasses] CSS classes to be added
  * @param  {string} [options.cssClasses.root] CSS classes added to the parent `<select>`
  * @param  {string} [options.cssClasses.item] CSS classes added to each `<option>`
- * @param  {boolean} [options.autoHideContainer=false] Hide the container when no results match
  * @return {Object}
  */
 

--- a/widgets/hits/hits.js
+++ b/widgets/hits/hits.js
@@ -12,10 +12,6 @@ let defaultTemplates = require('./defaultTemplates');
  * Display the list of results (hits) from the current search
  * @function hits
  * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
- * @param  {Object} [options.cssClasses] CSS classes to add
- * @param  {string} [options.cssClasses.root] CSS class to add to the wrapping element
- * @param  {string} [options.cssClasses.empty] CSS class to add to the wrapping element when no results
- * @param  {string} [options.cssClasses.item] CSS class to add to each result
  * @param  {Object} [options.templates] Templates to use for the widget
  * @param  {string|Function} [options.templates.empty=''] Template to use when there are no results.
  * @param  {string|Function} [options.templates.item=''] Template to use for each result.
@@ -23,6 +19,10 @@ let defaultTemplates = require('./defaultTemplates');
  * @param  {Function} [options.transformData.empty=identity] Method used to change the object passed to the empty template
  * @param  {Function} [options.transformData.item=identity] Method used to change the object passed to the item template
  * @param  {number} [hitsPerPage=20] The number of hits to display per page
+ * @param  {Object} [options.cssClasses] CSS classes to add
+ * @param  {string} [options.cssClasses.root] CSS class to add to the wrapping element
+ * @param  {string} [options.cssClasses.empty] CSS class to add to the wrapping element when no results
+ * @param  {string} [options.cssClasses.item] CSS class to add to each result
  * @return {Object}
  */
 const usage = `Usage:

--- a/widgets/menu/menu.js
+++ b/widgets/menu/menu.js
@@ -16,6 +16,12 @@ let defaultTemplates = require('./defaultTemplates.js');
  * @param  {string} options.attributeName Name of the attribute for faceting
  * @param  {string[]} [options.sortBy=['count:desc']] How to sort refinements. Possible values: `count|isRefined|name:asc|desc`
  * @param  {string} [options.limit=100] How many facets values to retrieve
+ * @param  {Object} [options.templates] Templates to use for the widget
+ * @param  {string|Function} [options.templates.header=''] Header template
+ * @param  {string|Function} [options.templates.item] Item template, provided with `name`, `count`, `isRefined`
+ * @param  {string|Function} [options.templates.footer=''] Footer template
+ * @param  {Function} [options.transformData] Method to change the object passed to the item template
+ * @param  {boolean} [options.autoHideContainer=true] Hide the container when there are no items in the menu
  * @param  {Object} [options.cssClasses] CSS classes to add to the wrapping elements: root, list, item
  * @param  {string|string[]} [options.cssClasses.root] CSS class to add to the root element
  * @param  {string|string[]} [options.cssClasses.header] CSS class to add to the header element
@@ -26,12 +32,6 @@ let defaultTemplates = require('./defaultTemplates.js');
  * @param  {string|string[]} [options.cssClasses.active] CSS class to add to each active element
  * @param  {string|string[]} [options.cssClasses.link] CSS class to add to each link (when using the default template)
  * @param  {string|string[]} [options.cssClasses.count] CSS class to add to each count element (when using the default template)
- * @param  {Object} [options.templates] Templates to use for the widget
- * @param  {string|Function} [options.templates.header=''] Header template
- * @param  {string|Function} [options.templates.item] Item template, provided with `name`, `count`, `isRefined`
- * @param  {string|Function} [options.templates.footer=''] Footer template
- * @param  {Function} [options.transformData] Method to change the object passed to the item template
- * @param  {boolean} [options.autoHideContainer=true] Hide the container when there are no items in the menu
  * @return {Object}
  */
 const usage = `Usage:

--- a/widgets/numeric-refinement-list/numeric-refinement-list.js
+++ b/widgets/numeric-refinement-list/numeric-refinement-list.js
@@ -18,6 +18,12 @@ let defaultTemplates = require('./defaultTemplates');
  * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
  * @param  {string} options.attributeName Name of the attribute for filtering
  * @param  {Object[]} options.options List of all the options
+ * @param  {Object} [options.templates] Templates to use for the widget
+ * @param  {string|Function} [options.templates.header] Header template
+ * @param  {string|Function} [options.templates.item] Item template, provided with `name`, `count`, `isRefined`
+ * @param  {string|Function} [options.templates.footer] Footer template
+ * @param  {Function} [options.transformData] Function to change the object passed to the item template
+ * @param  {boolean} [options.autoHideContainer=true] Hide the container when no results match
  * @param  {Object} [options.cssClasses] CSS classes to add to the wrapping elements: root, list, item
  * @param  {string|string[]} [options.cssClasses.root] CSS class to add to the root element
  * @param  {string|string[]} [options.cssClasses.header] CSS class to add to the header element
@@ -28,12 +34,6 @@ let defaultTemplates = require('./defaultTemplates');
  * @param  {string|string[]} [options.cssClasses.item] CSS class to add to each item element
  * @param  {string|string[]} [options.cssClasses.radio] CSS class to add to each radio element (when using the default template)
  * @param  {string|string[]} [options.cssClasses.active] CSS class to add to each active element
- * @param  {Object} [options.templates] Templates to use for the widget
- * @param  {string|Function} [options.templates.header] Header template
- * @param  {string|Function} [options.templates.item] Item template, provided with `name`, `count`, `isRefined`
- * @param  {string|Function} [options.templates.footer] Footer template
- * @param  {Function} [options.transformData] Function to change the object passed to the item template
- * @param  {boolean} [options.autoHideContainer=true] Hide the container when no results match
  * @return {Object}
  */
 const usage = `Usage:

--- a/widgets/numeric-selector/numeric-selector.js
+++ b/widgets/numeric-selector/numeric-selector.js
@@ -16,10 +16,10 @@ let bem = utils.bemHelper('ais-numeric-selector');
  * @param  {number} options.options[i].value The numerical value to refine with
  * @param  {string} options.options[i].label Label to display in the option
  * @param  {string} [options.operator] The operator to use to refine
+ * @param  {boolean} [options.autoHideContainer=false] Hide the container when no results match
  * @param  {Object} [options.cssClasses] CSS classes to be added
  * @param  {string} [options.cssClasses.root] CSS classes added to the parent `<select>`
  * @param  {string} [options.cssClasses.item] CSS classes added to each `<option>`
- * @param  {boolean} [options.autoHideContainer=false] Hide the container when no results match
  * @return {Object}
  */
 

--- a/widgets/pagination/pagination.js
+++ b/widgets/pagination/pagination.js
@@ -18,6 +18,16 @@ let defaultLabels = {
  * Add a pagination menu to navigate through the results
  * @function pagination
  * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
+ * @param  {Object} [options.labels] Text to display in the various links (prev, next, first, last)
+ * @param  {string} [options.labels.previous] Label for the Previous link
+ * @param  {string} [options.labels.next] Label for the Next link
+ * @param  {string} [options.labels.first] Label for the First link
+ * @param  {string} [options.labels.last] Label for the Last link
+ * @param  {number} [options.maxPages=20] The max number of pages to browse
+ * @param  {number} [options.padding=3] The number of pages to display on each side of the current page
+ * @param  {string|DOMElement|boolean} [options.scrollTo='body'] Where to scroll after a click, set to `false` to disable
+ * @param  {boolean} [options.showFirstLast=true] Define if the First and Last links should be displayed
+ * @param  {boolean} [options.autoHideContainer=true] Hide the container when no results match
  * @param  {Object} [options.cssClasses] CSS classes to be added
  * @param  {string} [options.cssClasses.root] CSS classes added to the parent `<ul>`
  * @param  {string} [options.cssClasses.item] CSS classes added to each `<li>`
@@ -29,16 +39,6 @@ let defaultLabels = {
  * @param  {string} [options.cssClasses.last] CSS classes added to the last `<li>`
  * @param  {string} [options.cssClasses.active] CSS classes added to the active `<li>`
  * @param  {string} [options.cssClasses.disabled] CSS classes added to the disabled `<li>`
- * @param  {Object} [options.labels] Text to display in the various links (prev, next, first, last)
- * @param  {string} [options.labels.previous] Label for the Previous link
- * @param  {string} [options.labels.next] Label for the Next link
- * @param  {string} [options.labels.first] Label for the First link
- * @param  {string} [options.labels.last] Label for the Last link
- * @param  {number} [options.maxPages=20] The max number of pages to browse
- * @param  {number} [options.padding=3] The number of pages to display on each side of the current page
- * @param  {string|DOMElement|boolean} [options.scrollTo='body'] Where to scroll after a click, set to `false` to disable
- * @param  {boolean} [options.showFirstLast=true] Define if the First and Last links should be displayed
- * @param  {boolean} [options.autoHideContainer=true] Hide the container when no results match
  * @return {Object}
  */
 const usage = `Usage:

--- a/widgets/price-ranges/price-ranges.js
+++ b/widgets/price-ranges/price-ranges.js
@@ -17,6 +17,13 @@ let cx = require('classnames');
  * @function priceRanges
  * @param  {string|DOMElement} options.container Valid CSS Selector as a string or DOMElement
  * @param  {string} options.attributeName Name of the attribute for faceting
+ * @param  {Object} [options.templates] Templates to use for the widget
+ * @param  {string|Function} [options.templates.item] Item template
+ * @param  {Object} [options.labels] Labels to use for the widget
+ * @param  {string|Function} [options.labels.currency] Currency label
+ * @param  {string|Function} [options.labels.separator] Separator label, between min and max
+ * @param  {string|Function} [options.labels.button] Button label
+ * @param  {boolean} [options.autoHideContainer=true] Hide the container when no refinements available
  * @param  {Object} [options.cssClasses] CSS classes to add
  * @param  {string} [options.cssClasses.root] CSS class to add to the root element
  * @param  {string} [options.cssClasses.header] CSS class to add to the header element
@@ -32,13 +39,6 @@ let cx = require('classnames');
  * @param  {string} [options.cssClasses.separator] CSS class to add to the separator of the form
  * @param  {string} [options.cssClasses.button] CSS class to add to the submit button of the form
  * @param  {string} [options.cssClasses.footer] CSS class to add to the footer element
- * @param  {Object} [options.templates] Templates to use for the widget
- * @param  {string|Function} [options.templates.item] Item template
- * @param  {Object} [options.labels] Labels to use for the widget
- * @param  {string|Function} [options.labels.currency] Currency label
- * @param  {string|Function} [options.labels.separator] Separator label, between min and max
- * @param  {string|Function} [options.labels.button] Button label
- * @param  {boolean} [options.autoHideContainer=true] Hide the container when no refinements available
  * @return {Object}
  */
 const usage = `Usage:

--- a/widgets/range-slider/range-slider.js
+++ b/widgets/range-slider/range-slider.js
@@ -24,10 +24,10 @@ let defaultTemplates = {
  * @param  {Object} [options.templates] Templates to use for the widget
  * @param  {string|Function} [options.templates.header=''] Header template
  * @param  {string|Function} [options.templates.footer=''] Footer template
+ * @param  {boolean} [options.autoHideContainer=true] Hide the container when no refinements available
  * @param  {Object} [options.cssClasses] CSS classes to add to the wrapping elements: root, body
  * @param  {string|string[]} [options.cssClasses.root] CSS class to add to the root element
  * @param  {string|string[]} [options.cssClasses.body] CSS class to add to the body element
- * @param  {boolean} [options.autoHideContainer=true] Hide the container when no refinements available
  * @return {Object}
  */
 const usage = `Usage:

--- a/widgets/refinement-list/refinement-list.js
+++ b/widgets/refinement-list/refinement-list.js
@@ -18,6 +18,12 @@ let defaultTemplates = require('./defaultTemplates');
  * @param  {string} [options.operator='or'] How to apply refinements. Possible values: `or`, `and`
  * @param  {string[]} [options.sortBy=['count:desc']] How to sort refinements. Possible values: `count|isRefined|name:asc|desc`
  * @param  {string} [options.limit=1000] How much facet values to get
+ * @param  {Object} [options.templates] Templates to use for the widget
+ * @param  {string|Function} [options.templates.header] Header template
+ * @param  {string|Function} [options.templates.item] Item template, provided with `name`, `count`, `isRefined`
+ * @param  {string|Function} [options.templates.footer] Footer template
+ * @param  {Function} [options.transformData] Function to change the object passed to the item template
+ * @param  {boolean} [options.autoHideContainer=true] Hide the container when no items in the refinement list
  * @param  {Object} [options.cssClasses] CSS classes to add to the wrapping elements: root, list, item
  * @param  {string|string[]} [options.cssClasses.root] CSS class to add to the root element
  * @param  {string|string[]} [options.cssClasses.header] CSS class to add to the header element
@@ -29,12 +35,6 @@ let defaultTemplates = require('./defaultTemplates');
  * @param  {string|string[]} [options.cssClasses.label] CSS class to add to each label element (when using the default template)
  * @param  {string|string[]} [options.cssClasses.checkbox] CSS class to add to each checkbox element (when using the default template)
  * @param  {string|string[]} [options.cssClasses.count] CSS class to add to each count element (when using the default template)
- * @param  {Object} [options.templates] Templates to use for the widget
- * @param  {string|Function} [options.templates.header] Header template
- * @param  {string|Function} [options.templates.item] Item template, provided with `name`, `count`, `isRefined`
- * @param  {string|Function} [options.templates.footer] Footer template
- * @param  {Function} [options.transformData] Function to change the object passed to the item template
- * @param  {boolean} [options.autoHideContainer=true] Hide the container when no items in the refinement list
  * @return {Object}
  */
 const usage = `Usage:

--- a/widgets/search-box/search-box.js
+++ b/widgets/search-box/search-box.js
@@ -13,16 +13,16 @@ const KEY_SUPPRESS = 8;
  * @function searchBox
  * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
  * @param  {string} [options.placeholder] Input's placeholder
- * @param  {Object} [options.cssClasses] CSS classes to add
- * @param  {string} [options.cssClasses.root] CSS class to add to the
- * wrapping div (if `wrapInput` set to `true`)
- * @param  {string} [options.cssClasses.input] CSS class to add to the input
- * @param  {string} [options.cssClasses.poweredBy] CSS class to add to the poweredBy element
  * @param  {boolean} [poweredBy=false] Show a powered by Algolia link below the input
  * @param  {boolean} [wrapInput=true] Wrap the input in a `div.ais-search-box`
  * @param  {boolean|string} [autofocus='auto'] autofocus on the input
  * @param  {boolean} [searchOnEnterKeyPressOnly=false] If set, trigger the search
  * once `<Enter>` is pressed only
+ * @param  {Object} [options.cssClasses] CSS classes to add
+ * @param  {string} [options.cssClasses.root] CSS class to add to the
+ * wrapping div (if `wrapInput` set to `true`)
+ * @param  {string} [options.cssClasses.input] CSS class to add to the input
+ * @param  {string} [options.cssClasses.poweredBy] CSS class to add to the poweredBy element
  * @return {Object}
  */
 const usage = `Usage:

--- a/widgets/sort-by-selector/sort-by-selector.js
+++ b/widgets/sort-by-selector/sort-by-selector.js
@@ -15,10 +15,10 @@ let autoHideContainerHOC = require('../../decorators/autoHideContainer');
  * @param  {Array} options.indices Array of objects defining the different indices to choose from.
  * @param  {string} options.indices[0].name Name of the index to target
  * @param  {string} options.indices[0].label Label displayed in the dropdown
+ * @param  {boolean} [options.autoHideContainer=false] Hide the container when no results match
  * @param  {Object} [options.cssClasses] CSS classes to be added
  * @param  {string} [options.cssClasses.root] CSS classes added to the parent <select>
  * @param  {string} [options.cssClasses.item] CSS classes added to each <option>
- * @param  {boolean} [options.autoHideContainer=false] Hide the container when no results match
  * @return {Object}
  */
 const usage = `Usage:

--- a/widgets/star-rating/star-rating.js
+++ b/widgets/star-rating/star-rating.js
@@ -30,6 +30,14 @@ starRating({
  * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
  * @param  {string} options.attributeName Name of the attribute for filtering
  * @param  {number} [options.max] The maximum rating value
+ * @param  {Object} [options.labels] Labels used by the default template
+ * @param  {string} [options.labels.andUp] The label suffixed after each line
+ * @param  {Object} [options.templates] Templates to use for the widget
+ * @param  {string|Function} [options.templates.header] Header template
+ * @param  {string|Function} [options.templates.item] Item template, provided with `name`, `count`, `isRefined`
+ * @param  {string|Function} [options.templates.footer] Footer template
+ * @param  {Function} [options.transformData] Function to change the object passed to the item template
+ * @param  {boolean} [options.autoHideContainer=true] Hide the container when no results match
  * @param  {Object} [options.cssClasses] CSS classes to add to the wrapping elements: root, list, item
  * @param  {string|string[]} [options.cssClasses.root] CSS class to add to the root element
  * @param  {string|string[]} [options.cssClasses.header] CSS class to add to the header element
@@ -42,14 +50,6 @@ starRating({
  * @param  {string|string[]} [options.cssClasses.star] CSS class to add to each star element (when using the default template)
  * @param  {string|string[]} [options.cssClasses.emptyStar] CSS class to add to each empty star element (when using the default template)
  * @param  {string|string[]} [options.cssClasses.active] CSS class to add to each active element
- * @param  {Object} [options.labels] Labels used by the default template
- * @param  {string} [options.labels.andUp] The label suffixed after each line
- * @param  {Object} [options.templates] Templates to use for the widget
- * @param  {string|Function} [options.templates.header] Header template
- * @param  {string|Function} [options.templates.item] Item template, provided with `name`, `count`, `isRefined`
- * @param  {string|Function} [options.templates.footer] Footer template
- * @param  {Function} [options.transformData] Function to change the object passed to the item template
- * @param  {boolean} [options.autoHideContainer=true] Hide the container when no results match
  * @return {Object}
  */
 function starRating({

--- a/widgets/stats/stats.js
+++ b/widgets/stats/stats.js
@@ -13,18 +13,18 @@ let defaultTemplates = require('./defaultTemplates.js');
  * Display various stats about the current search state
  * @function stats
  * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
- * @param  {Object} [options.cssClasses] CSS classes to add
- * @param  {string} [options.cssClasses.root] CSS class to add to the root element
- * @param  {string} [options.cssClasses.header] CSS class to add to the header element
- * @param  {string} [options.cssClasses.body] CSS class to add to the body element
- * @param  {string} [options.cssClasses.footer] CSS class to add to the footer element
- * @param  {string} [options.cssClasses.time] CSS class to add to the element wrapping the time processingTimeMs
  * @param  {Object} [options.templates] Templates to use for the widget
  * @param  {string|Function} [options.templates.header=''] Header template
  * @param  {string|Function} [options.templates.body] Body template
  * @param  {string|Function} [options.templates.footer=''] Footer template
  * @param  {Function} [options.transformData] Function to change the object passed to the `body` template
  * @param  {boolean} [options.autoHideContainer=true] Hide the container when no results match
+ * @param  {Object} [options.cssClasses] CSS classes to add
+ * @param  {string} [options.cssClasses.root] CSS class to add to the root element
+ * @param  {string} [options.cssClasses.header] CSS class to add to the header element
+ * @param  {string} [options.cssClasses.body] CSS class to add to the body element
+ * @param  {string} [options.cssClasses.footer] CSS class to add to the footer element
+ * @param  {string} [options.cssClasses.time] CSS class to add to the element wrapping the time processingTimeMs
  * @return {Object}
  */
 const usage = `Usage:

--- a/widgets/toggle/toggle.js
+++ b/widgets/toggle/toggle.js
@@ -22,6 +22,13 @@ let defaultTemplates = require('./defaultTemplates');
  * @param  {Object} [options.values] Lets you define the values to filter on when toggling
  * @param  {*} [options.values.on] Value to filter on when checked
  * @param  {*} [options.values.off] Value to filter on when unchecked
+ * element (when using the default template)
+ * @param  {Object} [options.templates] Templates to use for the widget
+ * @param  {string|Function} [options.templates.header=''] Header template
+ * @param  {string|Function} [options.templates.item] Item template
+ * @param  {string|Function} [options.templates.footer=''] Footer template
+ * @param  {Function} [options.transformData] Function to change the object passed to the item template
+ * @param  {boolean} [options.autoHideContainer=true] Hide the container when there's no results
  * @param  {Object} [options.cssClasses] CSS classes to add
  * @param  {string|string[]} [options.cssClasses.root] CSS class to add to the root element
  * @param  {string|string[]} [options.cssClasses.header] CSS class to add to the header element
@@ -35,13 +42,6 @@ let defaultTemplates = require('./defaultTemplates');
  * @param  {string|string[]} [options.cssClasses.checkbox] CSS class to add to each
  * checkbox element (when using the default template)
  * @param  {string|string[]} [options.cssClasses.count] CSS class to add to each count
- * element (when using the default template)
- * @param  {Object} [options.templates] Templates to use for the widget
- * @param  {string|Function} [options.templates.header=''] Header template
- * @param  {string|Function} [options.templates.item] Item template
- * @param  {string|Function} [options.templates.footer=''] Footer template
- * @param  {Function} [options.transformData] Function to change the object passed to the item template
- * @param  {boolean} [options.autoHideContainer=true] Hide the container when there's no results
  * @return {Object}
  */
 const usage = `Usage:


### PR DESCRIPTION
`ls widgets/*/*.js | xargs -I {} perl -0777 -pi.orig -e 's#(\n[^\n]*options.cssClasses.*options.cssClasses[^\n]*)(\n.*)(\n[^\n]*\@return[^\n]*\n)#\2\1\3#ms' {}`

Closes #645 