### PR TITLE
fix(doc): Expand input on documentation page

### DIFF
--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -11,7 +11,11 @@
         <ul class="nav navbar-nav navbar-right">
           <li class="hidden-xs">
             <form class="form search-form" action="#">
-              <input class="form-control" type="text" id="doc-search" />
+            {% if page.title == 'Documentation' %}
+              <input class="form-control search-active" placeholder="Search in the documentation" type="text" id="doc-search" />
+            {% else %}
+              <input class="form-control" placeholder="Search in the documentation" type="text" id="doc-search" />
+            {% endif %}
               <div class="search-icon"><i class="fa fa-search"></i></div>
             </form>
           </li>

--- a/docs/css/_search.sass
+++ b/docs/css/_search.sass
@@ -15,7 +15,7 @@
     color: white
     width: 36px
     overflow: hidden
-    &:focus, &:active
+    &:focus, &:active, &.search-active
       outline: none
       box-shadow: none
       width: 300px


### PR DESCRIPTION
As discussed with @Shipow I expanded the search bar on the documentation page.

I took the liberty of adding a placeholder, I think it's better with it but I can remove it if needed