### PR TITLE
chore(build): generate source map based on original files

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -35,7 +35,7 @@ done
 
 printf "$license" | cat - dist/${bundle}.js > /tmp/out && mv /tmp/out dist/${bundle}.js
 cd dist
-uglifyjs ${bundle}.js --source-map ${bundle}.min.map --preamble "$license" -c warnings=false -m -o ${bundle}.min.js
+uglifyjs ${bundle}.js --in-source-map ${bundle}.js.map --source-map ${bundle}.min.js.map --preamble "$license" -c warnings=false -m -o ${bundle}.min.js
 cd ..
 
 printf "=> ${bundle}.min.js gzipped will weight `cat dist/${bundle}.min.js | gzip -9 | wc -c | pretty-bytes`\n"

--- a/scripts/webpack.config.jsdelivr.babel.js
+++ b/scripts/webpack.config.jsdelivr.babel.js
@@ -2,6 +2,7 @@ import webpack from 'webpack';
 
 export default {
   entry: './index.js',
+  devtool: 'source-map',
   output: {
     path: './dist/',
     filename: 'instantsearch.js',


### PR DESCRIPTION
Instead of having the whole bundle being the source of all the code.

This will show individual source maps back to the original src/ filetree when debugging live implementations using jsdelivr. Nice