### PR TITLE
refactor(PoweredBy): Use "Search by Algolia"

### DIFF
--- a/src/components/PoweredBy/PoweredBy.js
+++ b/src/components/PoweredBy/PoweredBy.js
@@ -4,7 +4,7 @@ class PoweredBy extends React.Component {
   render() {
     return (
       <div className={this.props.cssClasses.root}>
-        Powered by
+        Search by
         <a className={this.props.cssClasses.link} href="https://www.algolia.com/" target="_blank">Algolia</a>
       </div>
     );

--- a/src/components/PoweredBy/__tests__/PoweredBy-test.js
+++ b/src/components/PoweredBy/__tests__/PoweredBy-test.js
@@ -25,7 +25,7 @@ describe('PoweredBy', () => {
     });
     expect(out).toEqualJSX(
     <div className="pb-root">
-      Powered by
+      Search by
       <a className="pb-link" href="https://www.algolia.com/" target="_blank">Algolia</a>
     </div>);
   });


### PR DESCRIPTION
Suggestion of Guillaume D that @redox approved. Makes a bit more sense, but definitely open to discussion.
If we chose to accept that, we could maybe also rename the `PoweredBy` component and the `searchBox` parameter `poweredBy`, but this would be a breaking change.