### PR TITLE
perf(autoHideContainer): stop re-creating React components when going from hide to show

### DIFF
--- a/functional-tests/app/app.js
+++ b/functional-tests/app/app.js
@@ -82,6 +82,7 @@ search.addWidget(
 
 search.addWidget(
   instantsearch.widgets.currentRefinedValues({
+    autoHideContainer: false,
     container: '#current-refined-values',
     cssClasses: {
       header: 'facet-title',

--- a/src/components/Slider/Slider.js
+++ b/src/components/Slider/Slider.js
@@ -22,6 +22,12 @@ class Slider extends React.Component {
   }
 
   render() {
+    if (this.props.range.min === this.props.range.max) {
+      // There's no need to try to render the Slider, it will not be usable
+      // and will throw
+      return null;
+    }
+
     // setup pips
     let pips;
     if (this.props.pips === false) {

--- a/src/components/Slider/__tests__/Slider-test.js
+++ b/src/components/Slider/__tests__/Slider-test.js
@@ -15,6 +15,7 @@ describe('Slider', () => {
   let renderer;
   let Slider;
   let Nouislider;
+  let props;
 
   beforeEach(() => {
     let {createRenderer} = TestUtils;
@@ -23,6 +24,9 @@ describe('Slider', () => {
     // need to be required AFTER jsdom has initialized global.window/navigator
     Slider = require('../Slider.js');
     Nouislider = require('react-nouislider');
+    props = {
+      range: {min: 0, max: 5000}
+    };
   });
 
 
@@ -33,17 +37,22 @@ describe('Slider', () => {
         animate={false}
         behaviour="snap"
         connect
-        cssClasses={{}}
         cssPrefix="ais-range-slider--"
         onChange={() => {}}
         pips={{density: 3, format: {to: function noRefCheck() {}}, mode: 'positions', stepped: true, values: [0, 50, 100]}}
-        templateProps={{}}
+        range={props.range}
       />
     );
   });
 
+  it('should not render anything when ranges are equal', () => {
+    props.range.min = props.range.max = 8;
+    let out = render();
+    expect(out).toEqual(null);
+  });
+
   function render() {
-    renderer.render(<Slider cssClasses={{}} templateProps={{}} />);
+    renderer.render(<Slider {...props} />);
     return renderer.getRenderOutput();
   }
 });

--- a/src/decorators/__tests__/autoHideContainer-test.js
+++ b/src/decorators/__tests__/autoHideContainer-test.js
@@ -1,36 +1,80 @@
 /* eslint-env mocha */
 
 import React from 'react';
+import ReactDOM from 'react-dom';
 import expect from 'expect';
 import TestUtils from 'react-addons-test-utils';
 import TestComponent from './TestComponent';
 import autoHideContainer from '../autoHideContainer';
+import jsdom from 'jsdom-global';
+import sinon from 'sinon';
 
 import expectJSX from 'expect-jsx';
 expect.extend(expectJSX);
 
 describe('autoHideContainer', () => {
-  let renderer;
+  beforeEach(function() {this.jsdom = jsdom();});
+  afterEach(function() {this.jsdom();});
 
-  beforeEach(() => {
-    let {createRenderer} = TestUtils;
-    renderer = createRenderer();
-  });
+  let props = {};
 
   it('should render autoHideContainer(<TestComponent />)', () => {
-    let out = render();
-    expect(out).toEqualJSX(<TestComponent />);
-  });
-
-  it('should not render autoHideContainer(<TestComponent />)', () => {
-    let out = render({shouldAutoHideContainer: true});
-    expect(out).toEqualJSX(<div />);
-  });
-
-  function render(props = {}) {
+    let {createRenderer} = TestUtils;
+    let renderer = createRenderer();
+    props.hello = 'son';
     let AutoHide = autoHideContainer(TestComponent);
     renderer.render(<AutoHide {...props} />);
-    return renderer.getRenderOutput();
-  }
-});
+    let out = renderer.getRenderOutput();
+    expect(out).toEqualJSX(<TestComponent hello="son" />);
+  });
 
+  context('props.shouldAutoHideContainer', () => {
+    let AutoHide;
+    let component;
+    let container;
+
+    beforeEach(() => {
+      AutoHide = autoHideContainer(TestComponent);
+      container = document.createElement('div');
+      props = {hello: 'mom'};
+      component = ReactDOM.render(<AutoHide {...props} />, container);
+    });
+
+    it('creates a component', () => expect(component).toExist());
+
+    it('shows the container at first', () => {
+      expect(container.style.display).toNotEqual('none');
+    });
+
+    context('when set to true', () => {
+      beforeEach(() => {
+        sinon.spy(component, 'render');
+        props.shouldAutoHideContainer = true;
+        ReactDOM.render(<AutoHide {...props} />, container);
+      });
+
+      it('hides the container', () => {
+        expect(container.style.display).toEqual('none');
+      });
+
+      it('does not call component.render()', () => {
+        expect(component.render.called).toBe(false);
+      });
+
+      context('when set back to false', () => {
+        beforeEach(() => {
+          props.shouldAutoHideContainer = false;
+          ReactDOM.render(<AutoHide {...props} />, container);
+        });
+
+        it('shows the container', () => {
+          expect(container.style.display).toNotEqual('none');
+        });
+
+        it('calls component.render()', () => {
+          expect(component.render.calledOnce).toBe(true);
+        });
+      });
+    });
+  });
+});

--- a/src/decorators/autoHideContainer.js
+++ b/src/decorators/autoHideContainer.js
@@ -11,7 +11,15 @@ function autoHideContainer(ComposedComponent) {
     }
 
     componentWillReceiveProps(nextProps) {
+      if (this.props.shouldAutoHideContainer === nextProps.shouldAutoHideContainer) {
+        return;
+      }
+
       this._hideOrShowContainer(nextProps);
+    }
+
+    shouldComponentUpdate(nextProps) {
+      return nextProps.shouldAutoHideContainer === false;
     }
 
     _hideOrShowContainer(props) {
@@ -20,10 +28,6 @@ function autoHideContainer(ComposedComponent) {
     }
 
     render() {
-      if (this.props.shouldAutoHideContainer === true) {
-        return <div />;
-      }
-
       return <ComposedComponent {...this.props} />;
     }
   }


### PR DESCRIPTION
The previous strategy for autoHideContainer was to either return an
empty div or the wrapped element.

So when the widget cycle was like this: init => hide (no results) =>
show (results) then we would re-create instances of React components because of a
different render() output in autoHideContainer.

This I discovered it while going to do #835: when the widgets would
hide => show we would lose the wrapped React component state resulting
in lost collaspable state.

Not only this commit will permit doing #835 easily but it also somehow
enhance performance since I also added a shouldComponentUpdate
strategy.

Added more precise tests on this decorator/HOC.

The slider needed an update because we are now trying to render it (once as soon as we are transitioning from hidden) with ranges being the same, we could also use shouldComponentUpdate inside the Slider that would work but not as specific than here.