### PR TITLE
docs(css): Fix example page on mobile (fix #636)

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -1,22 +1,21 @@
 <div class="spacer100 bg-white"></div>
-<footer class="site-footer">
+<footer class="site-footer container">
   <p>
     Designed and built with <i class="fa fa-heart"></i> by <a href="https://www.algolia.com/?utm_medium=social-owned&utm_source=instantsearch.js%20website&utm_campaign=homepage"><img src="{{site.baseurl}}/img/logo-algolia-dark.png" alt="Algolia" height="20"></a>
   </p>
   <div class="spacer50"></div>
+  <p>Currently v{{ site.version }}</p>
   <ul class="list-inline">
-    <li>Currently v{{ site.version }}</li>
-    <li>•</li>
-    <li>Code licensed under <a href="https://github.com/algolia/instantsearch.js/blob/master/LICENSE">MIT</a></li>
-    <li>•</li>
     <li><a href="https://github.com/algolia/instantsearch.js">GitHub</a></li>
     <li>•</li>
     <li><a href="https://github.com/algolia/instantsearch.js/issues">Issues</a></li>
     <li>•</li>
     <li><a href="https://github.com/algolia/instantsearch.js/releases">Releases</a></li>
-    <li>•</li>
-    <li>Updated {{ site.time | date: '%c' }}</li>
   </ul>
+  <div class="spacer20"></div>
+  <p>Updated {{ site.time | date: '%c' }}</p>
+  <div class="spacer20"></div>
+  <p>Code licensed under <a href="https://github.com/algolia/instantsearch.js/blob/master/LICENSE">MIT</a></p>
   <div class="spacer50"></div>
   <div class="m400 m-l-r-auto">
     {% include newsletter-mc.html %}

--- a/docs/css/_examples.scss
+++ b/docs/css/_examples.scss
@@ -1,0 +1,11 @@
+@media (max-width: 600px) {
+  .link-thumbnail {
+    width: 100%;
+  }
+}
+
+@media (max-width: 450px) {
+  .link-thumbnail {
+    text-align: center;
+  }
+}

--- a/docs/css/main.scss
+++ b/docs/css/main.scss
@@ -12,6 +12,7 @@
 
 @import "header";
 @import "home";
+@import "examples";
 @import "page";
 @import "documentation";
 @import "debug";

--- a/docs/examples.haml
+++ b/docs/examples.haml
@@ -4,7 +4,7 @@ title: Examples
 permalink: /examples/
 ---
 
-.hero
+.hero.container
   %h1.text-center Check out our examples!
   %p.text-center.lead <strong>instantsearch.js</strong> lets you build valuable search experiences.
 
@@ -13,8 +13,8 @@ permalink: /examples/
   .m800.m-l-r-auto
     .spacer40
     .demo-item.clearfix
-      %a{href: '{{ "/examples/media/" | prepend: site.baseurl }}'}
-        %img.m-b.img-thumbnail.pull-left.m-r{src: "{{ "/examples/media/capture.png" | prepend: site.baseurl }}", width: 270}
+      %a.pull-left.link-thumbnail{href: '{{ "/examples/media/" | prepend: site.baseurl }}'}
+        %img.m-b.img-thumbnail.m-r{src: "{{ "/examples/media/capture.png" | prepend: site.baseurl }}", width: 270}
       %a{href: '{{ "/examples/media/" | prepend: site.baseurl }}'}
         %h3 Media
       %p Browsing video, music and other media becomes much more intuitive with instant search.
@@ -31,8 +31,8 @@ permalink: /examples/
 
     .spacer40
     .demo-item.clearfix
-      %a{href: '{{ "/examples/e-commerce/" | prepend: site.baseurl }}'}
-        %img.m-b.img-thumbnail.pull-left.m-r{src: "{{ "/examples/e-commerce/capture.png" | prepend: site.baseurl }}", width: 270}
+      %a.pull-left.link-thumbnail{href: '{{ "/examples/e-commerce/" | prepend: site.baseurl }}'}
+        %img.m-b.img-thumbnail.m-r{src: "{{ "/examples/e-commerce/capture.png" | prepend: site.baseurl }}", width: 270}
       %a{href: '{{ "/examples/e-commerce/" | prepend: site.baseurl }}'}
         %h3 E-commerce
       %p An instant-search experience helps shoppers more easily find and buy what they want.
@@ -53,8 +53,8 @@ permalink: /examples/
 
     .spacer40
     .demo-item.clearfix
-      %a{href: '{{ "/examples/tourism/" | prepend: site.baseurl }}'}
-        %img.m-b.img-thumbnail.pull-left.m-r{src: "{{ "/examples/tourism/capture.png" | prepend: site.baseurl }}", width: 270}
+      %a.pull-left.link-thumbnail{href: '{{ "/examples/tourism/" | prepend: site.baseurl }}'}
+        %img.m-b.img-thumbnail.m-r{src: "{{ "/examples/tourism/capture.png" | prepend: site.baseurl }}", width: 270}
       %a{href: '{{ "/examples/tourism/" | prepend: site.baseurl }}'}
         %h3 Tourism
       %p Travel the world at the speed of search with instant results.


### PR DESCRIPTION
So I added breakpoints as @pixelastic suggested. If the screen is too small then the enclosing link will widen to 100%, and if the screen is even smaller the image will be centered.

Also I made sure that all the elements in the page were using the same left/right margin (container).