### PR TITLE
feat(refinementlist): lets configure showmore feature FIX #401

### DIFF
--- a/dev/app.js
+++ b/dev/app.js
@@ -114,6 +114,31 @@ search.addWidget(
     container: '#brands',
     attributeName: 'brand',
     operator: 'or',
+    limit: 3,
+    cssClasses: {
+      header: 'facet-title',
+      item: 'facet-value checkbox',
+      count: 'facet-count pull-right',
+      active: 'facet-active'
+    },
+    templates: {
+      header: 'Brands'
+    },
+    showMore: {
+      templates: {
+        'active': '<button>Show less</button>',
+        'inactive': '<button>Show more</button>'
+      },
+      limit: 10
+    }
+  })
+);
+
+search.addWidget(
+  instantsearch.widgets.refinementList({
+    container: '#brands-2',
+    attributeName: 'brand',
+    operator: 'or',
     limit: 10,
     cssClasses: {
       header: 'facet-title',

--- a/dev/index.html
+++ b/dev/index.html
@@ -24,6 +24,7 @@
         <div class="facet" id="current-refined-values"></div>
         <div class="facet" id="hierarchical-categories"></div>
         <div class="facet" id="brands"></div>
+        <div class="facet" id="brands-2"></div>
         <div class="facet" id="price-range"></div>
         <div class="facet" id="free-shipping"></div>
         <div class="facet" id="price"></div>

--- a/dev/style.css
+++ b/dev/style.css
@@ -118,3 +118,7 @@ body {
 .ais-refinement-list--label input[type=radio]{
   margin: 4px 8px 0 0;
 }
+
+.ais-showmore__active, .ais-showmore__inactive {
+  cursor: pointer;
+}

--- a/src/components/RefinementList/RefinementList.js
+++ b/src/components/RefinementList/RefinementList.js
@@ -5,6 +5,13 @@ import {isSpecialClick} from '../../lib/utils.js';
 import Template from '../Template.js';
 
 class RefinementList extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isShowMoreOpen: false
+    };
+  }
+
   refine(value) {
     this.props.toggleRefinement(value);
   }
@@ -45,7 +52,7 @@ class RefinementList extends React.Component {
       <div
         className={cssClassItem}
         key={key}
-        onClick={this.handleClick.bind(this, facetValue[this.props.attributeNameKey])}
+        onClick={this.handleItemClick.bind(this, facetValue[this.props.attributeNameKey])}
       >
         <Template data={templateData} templateKey="item" {...this.props.templateProps} />
         {subList}
@@ -69,7 +76,7 @@ class RefinementList extends React.Component {
   //
   // Finally, we always stop propagation of the event to avoid multiple levels RefinementLists to fail: click
   // on child would click on parent also
-  handleClick(value, e) {
+  handleItemClick(value, e) {
     if (isSpecialClick(e)) {
       // do not alter the default browser behavior
       // if one special key is down
@@ -101,6 +108,11 @@ class RefinementList extends React.Component {
     this.refine(value);
   }
 
+  handleClickShowMore() {
+    const isShowMoreOpen = !this.state.isShowMoreOpen;
+    this.setState({isShowMoreOpen});
+  }
+
   render() {
     // Adding `-lvl0` classes
     let cssClassList = [this.props.cssClasses.list];
@@ -108,9 +120,20 @@ class RefinementList extends React.Component {
       cssClassList.push(`${this.props.cssClasses.depth}${this.props.depth}`);
     }
 
+    const limit = this.state.isShowMoreOpen ? this.props.limitMax : this.props.limitMin;
+    const showmoreBtn =
+      this.props.showMore ?
+        <Template
+          onClick={() => this.handleClickShowMore()}
+          templateKey={'showmore-' + (this.state.isShowMoreOpen ? 'active' : 'inactive')}
+          {...this.props.templateProps}
+        /> :
+        undefined;
+
     return (
       <div className={cx(cssClassList)}>
-        {this.props.facetValues.map(this._generateFacetItem, this)}
+        {this.props.facetValues.map(this._generateFacetItem, this).slice(0, limit)}
+        {showmoreBtn}
       </div>
     );
   }
@@ -128,6 +151,9 @@ RefinementList.propTypes = {
   }),
   depth: React.PropTypes.number,
   facetValues: React.PropTypes.array,
+  limitMax: React.PropTypes.number,
+  limitMin: React.PropTypes.number,
+  showMore: React.PropTypes.bool,
   templateProps: React.PropTypes.object.isRequired,
   toggleRefinement: React.PropTypes.func.isRequired
 };

--- a/src/components/RefinementList/__tests__/RefinementList-test.js
+++ b/src/components/RefinementList/__tests__/RefinementList-test.js
@@ -56,8 +56,8 @@ describe('RefinementList', () => {
         </div>
       </div>
     );
-    expect(out.props.children[0].key).toEqual('facet1');
-    expect(out.props.children[1].key).toEqual('facet2');
+    expect(out.props.children[0][0].key).toEqual('facet1');
+    expect(out.props.children[0][1].key).toEqual('facet2');
   });
 
   it('should render default list highlighted', () => {
@@ -75,7 +75,26 @@ describe('RefinementList', () => {
         </div>
       </div>
     );
-    expect(out.props.children[0].key).toEqual('facet1/true/42');
+    expect(out.props.children[0][0].key).toEqual('facet1/true/42');
+  });
+
+  context('showmore', () => {
+    it('should display the number accordingly to the state : closed', () => {
+      const out = render({
+        facetValues: [
+          {name: 'facet1', isRefined: false, count: 42},
+          {name: 'facet2', isRefined: false, count: 42}
+        ],
+        showMore: true,
+        limitMin: 1,
+        limitMax: 2
+      });
+      expect(out.props.children.length).toBe(2);
+    });
+
+    it('should display the number accordingly to the state : open', () => {
+      // FIXME find a way to test this state...
+    });
   });
 
   context('sublist', () => {
@@ -140,7 +159,7 @@ describe('RefinementList', () => {
 
   function render(extraProps = {}) {
     let props = getProps(extraProps);
-    renderer.render(<RefinementList {...props} templateProps={{}} />);
+    renderer.render(<RefinementList {...props} ref="list" templateProps={{}} />);
     return renderer.getRenderOutput();
   }
 

--- a/src/components/Template.js
+++ b/src/components/Template.js
@@ -1,30 +1,39 @@
 import React from 'react';
-import mapValues from 'lodash/object/mapValues';
+
 import curry from 'lodash/function/curry';
 import cloneDeep from 'lodash/lang/cloneDeep';
+import keys from 'lodash/object/keys';
+import omit from 'lodash/object/omit';
+import mapValues from 'lodash/object/mapValues';
+
 import hogan from 'hogan.js';
 
-class Template extends React.Component {
-  render() {
-    let compileOptions = this.props.useCustomCompileOptions[this.props.templateKey] ?
-      this.props.templatesConfig.compileOptions :
-      {};
+function Template(props) {
+  const useCustomCompileOptions = props.useCustomCompileOptions[props.templateKey];
+  const compileOptions = useCustomCompileOptions ? props.templatesConfig.compileOptions : {};
 
-    let content = renderTemplate({
-      template: this.props.templates[this.props.templateKey],
-      compileOptions: compileOptions,
-      helpers: this.props.templatesConfig.helpers,
-      data: transformData(this.props.transformData, this.props.templateKey, this.props.data)
-    });
+  const content = renderTemplate({
+    template: props.templates[props.templateKey],
+    compileOptions: compileOptions,
+    helpers: props.templatesConfig.helpers,
+    data: transformData(props.transformData, props.templateKey, props.data)
+  });
 
-    if (content === null) {
-      // Adds a noscript to the DOM but virtual DOM is null
-      // See http://facebook.github.io/react/docs/component-specs.html#render
-      return null;
-    }
-
-    return <div className={this.props.cssClass} dangerouslySetInnerHTML={{__html: content}} />;
+  if (content === null) {
+    // Adds a noscript to the DOM but virtual DOM is null
+    // See http://facebook.github.io/react/docs/component-specs.html#render
+    return null;
   }
+
+  const otherProps = omit(props, keys(Template.propTypes));
+
+  return (
+    <div
+      {...otherProps}
+      className={props.cssClass}
+      dangerouslySetInnerHTML={{__html: content}}
+    />
+  );
 }
 
 Template.propTypes = {

--- a/src/components/Template.js
+++ b/src/components/Template.js
@@ -13,7 +13,8 @@ function Template(props) {
   const compileOptions = useCustomCompileOptions ? props.templatesConfig.compileOptions : {};
 
   const content = renderTemplate({
-    template: props.templates[props.templateKey],
+    templates: props.templates,
+    templateKey: props.templateKey,
     compileOptions: compileOptions,
     helpers: props.templatesConfig.helpers,
     data: transformData(props.transformData, props.templateKey, props.data)
@@ -79,9 +80,10 @@ function transformData(fn, templateKey, originalData) {
   let clonedData = cloneDeep(originalData);
 
   let data;
-  if (typeof fn === 'function') {
+  const typeFn = typeof fn;
+  if (typeFn === 'function') {
     data = fn(clonedData);
-  } else if (typeof fn === 'object') {
+  } else if (typeFn === 'object') {
     // ex: transformData: {hit, empty}
     if (fn[templateKey]) {
       data = fn[templateKey](clonedData);
@@ -91,7 +93,7 @@ function transformData(fn, templateKey, originalData) {
       data = originalData;
     }
   } else {
-    throw new Error('`transformData` must be a function or an object');
+    throw new Error(`transformData must be a function or an object, was ${typeFn} (key : ${templateKey})`);
   }
 
   let dataType = typeof data;
@@ -102,12 +104,14 @@ function transformData(fn, templateKey, originalData) {
   return data;
 }
 
-function renderTemplate({template, compileOptions, helpers, data}) {
-  let isTemplateString = typeof template === 'string';
-  let isTemplateFunction = typeof template === 'function';
+function renderTemplate({templates, templateKey, compileOptions, helpers, data}) {
+  const template = templates[templateKey];
+  const templateType = typeof template;
+  const isTemplateString = templateType === 'string';
+  const isTemplateFunction = templateType === 'function';
 
   if (!isTemplateString && !isTemplateFunction) {
-    throw new Error('Template must be `string` or `function`');
+    throw new Error(`Template must be 'string' or 'function', was '${templateType}' (key: ${templateKey})`);
   } else if (isTemplateFunction) {
     return template(data);
   } else {

--- a/src/components/__tests__/Template-test.js
+++ b/src/components/__tests__/Template-test.js
@@ -10,7 +10,7 @@ expect.extend(expectJSX);
 
 let {createRenderer} = TestUtils;
 
-describe.only('Template', () => {
+describe('Template', () => {
   let renderer;
 
   beforeEach(() => {

--- a/src/css/default/_refinement-list.scss
+++ b/src/css/default/_refinement-list.scss
@@ -30,3 +30,13 @@
     /* widget footer */
   }
 }
+
+/* Sub block for the show more of the refinement list */
+@include block(showmore) {
+  @include modifier(active) {
+    /* Show more button is activated */
+  }
+  @include modifier(inactive) {
+    /* Show more button is deactivated */
+  }
+}

--- a/src/lib/__tests__/utils-test.js
+++ b/src/lib/__tests__/utils-test.js
@@ -89,10 +89,9 @@ describe('prepareTemplateProps', function() {
     bar: 'tata'
   };
   let templatesConfig = [];
-  let transformData = function() {};
+  let transformData = function() {}; // eslint-disable-line func-style
 
-  it(
-    'should return the default templates and set useCustomCompileOptions to false when using the defaults',
+  it('should return the default templates and set useCustomCompileOptions to false when using the defaults',
     function() {
       let defaultsPrepared = utils.prepareTemplateProps({
         transformData,
@@ -108,8 +107,7 @@ describe('prepareTemplateProps', function() {
     }
   );
 
-  it(
-    'should return the missing default templates and set useCustomCompileOptions to true when for the customs',
+  it('should return the missing default templates and set useCustomCompileOptions for the custom template',
     function() {
       let templates = {foo: 'baz'};
       let defaultsPrepared = utils.prepareTemplateProps({
@@ -125,6 +123,26 @@ describe('prepareTemplateProps', function() {
       expect(defaultsPrepared.templatesConfig).toBe(templatesConfig);
     }
   );
+
+  it('should add also the templates that are not in the defaults', () => {
+    const templates = {
+      foo: 'something else',
+      baz: 'Of course!'
+    };
+
+    const preparedProps = utils.prepareTemplateProps({
+      transformData,
+      defaultTemplates,
+      templates,
+      templatesConfig
+    });
+
+
+    expect(preparedProps.transformData).toBe(transformData);
+    expect(preparedProps.useCustomCompileOptions).toEqual({foo: true, bar: false, baz: true});
+    expect(preparedProps.templates).toEqual({...defaultTemplates, ...templates});
+    expect(preparedProps.templatesConfig).toBe(templatesConfig);
+  });
 });
 
 describe('getRefinements', function() {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -3,6 +3,8 @@ import forEach from 'lodash/collection/forEach';
 import find from 'lodash/collection/find';
 import get from 'lodash/object/get';
 import isEmpty from 'lodash/lang/isEmpty';
+import keys from 'lodash/object/keys';
+import uniq from 'lodash/array/uniq';
 
 let utils = {
   getContainerNode,
@@ -112,16 +114,17 @@ function prepareTemplateProps({
   };
 }
 
-function prepareTemplates(defaultTemplates, templates) {
-  return reduce(defaultTemplates, (config, defaultTemplate, key) => {
-    let isCustomTemplate = templates && templates[key] !== undefined && (templates[key] !== defaultTemplate);
-    if (isCustomTemplate) {
-      config.templates[key] = templates[key];
-      config.useCustomCompileOptions[key] = true;
-    } else {
-      config.templates[key] = defaultTemplate;
-      config.useCustomCompileOptions[key] = false;
-    }
+function prepareTemplates(defaultTemplates = [], templates = []) {
+  const allKeys = uniq([...(keys(defaultTemplates)), ...(keys(templates))]);
+
+  return reduce(allKeys, (config, key) => {
+    const defaultTemplate = defaultTemplates[key];
+    const customTemplate = templates[key];
+    const isCustomTemplate = customTemplate !== undefined && (customTemplate !== defaultTemplate);
+
+    config.templates[key] = isCustomTemplate ? customTemplate : defaultTemplate;
+    config.useCustomCompileOptions[key] = isCustomTemplate;
+
     return config;
   }, {templates: {}, useCustomCompileOptions: {}});
 }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -114,7 +114,7 @@ function prepareTemplateProps({
   };
 }
 
-function prepareTemplates(defaultTemplates = [], templates = []) {
+function prepareTemplates(defaultTemplates = {}, templates = {}) {
   const allKeys = uniq([...(keys(defaultTemplates)), ...(keys(templates))]);
 
   return reduce(allKeys, (config, key) => {

--- a/src/widgets/refinement-list/__tests__/refinement-list-test.js
+++ b/src/widgets/refinement-list/__tests__/refinement-list-test.js
@@ -292,4 +292,25 @@ describe('refinementList()', () => {
       // Then
     });
   });
+
+  context('show more', () => {
+    it('should return a configuration with the highest limit value (default value)', () => {
+      const opts = {container, attributeName: 'attributeName', limit: 1, showMore: {}};
+      const wdgt = refinementList(opts);
+      const partialConfig = wdgt.getConfiguration({});
+      expect(partialConfig.maxValuesPerFacet).toBe(100);
+    });
+
+    it('should return a configuration with the highest limit value (custom value)', () => {
+      const opts = {container, attributeName: 'attributeName', limit: 1, showMore: {limit: 99}};
+      const wdgt = refinementList(opts);
+      const partialConfig = wdgt.getConfiguration({});
+      expect(partialConfig.maxValuesPerFacet).toBe(opts.showMore.limit);
+    });
+
+    it('should not accept a show more limit that is < limit', () => {
+      const opts = {container, attributeName: 'attributeName', limit: 100, showMore: {limit: 1}};
+      expect(() => refinementList(opts)).toThrow();
+    });
+  });
 });

--- a/src/widgets/refinement-list/defaultShowMoreTemplates.js
+++ b/src/widgets/refinement-list/defaultShowMoreTemplates.js
@@ -1,0 +1,4 @@
+export default {
+  active: '<a class="ais-showmore ais-showmore__active">Show less</a>',
+  inactive: '<a class="ais-showmore ais-showmore__inactive">Show more</a>'
+};

--- a/src/widgets/refinement-list/refinement-list.js
+++ b/src/widgets/refinement-list/refinement-list.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import mapKeys from 'lodash/object/mapKeys';
 
 import utils from '../../lib/utils.js';
 let bem = utils.bemHelper('ais-refinement-list');
@@ -9,6 +10,7 @@ import autoHideContainerHOC from '../../decorators/autoHideContainer.js';
 import headerFooterHOC from '../../decorators/headerFooter.js';
 
 import defaultTemplates from './defaultTemplates.js';
+import defaultShowMoreTemplates from './defaultShowMoreTemplates.js';
 
 /**
  * Instantiate a list of refinements based on a facet
@@ -17,7 +19,12 @@ import defaultTemplates from './defaultTemplates.js';
  * @param  {string} options.attributeName Name of the attribute for faceting
  * @param  {string} [options.operator='or'] How to apply refinements. Possible values: `or`, `and`
  * @param  {string[]} [options.sortBy=['count:desc']] How to sort refinements. Possible values: `count|isRefined|name:asc|desc`
- * @param  {string} [options.limit=1000] How much facet values to get
+ * @param  {string} [options.limit=10] How much facet values to get. When the show more feature is activated this is the minimun number of facets requested (the show more button is not in active state).
+ * @param  {object|boolean} [options.showmore] pass a configuration object, or true to use the default configuration
+ * @param  {object} [options.showmore.templates] templates to use
+ * @param  {object} [options.showmore.templates.active] template used when more facets are displayed
+ * @param  {object} [options.showmore.templates.inactive] template used when less facets are displayed
+ * @param  {object} [options.showmore.limit] the max number of facets values to display when the show more feature is active
  * @param  {Object} [options.templates] Templates to use for the widget
  * @param  {string|Function} [options.templates.header] Header template
  * @param  {string|Function} [options.templates.item] Item template, provided with `name`, `count`, `isRefined`, `url` data properties
@@ -43,25 +50,32 @@ refinementList({
   attributeName,
   [ operator='or' ],
   [ sortBy=['count:desc'] ],
-  [ limit=1000 ],
-  [ cssClasses.{root,header,body,footer,list,item,active,label,checkbox,count}],
+  [ limit=10 ],
+  [ cssClasses.{root, header, body, footer, list, item, active, label, checkbox, count}],
   [ templates.{header,item,footer} ],
   [ transformData ],
-  [ autoHideContainer=true ]
+  [ autoHideContainer=true ],
+  [ showmore.{templates: {active, inactive}, limit} ]
 })`;
 function refinementList({
     container,
     attributeName,
     operator = 'or',
     sortBy = ['count:desc'],
-    limit = 1000,
+    limit = 10,
     cssClasses: userCssClasses = {},
     templates = defaultTemplates,
     transformData,
-    autoHideContainer = true
+    autoHideContainer = true,
+    showMore
   }) {
-  let RefinementList = require('../../components/RefinementList/RefinementList.js');
+  let showMoreConfig = getShowMoreConfig(showMore);
+  if (showMoreConfig && showMoreConfig.limit < limit) {
+    throw new Error('showmore.limit configuration should be > than the limit in the main configuration'); // eslint-disable-line
+  }
+  let widgetMaxValuesPerFacet = (showMoreConfig && showMoreConfig.limit) || limit;
 
+  let RefinementList = require('../../components/RefinementList/RefinementList.js'); // eslint-disable-line
   if (!container || !attributeName) {
     throw new Error(usage);
   }
@@ -80,6 +94,12 @@ function refinementList({
     }
   }
 
+  const showMoreTemplates = showMoreConfig && prefixKeys('showmore-', showMoreConfig.templates);
+  const allTemplates =
+    showMoreTemplates ?
+      {...templates, ...showMoreTemplates} :
+      templates;
+
   return {
     getConfiguration: (configuration) => {
       let widgetConfiguration = {
@@ -87,7 +107,7 @@ function refinementList({
       };
 
       let currentMaxValuesPerFacet = configuration.maxValuesPerFacet || 0;
-      widgetConfiguration.maxValuesPerFacet = Math.max(currentMaxValuesPerFacet, limit);
+      widgetConfiguration.maxValuesPerFacet = Math.max(currentMaxValuesPerFacet, widgetMaxValuesPerFacet);
 
       return widgetConfiguration;
     },
@@ -101,10 +121,10 @@ function refinementList({
         transformData,
         defaultTemplates,
         templatesConfig,
-        templates
+        templates: allTemplates
       });
 
-      let facetValues = results.getFacetValues(attributeName, {sortBy: sortBy}).slice(0, limit);
+      let facetValues = results.getFacetValues(attributeName, {sortBy: sortBy});
 
       let hasNoFacetValues = facetValues.length === 0;
 
@@ -128,7 +148,10 @@ function refinementList({
           createURL={(facetValue) => createURL(state.toggleRefinement(attributeName, facetValue))}
           cssClasses={cssClasses}
           facetValues={facetValues}
+          limitMax={widgetMaxValuesPerFacet}
+          limitMin={limit}
           shouldAutoHideContainer={hasNoFacetValues}
+          showMore={showMoreConfig !== null}
           templateProps={templateProps}
           toggleRefinement={toggleRefinement}
         />,
@@ -136,6 +159,35 @@ function refinementList({
       );
     }
   };
+}
+
+const defaultShowMoreConfig = {
+  templates: defaultShowMoreTemplates,
+  limit: 100
+};
+
+function getShowMoreConfig(showMoreOptions) {
+  if (showMoreOptions === true) {
+    return defaultShowMoreConfig;
+  } else if (showMoreOptions) {
+    let config = {...showMoreOptions};
+    if (!showMoreOptions.templates) {
+      config.templates = defaultShowMoreConfig.templates;
+    }
+    if (!showMoreOptions.limit) {
+      config.limit = defaultShowMoreConfig.limit;
+    }
+    return config;
+  }
+  return null;
+}
+
+function prefixKeys(prefix, obj) {
+  if (obj) {
+    return mapKeys(obj, function(v, k) {
+      return prefix + k;
+    });
+  }
 }
 
 export default refinementList;


### PR DESCRIPTION
The API changed slightly from the original proposition; It still adds a new object in the configuration of the refinementlist, but the attributes are : 
 - limit : for the max number of items when showing more
 - templates : 
  - active: when showing more
  - inactive: when showing less
and it reuses the currently implemented limit parameter .