### PR TITLE
fix(getRefinements): hierarchical facets

### DIFF
--- a/src/lib/__tests__/utils-test.js
+++ b/src/lib/__tests__/utils-test.js
@@ -137,11 +137,11 @@ describe('getRefinements', function() {
       hierarchicalFacets: [{
         name: 'hierarchicalFacet1',
         attributes: ['hierarchicalFacet1.lvl0', 'hierarchicalFacet1.lvl1'],
-        separator: '>'
+        separator: ' > '
       }, {
         name: 'hierarchicalFacet2',
         attributes: ['hierarchicalFacet2.lvl0', 'hierarchicalFacet2.lvl1'],
-        separator: '>'
+        separator: ' > '
       }]
     });
     results = {};
@@ -150,7 +150,7 @@ describe('getRefinements', function() {
   it('should retrieve one tag', function() {
     helper.addTag('tag1');
     const expected = [
-      {attributeName: '_tags', name: 'tag1'}
+      {type: 'tag', attributeName: '_tags', name: 'tag1'}
     ];
     expect(utils.getRefinements(results, helper.state)).toInclude(expected[0]);
   });
@@ -158,8 +158,8 @@ describe('getRefinements', function() {
   it('should retrieve multiple tags', function() {
     helper.addTag('tag1').addTag('tag2');
     const expected = [
-      {attributeName: '_tags', name: 'tag1'},
-      {attributeName: '_tags', name: 'tag2'}
+      {type: 'tag', attributeName: '_tags', name: 'tag1'},
+      {type: 'tag', attributeName: '_tags', name: 'tag2'}
     ];
     expect(utils.getRefinements(results, helper.state)).toInclude(expected[0]);
   });
@@ -167,7 +167,7 @@ describe('getRefinements', function() {
   it('should retrieve one facetRefinement', function() {
     helper.toggleRefinement('facet1', 'facet1val1');
     const expected = [
-      {attributeName: 'facet1', name: 'facet1val1'}
+      {type: 'facet', attributeName: 'facet1', name: 'facet1val1'}
     ];
     expect(utils.getRefinements(results, helper.state)).toInclude(expected[0]);
   });
@@ -177,8 +177,8 @@ describe('getRefinements', function() {
       .toggleRefinement('facet1', 'facet1val1')
       .toggleRefinement('facet1', 'facet1val2');
     const expected = [
-      {attributeName: 'facet1', name: 'facet1val1'},
-      {attributeName: 'facet1', name: 'facet1val2'}
+      {type: 'facet', attributeName: 'facet1', name: 'facet1val1'},
+      {type: 'facet', attributeName: 'facet1', name: 'facet1val2'}
     ];
     expect(utils.getRefinements(results, helper.state)).toInclude(expected[0]);
     expect(utils.getRefinements(results, helper.state)).toInclude(expected[1]);
@@ -190,9 +190,9 @@ describe('getRefinements', function() {
       .toggleRefinement('facet1', 'facet1val2')
       .toggleRefinement('facet2', 'facet2val1');
     const expected = [
-      {attributeName: 'facet1', name: 'facet1val1'},
-      {attributeName: 'facet1', name: 'facet1val2'},
-      {attributeName: 'facet2', name: 'facet2val1'}
+      {type: 'facet', attributeName: 'facet1', name: 'facet1val1'},
+      {type: 'facet', attributeName: 'facet1', name: 'facet1val2'},
+      {type: 'facet', attributeName: 'facet2', name: 'facet2val1'}
     ];
     expect(utils.getRefinements(results, helper.state)).toInclude(expected[0]);
     expect(utils.getRefinements(results, helper.state)).toInclude(expected[1]);
@@ -210,7 +210,7 @@ describe('getRefinements', function() {
       }]
     };
     const expected = [
-      {attributeName: 'facet1', name: 'facet1val1', count: 4}
+      {type: 'facet', attributeName: 'facet1', name: 'facet1val1', count: 4}
     ];
     expect(utils.getRefinements(results, helper.state)).toInclude(expected[0]);
   });
@@ -224,7 +224,7 @@ describe('getRefinements', function() {
       }]
     };
     const expected = [
-      {attributeName: 'facet1', name: 'facet1val1', exhaustive: true}
+      {type: 'facet', attributeName: 'facet1', name: 'facet1val1', exhaustive: true}
     ];
     expect(utils.getRefinements(results, helper.state)).toInclude(expected[0]);
   });
@@ -232,7 +232,7 @@ describe('getRefinements', function() {
   it('should retrieve one facetExclude', function() {
     helper.toggleExclude('facet1', 'facet1exclude1');
     const expected = [
-      {attributeName: 'facet1', name: 'facet1exclude1', exclude: true}
+      {type: 'exclude', attributeName: 'facet1', name: 'facet1exclude1', exclude: true}
     ];
     expect(utils.getRefinements(results, helper.state)).toInclude(expected[0]);
   });
@@ -242,8 +242,8 @@ describe('getRefinements', function() {
       .toggleExclude('facet1', 'facet1exclude1')
       .toggleExclude('facet1', 'facet1exclude2');
     const expected = [
-      {attributeName: 'facet1', name: 'facet1exclude1', exclude: true},
-      {attributeName: 'facet1', name: 'facet1exclude2', exclude: true}
+      {type: 'exclude', attributeName: 'facet1', name: 'facet1exclude1', exclude: true},
+      {type: 'exclude', attributeName: 'facet1', name: 'facet1exclude2', exclude: true}
     ];
     expect(utils.getRefinements(results, helper.state)).toInclude(expected[0]);
     expect(utils.getRefinements(results, helper.state)).toInclude(expected[1]);
@@ -255,9 +255,9 @@ describe('getRefinements', function() {
       .toggleExclude('facet1', 'facet1exclude2')
       .toggleExclude('facet2', 'facet2exclude1');
     const expected = [
-      {attributeName: 'facet1', name: 'facet1exclude1', exclude: true},
-      {attributeName: 'facet1', name: 'facet1exclude2', exclude: true},
-      {attributeName: 'facet2', name: 'facet2exclude1', exclude: true}
+      {type: 'exclude', attributeName: 'facet1', name: 'facet1exclude1', exclude: true},
+      {type: 'exclude', attributeName: 'facet1', name: 'facet1exclude2', exclude: true},
+      {type: 'exclude', attributeName: 'facet2', name: 'facet2exclude1', exclude: true}
     ];
     expect(utils.getRefinements(results, helper.state)).toInclude(expected[0]);
     expect(utils.getRefinements(results, helper.state)).toInclude(expected[1]);
@@ -267,7 +267,7 @@ describe('getRefinements', function() {
   it('should retrieve one disjunctiveFacetRefinement', function() {
     helper.addDisjunctiveFacetRefinement('disjunctiveFacet1', 'disjunctiveFacet1val1');
     const expected = [
-      {attributeName: 'disjunctiveFacet1', name: 'disjunctiveFacet1val1'}
+      {type: 'disjunctive', attributeName: 'disjunctiveFacet1', name: 'disjunctiveFacet1val1'}
     ];
     expect(utils.getRefinements(results, helper.state)).toInclude(expected[0]);
   });
@@ -277,8 +277,8 @@ describe('getRefinements', function() {
       .addDisjunctiveFacetRefinement('disjunctiveFacet1', 'disjunctiveFacet1val1')
       .addDisjunctiveFacetRefinement('disjunctiveFacet1', 'disjunctiveFacet1val2');
     const expected = [
-      {attributeName: 'disjunctiveFacet1', name: 'disjunctiveFacet1val1'},
-      {attributeName: 'disjunctiveFacet1', name: 'disjunctiveFacet1val2'}
+      {type: 'disjunctive', attributeName: 'disjunctiveFacet1', name: 'disjunctiveFacet1val1'},
+      {type: 'disjunctive', attributeName: 'disjunctiveFacet1', name: 'disjunctiveFacet1val2'}
     ];
     expect(utils.getRefinements(results, helper.state)).toInclude(expected[0]);
     expect(utils.getRefinements(results, helper.state)).toInclude(expected[1]);
@@ -290,9 +290,9 @@ describe('getRefinements', function() {
       .toggleRefinement('disjunctiveFacet1', 'disjunctiveFacet1val2')
       .toggleRefinement('disjunctiveFacet2', 'disjunctiveFacet2val1');
     const expected = [
-      {attributeName: 'disjunctiveFacet1', name: 'disjunctiveFacet1val1'},
-      {attributeName: 'disjunctiveFacet1', name: 'disjunctiveFacet1val2'},
-      {attributeName: 'disjunctiveFacet2', name: 'disjunctiveFacet2val1'}
+      {type: 'disjunctive', attributeName: 'disjunctiveFacet1', name: 'disjunctiveFacet1val1'},
+      {type: 'disjunctive', attributeName: 'disjunctiveFacet1', name: 'disjunctiveFacet1val2'},
+      {type: 'disjunctive', attributeName: 'disjunctiveFacet2', name: 'disjunctiveFacet2val1'}
     ];
     expect(utils.getRefinements(results, helper.state)).toInclude(expected[0]);
     expect(utils.getRefinements(results, helper.state)).toInclude(expected[1]);
@@ -310,7 +310,7 @@ describe('getRefinements', function() {
       }]
     };
     const expected = [
-      {attributeName: 'disjunctiveFacet1', name: 'disjunctiveFacet1val1', count: 4}
+      {type: 'disjunctive', attributeName: 'disjunctiveFacet1', name: 'disjunctiveFacet1val1', count: 4}
     ];
     expect(utils.getRefinements(results, helper.state)).toInclude(expected[0]);
   });
@@ -324,7 +324,7 @@ describe('getRefinements', function() {
       }]
     };
     const expected = [
-      {attributeName: 'disjunctiveFacet1', name: 'disjunctiveFacet1val1', exhaustive: true}
+      {type: 'disjunctive', attributeName: 'disjunctiveFacet1', name: 'disjunctiveFacet1val1', exhaustive: true}
     ];
     expect(utils.getRefinements(results, helper.state)).toInclude(expected[0]);
   });
@@ -332,7 +332,7 @@ describe('getRefinements', function() {
   it('should retrieve one hierarchicalFacetRefinement', function() {
     helper.toggleRefinement('hierarchicalFacet1', 'hierarchicalFacet1lvl0val1');
     const expected = [
-      {attributeName: 'hierarchicalFacet1', name: 'hierarchicalFacet1lvl0val1'}
+      {type: 'hierarchical', attributeName: 'hierarchicalFacet1', name: 'hierarchicalFacet1lvl0val1'}
     ];
     expect(utils.getRefinements(results, helper.state)).toInclude(expected[0]);
   });
@@ -342,8 +342,8 @@ describe('getRefinements', function() {
       .toggleRefinement('hierarchicalFacet1', 'hierarchicalFacet1lvl0val1')
       .toggleRefinement('hierarchicalFacet2', 'hierarchicalFacet2lvl0val1');
     const expected = [
-      {attributeName: 'hierarchicalFacet1', name: 'hierarchicalFacet1lvl0val1'},
-      {attributeName: 'hierarchicalFacet2', name: 'hierarchicalFacet2lvl0val1'}
+      {type: 'hierarchical', attributeName: 'hierarchicalFacet1', name: 'hierarchicalFacet1lvl0val1'},
+      {type: 'hierarchical', attributeName: 'hierarchicalFacet2', name: 'hierarchicalFacet2lvl0val1'}
     ];
     expect(utils.getRefinements(results, helper.state)).toInclude(expected[0]);
     expect(utils.getRefinements(results, helper.state)).toInclude(expected[1]);
@@ -354,8 +354,8 @@ describe('getRefinements', function() {
       .toggleRefinement('hierarchicalFacet1', 'hierarchicalFacet1lvl0val1')
       .toggleRefinement('hierarchicalFacet2', 'hierarchicalFacet2lvl0val1 > lvl1val1');
     const expected = [
-      {attributeName: 'hierarchicalFacet1', name: 'hierarchicalFacet1lvl0val1'},
-      {attributeName: 'hierarchicalFacet2', name: 'hierarchicalFacet2lvl0val1 > lvl1val1'}
+      {type: 'hierarchical', attributeName: 'hierarchicalFacet1', name: 'hierarchicalFacet1lvl0val1'},
+      {type: 'hierarchical', attributeName: 'hierarchicalFacet2', name: 'lvl1val1'}
     ];
     expect(utils.getRefinements(results, helper.state)).toInclude(expected[0]);
     expect(utils.getRefinements(results, helper.state)).toInclude(expected[1]);
@@ -367,12 +367,12 @@ describe('getRefinements', function() {
       hierarchicalFacets: [{
         name: 'hierarchicalFacet1',
         data: {
-          hierarchicalFacet1val1: 4
+          hierarchicalFacet1val1: {name: 'hierarchicalFacet1val1', count: 4}
         }
       }]
     };
     const expected = [
-      {attributeName: 'hierarchicalFacet1', name: 'hierarchicalFacet1val1', count: 4}
+      {type: 'hierarchical', attributeName: 'hierarchicalFacet1', name: 'hierarchicalFacet1val1', count: 4}
     ];
     expect(utils.getRefinements(results, helper.state)).toInclude(expected[0]);
   });
@@ -382,11 +382,13 @@ describe('getRefinements', function() {
     results = {
       hierarchicalFacets: [{
         name: 'hierarchicalFacet1',
-        exhaustive: true
+        data: [
+          {name: 'hierarchicalFacet1val1', exhaustive: true}
+        ]
       }]
     };
     const expected = [
-      {attributeName: 'hierarchicalFacet1', name: 'hierarchicalFacet1val1', exhaustive: true}
+      {type: 'hierarchical', attributeName: 'hierarchicalFacet1', name: 'hierarchicalFacet1val1', exhaustive: true}
     ];
     expect(utils.getRefinements(results, helper.state)).toInclude(expected[0]);
   });
@@ -394,7 +396,7 @@ describe('getRefinements', function() {
   it('should retrieve a numericRefinement on one facet', function() {
     helper.addNumericRefinement('numericFacet1', '>', '1');
     const expected = [
-      {attributeName: 'numericFacet1', operator: '>', name: '1'}
+      {type: 'numeric', attributeName: 'numericFacet1', operator: '>', name: '1'}
     ];
     expect(utils.getRefinements(results, helper.state)).toInclude(expected[0]);
   });
@@ -402,7 +404,7 @@ describe('getRefinements', function() {
   it('should retrieve a numericRefinement on one disjunctive facet', function() {
     helper.addNumericRefinement('numericDisjunctiveFacet1', '>', '1');
     const expected = [
-      {attributeName: 'numericDisjunctiveFacet1', operator: '>', name: '1'}
+      {type: 'numeric', attributeName: 'numericDisjunctiveFacet1', operator: '>', name: '1'}
     ];
     expect(utils.getRefinements(results, helper.state)).toInclude(expected[0]);
   });
@@ -412,8 +414,8 @@ describe('getRefinements', function() {
       .addNumericRefinement('numericFacet1', '>', '1')
       .addNumericRefinement('numericFacet1', '>', '2');
     const expected = [
-      {attributeName: 'numericFacet1', operator: '>', name: '1'},
-      {attributeName: 'numericFacet1', operator: '>', name: '2'}
+      {type: 'numeric', attributeName: 'numericFacet1', operator: '>', name: '1'},
+      {type: 'numeric', attributeName: 'numericFacet1', operator: '>', name: '2'}
     ];
     expect(utils.getRefinements(results, helper.state)).toInclude(expected[0]);
     expect(utils.getRefinements(results, helper.state)).toInclude(expected[1]);
@@ -427,11 +429,11 @@ describe('getRefinements', function() {
       .addNumericRefinement('numericDisjunctiveFacet1', '>', '1')
       .addNumericRefinement('numericDisjunctiveFacet1', '>', '2');
     const expected = [
-      {attributeName: 'numericFacet1', operator: '>', name: '1'},
-      {attributeName: 'numericFacet1', operator: '>', name: '2'},
-      {attributeName: 'numericFacet1', operator: '<=', name: '3'},
-      {attributeName: 'numericDisjunctiveFacet1', operator: '>', name: '1'},
-      {attributeName: 'numericDisjunctiveFacet1', operator: '>', name: '2'}
+      {type: 'numeric', attributeName: 'numericFacet1', operator: '>', name: '1'},
+      {type: 'numeric', attributeName: 'numericFacet1', operator: '>', name: '2'},
+      {type: 'numeric', attributeName: 'numericFacet1', operator: '<=', name: '3'},
+      {type: 'numeric', attributeName: 'numericDisjunctiveFacet1', operator: '>', name: '1'},
+      {type: 'numeric', attributeName: 'numericDisjunctiveFacet1', operator: '>', name: '2'}
     ];
     expect(utils.getRefinements(results, helper.state)).toInclude(expected[0]);
     expect(utils.getRefinements(results, helper.state)).toInclude(expected[1]);


### PR DESCRIPTION
Bug fix of not retrieving the count on a hierarchical facet

It now only returns the last value (will be needed by `currentRefinedValues`).

Incidentally, getRefinements now also returns the type of facet for convenience.