### PR TITLE
chore(beta): do not commit to git the beta release meta

### DIFF
--- a/scripts/release-beta.sh
+++ b/scripts/release-beta.sh
@@ -25,51 +25,32 @@ git fetch origin --tags
 printf "Beta release: npm install"
 npm install
 
+currentBetaVersion=`cat .beta-version`
 currentVersion=`cat package.json | json version`
 
-# if not on a beta version already
-if [[ $currentVersion != *"-beta"* || $CHOOSE_BUMP ]]
-then
-  # header
-  printf "\n\nBeta release: current version is $currentVersion"
-  printf "\nBeta release: a changelog will be generated only if a fix/feat/performance/breaking token is found in git log"
-  printf "\nBeta release: you must choose a new ve.rs.ion (semver)"
-  printf "\nBeta release: press q to exit the next screen\n\n"
+# header
+printf "\n\nBeta release: current beta: $currentBetaVersion, current stable: $currentVersion"
+printf "\nBeta release: a changelog will be generated only if a fix/feat/performance/breaking token is found in git log"
+printf "\nBeta release: you must choose a new ve.rs.ion (semver)"
+printf "\nBeta release: press q to exit the next screen\n\n"
 
-  # preview changelog
-  read -p "=> Beta release: press [ENTER] to view changes since latest version.."
+# preview changelog
+read -p "=> Beta release: press [ENTER] to view changes since latest stable version.."
 
-  # nd (markdown renderer in terminal)
-  # has some output going on to stderr because of node v4, no big deal
-  conventional-changelog -p angular | nd | less -r 2>/dev/null
+# nd (markdown renderer in terminal)
+# has some output going on to stderr because of node v4, no big deal
+conventional-changelog -p angular | nd | less -r 2>/dev/null
 
-  # choose and bump new version
-  # printf "\n\nBeta release: Please enter the new chosen version > "
-  printf "\n=> Beta release: please type the new chosen version (-beta will be automatically appended) > "
-  read -e newVersion
-  newVersion="$newVersion-beta.0"
-else
-  # when already on a beta version, let's bump the beta-.X
-  newVersion=`semver ${currentVersion} -i prerelease -preid beta`
-
-  read -p "
-  => Beta release: The new version will be ${newVersion},
-  press [ENTER] to continue, CTRL+C to abort.
-  You can force specifying a different bump by using CHOOSE_BUMP=1 npm run release-beta"
-fi
+# choose and bump new version
+# printf "\n\nBeta release: Please enter the new chosen version > "
+printf "\n=> Beta release: please type the new chosen version > "
+read -e newVersion
 
 VERSION=$newVersion babel-node ./scripts/bump-package-version.js
+echo $newVersion > .beta-version
 
 # build new version
 NODE_ENV=production VERSION=$newVersion npm run build
-
-# regenerate readme TOC
-printf "\n\nBeta release: generate TOCS"
-npm run doctoc
-
-# regenerate widgets jsdoc
-printf "\n\nBeta release: regenerate widgets jsdoc"
-npm run docs:jsdoc
 
 # add a timestamp fake file to dist/ to avoid having beta released published to jsdelivr automatically
 # https://github.com/jsdelivr/jsdelivr/pull/8107#issuecomment-159562676
@@ -78,15 +59,18 @@ timestamp=$(date "+%Y.%m.%d-%H.%M.%S")
 tmpfile="dist/avoid-jsdelivr-beta-publish-$timestamp"
 touch $tmpfile
 
-# git add and tag
-commitMessage="v$newVersion\n\n$changelog"
-git add src/lib/version.js npm-shrinkwrap.json package.json CHANGELOG.md CONTRIBUTING.md README.md docs/_includes/widget-jsdoc
-printf "$commitMessage" | git commit --file -
-
 printf "\n\nBeta release: almost done, check everything in another terminal tab.\n"
 read -p "=> Beta release: when ready, press [ENTER] to push to github and publish the package to the beta channel"
 
+# git add and tag
+commitMessage="v$newVersion"
+git add .beta-version
+git tag "v$newVersion"
+printf "$commitMessage" | git commit --file -
+
 printf "\n\nBeta release: push to github, publish on npm"
 git push origin develop
-npm publish --tag beta
+git push origin --tags
+npm dist-tag add instantsearch.js@$newVersion beta
 rm $tmpfile
+git checkout .

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -83,8 +83,6 @@ printf "\n\nRelease: push to github, publish on npm"
 git push origin master
 git push origin --tags
 npm publish
-# also update beta
-npm dist-tag add instantsearch.js@$newVersion beta
 git checkout develop
 git pull origin develop
 git merge master


### PR DESCRIPTION
- stop releasing beta along with stable when releasing stable
- stop comitting beta version metadata to package.json etc.. It then trigger conflicts when merging stable into develop