### PR TITLE
Correct options.urlSync.useHash type to boolean

### DIFF
--- a/docs/_includes/widget-jsdoc/instantsearch.md
+++ b/docs/_includes/widget-jsdoc/instantsearch.md
@@ -7,7 +7,7 @@
 | <span class='attr-optional'>`options.searchParameters`</span><span class="attr-infos">Type: <code>string</code></span> | Initial search configuration. |
 | <span class='attr-optional'>`options.urlSync`</span><span class="attr-infos">Type: <code>Object</code></span> | Url synchronization configuration. |
 | <span class='attr-optional'>`options.urlSync.trackedParameters`</span><span class="attr-infos">Type: <code>string</code></span> | Parameters that will be synchronized in the URL. By default, it will track the query, all the refinable attribute (facets and numeric filters), the index and the page. |
-| <span class='attr-optional'>`options.urlSync.useHash`</span><span class="attr-infos">Type: <code>string</code></span> | If set to true, the url will be hash based. Otherwise, it'll use the query parameters using the modern history API. |
+| <span class='attr-optional'>`options.urlSync.useHash`</span><span class="attr-infos">Type: <code>boolean</code></span> | If set to true, the url will be hash based. Otherwise, it'll use the query parameters using the modern history API. |
 | <span class='attr-optional'>`options.urlSync.threshold`</span><span class="attr-infos">Type: <code>string</code></span> | Time in ms after which a new state is created in the browser history. The default value is 700. |
 
 <p class="attr-legend">* <span>Required</span></p>


### PR DESCRIPTION
From `string`. Taken from [here](https://github.com/algolia/instantsearch.js/blob/4a73f7af7cb0c80cecbd9b6286e27595f028a2d7/src/lib/InstantSearch.js#L22).