### PR TITLE
feat(currentRefinedValues): new widget

### DIFF
--- a/dev/app.js
+++ b/dev/app.js
@@ -82,6 +82,36 @@ search.addWidget(
 );
 
 search.addWidget(
+  instantsearch.widgets.currentRefinedValues({
+    container: '#current-refined-values',
+    cssClasses: {
+      header: 'facet-title',
+      link: 'facet-value facet-value-removable',
+      count: 'facet-count pull-right'
+    },
+    templates: {
+      header: 'Current refinements'
+    },
+    attributes: [
+      {
+        name: 'price',
+        label: 'Price',
+        transformData: (data) => { data.name = `$${data.name}`; return data; }
+      },
+      {
+        name: 'price_range',
+        label: 'Price range',
+        transformData: (data) => { data.name = data.name.replace(/(\d+)/g, '$$$1'); return data; }
+      },
+      {
+        name: 'free_shipping',
+        transformData: (data) => { if (data.name === 'true') data.name = 'Free shipping'; return data; }
+      }
+    ]
+  })
+);
+
+search.addWidget(
   instantsearch.widgets.refinementList({
     container: '#brands',
     attributeName: 'brand',

--- a/dev/index.html
+++ b/dev/index.html
@@ -21,7 +21,7 @@
 
     <div class="row search search--hidden">
       <div class="col-md-3">
-        <div id="clear-all"></div>
+        <div class="facet" id="current-refined-values"></div>
         <div class="facet" id="hierarchical-categories"></div>
         <div class="facet" id="brands"></div>
         <div class="facet" id="price-range"></div>
@@ -30,6 +30,7 @@
         <div class="facet" id="categories"></div>
         <div class="facet" id="price-ranges"></div>
         <div class="facet" id="price-numeric-list"></div>
+        <div id="clear-all"></div>
       </div>
       <div class="col-md-9">
         <div class="form-group">

--- a/dev/style.css
+++ b/dev/style.css
@@ -101,6 +101,11 @@ body {
   padding-left: 10px;
 }
 
+.facet-value-removable:hover {
+  text-decoration: line-through;
+  font-weight: normal;
+}
+
 .ais-refinement-list--label,
 .ais-toggle--label {
   display: block;

--- a/src/components/CurrentRefinedValues/CurrentRefinedValues.js
+++ b/src/components/CurrentRefinedValues/CurrentRefinedValues.js
@@ -1,0 +1,132 @@
+let React = require('react');
+
+let Template = require('../Template.js');
+
+let {isSpecialClick} = require('../../lib/utils.js');
+let map = require('lodash/collection/map');
+let cloneDeep = require('lodash/lang/cloneDeep');
+
+class CurrentRefinedValues extends React.Component {
+  _clearAllElement(position, requestedPosition) {
+    if (requestedPosition !== position) {
+      return undefined;
+    }
+    return (
+      <a
+        className={this.props.cssClasses.clearAll}
+        href={this.props.clearAllURL}
+        onClick={handleClick(this.props.clearAllClick)}
+      >
+        <Template templateKey="clearAll" {...this.props.templateProps} />
+      </a>
+    );
+  }
+
+  _refinementElement(refinement, i) {
+    const attribute = this.props.attributes[refinement.attributeName] || {};
+    const templateData = getTemplateData(attribute, refinement, this.props.cssClasses);
+    const customTemplateProps = getCustomTemplateProps(attribute);
+    const key = refinement.attributeName +
+      (refinement.operator ? refinement.operator : ':') +
+      (refinement.exclude ? refinement.exclude : '') +
+      refinement.name;
+    return (
+      <div
+        className={this.props.cssClasses.item}
+        key={key}
+      >
+        <a
+          className={this.props.cssClasses.link}
+          href={this.props.clearRefinementURLs[i]}
+          onClick={handleClick(this.props.clearRefinementClicks[i])}
+        >
+          <Template data={templateData} templateKey="item" {...this.props.templateProps} {...customTemplateProps} />
+        </a>
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <div>
+        {this._clearAllElement('before', this.props.clearAllPosition)}
+        <div className={this.props.cssClasses.list}>
+          {map(this.props.refinements, this._refinementElement, this)}
+        </div>
+        {this._clearAllElement('after', this.props.clearAllPosition)}
+      </div>
+    );
+  }
+}
+
+function getCustomTemplateProps(attribute) {
+  let customTemplateProps = {};
+  if (attribute.template !== undefined) {
+    customTemplateProps.templates = {
+      item: attribute.template
+    };
+  }
+  if (attribute.transformData !== undefined) {
+    customTemplateProps.transformData = attribute.transformData;
+  }
+  return customTemplateProps;
+}
+
+function getTemplateData(attribute, _refinement, cssClasses) {
+  let templateData = cloneDeep(_refinement);
+
+  templateData.cssClasses = cssClasses;
+  if (attribute.label !== undefined) {
+    templateData.label = attribute.label;
+  }
+  if (templateData.operator !== undefined) {
+    templateData.displayOperator = templateData.operator;
+    if (templateData.operator === '>=') {
+      templateData.displayOperator = '&ge;';
+    }
+    if (templateData.operator === '<=') {
+      templateData.displayOperator = '&le;';
+    }
+  }
+
+  return templateData;
+}
+
+function handleClick(cb) {
+  return (e) => {
+    if (isSpecialClick(e)) {
+      // do not alter the default browser behavior
+      // if one special key is down
+      return;
+    }
+    e.preventDefault();
+    cb();
+  };
+}
+
+CurrentRefinedValues.propTypes = {
+  attributes: React.PropTypes.object,
+  clearAllClick: React.PropTypes.func,
+  clearAllPosition: React.PropTypes.oneOfType([
+    React.PropTypes.string,
+    React.PropTypes.bool
+  ]),
+  clearAllURL: React.PropTypes.string,
+  clearRefinementClicks: React.PropTypes.arrayOf(
+    React.PropTypes.func
+  ),
+  clearRefinementURLs: React.PropTypes.arrayOf(
+    React.PropTypes.string
+  ),
+  cssClasses: React.PropTypes.shape({
+    clearAll: React.PropTypes.string,
+    list: React.PropTypes.string,
+    item: React.PropTypes.string,
+    link: React.PropTypes.string,
+    count: React.PropTypes.string
+  }).isRequired,
+  refinements: React.PropTypes.array,
+  templateProps: React.PropTypes.object.isRequired
+};
+
+module.exports = CurrentRefinedValues;

--- a/src/components/CurrentRefinedValues/__tests__/CurrentRefinedValues-test.js
+++ b/src/components/CurrentRefinedValues/__tests__/CurrentRefinedValues-test.js
@@ -1,0 +1,548 @@
+/* eslint-env mocha */
+
+import React from 'react';
+import expect from 'expect';
+import TestUtils from 'react-addons-test-utils';
+
+import forEach from 'lodash/collection/forEach';
+import map from 'lodash/collection/map';
+
+import CurrentRefinedValues from '../CurrentRefinedValues.js';
+import Template from '../../Template';
+
+import expectJSX from 'expect-jsx';
+expect.extend(expectJSX);
+
+describe('CurrentRefinedValues', () => {
+  let renderer;
+
+  let defaultTemplates;
+
+  let cssClasses;
+  let templateProps;
+  let refinements;
+  let refinementKeys;
+  let clearRefinementURLs;
+  let refinementTemplateData;
+  let refinementTemplateProps;
+
+  let parameters;
+
+  let listProps;
+  let clearAllLinkProps;
+  let clearAllTemplateProps;
+  let itemProps;
+  let itemLinkProps;
+  let itemTemplateProps;
+
+  function render() {
+    renderer.render(<CurrentRefinedValues {...parameters} />);
+    return renderer.getRenderOutput();
+  }
+
+  function buildList() {
+    return (
+      <div {...listProps}>
+        {map(refinements, (refinement, i) => {
+          return (
+            <div key={refinementKeys[i]} {...itemProps}>
+              <a href={clearRefinementURLs[i]} {...itemLinkProps}>
+                <Template
+                  data={refinementTemplateData[i]}
+                  {...itemTemplateProps}
+                  {...templateProps}
+                  {...refinementTemplateProps[i]}
+                />
+              </a>
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+  function build(position = 'before') {
+    if (position === 'before') {
+      return (
+        <div>
+          <a {...clearAllLinkProps}>
+            <Template {...clearAllTemplateProps} />
+          </a>
+          {buildList()}
+        </div>
+      );
+    }
+    if (position === 'after') {
+      return (
+        <div>
+          {buildList()}
+          <a {...clearAllLinkProps}>
+            <Template {...clearAllTemplateProps} />
+          </a>
+        </div>
+      );
+    }
+    return (
+      <div>
+        {buildList()}
+      </div>
+    );
+  }
+
+  beforeEach(() => {
+    let {createRenderer} = TestUtils;
+    renderer = createRenderer();
+
+    defaultTemplates = {
+      header: 'DEFAULT HEADER TEMPLATE',
+      clearAll: 'DEFAULT CLEAR ALL TEMPLATE',
+      item: 'DEFAULT ITEM TEMPLATE',
+      footer: 'DEFAULT FOOTER TEMPLATE'
+    };
+
+    templateProps = {
+      templates: {
+        clearAll: 'CLEAR ALL',
+        item: '{{attributeName}}: {{name}}'
+      },
+      defaultTemplates
+    };
+
+    cssClasses = {
+      clearAll: 'clear-all-class',
+      list: 'list-class',
+      item: 'item-class',
+      link: 'link-class',
+      count: 'count-class'
+    };
+
+    refinements = [
+      {type: 'facet', attributeName: 'facet', name: 'facet-val1', count: 1, exhaustive: true},
+      {type: 'facet', attributeName: 'facet', name: 'facet-val2', count: 2, exhaustive: true},
+      {type: 'exclude', attributeName: 'facetExclude', name: 'disjunctiveFacet-val1', exclude: true},
+      {type: 'disjunctive', attributeName: 'disjunctiveFacet', name: 'disjunctiveFacet-val1'},
+      {type: 'hierarchical', attributeName: 'hierarchicalFacet', name: 'hierarchicalFacet-val1'},
+      {type: 'numeric', attributeName: 'numericFacet', name: 'numericFacet-val1', operator: '>='},
+      {type: 'tag', attributeName: '_tags', name: 'tag1'}
+    ];
+
+    refinementKeys = [
+      'facet:facet-val1',
+      'facet:facet-val2',
+      'facetExclude:-facetExclude-val1',
+      'disjunctiveFacet:disjunctiveFacet-val1',
+      'hierarchical:hierarchicalFacet-val1',
+      'numericFacet>=numericFacet-val1',
+      '_tags:tag1'
+    ];
+
+    clearRefinementURLs = [
+      '#cleared-facet-val1',
+      '#cleared-facet-val2',
+      '#cleared-facetExclude-val1',
+      '#cleared-disjunctiveFacet-val1',
+      '#cleared-hierarchicalFacet-val1',
+      '#cleared-numericFacet-val1',
+      '#cleared-tag1'
+    ];
+
+    refinementTemplateData = [
+      {cssClasses, ...refinements[0]},
+      {cssClasses, ...refinements[1]},
+      {cssClasses, ...refinements[2]},
+      {cssClasses, ...refinements[3]},
+      {cssClasses, ...refinements[4]},
+      {displayOperator: '&ge;', cssClasses, ...refinements[5]},
+      {cssClasses, ...refinements[6]}
+    ];
+
+    refinementTemplateProps = [{}, {}, {}, {}, {}, {}, {}];
+
+    parameters = {
+      attributes: {
+        facet: {name: 'facet'},
+        facetExclude: {name: 'facetExclude'},
+        disjunctiveFacet: {name: 'disjunctiveFacet'},
+        hierarchicalFacet: {name: 'hierarchicalFacet'},
+        numericFacet: {name: 'numericFacet'},
+        _tags: {name: '_tags'}
+      },
+      clearAllClick: () => {},
+      clearAllPosition: 'before',
+      clearAllURL: '#cleared-all',
+      clearRefinementClicks: [() => {}, () => {}, () => {}, () => {}, () => {}, () => {}, () => {}],
+      clearRefinementURLs,
+      cssClasses,
+      refinements,
+      templateProps
+    };
+
+    listProps = {
+      className: 'list-class'
+    };
+    clearAllLinkProps = {
+      className: 'clear-all-class',
+      href: '#cleared-all',
+      onClick: () => {}
+    };
+    clearAllTemplateProps = {
+      templateKey: 'clearAll',
+      ...templateProps
+    };
+    itemProps = {
+      className: 'item-class'
+    };
+    itemLinkProps = {
+      className: 'link-class',
+      onClick: () => {}
+    };
+    itemTemplateProps = {
+      templateKey: 'item',
+      ...templateProps
+    };
+  });
+
+  it('should render twice all elements', () => {
+    const out1 = render();
+    const out2 = render();
+
+    let expected = build();
+
+    expect(out1).toEqualJSX(expected);
+    expect(out2).toEqualJSX(expected);
+  });
+
+  context('options.attributes', () => {
+    it('uses label', () => {
+      parameters.attributes.facet = {name: 'facet', label: 'label'};
+
+      const out = render();
+
+      forEach(refinementTemplateData, (data) => {
+        if (data.attributeName === 'facet') {
+          data.label = 'label';
+        }
+      });
+
+      expect(out).toEqualJSX(build());
+    });
+
+    it('uses template', () => {
+      parameters.attributes.facet = {name: 'facet', template: 'CUSTOM TEMPLATE'};
+
+      const out = render();
+
+      forEach(refinements, (refinement, i) => {
+        if (refinement.attributeName === 'facet') {
+          refinementTemplateProps[i].templates = {
+            item: 'CUSTOM TEMPLATE'
+          };
+        }
+      });
+
+      expect(out).toEqualJSX(build());
+    });
+
+    it('uses transformData', () => {
+      const transformData = () => { return {transform: 'data'}; };
+      parameters.attributes.facet = {name: 'facet', transformData};
+      forEach(refinements, (refinement, i) => {
+        if (refinement.attributeName === 'facet') {
+          refinementTemplateProps[i].transformData = transformData;
+        }
+      });
+
+      // expectJSX doesn't compare functions
+      const usedTransformData = render()
+        .props.children[1]
+        .props.children[0]
+        .props.children
+        .props.children
+        .props.transformData;
+
+      expect(usedTransformData).toBe(transformData);
+    });
+
+    it('doesn\'t use another attribute', () => {
+      parameters.attributes.facet = {name: 'facet', randomAttribute: 'RANDOM VALUE'};
+      expect(render()).toEqualJSX(build());
+    });
+  });
+
+  context('options.clearAllClick', () => {
+    beforeEach(() => {
+      // Not perfect since we depend on an internal
+      CurrentRefinedValues.__Rewire__('handleClick', (cb) => cb);
+    });
+
+    it('is used in the clearAll element before', () => {
+      parameters.clearAllPosition = 'before';
+
+      // expectJSX doesn't compare functions
+      const usedOnClick = render()
+        .props.children[0]
+        .props.onClick;
+
+      expect(usedOnClick).toBe(parameters.clearAllClick);
+    });
+
+    it('is used in the clearAll element after', () => {
+      parameters.clearAllPosition = 'after';
+
+      // expectJSX doesn't compare functions
+      const usedOnClick = render()
+        .props.children[2]
+        .props.onClick;
+
+      expect(usedOnClick).toBe(parameters.clearAllClick);
+    });
+
+    afterEach(() => {
+      CurrentRefinedValues.__ResetDependency__('handleClick');
+    });
+  });
+
+  context('options.clearAllPosition', () => {
+    it("'before'", () => {
+      parameters.clearAllPosition = 'before';
+      expect(render()).toEqualJSX(build('before'));
+    });
+
+    it("'after'", () => {
+      parameters.clearAllPosition = 'after';
+      expect(render()).toEqualJSX(build('after'));
+    });
+
+    it('false', () => {
+      parameters.clearAllPosition = false;
+      expect(render()).toEqualJSX(build(false));
+    });
+  });
+
+
+  context('options.clearAllURL', () => {
+    it('is used in the clearAll element before', () => {
+      parameters.clearAllPosition = 'before';
+      parameters.clearAllURL = '#custom-clear-all';
+
+      const out = render();
+
+      clearAllLinkProps.href = '#custom-clear-all';
+
+      expect(out).toEqualJSX(build('before'));
+    });
+
+    it('is used in the clearAll element after', () => {
+      parameters.clearAllPosition = 'after';
+      parameters.clearAllURL = '#custom-clear-all';
+
+      const out = render();
+
+      clearAllLinkProps.href = '#custom-clear-all';
+
+      expect(out).toEqualJSX(build('after'));
+    });
+  });
+
+  context('options.clearRefinementClicks', () => {
+    beforeEach(() => {
+      // Not perfect since we depend on an internal
+      CurrentRefinedValues.__Rewire__('handleClick', (cb) => cb);
+    });
+
+    it('is used in an item element', () => {
+      // expectJSX doesn't compare functions
+      const usedOnClick = render()
+        .props.children[1]
+        .props.children[1]
+        .props.children
+        .props.onClick;
+
+      expect(usedOnClick).toBe(parameters.clearRefinementClicks[1]);
+    });
+
+    afterEach(() => {
+      CurrentRefinedValues.__ResetDependency__('handleClick');
+    });
+  });
+
+  context('options.clearRefinementURLs', () => {
+    it('is used in an item element', () => {
+      parameters.clearRefinementURLs[1] = '#custom-clear-specific';
+
+      const out = render();
+
+      clearRefinementURLs[1] = '#custom-clear-specific';
+      expect(out).toEqualJSX(build());
+    });
+  });
+
+  context('options.cssClasses', () => {
+    it('uses clearAll', () => {
+      parameters.cssClasses.clearAll = 'custom-clear-all-class';
+
+      const out = render();
+
+      clearAllLinkProps.className = 'custom-clear-all-class';
+
+      expect(out).toEqualJSX(build());
+    });
+
+    it('uses list', () => {
+      parameters.cssClasses.list = 'custom-list-class';
+
+      const out = render();
+
+      listProps.className = 'custom-list-class';
+
+      expect(out).toEqualJSX(build());
+    });
+
+    it('uses item', () => {
+      parameters.cssClasses.item = 'custom-item-class';
+
+      const out = render();
+
+      itemProps.className = 'custom-item-class';
+
+      expect(out).toEqualJSX(build());
+    });
+
+    it('uses link', () => {
+      parameters.cssClasses.link = 'custom-link-class';
+
+      const out = render();
+
+      itemLinkProps.className = 'custom-link-class';
+
+      expect(out).toEqualJSX(build());
+    });
+
+    it('passes them to the item template', () => {
+      parameters.cssClasses.count = 'custom-count-class';
+
+      const out = render();
+
+      refinementTemplateData[0].cssClasses.count = 'custom-count-class';
+      refinementTemplateData[1].cssClasses.count = 'custom-count-class';
+
+      expect(out).toEqualJSX(build());
+    });
+  });
+
+  context('options.refinements', () => {
+    beforeEach(() => {
+      parameters.attributes = {};
+      parameters.clearRefinementURLs = ['#cleared-custom'];
+      parameters.clearRefinementClicks = [() => {}];
+
+      refinementKeys = [];
+      clearRefinementURLs = ['#cleared-custom'];
+      refinementTemplateData = [{cssClasses, ...refinements[0]}];
+      refinementTemplateProps = [{...templateProps}];
+    });
+
+    it('can be used with a facet', () => {
+      refinements = [{type: 'facet', attributeName: 'customFacet', name: 'val1'}];
+
+      parameters.refinements = refinements;
+
+      const out = render();
+
+      refinementKeys.push('customFacet:val1');
+      refinementTemplateData = [{cssClasses, ...refinements[0]}];
+
+      expect(out).toEqualJSX(build());
+    });
+
+    it('can be used with an exclude', () => {
+      refinements = [{type: 'exclude', attributeName: 'customExcludeFacet', name: 'val1', exclude: true}];
+
+      parameters.refinements = refinements;
+
+      const out = render();
+
+      refinementKeys.push('customExcludeFacet:-val1');
+      refinementTemplateData = [{cssClasses, ...refinements[0]}];
+
+      expect(out).toEqualJSX(build());
+    });
+
+    it('can be used with a disjunctive facet', () => {
+      refinements = [{type: 'disjunctive', attributeName: 'customDisjunctiveFacet', name: 'val1'}];
+
+      parameters.refinements = refinements;
+
+      const out = render();
+
+      refinementKeys.push('customDisjunctiveFacet:val1');
+      refinementTemplateData = [{cssClasses, ...refinements[0]}];
+
+      expect(out).toEqualJSX(build());
+    });
+
+    it('can be used with a hierarchical facet', () => {
+      refinements = [{type: 'hierarchical', attributeName: 'customHierarchicalFacet', name: 'val1'}];
+
+      parameters.refinements = refinements;
+
+      const out = render();
+
+      refinementKeys.push('customHierarchicalFacet:val1');
+      refinementTemplateData = [{cssClasses, ...refinements[0]}];
+
+      expect(out).toEqualJSX(build());
+    });
+
+    it('can be used with numeric filters', () => {
+      refinements = [
+        {type: 'numeric', attributeName: 'customNumericFilter', operator: '=', name: 'val1'},
+        {type: 'numeric', attributeName: 'customNumericFilter', operator: '<=', name: 'val2'},
+        {type: 'numeric', attributeName: 'customNumericFilter', operator: '>=', name: 'val3'}
+      ];
+
+      parameters.refinements = refinements;
+
+      const out = render();
+
+      refinementKeys.push([
+        'customNumericFilter=val1',
+        'customNumericFilter<=val2',
+        'customNumericFilter>=val3'
+      ]);
+      refinementTemplateData = [
+        {cssClasses, displayOperator: '=', ...refinements[0]},
+        {cssClasses, displayOperator: '&le;', ...refinements[1]},
+        {cssClasses, displayOperator: '&ge;', ...refinements[2]}
+      ];
+
+      expect(out).toEqualJSX(build());
+    });
+
+    it('can be used with a tag', () => {
+      refinements = [{type: 'tag', attributeName: '_tags', name: 'tag1'}];
+
+      parameters.refinements = refinements;
+
+      const out = render();
+
+      refinementKeys.push('_tags:tag1');
+      refinementTemplateData = [{cssClasses, ...refinements[0]}];
+
+      expect(out).toEqualJSX(build());
+    });
+  });
+
+  context('options.templateProps', () => {
+    it('passes a custom template if given', () => {
+      parameters.templateProps.templates.item = 'CUSTOM ITEM TEMPLATE';
+
+      const out = render();
+
+      clearAllTemplateProps.templates.item = 'CUSTOM ITEM TEMPLATE';
+      itemTemplateProps.templates.item = 'CUSTOM ITEM TEMPLATE';
+
+      expect(out).toEqualJSX(build());
+    });
+  });
+});

--- a/src/css/default/_current-refined-values.scss
+++ b/src/css/default/_current-refined-values.scss
@@ -1,0 +1,36 @@
+@import "../base";
+@import "variables";
+
+@include block(current-refined-values) {
+  @include element(header) {
+    /* widget header */
+  }
+
+  @include element(body) {
+    /* widget body */
+  }
+
+  @include element(clear-all) {
+    /* widget clearAll link */
+  }
+
+  @include element(list) {
+    /* widget list */
+  }
+
+  @include element(item) {
+    /* widget item */
+  }
+
+  @include element(link) {
+    /* widget link */
+  }
+
+  @include element(count) {
+    /* widget count */
+  }
+
+  @include element(footer) {
+    /* widget footer */
+  }
+}

--- a/src/css/instantsearch.scss
+++ b/src/css/instantsearch.scss
@@ -13,4 +13,5 @@
 @import "default/star-rating";
 @import "default/price-ranges" ;
 @import "default/clear-all";
+@import "default/current-refined-values";
 

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -9,6 +9,7 @@ let algoliasearchHelper = require('algoliasearch-helper');
 
 instantsearch.widgets = {
   clearAll: require('../widgets/clear-all/clear-all'),
+  currentRefinedValues: require('../widgets/current-refined-values/current-refined-values'),
   hierarchicalMenu: require('../widgets/hierarchical-menu/hierarchical-menu'),
   hits: require('../widgets/hits/hits'),
   hitsPerPageSelector: require('../widgets/hits-per-page-selector/hits-per-page-selector'),

--- a/src/widgets/current-refined-values/__tests__/current-refined-values-test.js
+++ b/src/widgets/current-refined-values/__tests__/current-refined-values-test.js
@@ -1,0 +1,898 @@
+/* eslint-env mocha */
+
+import React from 'react';
+import expect from 'expect';
+import sinon from 'sinon';
+import jsdom from 'mocha-jsdom';
+
+import map from 'lodash/collection/map';
+import filter from 'lodash/collection/filter';
+
+import algoliasearch from 'algoliasearch';
+import algoliasearchHelper from 'algoliasearch-helper';
+
+import {prepareTemplateProps} from '../../../lib/utils';
+
+import currentRefinedValues from '../current-refined-values';
+import CurrentRefinedValues from '../../../components/CurrentRefinedValues/CurrentRefinedValues';
+import defaultTemplates from '../defaultTemplates';
+
+import expectJSX from 'expect-jsx';
+expect.extend(expectJSX);
+
+describe('currentRefinedValues()', () => {
+  jsdom({useEach: true});
+
+  context('types checking', () => {
+    let boundWidget;
+    let parameters;
+
+    beforeEach(() => {
+      parameters = {
+        container: document.createElement('div'),
+        attributes: [],
+        onlyListedAttributes: false,
+        clearAll: 'after',
+        templates: {},
+        transformData: (data) => data,
+        autoHideContainer: false,
+        cssClasses: {}
+      };
+      boundWidget = currentRefinedValues.bind(null, parameters);
+    });
+
+    context('options.container', () => {
+      it('doesn\'t throw usage with a string', () => {
+        let element = document.createElement('div');
+        element.id = 'testid';
+        document.body.appendChild(element);
+        parameters.container = '#testid';
+        expect(boundWidget).toNotThrow();
+      });
+
+      it('doesn\'t throw usage with a DOMElement', () => {
+        parameters.container = document.createElement('div');
+        expect(boundWidget).toNotThrow();
+      });
+
+      it('throws usage if not defined', () => {
+        delete parameters.container;
+        expect(boundWidget).toThrow(/Usage/);
+      });
+
+      it('throws usage with another type than string or DOMElement', () => {
+        parameters.container = true;
+        expect(boundWidget).toThrow(/Usage/);
+      });
+    });
+
+    context('options.attributes', () => {
+      it('doesn\'t throw usage if not defined', () => {
+        delete parameters.attributes;
+        expect(boundWidget).toNotThrow();
+      });
+
+      it('doesn\'t throw usage if attributes is an empty array', () => {
+        parameters.attributes = [];
+        expect(boundWidget).toNotThrow();
+      });
+
+      it('doesn\'t throw usage with name, label, template and transformData', () => {
+        parameters.attributes = [
+          {
+            name: 'attr1'
+          }, {
+            name: 'attr2',
+            label: 'Attr 2'
+          }, {
+            name: 'attr3',
+            template: 'SPECIFIC TEMPLATE'
+          }, {
+            name: 'attr4',
+            transformData: (data) => { data.name = 'newname'; return data; }
+          }
+        ];
+        expect(boundWidget).toNotThrow();
+      });
+
+      it('doesn\'t throw usage with a function template', () => {
+        parameters.attributes = [{name: 'attr1'}, {name: 'attr2', template: () => 'CUSTOM TEMPLATE'}];
+        expect(boundWidget).toNotThrow();
+      });
+
+      it('throws usage if attributes isn\'t an array', () => {
+        parameters.attributes = 'a string';
+        expect(boundWidget).toThrow(/Usage/);
+      });
+
+      it('throws usage if attributes doesn\'t contain only objects', () => {
+        parameters.attributes = [{name: 'test'}, 'string'];
+        expect(boundWidget).toThrow(/Usage/);
+      });
+
+      it('throws usage if attributes contains an object without name', () => {
+        parameters.attributes = [{name: 'test'}, {label: ''}];
+        expect(boundWidget).toThrow(/Usage/);
+      });
+
+      it('throws usage if attributes contains an object with a not string name', () => {
+        parameters.attributes = [{name: 'test'}, {name: true}];
+        expect(boundWidget).toThrow(/Usage/);
+      });
+
+      it('throws usage if attributes contains an object with a not string label', () => {
+        parameters.attributes = [{name: 'test'}, {label: true}];
+        expect(boundWidget).toThrow(/Usage/);
+      });
+
+      it('throws usage if attributes contains an object with a not string or function template', () => {
+        parameters.attributes = [{name: 'test'}, {template: true}];
+        expect(boundWidget).toThrow(/Usage/);
+      });
+
+      it('throws usage if attributes contains an object with a not function transformData', () => {
+        parameters.attributes = [{name: 'test'}, {transformData: true}];
+        expect(boundWidget).toThrow(/Usage/);
+      });
+    });
+
+    context('options.onlyListedAttributes', () => {
+      it('doesn\'t throw usage if not defined', () => {
+        delete parameters.onlyListedAttributes;
+        expect(boundWidget).toNotThrow();
+      });
+
+      it('doesn\'t throw usage if true', () => {
+        parameters.onlyListedAttributes = true;
+        expect(boundWidget).toNotThrow();
+      });
+
+      it('doesn\'t throw usage if false', () => {
+        parameters.onlyListedAttributes = false;
+        expect(boundWidget).toNotThrow();
+      });
+
+      it('throws usage if not boolean', () => {
+        parameters.onlyListedAttributes = 'truthy value';
+        expect(boundWidget).toThrow(/Usage/);
+      });
+    });
+
+    context('options.clearAll', () => {
+      it('doesn\'t throw usage if not defined', () => {
+        delete parameters.clearAll;
+        expect(boundWidget).toNotThrow();
+      });
+
+      it('doesn\'t throw usage if false', () => {
+        parameters.clearAll = false;
+        expect(boundWidget).toNotThrow();
+      });
+
+      it('doesn\'t throw usage if \'before\'', () => {
+        parameters.clearAll = 'before';
+        expect(boundWidget).toNotThrow();
+      });
+
+      it('doesn\'t throw usage if \'after\'', () => {
+        parameters.clearAll = 'after';
+        expect(boundWidget).toNotThrow();
+      });
+
+      it('throws usage if not one of [false, \'before\', \'after\']', () => {
+        parameters.clearAll = 'truthy value';
+        expect(boundWidget).toThrow(/Usage/);
+      });
+    });
+
+    context('options.templates', () => {
+      it('doesn\'t throw usage if not defined', () => {
+        delete parameters.templates;
+        expect(boundWidget).toNotThrow();
+      });
+
+      it('doesn\'t throw usage with an empty object', () => {
+        parameters.templates = {};
+        expect(boundWidget).toNotThrow();
+      });
+
+      it('doesn\'t throw usage with a string template', () => {
+        parameters.templates = {
+          item: 'STRING TEMPLATE'
+        };
+        expect(boundWidget).toNotThrow();
+      });
+
+      it('doesn\'t throw usage with a function template', () => {
+        parameters.templates = {
+          item: () => 'ITEM TEMPLATE'
+        };
+        expect(boundWidget).toNotThrow();
+      });
+
+      it('doesn\'t throw usage with all keys', () => {
+        parameters.templates = {
+          header: 'HEADER TEMPLATE',
+          item: 'ITEM TEMPLATE',
+          clearAll: 'CLEAR ALL TEMPLATE',
+          footer: 'FOOTER TEMPLATE'
+        };
+        expect(boundWidget).toNotThrow();
+      });
+
+      it('throws usage with template being something else than an object', () => {
+        parameters.templates = true;
+        expect(boundWidget).toThrow(/Usage/);
+      });
+
+      it('throws usage if one of the template keys doesn\'t exist', () => {
+        parameters.templates = {
+          header: 'HEADER TEMPLATE',
+          not_existing_key: 'NOT EXISTING KEY TEMPLATE'
+        };
+        expect(boundWidget).toThrow(/Usage/);
+      });
+
+      it('throws usage if a template is not a string or a function', () => {
+        parameters.templates = {
+          item: true
+        };
+        expect(boundWidget).toThrow(/Usage/);
+      });
+    });
+
+    context('options.transformData', () => {
+      it('doesn\'t throw usage if not defined', () => {
+        delete parameters.transformData;
+        expect(boundWidget).toNotThrow();
+      });
+
+      it('doesn\'t throw usage with a function', () => {
+        parameters.transformData = (data) => data;
+        expect(boundWidget).toNotThrow();
+      });
+
+      it('throws usage if not a function', () => {
+        parameters.transformData = true;
+        expect(boundWidget).toThrow();
+      });
+    });
+
+    context('options.autoHideContainer', () => {
+      it('doesn\'t throw usage if not defined', () => {
+        delete parameters.autoHideContainer;
+        expect(boundWidget).toNotThrow();
+      });
+
+      it('doesn\'t throw usage with true', () => {
+        parameters.autoHideContainer = true;
+        expect(boundWidget).toNotThrow();
+      });
+
+      it('doesn\'t throw usage with false', () => {
+        parameters.autoHideContainer = false;
+        expect(boundWidget).toNotThrow();
+      });
+
+      it('throws usage if not boolean', () => {
+        parameters.autoHideContainer = 'truthy value';
+        expect(boundWidget).toThrow(/Usage/);
+      });
+    });
+
+    context('options.cssClasses', () => {
+      it('doesn\'t throw usage if not defined', () => {
+        delete parameters.cssClasses;
+        expect(boundWidget).toNotThrow();
+      });
+
+      it('doesn\'t throw usage with an empty object', () => {
+        parameters.cssClasses = {};
+        expect(boundWidget).toNotThrow();
+      });
+
+      it('doesn\'t throw usage with string class', () => {
+        parameters.cssClasses = {
+          item: 'item-class'
+        };
+        expect(boundWidget).toNotThrow();
+      });
+
+      it('doesn\'t throw usage with all keys', () => {
+        parameters.cssClasses = {
+          root: 'root-class',
+          header: 'header-class',
+          body: 'body-class',
+          clearAll: 'clear-all-class',
+          list: 'list-class',
+          item: 'item-class',
+          link: 'link-class',
+          count: 'count-class',
+          footer: 'footer-class'
+        };
+        expect(boundWidget).toNotThrow();
+      });
+
+      it('throws usage with cssClasses being something else than an object', () => {
+        parameters.cssClasses = 'truthy value';
+        expect(boundWidget).toThrow(/Usage/);
+      });
+
+      it('throws usage if one of the cssClasses keys doesn\'t exist', () => {
+        parameters.cssClasses = {
+          not_existing_key: 'not-existing-class'
+        };
+        expect(boundWidget).toThrow(/Usage/);
+      });
+
+      it('throws usage if one of the cssClasses values is not a string', () => {
+        parameters.cssClasses = {
+          item: true
+        };
+        expect(boundWidget).toThrow(/Usage/);
+      });
+    });
+  });
+
+
+  context('getConfiguration()', () => {
+    it('configures nothing', () => {
+      const widget = currentRefinedValues({
+        container: document.createElement('div')
+      });
+      expect(widget.getConfiguration).toEqual(undefined);
+    });
+  });
+
+  context('render()', () => {
+    let ReactDOM;
+    let autoHideContainerHOC;
+    let headerFooterHOC;
+
+    let parameters;
+    let client;
+    let helper;
+    let renderParameters;
+    let refinements;
+    let expectedProps;
+
+    function setRefinementsInExpectedProps() {
+      expectedProps.refinements = refinements;
+      expectedProps.clearRefinementClicks = map(refinements, () => () => {});
+      expectedProps.clearRefinementURLs = map(refinements, () => '#cleared');
+    }
+
+    beforeEach(() => {
+      ReactDOM = {render: sinon.spy()};
+      currentRefinedValues.__Rewire__('ReactDOM', ReactDOM);
+      autoHideContainerHOC = sinon.stub().returns(CurrentRefinedValues);
+      currentRefinedValues.__Rewire__('autoHideContainerHOC', autoHideContainerHOC);
+      headerFooterHOC = sinon.stub().returns(CurrentRefinedValues);
+      currentRefinedValues.__Rewire__('headerFooterHOC', headerFooterHOC);
+
+      parameters = {
+        container: document.createElement('div'),
+        attributes: [
+          {name: 'facet'},
+          {name: 'facetExclude'},
+          {name: 'disjunctiveFacet'},
+          {name: 'hierarchicalFacet'},
+          {name: 'numericFacet'},
+          {name: 'numericDisjunctiveFacet'},
+          {name: '_tags'}
+        ],
+        onlyListedAttributes: true,
+        clearAll: 'after',
+        templates: {
+          header: 'HEADER',
+          item: 'ITEM',
+          clearAll: 'CLEAR ALL',
+          footer: 'FOOTER'
+        },
+        autoHideContainer: false,
+        cssClasses: {
+          root: 'root-css-class',
+          header: 'header-css-class',
+          body: 'body-css-class',
+          clearAll: 'clear-all-css-class',
+          list: 'list-css-class',
+          item: 'item-css-class',
+          link: 'link-css-class',
+          count: 'count-css-class',
+          footer: 'footer-css-class'
+        }
+      };
+
+      client = algoliasearch('APP_ID', 'API_KEY');
+      helper = algoliasearchHelper(client, 'index_name', {
+        facets: ['facet', 'facetExclude', 'numericFacet', 'extraFacet'],
+        disjunctiveFacets: ['disjunctiveFacet', 'numericDisjunctiveFacet'],
+        hierarchicalFacets: [{
+          name: 'hierarchicalFacet',
+          attributes: ['hierarchicalFacet.lvl0', 'hierarchicalFacet.lvl1'],
+          separator: ' > '
+        }]
+      });
+      helper
+        .toggleRefinement('facet', 'facet-val1')
+        .toggleRefinement('facet', 'facet-val2')
+        .toggleRefinement('extraFacet', 'extraFacet-val1')
+        .toggleFacetExclusion('facetExclude', 'facetExclude-val1')
+        .toggleFacetExclusion('facetExclude', 'facetExclude-val2')
+        .toggleRefinement('disjunctiveFacet', 'disjunctiveFacet-val1')
+        .toggleRefinement('disjunctiveFacet', 'disjunctiveFacet-val2')
+        .toggleRefinement('hierarchicalFacet', 'hierarchicalFacet-val1 > hierarchicalFacet-val2')
+        .addNumericRefinement('numericFacet', '>=', 1)
+        .addNumericRefinement('numericFacet', '<=', 2)
+        .addNumericRefinement('numericDisjunctiveFacet', '>=', 3)
+        .addNumericRefinement('numericDisjunctiveFacet', '<=', 4)
+        .toggleTag('tag1')
+        .toggleTag('tag2');
+
+      renderParameters = {
+        results: {
+          facets: [{
+            name: 'facet',
+            exhaustive: true,
+            data: {
+              'facet-val1': 1,
+              'facet-val2': 2,
+              'facet-val3': 42
+            }
+          }, {
+            name: 'extraFacet',
+            exhaustive: true,
+            data: {
+              'extraFacet-val1': 42,
+              'extraFacet-val2': 42
+            }
+          }],
+          disjunctiveFacets: [{
+            name: 'disjunctiveFacet',
+            exhaustive: true,
+            data: {
+              'disjunctiveFacet-val1': 3,
+              'disjunctiveFacet-val2': 4,
+              'disjunctiveFacet-val3': 42
+            }
+          }],
+          hierarchicalFacets: [{
+            name: 'hierarchicalFacet',
+            data: [{
+              name: 'hierarchicalFacet-val1',
+              count: 5,
+              exhaustive: true,
+              data: [{
+                name: 'hierarchicalFacet-val2',
+                count: 6,
+                exhaustive: true
+              }]
+            }, { // Here to confirm we're taking the right nested one
+              name: 'hierarchicalFacet-val2',
+              count: 42,
+              exhaustive: true
+            }]
+          }]
+        },
+        helper,
+        state: helper.state,
+        templatesConfig: {randomAttributeNeverUsed: 'value'},
+        createURL: () => '#cleared'
+      };
+
+      refinements = [
+        {type: 'facet', attributeName: 'facet', name: 'facet-val1', count: 1, exhaustive: true},
+        {type: 'facet', attributeName: 'facet', name: 'facet-val2', count: 2, exhaustive: true},
+        {type: 'exclude', attributeName: 'facetExclude', name: 'facetExclude-val1', exclude: true},
+        {type: 'exclude', attributeName: 'facetExclude', name: 'facetExclude-val2', exclude: true},
+        {type: 'disjunctive', attributeName: 'disjunctiveFacet', name: 'disjunctiveFacet-val1', count: 3, exhaustive: true},
+        {type: 'disjunctive', attributeName: 'disjunctiveFacet', name: 'disjunctiveFacet-val2', count: 4, exhaustive: true},
+        {type: 'hierarchical', attributeName: 'hierarchicalFacet', name: 'hierarchicalFacet-val2', count: 6, exhaustive: true},
+        {type: 'numeric', attributeName: 'numericFacet', name: 1, operator: '>='},
+        {type: 'numeric', attributeName: 'numericFacet', name: 2, operator: '<='},
+        {type: 'numeric', attributeName: 'numericDisjunctiveFacet', name: 3, operator: '>='},
+        {type: 'numeric', attributeName: 'numericDisjunctiveFacet', name: 4, operator: '<='},
+        {type: 'tag', attributeName: '_tags', name: 'tag1'},
+        {type: 'tag', attributeName: '_tags', name: 'tag2'}
+      ];
+
+      expectedProps = {
+        attributes: {
+          facet: {name: 'facet'},
+          facetExclude: {name: 'facetExclude'},
+          disjunctiveFacet: {name: 'disjunctiveFacet'},
+          hierarchicalFacet: {name: 'hierarchicalFacet'},
+          numericFacet: {name: 'numericFacet'},
+          numericDisjunctiveFacet: {name: 'numericDisjunctiveFacet'},
+          _tags: {name: '_tags'}
+        },
+        clearAllClick: () => {},
+        clearAllPosition: 'after',
+        clearAllURL: '#cleared',
+        cssClasses: {
+          root: 'ais-current-refined-values root-css-class',
+          header: 'ais-current-refined-values--header header-css-class',
+          body: 'ais-current-refined-values--body body-css-class',
+          clearAll: 'ais-current-refined-values--clear-all clear-all-css-class',
+          list: 'ais-current-refined-values--list list-css-class',
+          item: 'ais-current-refined-values--item item-css-class',
+          link: 'ais-current-refined-values--link link-css-class',
+          count: 'ais-current-refined-values--count count-css-class',
+          footer: 'ais-current-refined-values--footer footer-css-class'
+        },
+        shouldAutoHideContainer: false,
+        templateProps: prepareTemplateProps({
+          defaultTemplates,
+          templatesConfig: {randomAttributeNeverUsed: 'value'},
+          templates: {
+            header: 'HEADER',
+            item: 'ITEM',
+            clearAll: 'CLEAR ALL',
+            footer: 'FOOTER'
+          }
+        })
+      };
+      setRefinementsInExpectedProps();
+    });
+
+    it('should render twice <CurrentRefinedValues ... />', () => {
+      const widget = currentRefinedValues(parameters);
+
+      widget.render(renderParameters);
+      widget.render(renderParameters);
+
+      expect(ReactDOM.render.calledTwice).toBe(true);
+      expect(ReactDOM.render.firstCall.args[0]).toEqualJSX(<CurrentRefinedValues {...expectedProps} />);
+      expect(ReactDOM.render.firstCall.args[1]).toBe(parameters.container);
+      expect(ReactDOM.render.secondCall.args[0]).toEqualJSX(<CurrentRefinedValues {...expectedProps} />);
+      expect(ReactDOM.render.secondCall.args[1]).toBe(parameters.container);
+    });
+
+    context('options.container', () => {
+      it('should render with a string container', () => {
+        let element = document.createElement('div');
+        element.id = 'testid';
+        document.body.appendChild(element);
+
+        parameters.container = '#testid';
+
+        currentRefinedValues(parameters).render(renderParameters);
+        expect(ReactDOM.render.calledOnce).toBe(true);
+        expect(ReactDOM.render.firstCall.args[0]).toEqualJSX(<CurrentRefinedValues {...expectedProps} />);
+        expect(ReactDOM.render.firstCall.args[1]).toBe(element);
+      });
+
+      it('should render with a DOMElement container', () => {
+        let element = document.createElement('div');
+
+        parameters.container = element;
+
+        currentRefinedValues(parameters).render(renderParameters);
+        expect(ReactDOM.render.calledOnce).toBe(true);
+        expect(ReactDOM.render.firstCall.args[0]).toEqualJSX(<CurrentRefinedValues {...expectedProps} />);
+        expect(ReactDOM.render.firstCall.args[1]).toBe(element);
+      });
+    });
+
+    context('options.attributes', () => {
+      context('with options.onlyListedAttributes === true', () => {
+        beforeEach(() => {
+          parameters.onlyListedAttributes = true;
+        });
+
+        it('should render all attributes with not defined attributes', () => {
+          delete parameters.attributes;
+
+          refinements.splice(0, 0, {type: 'facet', attributeName: 'extraFacet', name: 'extraFacet-val1', count: 42, exhaustive: true});
+
+          currentRefinedValues(parameters).render(renderParameters);
+
+          setRefinementsInExpectedProps();
+          expectedProps.attributes = {};
+
+          expect(ReactDOM.render.calledOnce).toBe(true);
+          expect(ReactDOM.render.firstCall.args[0]).toEqualJSX(<CurrentRefinedValues {...expectedProps} />);
+        });
+
+        it('should render all attributes with an empty array', () => {
+          parameters.attributes = [];
+
+          refinements.splice(0, 0, {type: 'facet', attributeName: 'extraFacet', name: 'extraFacet-val1', count: 42, exhaustive: true});
+
+          currentRefinedValues(parameters).render(renderParameters);
+
+          setRefinementsInExpectedProps();
+          expectedProps.attributes = {};
+
+          expect(ReactDOM.render.calledOnce).toBe(true);
+          expect(ReactDOM.render.firstCall.args[0]).toEqualJSX(<CurrentRefinedValues {...expectedProps} />);
+        });
+
+        it('should render and pass all attributes defined in each objects', () => {
+          parameters.attributes = [{
+            name: 'facet'
+          }, {
+            name: 'facetExclude',
+            label: 'Facet exclude'
+          }, {
+            name: 'disjunctiveFacet',
+            transformData: (data) => { data.name = 'newname'; return data; }
+          }];
+
+          refinements = filter(refinements, (refinement) => {
+            return ['facet', 'facetExclude', 'disjunctiveFacet'].indexOf(refinement.attributeName) !== -1;
+          });
+
+          currentRefinedValues(parameters).render(renderParameters);
+
+          setRefinementsInExpectedProps();
+          expectedProps.attributes = {
+            facet: {
+              name: 'facet'
+            },
+            facetExclude: {
+              name: 'facetExclude',
+              label: 'Facet exclude'
+            },
+            disjunctiveFacet: {
+              name: 'disjunctiveFacet',
+              transformData: (data) => { data.name = 'newname'; return data; }
+            }
+          };
+
+          expect(ReactDOM.render.calledOnce).toBe(true);
+          expect(ReactDOM.render.firstCall.args[0]).toEqualJSX(<CurrentRefinedValues {...expectedProps} />);
+        });
+      });
+
+      context('with options.onlyListedAttributes === false', () => {
+        beforeEach(() => {
+          parameters.onlyListedAttributes = false;
+        });
+
+        it('should render all attributes with not defined attributes', () => {
+          delete parameters.attributes;
+
+          refinements.splice(0, 0, {type: 'facet', attributeName: 'extraFacet', name: 'extraFacet-val1', count: 42, exhaustive: true});
+
+          currentRefinedValues(parameters).render(renderParameters);
+
+          setRefinementsInExpectedProps();
+          expectedProps.attributes = {};
+
+          expect(ReactDOM.render.calledOnce).toBe(true);
+          expect(ReactDOM.render.firstCall.args[0]).toEqualJSX(<CurrentRefinedValues {...expectedProps} />);
+        });
+
+        it('should render all attributes with an empty array', () => {
+          parameters.attributes = [];
+
+          refinements.splice(0, 0, {type: 'facet', attributeName: 'extraFacet', name: 'extraFacet-val1', count: 42, exhaustive: true});
+
+          currentRefinedValues(parameters).render(renderParameters);
+
+          setRefinementsInExpectedProps();
+          expectedProps.attributes = {};
+
+          expect(ReactDOM.render.calledOnce).toBe(true);
+          expect(ReactDOM.render.firstCall.args[0]).toEqualJSX(<CurrentRefinedValues {...expectedProps} />);
+        });
+
+        it('should render and pass all attributes defined in each objects', () => {
+          parameters.attributes = [{
+            name: 'facet'
+          }, {
+            name: 'facetExclude',
+            label: 'Facet exclude'
+          }, {
+            name: 'disjunctiveFacet',
+            transformData: (data) => { data.name = 'newname'; return data; }
+          }];
+
+          refinements.splice(0, 0, {type: 'facet', attributeName: 'extraFacet', name: 'extraFacet-val1', count: 42, exhaustive: true});
+          const firstRefinements = filter(refinements, (refinement) => {
+            return ['facet', 'facetExclude', 'disjunctiveFacet'].indexOf(refinement.attributeName) !== -1;
+          });
+          const otherRefinements = filter(refinements, (refinement) => {
+            return ['facet', 'facetExclude', 'disjunctiveFacet'].indexOf(refinement.attributeName) === -1;
+          });
+          refinements = [].concat(firstRefinements).concat(otherRefinements);
+
+          currentRefinedValues(parameters).render(renderParameters);
+
+          setRefinementsInExpectedProps();
+          expectedProps.attributes = {
+            facet: {
+              name: 'facet'
+            },
+            facetExclude: {
+              name: 'facetExclude',
+              label: 'Facet exclude'
+            },
+            disjunctiveFacet: {
+              name: 'disjunctiveFacet',
+              transformData: (data) => { data.name = 'newname'; return data; }
+            }
+          };
+
+          expect(ReactDOM.render.calledOnce).toBe(true);
+          expect(ReactDOM.render.firstCall.args[0]).toEqualJSX(<CurrentRefinedValues {...expectedProps} />);
+        });
+      });
+
+      context('with options.onlyListedAttributes not defined', () => {
+        beforeEach(() => {
+          delete parameters.onlyListedAttributes;
+        });
+
+        it('should default to false', () => {
+          parameters.attributes = [{
+            name: 'facet'
+          }, {
+            name: 'facetExclude',
+            label: 'Facet exclude'
+          }, {
+            name: 'disjunctiveFacet',
+            transformData: (data) => { data.name = 'newname'; return data; }
+          }];
+
+          refinements.splice(0, 0, {type: 'facet', attributeName: 'extraFacet', name: 'extraFacet-val1', count: 42, exhaustive: true});
+          const firstRefinements = filter(refinements, (refinement) => {
+            return ['facet', 'facetExclude', 'disjunctiveFacet'].indexOf(refinement.attributeName) !== -1;
+          });
+          const otherRefinements = filter(refinements, (refinement) => {
+            return ['facet', 'facetExclude', 'disjunctiveFacet'].indexOf(refinement.attributeName) === -1;
+          });
+          refinements = [].concat(firstRefinements).concat(otherRefinements);
+
+          currentRefinedValues(parameters).render(renderParameters);
+
+          setRefinementsInExpectedProps();
+          expectedProps.attributes = {
+            facet: {
+              name: 'facet'
+            },
+            facetExclude: {
+              name: 'facetExclude',
+              label: 'Facet exclude'
+            },
+            disjunctiveFacet: {
+              name: 'disjunctiveFacet',
+              transformData: (data) => { data.name = 'newname'; return data; }
+            }
+          };
+
+          expect(ReactDOM.render.calledOnce).toBe(true);
+          expect(ReactDOM.render.firstCall.args[0]).toEqualJSX(<CurrentRefinedValues {...expectedProps} />);
+        });
+      });
+    });
+
+    context('options.clearAll', () => {
+      it('should pass it as clearAllPosition', () => {
+        parameters.clearAll = 'before';
+
+        currentRefinedValues(parameters).render(renderParameters);
+
+        expectedProps.clearAllPosition = 'before';
+
+        expect(ReactDOM.render.calledOnce).toBe(true);
+        expect(ReactDOM.render.firstCall.args[0]).toEqualJSX(<CurrentRefinedValues {...expectedProps} />);
+      });
+    });
+
+    context('options.templates', () => {
+      it('should pass it in templateProps', () => {
+        parameters.templates.item = 'MY CUSTOM TEMPLATE';
+
+        currentRefinedValues(parameters).render(renderParameters);
+
+        expectedProps.templateProps.templates.item = 'MY CUSTOM TEMPLATE';
+
+        expect(ReactDOM.render.calledOnce).toBe(true);
+        expect(ReactDOM.render.firstCall.args[0]).toEqualJSX(<CurrentRefinedValues {...expectedProps} />);
+      });
+    });
+
+    context('options.autoHideContainer', () => {
+      context('without refinements', () => {
+        beforeEach(() => {
+          helper.clearRefinements().clearTags();
+          renderParameters.state = helper.state;
+
+          expectedProps.refinements = [];
+          expectedProps.clearRefinementClicks = [];
+          expectedProps.clearRefinementURLs = [];
+          expectedProps.shouldAutoHideContainer = true;
+        });
+
+        it('shouldAutoHideContainer should be true with autoHideContainer = true', () => {
+          parameters.autoHideContainer = true;
+
+          currentRefinedValues(parameters).render(renderParameters);
+
+          expect(ReactDOM.render.calledOnce).toBe(true);
+          expect(ReactDOM.render.firstCall.args[0]).toEqualJSX(<CurrentRefinedValues {...expectedProps} />);
+        });
+
+        it('shouldAutoHideContainer should be true with autoHideContainer = false', () => {
+          parameters.autoHideContainer = false;
+
+          currentRefinedValues(parameters).render(renderParameters);
+
+          expect(ReactDOM.render.calledOnce).toBe(true);
+          expect(ReactDOM.render.firstCall.args[0]).toEqualJSX(<CurrentRefinedValues {...expectedProps} />);
+        });
+      });
+
+      context('with refinements', () => {
+        it('shouldAutoHideContainer should be false with autoHideContainer = true', () => {
+          parameters.autoHideContainer = true;
+
+          currentRefinedValues(parameters).render(renderParameters);
+
+          expectedProps.shouldAutoHideContainer = false;
+
+          expect(ReactDOM.render.calledOnce).toBe(true);
+          expect(ReactDOM.render.firstCall.args[0]).toEqualJSX(<CurrentRefinedValues {...expectedProps} />);
+        });
+
+        it('shouldAutoHideContainer should be false with autoHideContainer = false', () => {
+          parameters.autoHideContainer = false;
+
+          currentRefinedValues(parameters).render(renderParameters);
+
+          expectedProps.shouldAutoHideContainer = false;
+
+          expect(ReactDOM.render.calledOnce).toBe(true);
+          expect(ReactDOM.render.firstCall.args[0]).toEqualJSX(<CurrentRefinedValues {...expectedProps} />);
+        });
+      });
+    });
+
+    context('options.cssClasses', () => {
+      it('should be passed in the cssClasses', () => {
+        parameters.cssClasses.body = 'custom-passed-body';
+
+        currentRefinedValues(parameters).render(renderParameters);
+
+        expectedProps.cssClasses.body = 'ais-current-refined-values--body custom-passed-body';
+
+        expect(ReactDOM.render.calledOnce).toBe(true);
+        expect(ReactDOM.render.firstCall.args[0]).toEqualJSX(<CurrentRefinedValues {...expectedProps} />);
+      });
+    });
+
+    context('with attributes', () => {
+      it('should sort the refinements according to their order', () => {
+        parameters.attributes = [{name: 'disjunctiveFacet'}, {name: 'facetExclude'}];
+        parameters.onlyListedAttributes = false;
+
+        refinements.splice(0, 0, {type: 'facet', attributeName: 'extraFacet', name: 'extraFacet-val1', count: 42, exhaustive: true});
+        const firstRefinements = filter(refinements, {attributeName: 'disjunctiveFacet'});
+        const secondRefinements = filter(refinements, {attributeName: 'facetExclude'});
+        const otherRefinements = filter(refinements, (refinement) => {
+          return ['disjunctiveFacet', 'facetExclude'].indexOf(refinement.attributeName) === -1;
+        });
+        refinements = [].concat(firstRefinements).concat(secondRefinements).concat(otherRefinements);
+
+        currentRefinedValues(parameters).render(renderParameters);
+
+        setRefinementsInExpectedProps();
+        expectedProps.attributes = {
+          disjunctiveFacet: {name: 'disjunctiveFacet'},
+          facetExclude: {name: 'facetExclude'}
+        };
+
+        expect(ReactDOM.render.calledOnce).toBe(true);
+        expect(ReactDOM.render.firstCall.args[0]).toEqualJSX(<CurrentRefinedValues {...expectedProps} />);
+      });
+    });
+
+    afterEach(() => {
+      currentRefinedValues.__ResetDependency__('ReactDOM');
+      currentRefinedValues.__ResetDependency__('autoHideContainerHOC');
+      currentRefinedValues.__ResetDependency__('headerFooterHOC');
+    });
+  });
+});

--- a/src/widgets/current-refined-values/current-refined-values.js
+++ b/src/widgets/current-refined-values/current-refined-values.js
@@ -1,0 +1,246 @@
+let React = require('react');
+let ReactDOM = require('react-dom');
+
+let {
+  bemHelper,
+  isDomElement,
+  getContainerNode,
+  prepareTemplateProps,
+  getRefinements,
+  clearRefinementsFromState,
+  clearRefinementsAndSearch
+} = require('../../lib/utils.js');
+
+let bem = bemHelper('ais-current-refined-values');
+let cx = require('classnames');
+
+let isUndefined = require('lodash/lang/isUndefined');
+let isBoolean = require('lodash/lang/isBoolean');
+let isString = require('lodash/lang/isString');
+let isArray = require('lodash/lang/isArray');
+let isPlainObject = require('lodash/lang/isPlainObject');
+let isFunction = require('lodash/lang/isFunction');
+let isEmpty = require('lodash/lang/isEmpty');
+
+let map = require('lodash/collection/map');
+let reduce = require('lodash/collection/reduce');
+let filter = require('lodash/collection/filter');
+
+let headerFooterHOC = require('../../decorators/headerFooter.js');
+let autoHideContainerHOC = require('../../decorators/autoHideContainer');
+
+let defaultTemplates = require('./defaultTemplates');
+
+/**
+ * Instantiate a list of current refinements with the possibility to clear them
+ * @param  {string|DOMElement}  options.container CSS Selector or DOMElement to insert the widget
+ * @param  {Array}             [option.attributes] Attributes configuration
+ * @param  {string}            [option.attributes[].name] Required attribute name
+ * @param  {string}            [option.attributes[].label] Attribute label (passed to the item template)
+ * @param  {string|Function}   [option.attributes[].template] Attribute specific template
+ * @param  {Function}          [option.attributes[].transformData] Attribute specific transformData
+ * @param  {boolean|string}    [option.clearAll='before'] Clear all position (one of ('before', 'after', false))
+ * @param  {boolean}           [options.onlyListedAttributes=false] Only use declared attributes
+ * @param  {Object}            [options.templates] Templates to use for the widget
+ * @param  {string|Function}   [options.templates.header=''] Header template
+ * @param  {string|Function}   [options.templates.item] Item template
+ * @param  {string|Function}   [options.templates.clearAll] Clear all template
+ * @param  {string|Function}   [options.templates.footer=''] Footer template
+ * @param  {Function}          [options.transformData] Function to change the object passed to the `body` template
+ * @param  {boolean}           [options.autoHideContainer=true] Hide the container when no current refinements
+ * @param  {Object}            [options.cssClasses] CSS classes to be added
+ * @param  {string}            [options.cssClasses.root] CSS classes added to the root element
+ * @param  {string}            [options.cssClasses.header] CSS classes added to the header element
+ * @param  {string}            [options.cssClasses.body] CSS classes added to the body element
+ * @param  {string}            [options.cssClasses.clearAll] CSS classes added to the clearAll element
+ * @param  {string}            [options.cssClasses.list] CSS classes added to the list element
+ * @param  {string}            [options.cssClasses.item] CSS classes added to the item element
+ * @param  {string}            [options.cssClasses.link] CSS classes added to the link element
+ * @param  {string}            [options.cssClasses.count] CSS classes added to the count element
+ * @param  {string}            [options.cssClasses.footer] CSS classes added to the footer element
+ * @return {Object}
+ */
+const usage = `Usage:
+currentRefinedValues({
+  container,
+  [ attributes: [{name[, label, template, transformData]}] ],
+  [ onlyListedAttributes = false ],
+  [ clearAll = 'before' ] // One of ['before', 'after', false]
+  [ templates.{header = '', item, clearAll, footer = ''} ],
+  [ transformData ],
+  [ autoHideContainer = true ],
+  [ cssClasses.{root, header, body, clearAll, list, item, link, count, footer} = {} ]
+})`;
+function currentRefinedValues({
+    container,
+    attributes = [],
+    onlyListedAttributes = false,
+    clearAll = 'before',
+    templates = defaultTemplates,
+    transformData,
+    autoHideContainer = true,
+    cssClasses: userCssClasses = {}
+  }) {
+  const attributesOK = isArray(attributes) &&
+    reduce(attributes, (res, val) => {
+      return res &&
+        isPlainObject(val) &&
+        isString(val.name) &&
+        (isUndefined(val.label) || isString(val.label)) &&
+        (isUndefined(val.template) || isString(val.template) || isFunction(val.template)) &&
+        (isUndefined(val.transformData) || isFunction(val.transformData));
+    }, true);
+
+  const templatesKeys = ['header', 'item', 'clearAll', 'footer'];
+  const templatesOK = isPlainObject(templates) &&
+    reduce(templates, (res, val, key) => {
+      return res &&
+        templatesKeys.indexOf(key) !== -1 &&
+        (isString(val) || isFunction(val));
+    }, true);
+
+  const userCssClassesKeys = ['root', 'header', 'body', 'clearAll', 'list', 'item', 'link', 'count', 'footer'];
+  const userCssClassesOK = isPlainObject(userCssClasses) &&
+    reduce(userCssClasses, (res, val, key) => {
+      return res &&
+       userCssClassesKeys.indexOf(key) !== -1 &&
+       isString(val);
+    }, true);
+
+  const showUsage = false ||
+    !(isString(container) || isDomElement(container)) ||
+    !isArray(attributes) ||
+    !attributesOK ||
+    !isBoolean(onlyListedAttributes) ||
+    [false, 'before', 'after'].indexOf(clearAll) === -1 ||
+    !isPlainObject(templates) ||
+    !templatesOK ||
+    !(isUndefined(transformData) || isFunction(transformData)) ||
+    !isBoolean(autoHideContainer) ||
+    !userCssClassesOK;
+
+  if (showUsage) {
+    throw new Error(usage);
+  }
+
+  let containerNode = getContainerNode(container);
+  let CurrentRefinedValues = headerFooterHOC(require('../../components/CurrentRefinedValues/CurrentRefinedValues.js'));
+  if (autoHideContainer === true) {
+    CurrentRefinedValues = autoHideContainerHOC(CurrentRefinedValues);
+  }
+
+  let attributeNames = map(attributes, (attribute) => attribute.name);
+  let restrictedTo = onlyListedAttributes ? attributeNames : [];
+
+  let attributesObj = reduce(attributes, (res, attribute) => {
+    res[attribute.name] = attribute;
+    return res;
+  }, {});
+
+  return {
+    render: function({results, helper, state, templatesConfig, createURL}) {
+      let cssClasses = {
+        root: cx(bem(null), userCssClasses.root),
+        header: cx(bem('header'), userCssClasses.header),
+        body: cx(bem('body'), userCssClasses.body),
+        clearAll: cx(bem('clear-all'), userCssClasses.clearAll),
+        list: cx(bem('list'), userCssClasses.list),
+        item: cx(bem('item'), userCssClasses.item),
+        link: cx(bem('link'), userCssClasses.link),
+        count: cx(bem('count'), userCssClasses.count),
+        footer: cx(bem('footer'), userCssClasses.footer)
+      };
+
+      let templateProps = prepareTemplateProps({
+        defaultTemplates,
+        templatesConfig,
+        templates
+      });
+
+      const clearAllURL = createURL(clearRefinementsFromState(state, restrictedTo));
+      let clearAllClick = clearRefinementsAndSearch.bind(null, helper, restrictedTo);
+
+      const refinements = getFilteredRefinements(results, state, attributeNames, onlyListedAttributes);
+      let clearRefinementURLs = refinements.map((refinement) => createURL(clearRefinementFromState(state, refinement)));
+      let clearRefinementClicks = refinements.map((refinement) => clearRefinement.bind(null, helper, refinement));
+
+      const shouldAutoHideContainer = refinements.length === 0;
+
+      ReactDOM.render(
+        <CurrentRefinedValues
+          attributes={attributesObj}
+          clearAllClick={clearAllClick}
+          clearAllPosition={clearAll}
+          clearAllURL={clearAllURL}
+          clearRefinementClicks={clearRefinementClicks}
+          clearRefinementURLs={clearRefinementURLs}
+          cssClasses={cssClasses}
+          refinements={refinements}
+          shouldAutoHideContainer={shouldAutoHideContainer}
+          templateProps={templateProps}
+        />,
+        containerNode
+      );
+    }
+  };
+}
+
+function getRestrictedIndexForSort(attributeNames, otherAttributeNames, attributeName) {
+  let idx = attributeNames.indexOf(attributeName);
+  if (idx !== -1) {
+    return idx;
+  }
+  return attributeNames.length + otherAttributeNames.indexOf(attributeName);
+}
+
+function compareRefinements(attributeNames, otherAttributeNames, a, b) {
+  const idxa = getRestrictedIndexForSort(attributeNames, otherAttributeNames, a.attributeName);
+  const idxb = getRestrictedIndexForSort(attributeNames, otherAttributeNames, b.attributeName);
+  if (idxa === idxb) {
+    if (a.name === b.name) {
+      return 0;
+    }
+    return (a.name < b.name) ? -1 : 1;
+  }
+  return (idxa < idxb) ? -1 : 1;
+}
+
+function getFilteredRefinements(results, state, attributeNames, onlyListedAttributes) {
+  let refinements = getRefinements(results, state);
+  let otherAttributeNames = reduce(refinements, (res, refinement) => {
+    if (attributeNames.indexOf(refinement.attributeName) === -1 && res.indexOf(refinement.attributeName === -1)) {
+      res.push(refinement.attributeName);
+    }
+    return res;
+  }, []);
+  refinements = refinements.sort(compareRefinements.bind(null, attributeNames, otherAttributeNames));
+  if (onlyListedAttributes && !isEmpty(attributeNames)) {
+    refinements = filter(refinements, refinement => attributeNames.indexOf(refinement.attributeName) !== -1);
+  }
+  return refinements;
+}
+
+function clearRefinementFromState(state, refinement) {
+  switch (refinement.type) {
+  case 'facet':
+    return state.removeFacetRefinement(refinement.attributeName, refinement.name);
+  case 'disjunctive':
+    return state.removeDisjunctiveFacetRefinement(refinement.attributeName, refinement.name);
+  case 'hierarchical':
+    return state.clearRefinements(refinement.attributeName);
+  case 'exclude':
+    return state.removeExcludeRefinement(refinement.attributeName, refinement.name);
+  case 'numeric':
+    return state.removeNumericRefinement(refinement.attributeName, refinement.operator, refinement.name);
+  case 'tag':
+    return state.removeTagRefinement(refinement.name);
+  default:
+    throw new Error('clearRefinement: type ' + refinement.type + 'isn\'t handled');
+  }
+}
+
+function clearRefinement(helper, refinement) {
+  helper.setState(clearRefinementFromState(helper.state, refinement)).search();
+}
+
+module.exports = currentRefinedValues;

--- a/src/widgets/current-refined-values/defaultTemplates.js
+++ b/src/widgets/current-refined-values/defaultTemplates.js
@@ -1,0 +1,14 @@
+module.exports = {
+  header: '',
+  item: '' +
+    '{{#label}}' +
+      '{{label}}' +
+      '{{^operator}}:{{/operator}}' +
+      ' ' +
+    '{{/label}}' +
+    '{{#operator}}{{{displayOperator}}} {{/operator}}' +
+    '{{#exclude}}-{{/exclude}}' +
+    '{{name}} <span class="{{cssClasses.count}}">{{count}}</span>',
+  clearAll: 'Clear all',
+  footer: ''
+};


### PR DESCRIPTION
### currentRefinedValues widget

New widget specified in multiple issues (#112, #378 and #404) and took a long time. :)
Closes #404.

Needs #698 and #699 merged first.

#### Differences with the API proposal

- A `label` can be specified in the `attributes` objects and is used in the default *item* template if given.
  This is especially needed for numeric filters, where displaying a label is needed, and the `attributeName` is rarely what you want to display.
  In the end, this allows to do this:

  ```js
  currentRefinedValues({
    container: '#my-container',
    attributes: [
      {
        name: 'price_range',
        label: 'Price range'
      }
    ]
  })
  /*
   * => Displays:
   * Price range: $10 - $20
   * Price range: $20 - $30
   * Price range: $30 - $40
   */
  ```

- A `template` can also be passed to a specific attribute. Since you can pass a custom `transformData`, it also made sense to be able to pass a template.
  This allows to have, instead of this code:

  ```js
  currentRefinedValues({
    container: '#my-container',
    attributes: [{
      name: 'price',
      label: 'Price',
      transformData: function(data) {
        data.price = '$' + data.price;
        return data;
      }
    }]
  });
  ```

  this code:

  ```js
  currentRefinedValues({
    container: '#my-container',
    attributes: [{
      name: 'price',
      template: 'Price{{displayOperator}}${{name}}'
    }]
  });
  ```

- The `attributes` object `{name[, label, template, transformData]}` is passed to the *item* template
- The *item* template now also receives a `displayOperator` to correctly display `>=`(`&ge;`) or `<=`(`&le;`).
- New parameter: *boolean* `onlyListedAttributes` (defaults to `false`). When set to `true`, lists only refinements for attributes declared in `attributes` (default behaviour when `attributes` was not empty in the API proposal).
  The real use case for this parameter is to allow to use a `label`, a `template` or a `transformData` for specific attributes without listing all of them.
  For instance, if we had `attr1`, `attr2`, `attr3` and `attr4` as facets and just want to have a `transformData` on `attr2`, we would have needed to specify

  ```js
  currentRefinedValues({
    container: '#my-container',
    attributes: [
      { name: 'attr1' },
      {
        name: 'attr2',
        transformData: (data) => { data.name = `$${data.name}`; return data; }
      },
      { name: 'attr3' },
      { name: 'attr4' }
    ]
  })
  ```

  Now we can just do:

  ```js
  currentRefinedValues({
    container: '#my-container',
    attributes: [
      {
        name: 'attr2',
        transformData: (data) => { data.name = `$${data.name}`; return data; }
      }
    ],
    onlyListedAttributes: false // Default behaviour
  })
  ```

#### Other notes

**Type-checking**

I've added type-checking on the parameters. I don't remember where I read it, but I know we wanted to do more than only checking `if (!container)`.
It might seem overkill, but I really feel like it is a first step towards

> Ok we can do it by hand right now but in the end this could all be factorized into a module that check usage/report/throw.
> Something like.. https://github.com/hapijs/joi
> -- Vincent ( https://github.com/algolia/instantsearch.js/issues/396#issuecomment-153029162 )

**Documentation**

I haven't added it to the documentation website for these reasons:
- We might want to have an icon first
- It needs some refinements to have any interest as a standalone object, so it will need a custom behaviour as `hitsPerPageSelector`
- I couldn't generate it with `npm run jsdoc:widget`; I don't remember how it works, we should document it somewhere
