### PR TITLE
style(require/from): Never use .js in requires and froms

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./src/lib/main.js');
+module.exports = require('./src/lib/main');

--- a/scripts/bump-package-version.js
+++ b/scripts/bump-package-version.js
@@ -8,7 +8,7 @@ if (!process.env.VERSION) {
 }
 
 let semver = require('semver');
-let currentVersion = require('../src/lib/version.js');
+let currentVersion = require('../src/lib/version');
 let newVersion = process.env.VERSION;
 
 if (!semver.valid(newVersion)) {

--- a/src/components/ClearAll/ClearAll.js
+++ b/src/components/ClearAll/ClearAll.js
@@ -1,8 +1,8 @@
 let React = require('react');
 
-let Template = require('../Template.js');
+let Template = require('../Template');
 
-let {isSpecialClick} = require('../../lib/utils.js');
+let {isSpecialClick} = require('../../lib/utils');
 
 class ClearAll extends React.Component {
   handleClick(e) {

--- a/src/components/ClearAll/__tests__/ClearAll-test.js
+++ b/src/components/ClearAll/__tests__/ClearAll-test.js
@@ -4,8 +4,8 @@ import React from 'react';
 import expect from 'expect';
 import sinon from 'sinon';
 import TestUtils from 'react-addons-test-utils';
-import ClearAll from '../ClearAll.js';
-import Template from '../../Template.js';
+import ClearAll from '../ClearAll';
+import Template from '../../Template';
 
 import expectJSX from 'expect-jsx';
 expect.extend(expectJSX);

--- a/src/components/Pagination/Pagination.js
+++ b/src/components/Pagination/Pagination.js
@@ -1,7 +1,7 @@
 let React = require('react');
 let forEach = require('lodash/collection/forEach');
 let defaultsDeep = require('lodash/object/defaultsDeep');
-let {isSpecialClick} = require('../../lib/utils.js');
+let {isSpecialClick} = require('../../lib/utils');
 
 let Paginator = require('./Paginator');
 let PaginationLink = require('./PaginationLink');

--- a/src/components/RefinementList/RefinementList.js
+++ b/src/components/RefinementList/RefinementList.js
@@ -4,7 +4,7 @@ let cx = require('classnames');
 
 let Template = require('../Template');
 
-let {isSpecialClick} = require('../../lib/utils.js');
+let {isSpecialClick} = require('../../lib/utils');
 
 class RefinementList extends React.Component {
   refine(value) {

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -59,7 +59,7 @@ Usage: instantsearch({
     this.searchParameters = searchParameters || {};
     this.widgets = [];
     this.templatesConfig = {
-      helpers: require('./helpers.js')({numberLocale}),
+      helpers: require('./helpers')({numberLocale}),
       compileOptions: {}
     };
     this.urlSync = urlSync;

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -1,5 +1,5 @@
 // required for browsers not supporting this
-require('../shams/Object.freeze.js');
+require('../shams/Object.freeze');
 
 let toFactory = require('to-factory');
 
@@ -8,16 +8,16 @@ let instantsearch = toFactory(InstantSearch);
 let algoliasearchHelper = require('algoliasearch-helper');
 
 instantsearch.widgets = {
-  clearAll: require('../widgets/clear-all/clear-all.js'),
-  hierarchicalMenu: require('../widgets/hierarchical-menu/hierarchical-menu.js'),
+  clearAll: require('../widgets/clear-all/clear-all'),
+  hierarchicalMenu: require('../widgets/hierarchical-menu/hierarchical-menu'),
   hits: require('../widgets/hits/hits'),
   hitsPerPageSelector: require('../widgets/hits-per-page-selector/hits-per-page-selector'),
-  menu: require('../widgets/menu/menu.js'),
-  refinementList: require('../widgets/refinement-list/refinement-list.js'),
-  numericRefinementList: require('../widgets/numeric-refinement-list/numeric-refinement-list.js'),
-  numericSelector: require('../widgets/numeric-selector/numeric-selector.js'),
+  menu: require('../widgets/menu/menu'),
+  refinementList: require('../widgets/refinement-list/refinement-list'),
+  numericRefinementList: require('../widgets/numeric-refinement-list/numeric-refinement-list'),
+  numericSelector: require('../widgets/numeric-selector/numeric-selector'),
   pagination: require('../widgets/pagination/pagination'),
-  priceRanges: require('../widgets/price-ranges/price-ranges.js'),
+  priceRanges: require('../widgets/price-ranges/price-ranges'),
   searchBox: require('../widgets/search-box/search-box'),
   rangeSlider: require('../widgets/range-slider/range-slider'),
   sortBySelector: require('../widgets/sort-by-selector/sort-by-selector'),

--- a/src/lib/url-sync.js
+++ b/src/lib/url-sync.js
@@ -1,6 +1,6 @@
 let algoliasearchHelper = require('algoliasearch-helper');
 let AlgoliaSearchHelper = algoliasearchHelper.AlgoliaSearchHelper;
-let majorVersionNumber = require('../lib/version.js').split('.')[0];
+let majorVersionNumber = require('../lib/version').split('.')[0];
 
 let isEqual = require('lodash/lang/isEqual');
 let merge = require('lodash/object/merge');

--- a/src/widgets/clear-all/clear-all.js
+++ b/src/widgets/clear-all/clear-all.js
@@ -8,7 +8,7 @@ let {
   getRefinements,
   clearRefinementsFromState,
   clearRefinementsAndSearch
-} = require('../../lib/utils.js');
+} = require('../../lib/utils');
 let bem = bemHelper('ais-clear-all');
 let cx = require('classnames');
 
@@ -52,7 +52,7 @@ function clearAll({
   }
 
   let containerNode = getContainerNode(container);
-  let ClearAll = headerFooterHOC(require('../../components/ClearAll/ClearAll.js'));
+  let ClearAll = headerFooterHOC(require('../../components/ClearAll/ClearAll'));
   if (autoHideContainer === true) {
     ClearAll = autoHideContainerHOC(ClearAll);
   }

--- a/src/widgets/hierarchical-menu/hierarchical-menu.js
+++ b/src/widgets/hierarchical-menu/hierarchical-menu.js
@@ -1,13 +1,13 @@
 let React = require('react');
 let ReactDOM = require('react-dom');
 
-let utils = require('../../lib/utils.js');
+let utils = require('../../lib/utils');
 let bem = utils.bemHelper('ais-hierarchical-menu');
 let cx = require('classnames');
 let autoHideContainerHOC = require('../../decorators/autoHideContainer');
 let headerFooterHOC = require('../../decorators/headerFooter');
 
-let defaultTemplates = require('./defaultTemplates.js');
+let defaultTemplates = require('./defaultTemplates');
 
 /**
  * Create a hierarchical menu using multiple attributes
@@ -72,7 +72,7 @@ function hierarchicalMenu({
 
   let containerNode = utils.getContainerNode(container);
 
-  let RefinementList = headerFooterHOC(require('../../components/RefinementList/RefinementList.js'));
+  let RefinementList = headerFooterHOC(require('../../components/RefinementList/RefinementList'));
   if (autoHideContainer === true) {
     RefinementList = autoHideContainerHOC(RefinementList);
   }

--- a/src/widgets/hits-per-page-selector/hits-per-page-selector.js
+++ b/src/widgets/hits-per-page-selector/hits-per-page-selector.js
@@ -1,7 +1,7 @@
 let React = require('react');
 let ReactDOM = require('react-dom');
 
-let utils = require('../../lib/utils.js');
+let utils = require('../../lib/utils');
 let any = require('lodash/collection/any');
 let bem = utils.bemHelper('ais-hits-per-page-selector');
 let cx = require('classnames');

--- a/src/widgets/hits/hits.js
+++ b/src/widgets/hits/hits.js
@@ -1,7 +1,7 @@
 let React = require('react');
 let ReactDOM = require('react-dom');
 
-let utils = require('../../lib/utils.js');
+let utils = require('../../lib/utils');
 let bem = utils.bemHelper('ais-hits');
 let cx = require('classnames');
 

--- a/src/widgets/menu/menu.js
+++ b/src/widgets/menu/menu.js
@@ -1,13 +1,13 @@
 let React = require('react');
 let ReactDOM = require('react-dom');
 
-let utils = require('../../lib/utils.js');
+let utils = require('../../lib/utils');
 let bem = utils.bemHelper('ais-menu');
 let cx = require('classnames');
 let autoHideContainerHOC = require('../../decorators/autoHideContainer');
 let headerFooterHOC = require('../../decorators/headerFooter');
 
-let defaultTemplates = require('./defaultTemplates.js');
+let defaultTemplates = require('./defaultTemplates');
 
 /**
  * Create a menu out of a facet
@@ -60,7 +60,7 @@ function menu({
   }
 
   let containerNode = utils.getContainerNode(container);
-  let RefinementList = headerFooterHOC(require('../../components/RefinementList/RefinementList.js'));
+  let RefinementList = headerFooterHOC(require('../../components/RefinementList/RefinementList'));
   if (autoHideContainer === true) {
     RefinementList = autoHideContainerHOC(RefinementList);
   }

--- a/src/widgets/numeric-refinement-list/numeric-refinement-list.js
+++ b/src/widgets/numeric-refinement-list/numeric-refinement-list.js
@@ -1,7 +1,7 @@
 let React = require('react');
 let ReactDOM = require('react-dom');
 
-let utils = require('../../lib/utils.js');
+let utils = require('../../lib/utils');
 let bem = utils.bemHelper('ais-refinement-list');
 let cx = require('classnames');
 let find = require('lodash/collection/find');
@@ -62,7 +62,7 @@ function numericRefinementList({
   }
 
   let containerNode = utils.getContainerNode(container);
-  let RefinementList = headerFooterHOC(require('../../components/RefinementList/RefinementList.js'));
+  let RefinementList = headerFooterHOC(require('../../components/RefinementList/RefinementList'));
   if (autoHideContainer === true) {
     RefinementList = autoHideContainerHOC(RefinementList);
   }

--- a/src/widgets/numeric-selector/numeric-selector.js
+++ b/src/widgets/numeric-selector/numeric-selector.js
@@ -1,7 +1,7 @@
 let React = require('react');
 let ReactDOM = require('react-dom');
 
-let utils = require('../../lib/utils.js');
+let utils = require('../../lib/utils');
 let cx = require('classnames');
 let find = require('lodash/collection/find');
 let autoHideContainerHOC = require('../../decorators/autoHideContainer');

--- a/src/widgets/pagination/pagination.js
+++ b/src/widgets/pagination/pagination.js
@@ -3,7 +3,7 @@ let ReactDOM = require('react-dom');
 let defaults = require('lodash/object/defaults');
 let cx = require('classnames');
 
-let utils = require('../../lib/utils.js');
+let utils = require('../../lib/utils');
 let bem = utils.bemHelper('ais-pagination');
 
 let autoHideContainerHOC = require('../../decorators/autoHideContainer');
@@ -72,7 +72,7 @@ function pagination({
 
   let containerNode = utils.getContainerNode(container);
   let scrollToNode = scrollTo !== false ? utils.getContainerNode(scrollTo) : false;
-  let Pagination = require('../../components/Pagination/Pagination.js');
+  let Pagination = require('../../components/Pagination/Pagination');
   if (autoHideContainer === true) {
     Pagination = autoHideContainerHOC(Pagination);
   }

--- a/src/widgets/price-ranges/price-ranges.js
+++ b/src/widgets/price-ranges/price-ranges.js
@@ -1,9 +1,9 @@
 let React = require('react');
 let ReactDOM = require('react-dom');
 
-let utils = require('../../lib/utils.js');
+let utils = require('../../lib/utils');
 
-let generateRanges = require('./generate-ranges.js');
+let generateRanges = require('./generate-ranges');
 
 let defaultTemplates = require('./defaultTemplates');
 let autoHideContainerHOC = require('../../decorators/autoHideContainer');

--- a/src/widgets/range-slider/range-slider.js
+++ b/src/widgets/range-slider/range-slider.js
@@ -1,7 +1,7 @@
 let React = require('react');
 let ReactDOM = require('react-dom');
 
-let utils = require('../../lib/utils.js');
+let utils = require('../../lib/utils');
 let find = require('lodash/collection/find');
 let autoHideContainerHOC = require('../../decorators/autoHideContainer');
 let headerFooterHOC = require('../../decorators/headerFooter');

--- a/src/widgets/refinement-list/__tests__/refinement-list-test.js
+++ b/src/widgets/refinement-list/__tests__/refinement-list-test.js
@@ -12,7 +12,7 @@ expect.extend(expectJSX);
 import refinementList from '../refinement-list';
 import Template from '../../../components/Template.js';
 
-const helpers = require('../../../lib/helpers.js')('en-US');
+const helpers = require('../../../lib/helpers')('en-US');
 
 describe('refinementList()', () => {
   let autoHideContainer;

--- a/src/widgets/refinement-list/__tests__/refinement-list-test.js
+++ b/src/widgets/refinement-list/__tests__/refinement-list-test.js
@@ -10,7 +10,7 @@ import expectJSX from 'expect-jsx';
 expect.extend(expectJSX);
 
 import refinementList from '../refinement-list';
-import Template from '../../../components/Template.js';
+import Template from '../../../components/Template';
 
 const helpers = require('../../../lib/helpers')('en-US');
 

--- a/src/widgets/refinement-list/refinement-list.js
+++ b/src/widgets/refinement-list/refinement-list.js
@@ -1,7 +1,7 @@
 let React = require('react');
 let ReactDOM = require('react-dom');
 
-let utils = require('../../lib/utils.js');
+let utils = require('../../lib/utils');
 let bem = utils.bemHelper('ais-refinement-list');
 let cx = require('classnames');
 
@@ -60,7 +60,7 @@ function refinementList({
     transformData,
     autoHideContainer = true
   }) {
-  let RefinementList = require('../../components/RefinementList/RefinementList.js');
+  let RefinementList = require('../../components/RefinementList/RefinementList');
 
   if (!container || !attributeName) {
     throw new Error(usage);

--- a/src/widgets/search-box/search-box.js
+++ b/src/widgets/search-box/search-box.js
@@ -1,6 +1,6 @@
 let React = require('react');
 let ReactDOM = require('react-dom');
-let utils = require('../../lib/utils.js');
+let utils = require('../../lib/utils');
 let forEach = require('lodash/collection/forEach');
 let bem = require('../../lib/utils').bemHelper('ais-search-box');
 let cx = require('classnames');
@@ -94,7 +94,7 @@ function searchBox({
       input.classList.add(cx(bem('input'), cssClasses.input));
     },
     addPoweredBy: function(input) {
-      let PoweredBy = require('../../components/PoweredBy/PoweredBy.js');
+      let PoweredBy = require('../../components/PoweredBy/PoweredBy');
       let poweredByContainer = document.createElement('div');
       input.parentNode.insertBefore(poweredByContainer, input.nextSibling);
       let poweredByCssClasses = {

--- a/src/widgets/sort-by-selector/sort-by-selector.js
+++ b/src/widgets/sort-by-selector/sort-by-selector.js
@@ -3,7 +3,7 @@ let ReactDOM = require('react-dom');
 
 let findIndex = require('lodash/array/findIndex');
 let map = require('lodash/collection/map');
-let utils = require('../../lib/utils.js');
+let utils = require('../../lib/utils');
 let bem = utils.bemHelper('ais-sort-by-selector');
 let cx = require('classnames');
 let autoHideContainerHOC = require('../../decorators/autoHideContainer');

--- a/src/widgets/star-rating/star-rating.js
+++ b/src/widgets/star-rating/star-rating.js
@@ -1,7 +1,7 @@
 let React = require('react');
 let ReactDOM = require('react-dom');
 
-let utils = require('../../lib/utils.js');
+let utils = require('../../lib/utils');
 let bem = utils.bemHelper('ais-star-rating');
 let cx = require('classnames');
 
@@ -63,7 +63,7 @@ function starRating({
   autoHideContainer = true
   }) {
   let containerNode = utils.getContainerNode(container);
-  let RefinementList = headerFooterHOC(require('../../components/RefinementList/RefinementList.js'));
+  let RefinementList = headerFooterHOC(require('../../components/RefinementList/RefinementList'));
   if (autoHideContainer === true) {
     RefinementList = autoHideContainerHOC(RefinementList);
   }

--- a/src/widgets/stats/stats.js
+++ b/src/widgets/stats/stats.js
@@ -1,13 +1,13 @@
 let React = require('react');
 let ReactDOM = require('react-dom');
 
-let utils = require('../../lib/utils.js');
+let utils = require('../../lib/utils');
 let autoHideContainerHOC = require('../../decorators/autoHideContainer');
 let headerFooterHOC = require('../../decorators/headerFooter');
 let bem = require('../../lib/utils').bemHelper('ais-stats');
 let cx = require('classnames');
 
-let defaultTemplates = require('./defaultTemplates.js');
+let defaultTemplates = require('./defaultTemplates');
 
 /**
  * Display various stats about the current search state
@@ -44,7 +44,7 @@ function stats({
   if (!container) throw new Error(usage);
   let containerNode = utils.getContainerNode(container);
 
-  let Stats = headerFooterHOC(require('../../components/Stats/Stats.js'));
+  let Stats = headerFooterHOC(require('../../components/Stats/Stats'));
   if (autoHideContainer === true) {
     Stats = autoHideContainerHOC(Stats);
   }

--- a/src/widgets/toggle/__tests__/toggle-test.js
+++ b/src/widgets/toggle/__tests__/toggle-test.js
@@ -7,8 +7,8 @@ import jsdom from 'mocha-jsdom';
 import {createRenderer} from 'react-addons-test-utils';
 
 import toggle from '../toggle';
-import RefinementList from '../../../components/RefinementList/RefinementList.js';
-import Template from '../../../components/Template.js';
+import RefinementList from '../../../components/RefinementList/RefinementList';
+import Template from '../../../components/Template';
 
 import expectJSX from 'expect-jsx';
 expect.extend(expectJSX);

--- a/src/widgets/toggle/__tests__/toggle-test.js
+++ b/src/widgets/toggle/__tests__/toggle-test.js
@@ -13,7 +13,7 @@ import Template from '../../../components/Template.js';
 import expectJSX from 'expect-jsx';
 expect.extend(expectJSX);
 
-const helpers = require('../../../lib/helpers.js')('en-US');
+const helpers = require('../../../lib/helpers')('en-US');
 
 describe('toggle()', () => {
   jsdom({useEach: true});

--- a/src/widgets/toggle/toggle.js
+++ b/src/widgets/toggle/toggle.js
@@ -2,7 +2,7 @@ let find = require('lodash/collection/find');
 let React = require('react');
 let ReactDOM = require('react-dom');
 
-let utils = require('../../lib/utils.js');
+let utils = require('../../lib/utils');
 let bem = utils.bemHelper('ais-toggle');
 let cx = require('classnames');
 
@@ -67,7 +67,7 @@ function toggle({
   } = {}) {
   let containerNode = utils.getContainerNode(container);
 
-  let RefinementList = headerFooterHOC(require('../../components/RefinementList/RefinementList.js'));
+  let RefinementList = headerFooterHOC(require('../../components/RefinementList/RefinementList'));
   if (autoHideContainer === true) {
     RefinementList = autoHideContainerHOC(RefinementList);
   }


### PR DESCRIPTION
For `require`s

```sh
ag -l "require\(.*.js.\)" | xargs -I {} sed -i -r '/(hogan|instantsearch)/! s#(require\(.*)\.js(.\))#\1\2#g' {}
```

For `import ... from ...`

```sh
ag -l "import .* from .*\.js" | xargs -I {} sed -i -r 's/(import.*from .*)\.js/\1/g' {}
```

Just here for consistency.