### PR TITLE
fix(priceRanges): Remove round from first range

### DIFF
--- a/src/widgets/price-ranges/__tests__/generate-ranges-test.js
+++ b/src/widgets/price-ranges/__tests__/generate-ranges-test.js
@@ -7,14 +7,14 @@ import generateRanges from '../generate-ranges';
 describe('generateRanges()', () => {
   it('should generate ranges', () => {
     let stats = {
-      min: 1.99,
+      min: 1.01,
       max: 4999.98,
       avg: 243.349,
       sum: 2433490.0
     };
     let expected = [
-      {to: 1},
-      {from: 1, to: 80},
+      {to: 2},
+      {from: 2, to: 80},
       {from: 80, to: 160},
       {from: 160, to: 240},
       {from: 240, to: 1820},

--- a/src/widgets/price-ranges/generate-ranges.js
+++ b/src/widgets/price-ranges/generate-ranges.js
@@ -26,10 +26,12 @@ function generateRanges(stats) {
   let from;
   let facetValues = [];
   if (min !== max) {
-    next = round(min, precision);
+    next = min;
+
     facetValues.push({
       to: next
     });
+
     while (next < avg) {
       from = facetValues[facetValues.length - 1].to;
       next = round(from + (avg - min) / 3, precision);


### PR DESCRIPTION
This is to avoid having a no result "<= n" first range if the round was < to stats.min