### PR TITLE
(docs): fix link to full documentation for Ion.RangeSlider

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1047,7 +1047,7 @@ Provides [Ion.RangeSlider](https://github.com/IonDen/ion.rangeSlider) as a widge
 **Widget demo**:
 <img src="{{site.baseurl}}/img/ionRangeSlider.gif" width="100%" />
 
-See the [full documentation](https://github.com/instantsearch/instantsearch-googlemaps#readme).
+See the [full documentation](https://github.com/instantsearch/instantsearch-ion.rangeSlider#readme).
 
 ## Templates
 


### PR DESCRIPTION
Link was incorrectly pointing to documentation for the googleMaps widget.