### PR TITLE
fix(menu,refinementList): sort by count AND name to avoid reorders on refine

### DIFF
--- a/src/widgets/menu/menu.js
+++ b/src/widgets/menu/menu.js
@@ -20,7 +20,7 @@ let bem = bemHelper('ais-menu');
  * @function menu
  * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
  * @param  {string} options.attributeName Name of the attribute for faceting
- * @param  {string[]|Function} [options.sortBy=['count:desc']] How to sort refinements. Possible values: `count|isRefined|name:asc|desc`
+ * @param  {string[]|Function} [options.sortBy=['count:desc', 'name:asc']] How to sort refinements. Possible values: `count|isRefined|name:asc|desc`
  * @param  {string} [options.limit=10] How many facets values to retrieve
  * @param  {object|boolean} [options.showMore=false] Limit the number of results and display a showMore button
  * @param  {object} [options.showMore.templates] Templates to use for showMore
@@ -51,7 +51,7 @@ const usage = `Usage:
 menu({
   container,
   attributeName,
-  [ sortBy ],
+  [ sortBy=['count:desc', 'name:asc'] ],
   [ limit=10 ],
   [ cssClasses.{root,list,item} ],
   [ templates.{header,item,footer} ],
@@ -63,7 +63,7 @@ menu({
 function menu({
     container,
     attributeName,
-    sortBy = ['count:desc'],
+    sortBy = ['count:desc', 'name:asc'],
     limit = 10,
     cssClasses: userCssClasses = {},
     templates = defaultTemplates,

--- a/src/widgets/refinement-list/refinement-list.js
+++ b/src/widgets/refinement-list/refinement-list.js
@@ -20,7 +20,7 @@ let bem = bemHelper('ais-refinement-list');
  * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
  * @param  {string} options.attributeName Name of the attribute for faceting
  * @param  {string} [options.operator='or'] How to apply refinements. Possible values: `or`, `and`
- * @param  {string[]|Function} [options.sortBy=['count:desc']] How to sort refinements. Possible values: `count|isRefined|name:asc|desc`
+ * @param  {string[]|Function} [options.sortBy=['count:desc', 'name:asc']] How to sort refinements. Possible values: `count|isRefined|name:asc|desc`
  * @param  {string} [options.limit=10] How much facet values to get. When the show more feature is activated this is the minimun number of facets requested (the show more button is not in active state).
  * @param  {object|boolean} [options.showMore=false] Limit the number of results and display a showMore button
  * @param  {object} [options.showMore.templates] Templates to use for showMore
@@ -53,7 +53,7 @@ refinementList({
   container,
   attributeName,
   [ operator='or' ],
-  [ sortBy=['count:desc'] ],
+  [ sortBy=['count:desc', 'name:asc'] ],
   [ limit=10 ],
   [ cssClasses.{root, header, body, footer, list, item, active, label, checkbox, count}],
   [ templates.{header,item,footer} ],
@@ -67,7 +67,7 @@ function refinementList({
     container,
     attributeName,
     operator = 'or',
-    sortBy = ['count:desc'],
+    sortBy = ['count:desc', 'name:asc'],
     limit = 10,
     cssClasses: userCssClasses = {},
     templates = defaultTemplates,


### PR DESCRIPTION
This should be a non breaking change since we are ranking the same way as before but on cases where we have same counts, we rank by name