### PR TITLE
docs(hits): Update documentation for the `allItems` property

### DIFF
--- a/src/widgets/hits/hits.js
+++ b/src/widgets/hits/hits.js
@@ -15,11 +15,11 @@ import defaultTemplates from './defaultTemplates.js';
  * @param  {Object} [options.templates] Templates to use for the widget
  * @param  {string|Function} [options.templates.empty=''] Template to use when there are no results.
  * @param  {string|Function} [options.templates.item=''] Template to use for each result. This template will receive an object containing a single record.
- * @param  {string|Function} [options.templates.allItems=''] Template to use for each result. (can't be used with item template). This template will receive a complete SearchResults result object, this object contains the key hits that contains all the records retrieved.
+ * @param  {string|Function} [options.templates.allItems=''] Template to use for the list of all results. (Can't be used with `item` template). This template will receive a complete SearchResults result object, this object contains the key hits that contains all the records retrieved.
  * @param  {Object} [options.transformData] Method to change the object passed to the templates
- * @param  {Function} [options.transformData.empty=identity] Method used to change the object passed to the empty template
- * @param  {Function} [options.transformData.item=identity] Method used to change the object passed to the item template
- * @param  {Function} [options.transformData.allItems=identity] Method used to change the object passed to the item template
+ * @param  {Function} [options.transformData.empty=identity] Method used to change the object passed to the `empty` template
+ * @param  {Function} [options.transformData.item=identity] Method used to change the object passed to the `item` template
+ * @param  {Function} [options.transformData.allItems=identity] Method used to change the object passed to the `allItems` template
  * @param  {number} [hitsPerPage=20] The number of hits to display per page
  * @param  {Object} [options.cssClasses] CSS classes to add
  * @param  {string|string[]} [options.cssClasses.root] CSS class to add to the wrapping element


### PR DESCRIPTION
Seems like the `allItems` property for both template and transformData
was a copy-paste of the `item` one.