### PR TITLE
feat(validate-pr): Allow `docs()` commits to be merged in master

### DIFF
--- a/scripts/validate-pr-done-on-develop.sh
+++ b/scripts/validate-pr-done-on-develop.sh
@@ -2,18 +2,26 @@
 
 set -e # exit when error
 
-COMMIT_MSG=`git log --format=%B --no-merges -n 1`
+COMMIT_MSG=$(git log --format=%B --no-merges -n 1)
+[[ "$COMMIT_MSG" =~ hotfix ]] && is_hotfix=1 || is_hotfix=0
+[[ "$COMMIT_MSG" =~ /^docs/ ]] && is_doc=1 || is_doc=0
+[[ "$TRAVIS_PULL_REQUEST" == false ]] && is_travis=1 || is_travis=0
+[[ "$TRAVIS_BRANCH" == master ]] && is_master=1 || is_master=0
+[[ "$TRAVIS_BRANCH" != develop ]] && is_develop=1 || is_develop=0
 
-if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-  MSG="No need to check pull request done on develop branch when not in a pull request"
-  EXIT=0
-elif [[ "$COMMIT_MSG" =~ "hotfix" ]] && [ "$TRAVIS_BRANCH" == 'master' ]; then
-  MSG="Hotfix submitted to master, good"
-  EXIT=0
-elif [ "$TRAVIS_BRANCH" != 'develop' ]; then
-  MSG="Pull request must be done on develop branch"
-  EXIT=1
+if [[ $is_travis == 0 ]]; then
+  echo "No need to check pull request done on develop branch when not in a pull request"
+  exit 0
 fi
 
-echo $MSG;
-exit $EXIT;
+if [[ ($is_hotfix == 1 || $is_doc == 1) && $is_master == 1 ]]; then
+  echo "Hotfix submitted to master, good"
+  exit 0
+fi
+
+if [[ $is_develop == 0 ]]; then
+  echo "Pull request must be done on develop branch"
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
I've added the possibility to push `docs()` commits when doing a PR to
master. Previously only messages containing the word `hotfix` could
pass the test. This should allow us more flexibility in fixing
documentation issues.

The public website is automatically build whenever a new commit lands
on master.

I've also refactored the file to follow linting advice from
`shellcheck` and make the three tests (hopefully) more readable.