### PR TITLE
fix(index): Use module.exports instead of export on index

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,4 @@
-export default require('./src/lib/main.js');
+/* eslint algolia/no-module-exports: 0 */
+
+import main from './src/lib/main.js';
+module.exports = main;


### PR DESCRIPTION
Related to https://github.com/webpack/webpack/issues/706 .
Basically, we can't do `export default mymodule;` with webpack. The library would end up being:
```js
{
  default: MyLib
}
```