### PR TITLE
feat(instantsearch): allow overriding the helper.search function

### DIFF
--- a/dev/app.js
+++ b/dev/app.js
@@ -302,10 +302,6 @@ search.addWidget(
   })
 );
 
-search.once('render', function() {
-  document.querySelector('.search').className = 'row search search--visible';
-});
-
 search.addWidget(
   instantsearch.widgets.priceRanges({
     container: '#price-ranges',
@@ -337,6 +333,11 @@ search.addWidget(
     ]
   })
 );
+
+search.once('render', function() {
+  [...document.querySelectorAll('.smooth-search--hidden')]
+    .forEach(element => element.classList.remove('smooth-search--hidden'));
+});
 
 search.start();
 

--- a/dev/index.html
+++ b/dev/index.html
@@ -19,8 +19,8 @@
       <h1><a href="./">Instant search demo</a> <small>using instantsearch.js</small></h1>
     </div>
 
-    <div class="row search search--hidden">
-      <div class="col-md-3">
+    <div class="row">
+      <div class="col-md-3 smooth-search smooth-search--hidden">
         <div class="facet" id="current-refined-values"></div>
         <div class="facet" id="hierarchical-categories"></div>
         <div class="facet" id="brands"></div>
@@ -38,40 +38,42 @@
         <div class="form-group">
           <input id="search-box" class="form-control" />
         </div>
-        <div class="row">
-          <div class="col-md-3">
-            <div id="stats"></div>
-          </div>
-          <div class="col-md-3 text-right">
-            <div class="form-inline">
-              <div class="form-group">
-                <label for="hits-per-page-select">Show:</label>
-                <span id="hits-per-page-selector"></span>
+        <div class="smooth-search smooth-search--hidden">
+          <div class="row">
+            <div class="col-md-3">
+              <div id="stats"></div>
+            </div>
+            <div class="col-md-3 text-right">
+              <div class="form-inline">
+                <div class="form-group">
+                  <label for="hits-per-page-select">Show:</label>
+                  <span id="hits-per-page-selector"></span>
+                </div>
+              </div>
+            </div>
+            <div class="col-md-3 text-right">
+              <div class="form-inline">
+                <div class="form-group">
+                  <label for="sort-by-selector-select">Popularity:</label>
+                  <span id="popularity-selector"></span>
+                </div>
+              </div>
+            </div>
+            <div class="col-md-3 text-right">
+              <div class="form-inline">
+                <div class="form-group">
+                  <label for="sort-by-selector-select">Sort by:</label>
+                  <span id="sort-by-selector"></span>
+                </div>
               </div>
             </div>
           </div>
-          <div class="col-md-3 text-right">
-            <div class="form-inline">
-              <div class="form-group">
-                <label for="sort-by-selector-select">Popularity:</label>
-                <span id="popularity-selector"></span>
-              </div>
-            </div>
-          </div>
-          <div class="col-md-3 text-right">
-            <div class="form-inline">
-              <div class="form-group">
-                <label for="sort-by-selector-select">Sort by:</label>
-                <span id="sort-by-selector"></span>
-              </div>
-            </div>
-          </div>
+          <h3>Results overview</h3>
+          <div id="hits-table"></div>
+          <h3>Results</h3>
+          <div id="hits"></div>
+          <div id="pagination" class="text-center"></div>
         </div>
-        <h3>Results overview</h3>
-        <div id="hits-table"></div>
-        <h3>Results</h3>
-        <div id="hits"></div>
-        <div id="pagination" class="text-center"></div>
       </div>
     </div>
   </div>

--- a/dev/style.css
+++ b/dev/style.css
@@ -8,16 +8,12 @@ body {
   padding: 2em 0;
 }
 
-.search {
+.smooth-search {
   transition: opacity 200ms;
 }
 
-.search--hidden {
+.smooth-search--hidden {
   opacity: 0;
-}
-
-.search--visible {
-
 }
 
 /* Hits widget */


### PR DESCRIPTION
add a new option to the instantsearch: searchFunction. It allows user
to override the default call to helper.search() by anything they want.

With this, they will be able to implement:
- do not search at first render
- do not search when query < 3 chars
- any conditional we cannot think of

Example usages:

```js
var search = instantsearch({
  searchFunction(helper) {
    if (initialRender) {
      initialRender = false;
      return;
    }

    if (helper.state.query.length < 3) {
      return;
    }

    helper.search();
  }
})
```