### PR TITLE
fix(lodash): stop leaking lodash in the global scope

### DIFF
--- a/src/components/CurrentRefinedValues/CurrentRefinedValues.js
+++ b/src/components/CurrentRefinedValues/CurrentRefinedValues.js
@@ -5,7 +5,7 @@ import Template from '../Template.js';
 import {isSpecialClick} from '../../lib/utils.js';
 import map from 'lodash/collection/map';
 import cloneDeep from 'lodash/lang/cloneDeep';
-import {isEqual} from 'lodash';
+import isEqual from 'lodash/lang/isEqual';
 
 class CurrentRefinedValues extends React.Component {
   shouldComponentUpdate(nextProps) {

--- a/src/components/Hits.js
+++ b/src/components/Hits.js
@@ -3,7 +3,7 @@ import map from 'lodash/collection/map';
 
 import Template from './Template.js';
 
-import {isEqual} from 'lodash';
+import isEqual from 'lodash/lang/isEqual';
 
 class Hits extends React.Component {
   shouldComponentUpdate(nextProps) {

--- a/src/components/Pagination/PaginationLink.js
+++ b/src/components/Pagination/PaginationLink.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {isEqual} from 'lodash';
+import isEqual from 'lodash/lang/isEqual';
 
 class PaginationLink extends React.Component {
   componentWillMount() {

--- a/src/components/PriceRanges/PriceRanges.js
+++ b/src/components/PriceRanges/PriceRanges.js
@@ -3,7 +3,7 @@ import React from 'react';
 import Template from '../Template.js';
 import PriceRangesForm from './PriceRangesForm.js';
 import cx from 'classnames';
-import {isEqual} from 'lodash';
+import isEqual from 'lodash/lang/isEqual';
 
 class PriceRanges extends React.Component {
   componentWillMount() {

--- a/src/components/RefinementList/RefinementList.js
+++ b/src/components/RefinementList/RefinementList.js
@@ -4,7 +4,7 @@ import {isSpecialClick} from '../../lib/utils.js';
 
 import Template from '../Template.js';
 import RefinementListItem from './RefinementListItem.js';
-import {isEqual} from 'lodash';
+import isEqual from 'lodash/lang/isEqual';
 
 class RefinementList extends React.Component {
   constructor(props) {

--- a/src/components/RefinementList/RefinementListItem.js
+++ b/src/components/RefinementList/RefinementListItem.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import Template from '../Template.js';
-import {isEqual} from 'lodash';
+import isEqual from 'lodash/lang/isEqual';
 
 class RefinementListItem extends React.Component {
   componentWillMount() {

--- a/src/components/Slider/Slider.js
+++ b/src/components/Slider/Slider.js
@@ -4,7 +4,7 @@ import Nouislider from 'react-nouislider';
 
 let cssPrefix = 'ais-range-slider--';
 
-import {isEqual} from 'lodash';
+import isEqual from 'lodash/lang/isEqual';
 
 class Slider extends React.Component {
   componentWillMount() {

--- a/src/components/Template.js
+++ b/src/components/Template.js
@@ -8,7 +8,7 @@ import mapValues from 'lodash/object/mapValues';
 
 import hogan from 'hogan.js';
 
-import {isEqual} from 'lodash';
+import isEqual from 'lodash/lang/isEqual';
 
 class Template extends React.Component {
   constructor(props) {

--- a/src/lib/__tests__/main-test.js
+++ b/src/lib/__tests__/main-test.js
@@ -3,7 +3,7 @@
 import expect from 'expect';
 import jsdom from 'jsdom-global';
 import instantsearch from '../main.js';
-import {forEach} from 'lodash';
+import forEach from 'lodash/collection/forEach';
 
 describe('instantsearch()', () => {
   beforeEach(function() {this.jsdom = jsdom();});


### PR DESCRIPTION
Using import {forEach} from 'lodash'; seems not supported in lodash 3:
the function is imported but also the whole lodash code is exposed and
erase the `window._`.

Not good!

This is a hotfix