### PR TITLE
fix(url-sync): adds indexName in the helper configuration

### DIFF
--- a/src/components/Hits.js
+++ b/src/components/Hits.js
@@ -21,7 +21,7 @@ class Hits extends React.Component {
   }
 
   renderNoResults() {
-    let className = `${this.props.cssClasses.root} ${this.props.cssClasses.empty}`;
+    let className = this.props.cssClasses.root + ' ' + this.props.cssClasses.empty;
     return (
       <Template
         cssClass={className}

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -60,7 +60,7 @@ Usage: instantsearch({
     this.client = client;
     this.helper = null;
     this.indexName = indexName;
-    this.searchParameters = searchParameters || {};
+    this.searchParameters = {...searchParameters, index: indexName};
     this.widgets = [];
     this.templatesConfig = {
       helpers: require('./helpers.js')({numberLocale}),

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -39,7 +39,7 @@ describe('InstantSearch lifecycle', () => {
     apiKey = 'apiKey';
     indexName = 'lifeycle';
 
-    searchParameters = {some: 'configuration', values: [-2, -1], another: {config: 'parameter'}};
+    searchParameters = {some: 'configuration', values: [-2, -1], index: indexName, another: {config: 'parameter'}};
 
     InstantSearch.__Rewire__('algoliasearch', algoliasearch);
     InstantSearch.__Rewire__('algoliasearchHelper', algoliasearchHelper);
@@ -113,7 +113,7 @@ describe('InstantSearch lifecycle', () => {
           .toEqual([
             client,
             indexName,
-            {some: 'modified', values: [-2, -1], another: {different: 'parameter', config: 'parameter'}}
+            {some: 'modified', values: [-2, -1], index: indexName, another: {different: 'parameter', config: 'parameter'}}
           ]);
       });
 


### PR DESCRIPTION
This solves a bug found using safari and that may or may not
break an implementation based on InstantSearch.

Safari triggers a pop state event on load, which triggers a new
search. But at this point the index is not in the initial
configuration, so this search will fail with a 400, indexName not
valid.

With this fix the value for the index name is taken from the parameters
and its value is added to the initial search configuration.