### PR TITLE
chore(doc): documentation reindexing

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -29,7 +29,7 @@ gems:
 
 # search
 algolia:
-  application_id: YE0A9ATLJG
+  application_id: latency
   index_name: instantsearch.js
   excluded_files:
     - index.haml

--- a/docs/js/search.js
+++ b/docs/js/search.js
@@ -3,7 +3,7 @@
 (function($) {
   'use strict';
 
-  var algolia = algoliasearch('YE0A9ATLJG', '1abceba46dace8485375bc325f0144b5');
+  var algolia = algoliasearch('latency', '7e05cab6d894e94ffee4148458f716d9');
   var $searchInput = $('#doc-search');
 
   function goToSuggestion(event, item) {

--- a/scripts/gh-pages.sh
+++ b/scripts/gh-pages.sh
@@ -15,4 +15,5 @@ for example in _site/examples/*; do
     (cd "$example" && zip -r ../$name.zip *)
   fi
 done
+bundle exec jekyll algolia push
 gh-pages --dist _site --branch gh-pages


### PR DESCRIPTION
Reindex the documentation as soon as you release a new version of the
website. You need to export the associated ALGOLIA_API_KEY env variable.

Also move to the world-wildly replicated `latency` account.