### PR TITLE
docs(toggle): refresh the widget description

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -673,6 +673,7 @@ The attribute defined in `attributeName` must be defined as an
 
 <img class="widget-icon pull-left" src="../img/icon-widget-toggle.svg">
 This widget provides an on/off filtering feature based on an attribute value.
+Note that if you provide an "off" option, it will be refined at initialization.
 {:.description}
 
 <div class="code-box">

--- a/src/widgets/toggle/toggle.js
+++ b/src/widgets/toggle/toggle.js
@@ -13,8 +13,6 @@ import defaultTemplates from './defaultTemplates.js';
 
 /**
  * Instantiate the toggling of a boolean facet filter on and off.
- * Note that it will not toggle between `true` and `false, but between `true`
- * and `undefined`.
  * @function toggle
  * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
  * @param  {string} options.attributeName Name of the attribute for faceting (eg. "free_shipping")


### PR DESCRIPTION
When we updated the toggle widget to provide on/off values, we didn't properly document the update.
Related to http://stackoverflow.com/questions/35750620/setting-initial-facet-refinement-values-when-using-instantsearch-js .