### PR TITLE
fix(url-sync): Makes url sync more reliable

### DIFF
--- a/dev/app.js
+++ b/dev/app.js
@@ -5,9 +5,7 @@ var search = instantsearch({
   appId: 'latency',
   apiKey: '6be0576ff61c053d5f9a3225e2a90f76',
   indexName: 'instant_search',
-  urlSync: {
-    useHash: true
-  }
+  urlSync: true
 });
 
 search.addWidget(
@@ -281,3 +279,4 @@ search.addWidget(
 );
 
 search.start();
+

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -39,7 +39,12 @@ describe('InstantSearch lifecycle', () => {
     apiKey = 'apiKey';
     indexName = 'lifecycle';
 
-    searchParameters = {some: 'configuration', values: [-2, -1], index: indexName, another: {config: 'parameter'}};
+    searchParameters = {
+      some: 'configuration',
+      values: [-2, -1],
+      index: indexName,
+      another: {config: 'parameter'}
+    };
 
     InstantSearch.__Rewire__('algoliasearch', algoliasearch);
     InstantSearch.__Rewire__('algoliasearchHelper', algoliasearchHelper);
@@ -113,7 +118,12 @@ describe('InstantSearch lifecycle', () => {
           .toEqual([
             client,
             indexName,
-            {some: 'modified', values: [-2, -1], index: indexName, another: {different: 'parameter', config: 'parameter'}}
+            {
+              some: 'modified',
+              values: [-2, -1],
+              index: indexName,
+              another: {different: 'parameter', config: 'parameter'}
+            }
           ]);
       });
 
@@ -125,12 +135,11 @@ describe('InstantSearch lifecycle', () => {
         expect(widget.init.calledOnce).toBe(true, 'widget.init called once');
         expect(widget.init.calledAfter(widget.getConfiguration))
           .toBe(true, 'widget.init() was called after widget.getConfiguration()');
-        expect(widget.init.args[0][0]).
-          toEqual({
-            state: helper.state,
-            helper,
-            templatesConfig: search.templatesConfig
-          });
+        const args = widget.init.args[0][0];
+        expect(args.state).toBe(helper.state);
+        expect(args.helper).toBe(helper);
+        expect(args.templatesConfig).toBe(search.templatesConfig);
+        expect(args.onHistoryChange).toBe(search._onHistoryChange);
       });
 
       it('does not call widget.render', () => {

--- a/src/widgets/search-box/__tests__/search-box-test.js
+++ b/src/widgets/search-box/__tests__/search-box-test.js
@@ -24,6 +24,7 @@ describe('search-box()', () => {
   let state;
   let helper;
   let widget;
+  let onHistoryChange;
 
   beforeEach(() => {
     ReactDOM = {render: sinon.spy()};
@@ -39,6 +40,7 @@ describe('search-box()', () => {
       },
       ...EventEmitter.prototype
     };
+    onHistoryChange = function() {};
   });
 
   context('bad usage', () => {
@@ -59,14 +61,14 @@ describe('search-box()', () => {
 
     it('adds an input inside the div', () => {
       widget = searchBox(opts);
-      widget.init({state, helper});
+      widget.init({state, helper, onHistoryChange});
       let inputs = container.getElementsByTagName('input');
       expect(inputs.length).toEqual(1);
     });
 
     it('sets default HTML attribute to the input', () => {
       widget = searchBox(opts);
-      widget.init({state, helper});
+      widget.init({state, helper, onHistoryChange});
       let input = container.getElementsByTagName('input')[0];
       expect(input.getAttribute('autocapitalize')).toEqual('off');
       expect(input.getAttribute('autocomplete')).toEqual('off');
@@ -85,7 +87,7 @@ describe('search-box()', () => {
       };
 
       widget = searchBox(opts);
-      widget.init({state, helper});
+      widget.init({state, helper, onHistoryChange});
       let actualRootClasses = container.querySelector('input').parentNode.getAttribute('class');
       let actualInputClasses = container.querySelector('input').getAttribute('class');
       let expectedRootClasses = 'ais-search-box root-class';
@@ -100,7 +102,7 @@ describe('search-box()', () => {
     it('reuse the existing input', () => {
       container = createHTMLNodeFromString('<input />');
       widget = searchBox({container});
-      widget.init({state, helper});
+      widget.init({state, helper, onHistoryChange});
       expect(container.tagName).toEqual('INPUT');
       expect(container.getAttribute('autocapitalize')).toEqual('off');
       expect(container.getAttribute('autocomplete')).toEqual('off');
@@ -115,7 +117,7 @@ describe('search-box()', () => {
     it('passes HTML attributes', () => {
       container = createHTMLNodeFromString('<input id="foo" class="my-class" placeholder="Search" />');
       widget = searchBox({container});
-      widget.init({state, helper});
+      widget.init({state, helper, onHistoryChange});
       expect(container.getAttribute('id')).toEqual('foo');
       expect(container.getAttribute('class')).toEqual('my-class ais-search-box--input');
       expect(container.getAttribute('placeholder')).toEqual('Search');
@@ -124,7 +126,7 @@ describe('search-box()', () => {
     it('supports cssClasses', () => {
       container = createHTMLNodeFromString('<input class="my-class" />');
       widget = searchBox({container, cssClasses: {root: 'root-class', input: 'input-class'}});
-      widget.init({state, helper});
+      widget.init({state, helper, onHistoryChange});
 
       let actualRootClasses = container.parentNode.getAttribute('class');
       let actualInputClasses = container.getAttribute('class');
@@ -143,7 +145,7 @@ describe('search-box()', () => {
       widget = searchBox({container});
 
       // When
-      widget.init({state, helper});
+      widget.init({state, helper, onHistoryChange});
 
       // Then
       let wrapper = container.querySelectorAll('div.ais-search-box')[0];
@@ -159,7 +161,7 @@ describe('search-box()', () => {
       widget = searchBox({container});
 
       // When
-      widget.init({state, helper});
+      widget.init({state, helper, onHistoryChange});
 
       // Then
       let wrapper = container.parentNode;
@@ -172,7 +174,7 @@ describe('search-box()', () => {
       widget = searchBox({container, wrapInput: false});
 
       // When
-      widget.init({state, helper});
+      widget.init({state, helper, onHistoryChange});
 
       // Then
       let wrapper = container.querySelectorAll('div.ais-search-box');
@@ -189,13 +191,13 @@ describe('search-box()', () => {
 
     it('do not add the poweredBy if not specified', () => {
       widget = searchBox({container});
-      widget.init({state, helper});
+      widget.init({state, helper, onHistoryChange});
       expect(ReactDOM.render.notCalled).toBe(true);
     });
 
     it('add the poweredBy if specified', () => {
       widget = searchBox({container, poweredBy: true});
-      widget.init({state, helper});
+      widget.init({state, helper, onHistoryChange});
       expect(ReactDOM.render.notCalled).toBe(false);
     });
   });
@@ -212,7 +214,7 @@ describe('search-box()', () => {
       // Given
       helper.state.query = 'foo';
       // When
-      widget.init({state, helper});
+      widget.init({state, helper, onHistoryChange});
       // Then
       expect(input.addEventListener.called).toEqual(true);
       expect(input.addEventListener.args[1].length).toEqual(3);
@@ -261,7 +263,7 @@ describe('search-box()', () => {
       // Given
       helper.state.query = 'foo';
       // When
-      widget.init({state, helper});
+      widget.init({state, helper, onHistoryChange});
       // Then
       expect(input.addEventListener.called).toEqual(true);
       expect(input.addEventListener.args[0].length).toEqual(2);
@@ -304,14 +306,18 @@ describe('search-box()', () => {
     });
   });
 
-  it('updates the input on an helper update', () => {
+  it('updates the input on history update', () => {
+    let cb;
+    onHistoryChange = function(fn) {
+      cb = fn;
+    };
     container = document.createElement('div');
     widget = searchBox({container});
-    widget.init({state, helper});
+    widget.init({state, helper, onHistoryChange});
     let input = container.querySelector('input');
     expect(input.value).toBe('');
     input.blur();
-    helper.emit('change', {query: 'iphone'});
+    cb({query: 'iphone'});
     expect(input.value).toBe('iphone');
   });
 
@@ -333,7 +339,7 @@ describe('search-box()', () => {
         // Given
         helper.state.query = '';
         // When
-        widget.init({state, helper});
+        widget.init({state, helper, onHistoryChange});
         // Then
         expect(input.focus.called).toEqual(true);
       });
@@ -342,7 +348,7 @@ describe('search-box()', () => {
         // Given
         helper.state.query = 'foo';
         // When
-        widget.init({state, helper});
+        widget.init({state, helper, onHistoryChange});
         // Then
         expect(input.focus.called).toEqual(false);
       });
@@ -358,7 +364,7 @@ describe('search-box()', () => {
         // Given
         helper.state.query = '';
         // When
-        widget.init({state, helper});
+        widget.init({state, helper, onHistoryChange});
         // Then
         expect(input.focus.called).toEqual(true);
       });
@@ -367,7 +373,7 @@ describe('search-box()', () => {
         // Given
         helper.state.query = 'foo';
         // When
-        widget.init({state, helper});
+        widget.init({state, helper, onHistoryChange});
         // Then
         expect(input.focus.called).toEqual(true);
       });
@@ -383,7 +389,7 @@ describe('search-box()', () => {
         // Given
         helper.state.query = '';
         // When
-        widget.init({state, helper});
+        widget.init({state, helper, onHistoryChange});
         // Then
         expect(input.focus.called).toEqual(false);
       });
@@ -392,7 +398,7 @@ describe('search-box()', () => {
         // Given
         helper.state.query = 'foo';
         // When
-        widget.init({state, helper});
+        widget.init({state, helper, onHistoryChange});
         // Then
         expect(input.focus.called).toEqual(false);
       });

--- a/src/widgets/search-box/search-box.js
+++ b/src/widgets/search-box/search-box.js
@@ -110,7 +110,7 @@ function searchBox({
         poweredByContainer
       );
     },
-    init: function({state, helper}) {
+    init: function({state, helper, onHistoryChange}) {
       let isInputTargeted = container.tagName === 'INPUT';
       let input = this.getInput();
 
@@ -162,10 +162,8 @@ function searchBox({
       }
 
       // Update value when query change outside of the input
-      helper.on('change', function(newState) {
-        if (input !== document.activeElement && input.value !== newState.query) {
-          input.value = newState.query;
-        }
+      onHistoryChange(function(fullState) {
+        input.value = fullState.query || '';
       });
 
       if (autofocus === true || autofocus === 'auto' && helper.state.query === '') {


### PR DESCRIPTION
2 main changes here :
 - the url-sync internal widget now relies on the helper directly and
   not on the instantsearch lifecycle anymore.
 - there is dedicated channel of update for the changes coming from the
   history (private API for the moment)

FIX #730
FIX #729