### PR TITLE
chore(build): upgrade nouislider to reduce build size

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -11982,12 +11982,12 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.14.2.tgz"
     },
     "react-nouislider": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/react-nouislider/-/react-nouislider-1.5.2.tgz",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/react-nouislider/-/react-nouislider-1.6.0.tgz",
       "dependencies": {
         "nouislider-algolia-fork": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/nouislider-algolia-fork/-/nouislider-algolia-fork-8.1.1.tgz"
+          "version": "8.1.2",
+          "resolved": "https://registry.npmjs.org/nouislider-algolia-fork/-/nouislider-algolia-fork-8.1.2.tgz"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "lodash": "^3.10.1",
     "react": "^0.14.2",
     "react-dom": "^0.14.2",
-    "react-nouislider": "^1.5.2",
+    "react-nouislider": "^1.6.0",
     "to-factory": "^1.0.0"
   },
   "license": "MIT"


### PR DESCRIPTION
Before:
```sh
=> instantsearch.min.js gzipped will weight 104.14 kB
```

After:
```sh
=> instantsearch.min.js gzipped will weight 96.82 kB
```

=> -7% filesize

Found out that we were using bad files by using http://chrisbateman.github.io/webpack-visualizer/ and https://github.com/danvk/source-map-explorer which are doing the same thing but showing the filetree differently.

I had done a bad thing: insert a copy pasted cloning function into
nouislider algolia fork. This clone function made usage of nodejs
Buffer class (for nothing, just importing it in case there was a
Buffer to copy).

It's now removed since we are re-creating instances of nouislider
everytime props changes.

It's still tracked in nouislider repo:
leongersen/noUiSlider#537