### PR TITLE
feat(collapsable widgets): add collapsable and collapsed option

### DIFF
--- a/dev/app.js
+++ b/dev/app.js
@@ -122,6 +122,9 @@ search.addWidget(
 
 search.addWidget(
   instantsearch.widgets.refinementList({
+    collapsible: {
+      collapsed: true
+    },
     container: '#brands',
     attributeName: 'brand',
     operator: 'or',
@@ -133,7 +136,7 @@ search.addWidget(
       active: 'facet-active'
     },
     templates: {
-      header: 'Brands'
+      header: 'Brands with collapsible <span class="collapse-arrow"></span>'
     },
     showMore: {
       templates: {

--- a/dev/style.css
+++ b/dev/style.css
@@ -122,3 +122,21 @@ body {
 .ais-show-more__active, .ais-show-more__inactive {
   cursor: pointer;
 }
+
+.ais-header {
+  position: relative;
+}
+
+.collapse-arrow {
+  position: absolute;
+  right: 0;
+}
+
+.collapse-arrow:after {
+  content: "[-]";
+  font-family: monospace;
+}
+
+.ais-root__collapsed .collapse-arrow:after {
+  content: "[+]";
+}

--- a/src/css/_base.scss
+++ b/src/css/_base.scss
@@ -29,3 +29,11 @@
     }
   }
 }
+
+.ais-root__collapsible .ais-header {
+  cursor: pointer;
+}
+
+.ais-root__collapsed .ais-body, .ais-root__collapsed .ais-footer {
+  display: none;
+}

--- a/src/decorators/__tests__/headerFooter-test.js
+++ b/src/decorators/__tests__/headerFooter-test.js
@@ -21,6 +21,7 @@ describe('headerFooter', () => {
         root: 'root',
         body: 'body'
       },
+      collapsible: false,
       templateProps: {
       }
     };
@@ -30,8 +31,8 @@ describe('headerFooter', () => {
   it('should render the component in a root and body', () => {
     let out = render(defaultProps);
     expect(out).toEqualJSX(
-      <div className="root">
-        <div className="body">
+      <div className="ais-root root">
+        <div className="ais-body body">
           <TestComponent {...defaultProps} />
         </div>
       </div>
@@ -55,9 +56,9 @@ describe('headerFooter', () => {
       }
     };
     expect(out).toEqualJSX(
-      <div className="root">
-        <Template cssClass="ais-header" {...templateProps} />
-        <div className="body">
+      <div className="ais-root root">
+        <Template cssClass="ais-header" {...templateProps} onClick={null} />
+        <div className="ais-body body">
           <TestComponent {...defaultProps} />
         </div>
       </div>
@@ -81,11 +82,11 @@ describe('headerFooter', () => {
       }
     };
     expect(out).toEqualJSX(
-      <div className="root">
-        <div className="body">
+      <div className="ais-root root">
+        <div className="ais-body body">
           <TestComponent {...defaultProps} />
         </div>
-        <Template cssClass="ais-footer" {...templateProps} />
+        <Template cssClass="ais-footer" {...templateProps} onClick={null} />
       </div>
     );
   });

--- a/src/widgets/clear-all/__tests__/clear-all-test.js
+++ b/src/widgets/clear-all/__tests__/clear-all-test.js
@@ -57,6 +57,7 @@ describe('clearAll()', () => {
         footer: 'ais-clear-all--footer',
         link: 'ais-clear-all--link'
       },
+      collapsible: false,
       hasRefinements: false,
       shouldAutoHideContainer: true,
       templateProps: {

--- a/src/widgets/clear-all/clear-all.js
+++ b/src/widgets/clear-all/clear-all.js
@@ -33,19 +33,23 @@ let bem = bemHelper('ais-clear-all');
  * @param  {string|string[]} [options.cssClasses.body] CSS class to add to the body element
  * @param  {string|string[]} [options.cssClasses.footer] CSS class to add to the footer element
  * @param  {string|string[]} [options.cssClasses.link] CSS class to add to the link element
+ * @param  {object|boolean} [options.collapsible=false] Hide the widget body and footer when clicking on header
+ * @param  {boolean} [options.collapsible.collapsed] Initial collapsed state of a collapsible widget
  * @return {Object}
  */
 const usage = `Usage:
 clearAll({
   container,
-  [cssClasses.{root,header,body,footer,link}={}],
-  [templates.{header,link,footer}={header: '', link: 'Clear all', footer: ''}],
-  [autoHideContainer=true]
+  [ cssClasses.{root,header,body,footer,link}={} ],
+  [ templates.{header,link,footer}={header: '', link: 'Clear all', footer: ''} ],
+  [ autoHideContainer=true ],
+  [ collapsible=false ]
 })`;
 function clearAll({
     container,
     templates = defaultTemplates,
     cssClasses: userCssClasses = {},
+    collapsible = false,
     autoHideContainer = true
   } = {}) {
   if (!container) {
@@ -79,6 +83,7 @@ function clearAll({
       ReactDOM.render(
         <ClearAll
           clearAll={this._clearRefinementsAndSearch}
+          collapsible={collapsible}
           cssClasses={cssClasses}
           hasRefinements={hasRefinements}
           shouldAutoHideContainer={!hasRefinements}

--- a/src/widgets/current-refined-values/__tests__/current-refined-values-test.js
+++ b/src/widgets/current-refined-values/__tests__/current-refined-values-test.js
@@ -508,6 +508,7 @@ describe('currentRefinedValues()', () => {
           _tags: {name: '_tags'}
         },
         clearAllClick: () => {},
+        collapsible: false,
         clearAllPosition: 'after',
         clearAllURL: '#cleared',
         cssClasses: {

--- a/src/widgets/current-refined-values/current-refined-values.js
+++ b/src/widgets/current-refined-values/current-refined-values.js
@@ -60,6 +60,8 @@ let bem = bemHelper('ais-current-refined-values');
  * @param  {string}            [options.cssClasses.link] CSS classes added to the link element
  * @param  {string}            [options.cssClasses.count] CSS classes added to the count element
  * @param  {string}            [options.cssClasses.footer] CSS classes added to the footer element
+ * @param  {object|boolean} [options.collapsible=false] Hide the widget body and footer when clicking on header
+ * @param  {boolean} [options.collapsible.collapsed] Initial collapsed state of a collapsible widget
  * @return {Object}
  */
 const usage = `Usage:
@@ -71,7 +73,8 @@ currentRefinedValues({
   [ templates.{header = '', item, clearAll, footer = ''} ],
   [ transformData ],
   [ autoHideContainer = true ],
-  [ cssClasses.{root, header, body, clearAll, list, item, link, count, footer} = {} ]
+  [ cssClasses.{root, header, body, clearAll, list, item, link, count, footer} = {} ],
+  [ collapsible=false ]
 })`;
 function currentRefinedValues({
     container,
@@ -79,6 +82,7 @@ function currentRefinedValues({
     onlyListedAttributes = false,
     clearAll = 'before',
     templates = defaultTemplates,
+    collapsible = false,
     transformData,
     autoHideContainer = true,
     cssClasses: userCssClasses = {}
@@ -179,6 +183,7 @@ function currentRefinedValues({
           clearAllURL={clearAllURL}
           clearRefinementClicks={clearRefinementClicks}
           clearRefinementURLs={clearRefinementURLs}
+          collapsible={collapsible}
           cssClasses={cssClasses}
           refinements={refinements}
           shouldAutoHideContainer={shouldAutoHideContainer}

--- a/src/widgets/hierarchical-menu/__tests__/hierarchical-menu-test.js
+++ b/src/widgets/hierarchical-menu/__tests__/hierarchical-menu-test.js
@@ -218,6 +218,7 @@ describe('hierarchicalMenu()', () => {
       expect(ReactDOM.render.firstCall.args[0]).toEqualJSX(
         <RefinementList
           attributeNameKey="path"
+          collapsible={false}
           cssClasses={cssClasses}
           facetValues={[{name: 'foo', url: '#'}, {name: 'bar', url: '#'}]}
           shouldAutoHideContainer={false}

--- a/src/widgets/hierarchical-menu/hierarchical-menu.js
+++ b/src/widgets/hierarchical-menu/hierarchical-menu.js
@@ -37,6 +37,8 @@ import defaultTemplates from './defaultTemplates.js';
  * @param  {string|string[]} [options.cssClasses.active] CSS class to add to each active element
  * @param  {string|string[]} [options.cssClasses.link] CSS class to add to each link (when using the default template)
  * @param  {string|string[]} [options.cssClasses.count] CSS class to add to each count element (when using the default template)
+ * @param  {object|boolean} [options.collapsible=false] Hide the widget body and footer when clicking on header
+ * @param  {boolean} [options.collapsible.collapsed] Initial collapsed state of a collapsible widget
  * @return {Object}
  */
 const usage = `Usage:
@@ -51,7 +53,8 @@ hierarchicalMenu({
   [ cssClasses.{root , header, body, footer, list, depth, item, active, link}={} ],
   [ templates.{header, item, footer} ],
   [ transformData ],
-  [ autoHideContainer=true ]
+  [ autoHideContainer=true ],
+  [ collapsible=false ]
 })`;
 function hierarchicalMenu({
     container,
@@ -64,6 +67,7 @@ function hierarchicalMenu({
     cssClasses: userCssClasses = {},
     autoHideContainer = true,
     templates = defaultTemplates,
+    collapsible = false,
     transformData
   } = {}) {
   if (!container || !attributes || !attributes.length) {
@@ -139,6 +143,7 @@ function hierarchicalMenu({
       ReactDOM.render(
         <RefinementList
           attributeNameKey="path"
+          collapsible={collapsible}
           cssClasses={cssClasses}
           facetValues={facetValues}
           shouldAutoHideContainer={facetValues.length === 0}

--- a/src/widgets/menu/menu.js
+++ b/src/widgets/menu/menu.js
@@ -38,19 +38,22 @@ import defaultTemplates from './defaultTemplates.js';
  * @param  {string|string[]} [options.cssClasses.active] CSS class to add to each active element
  * @param  {string|string[]} [options.cssClasses.link] CSS class to add to each link (when using the default template)
  * @param  {string|string[]} [options.cssClasses.count] CSS class to add to each count element (when using the default template)
+ * @param  {object|boolean} [options.collapsible=false] Hide the widget body and footer when clicking on header
+ * @param  {boolean} [options.collapsible.collapsed] Initial collapsed state of a collapsible widget
  * @return {Object}
  */
 const usage = `Usage:
 menu({
   container,
   attributeName,
-  [sortBy],
-  [limit=10],
-  [cssClasses.{root,list,item}],
-  [templates.{header,item,footer}],
-  [transformData],
-  [autoHideContainer]
-  [showMore.{templates: {active, inactive}, limit}]
+  [ sortBy ],
+  [ limit=10 ],
+  [ cssClasses.{root,list,item} ],
+  [ templates.{header,item,footer} ],
+  [ transformData ],
+  [ autoHideContainer ],
+  [ showMore.{templates: {active, inactive}, limit} ],
+  [ collapsible=false ]
 })`;
 function menu({
     container,
@@ -59,6 +62,7 @@ function menu({
     limit = 10,
     cssClasses: userCssClasses = {},
     templates = defaultTemplates,
+    collapsible = false,
     transformData,
     autoHideContainer = true,
     showMore = false
@@ -140,6 +144,7 @@ function menu({
 
       ReactDOM.render(
         <RefinementList
+          collapsible={collapsible}
           cssClasses={cssClasses}
           facetValues={facetValues}
           limitMax={widgetMaxValuesPerFacet}

--- a/src/widgets/numeric-refinement-list/__tests__/numeric-refinement-list-test.js
+++ b/src/widgets/numeric-refinement-list/__tests__/numeric-refinement-list-test.js
@@ -114,6 +114,7 @@ describe('numericRefinementList()', () => {
         radio: 'ais-refinement-list--radio',
         root: 'ais-refinement-list root cx'
       },
+      collapsible: false,
       facetValues: [
         {attributeName: 'price', isRefined: true, name: 'All', url: '#'},
         {attributeName: 'price', end: 4, isRefined: false, name: 'less than 4', url: '#'},

--- a/src/widgets/numeric-refinement-list/numeric-refinement-list.js
+++ b/src/widgets/numeric-refinement-list/numeric-refinement-list.js
@@ -34,6 +34,8 @@ import defaultTemplates from './defaultTemplates.js';
  * @param  {string|string[]} [options.cssClasses.item] CSS class to add to each item element
  * @param  {string|string[]} [options.cssClasses.radio] CSS class to add to each radio element (when using the default template)
  * @param  {string|string[]} [options.cssClasses.active] CSS class to add to each active element
+ * @param  {object|boolean} [options.collapsible=false] Hide the widget body and footer when clicking on header
+ * @param  {boolean} [options.collapsible.collapsed] Initial collapsed state of a collapsible widget
  * @return {Object}
  */
 const usage = `Usage:
@@ -46,16 +48,18 @@ numericRefinementList({
   [ cssClasses.{root,header,body,footer,list,item,active,label,checkbox,count} ],
   [ templates.{header,item,footer} ],
   [ transformData ],
-  [ autoHideContainer ]
+  [ autoHideContainer ],
+  [ collapsible=false ]
 })`;
 function numericRefinementList({
-  container,
-  attributeName,
-  options,
-  cssClasses: userCssClasses = {},
-  templates = defaultTemplates,
-  transformData,
-  autoHideContainer = true
+    container,
+    attributeName,
+    options,
+    cssClasses: userCssClasses = {},
+    templates = defaultTemplates,
+    collapsible = false,
+    transformData,
+    autoHideContainer = true
   }) {
   if (!container || !attributeName || !options) {
     throw new Error(usage);
@@ -102,6 +106,7 @@ function numericRefinementList({
 
       ReactDOM.render(
         <RefinementList
+          collapsible={collapsible}
           cssClasses={cssClasses}
           facetValues={facetValues}
           shouldAutoHideContainer={results.nbHits === 0}

--- a/src/widgets/price-ranges/__tests__/price-ranges-test.js
+++ b/src/widgets/price-ranges/__tests__/price-ranges-test.js
@@ -103,6 +103,7 @@ describe('priceRanges()', () => {
           root: 'ais-price-ranges root cx',
           separator: 'ais-price-ranges--separator'
         },
+        collapsible: false,
         shouldAutoHideContainer: false,
         facetValues: generateRanges(results.getFacetStats()).map(facetValue => {
           facetValue.url = '#createURL';

--- a/src/widgets/price-ranges/price-ranges.js
+++ b/src/widgets/price-ranges/price-ranges.js
@@ -39,6 +39,8 @@ import cx from 'classnames';
  * @param  {string|string[]} [options.cssClasses.separator] CSS class to add to the separator of the form
  * @param  {string|string[]} [options.cssClasses.button] CSS class to add to the submit button of the form
  * @param  {string|string[]} [options.cssClasses.footer] CSS class to add to the footer element
+ * @param  {object|boolean} [options.collapsible=false] Hide the widget body and footer when clicking on header
+ * @param  {boolean} [options.collapsible.collapsed] Initial collapsed state of a collapsible widget
  * @return {Object}
  */
 const usage = `Usage:
@@ -49,13 +51,15 @@ priceRanges({
   [ cssClasses.{root,header,body,list,item,active,link,form,label,input,currency,separator,button,footer} ],
   [ templates.{header,item,footer} ],
   [ labels.{currency,separator,button} ],
-  [ autoHideContainer=true ]
+  [ autoHideContainer=true ],
+  [ collapsible=false ]
 })`;
 function priceRanges({
     container,
     attributeName,
     cssClasses: userCssClasses = {},
     templates = defaultTemplates,
+    collapsible = false,
     labels: userLabels = {},
     currency = '$',
     autoHideContainer = true
@@ -179,6 +183,7 @@ function priceRanges({
 
       ReactDOM.render(
         <PriceRanges
+          collapsible={collapsible}
           cssClasses={cssClasses}
           currency={currency}
           facetValues={facetValues}

--- a/src/widgets/range-slider/__tests__/range-slider-test.js
+++ b/src/widgets/range-slider/__tests__/range-slider-test.js
@@ -80,6 +80,7 @@ describe('rangeSlider()', () => {
           body: 'ais-range-slider--body',
           footer: 'ais-range-slider--footer'
         },
+        collapsible: false,
         onChange: () => {},
         pips: true,
         range: {max: 0, min: 0},
@@ -131,6 +132,7 @@ describe('rangeSlider()', () => {
           body: 'ais-range-slider--body',
           footer: 'ais-range-slider--footer'
         },
+        collapsible: false,
         onChange: () => {},
         pips: true,
         range: {max: 65, min: 65},
@@ -203,6 +205,7 @@ describe('rangeSlider()', () => {
           body: 'ais-range-slider--body',
           footer: 'ais-range-slider--footer'
         },
+        collapsible: false,
         onChange: () => {},
         pips: true,
         range: {max: 5000, min: 1},

--- a/src/widgets/range-slider/range-slider.js
+++ b/src/widgets/range-slider/range-slider.js
@@ -32,6 +32,8 @@ let defaultTemplates = {
  * @param  {string|string[]} [options.cssClasses.header] CSS class to add to the header element
  * @param  {string|string[]} [options.cssClasses.body] CSS class to add to the body element
  * @param  {string|string[]} [options.cssClasses.footer] CSS class to add to the footer element
+ * @param  {object|boolean} [options.collapsible=false] Hide the widget body and footer when clicking on header
+ * @param  {boolean} [options.collapsible.collapsed] Initial collapsed state of a collapsible widget
  * @return {Object}
  */
 const usage = `Usage:
@@ -43,7 +45,8 @@ rangeSlider({
   [ cssClasses.{root, header, body, footer} ],
   [ step=1 ],
   [ pips=true ],
-  [ autoHideContainer=true ]
+  [ autoHideContainer=true ],
+  [ collapsible=false ]
 });
 `;
 function rangeSlider({
@@ -51,6 +54,7 @@ function rangeSlider({
     attributeName,
     tooltips = true,
     templates = defaultTemplates,
+    collapsible = false,
     cssClasses: userCssClasses = {},
     step = 1,
     pips = true,
@@ -133,6 +137,7 @@ function rangeSlider({
 
       ReactDOM.render(
         <Slider
+          collapsible={collapsible}
           cssClasses={cssClasses}
           onChange={this._refine.bind(this, helper, stats)}
           pips={pips}

--- a/src/widgets/refinement-list/refinement-list.js
+++ b/src/widgets/refinement-list/refinement-list.js
@@ -41,6 +41,8 @@ import defaultTemplates from './defaultTemplates.js';
  * @param  {string|string[]} [options.cssClasses.label] CSS class to add to each label element (when using the default template)
  * @param  {string|string[]} [options.cssClasses.checkbox] CSS class to add to each checkbox element (when using the default template)
  * @param  {string|string[]} [options.cssClasses.count] CSS class to add to each count element (when using the default template)
+ * @param  {object|boolean} [options.collapsible=false] Hide the widget body and footer when clicking on header
+ * @param  {boolean} [options.collapsible.collapsed] Initial collapsed state of a collapsible widget
  * @return {Object}
  */
 const usage = `Usage:
@@ -54,7 +56,9 @@ refinementList({
   [ templates.{header,item,footer} ],
   [ transformData ],
   [ autoHideContainer=true ],
-  [ showMore.{templates: {active, inactive}, limit} ]
+  [ collapsible=false ],
+  [ showMore.{templates: {active, inactive}, limit} ],
+  [ collapsible=false ]
 })`;
 function refinementList({
     container,
@@ -64,6 +68,7 @@ function refinementList({
     limit = 10,
     cssClasses: userCssClasses = {},
     templates = defaultTemplates,
+    collapsible = false,
     transformData,
     autoHideContainer = true,
     showMore = false
@@ -145,6 +150,7 @@ function refinementList({
 
       ReactDOM.render(
         <RefinementList
+          collapsible={collapsible}
           cssClasses={cssClasses}
           facetValues={facetValues}
           limitMax={widgetMaxValuesPerFacet}

--- a/src/widgets/star-rating/__tests__/star-rating-test.js
+++ b/src/widgets/star-rating/__tests__/star-rating-test.js
@@ -81,6 +81,7 @@ describe('starRating()', () => {
         emptyStar: 'ais-star-rating--star__empty',
         root: 'ais-star-rating'
       },
+      collapsible: false,
       facetValues: [
         {isRefined: false, stars: [true, true, true, true, false], count: 0, name: '4', labels: defaultLabels, url: '#'},
         {isRefined: false, stars: [true, true, true, false, false], count: 0, name: '3', labels: defaultLabels, url: '#'},

--- a/src/widgets/star-rating/star-rating.js
+++ b/src/widgets/star-rating/star-rating.js
@@ -20,7 +20,8 @@ starRating({
   [ templates.{header,item,footer} ],
   [ labels.{andUp} ],
   [ transformData ],
-  [ autoHideContainer=true ]
+  [ autoHideContainer=true ],
+  [ collapsible=false ]
 })`;
 
 /**
@@ -50,17 +51,20 @@ starRating({
  * @param  {string|string[]} [options.cssClasses.star] CSS class to add to each star element (when using the default template)
  * @param  {string|string[]} [options.cssClasses.emptyStar] CSS class to add to each empty star element (when using the default template)
  * @param  {string|string[]} [options.cssClasses.active] CSS class to add to each active element
+ * @param  {object|boolean} [options.collapsible=false] Hide the widget body and footer when clicking on header
+ * @param  {boolean} [options.collapsible.collapsed] Initial collapsed state of a collapsible widget
  * @return {Object}
  */
 function starRating({
-  container,
-  attributeName,
-  max = 5,
-  cssClasses: userCssClasses = {},
-  labels = defaultLabels,
-  templates = defaultTemplates,
-  transformData,
-  autoHideContainer = true
+    container,
+    attributeName,
+    max = 5,
+    cssClasses: userCssClasses = {},
+    labels = defaultLabels,
+    templates = defaultTemplates,
+    collapsible = false,
+    transformData,
+    autoHideContainer = true
   }) {
   let containerNode = utils.getContainerNode(container);
   let RefinementList = headerFooterHOC(require('../../components/RefinementList/RefinementList.js'));
@@ -142,6 +146,7 @@ function starRating({
 
       ReactDOM.render(
         <RefinementList
+          collapsible={collapsible}
           cssClasses={cssClasses}
           facetValues={facetValues}
           shouldAutoHideContainer={results.nbHits === 0}

--- a/src/widgets/stats/__tests__/stats-test.js
+++ b/src/widgets/stats/__tests__/stats-test.js
@@ -68,6 +68,7 @@ describe('stats()', () => {
         root: 'ais-stats',
         time: 'ais-stats--time'
       },
+      collapsible: false,
       hitsPerPage: 2,
       nbHits: 20,
       nbPages: 10,

--- a/src/widgets/stats/stats.js
+++ b/src/widgets/stats/stats.js
@@ -39,6 +39,7 @@ function stats({
     cssClasses: userCssClasses = {},
     autoHideContainer = true,
     templates = defaultTemplates,
+    collapsible = false,
     transformData
   } = {}) {
   if (!container) throw new Error(usage);
@@ -74,6 +75,7 @@ function stats({
     render: function({results}) {
       ReactDOM.render(
         <Stats
+          collapsible={collapsible}
           cssClasses={cssClasses}
           hitsPerPage={results.hitsPerPage}
           nbHits={results.nbHits}

--- a/src/widgets/toggle/__tests__/toggle-test.js
+++ b/src/widgets/toggle/__tests__/toggle-test.js
@@ -115,6 +115,7 @@ describe('toggle()', () => {
             checkbox: 'ais-toggle--checkbox',
             count: 'ais-toggle--count'
           },
+          collapsible: false,
           templateProps,
           toggleRefinement: function() {}
         };

--- a/src/widgets/toggle/toggle.js
+++ b/src/widgets/toggle/toggle.js
@@ -42,6 +42,8 @@ import defaultTemplates from './defaultTemplates.js';
  * @param  {string|string[]} [options.cssClasses.checkbox] CSS class to add to each
  * checkbox element (when using the default template)
  * @param  {string|string[]} [options.cssClasses.count] CSS class to add to each count
+ * @param  {object|boolean} [options.collapsible=false] Hide the widget body and footer when clicking on header
+ * @param  {boolean} [options.collapsible.collapsed] Initial collapsed state of a collapsible widget
  * @return {Object}
  */
 const usage = `Usage:
@@ -53,7 +55,8 @@ toggle({
   [ cssClasses.{root,header,body,footer,list,item,active,label,checkbox,count} ],
   [ templates.{header,item,footer} ],
   [ transformData ],
-  [ autoHideContainer=true ]
+  [ autoHideContainer=true ],
+  [ collapsible=false ]
 })`;
 function toggle({
     container,
@@ -61,6 +64,7 @@ function toggle({
     label,
     values: userValues = {on: true, off: undefined},
     templates = defaultTemplates,
+    collapsible = false,
     cssClasses: userCssClasses = {},
     transformData,
     autoHideContainer = true
@@ -146,6 +150,7 @@ function toggle({
 
       ReactDOM.render(
         <RefinementList
+          collapsible={collapsible}
           cssClasses={cssClasses}
           facetValues={[facetValue]}
           shouldAutoHideContainer={results.nbHits === 0}


### PR DESCRIPTION
Demo:

![demo](https://cloud.githubusercontent.com/assets/123822/13190726/48f59176-d75f-11e5-95c1-00bbed3e7b0c.gif)

All `header` capable widgets are now collapsable aware.

New options:
- collapsable: Hide the widget body and footer when clicking on header
- collapsed: Initialize the widget in collapsed state

This also adds:
- ais-root generic css class
- ais-body generic css class

To be in par with already existing ais-header, ais-footer.

This also adds:
- ais-root__collapsable css class
- ais-root__collapsed css class