### PR TITLE
fix(search-box): update value when state changes from the outside

### DIFF
--- a/src/widgets/search-box/__tests__/search-box-test.js
+++ b/src/widgets/search-box/__tests__/search-box-test.js
@@ -5,6 +5,7 @@ import sinon from 'sinon';
 import jsdom from 'mocha-jsdom';
 
 import searchBox from '../search-box';
+import EventEmitter from 'events';
 
 import expectJSX from 'expect-jsx';
 expect.extend(expectJSX);
@@ -31,12 +32,12 @@ describe('search-box()', () => {
       query: ''
     };
     helper = {
-      on: sinon.spy(),
       setQuery: sinon.spy(),
       search: sinon.spy(),
       state: {
         query: ''
-      }
+      },
+      ...EventEmitter.prototype
     };
   });
 
@@ -270,6 +271,17 @@ describe('search-box()', () => {
         expect(helper.search.calledOnce).toBe(false);
       });
     });
+  });
+
+  it('updates the input on an helper update', () => {
+    container = document.createElement('div');
+    widget = searchBox({container});
+    widget.init({state, helper});
+    let input = container.querySelector('input');
+    expect(input.value).toBe('');
+    input.blur();
+    helper.emit('change', {query: 'iphone'});
+    expect(input.value).toBe('iphone');
   });
 
   context('focus', () => {

--- a/src/widgets/search-box/search-box.js
+++ b/src/widgets/search-box/search-box.js
@@ -162,7 +162,7 @@ function searchBox({
       // Update value when query change outside of the input
       helper.on('change', function(newState) {
         if (input !== document.activeElement && input.value !== newState.query) {
-          input.value = state.query;
+          input.value = newState.query;
         }
       });
 


### PR DESCRIPTION
we were previously using the previous state I believe.

This bug can be seen by hitting the back button while not being
focused.