### PR TITLE
fix(Template): stop leaking `data="[object Object]"` attributes in production

### DIFF
--- a/src/components/Hits.js
+++ b/src/components/Hits.js
@@ -4,6 +4,7 @@ import map from 'lodash/collection/map';
 import Template from './Template.js';
 
 import isEqual from 'lodash/lang/isEqual';
+import cx from 'classnames';
 
 class Hits extends React.Component {
   shouldComponentUpdate(nextProps) {
@@ -16,9 +17,9 @@ class Hits extends React.Component {
     let renderedHits = map(this.props.results.hits, hit => {
       return (
         <Template
-          cssClass={this.props.cssClasses.item}
           data={hit}
           key={hit.objectID}
+          rootProps={{className: this.props.cssClasses.item}}
           templateKey="item"
           {...this.props.templateProps}
         />
@@ -31,8 +32,8 @@ class Hits extends React.Component {
   renderAllResults() {
     return (
       <Template
-        cssClass={this.props.cssClasses.allItems}
         data={this.props.results}
+        rootProps={{className: this.props.cssClasses.allItems}}
         templateKey="allItems"
         {...this.props.templateProps}
       />
@@ -40,11 +41,10 @@ class Hits extends React.Component {
   }
 
   renderNoResults() {
-    let className = this.props.cssClasses.root + ' ' + this.props.cssClasses.empty;
     return (
       <Template
-        cssClass={className}
         data={this.props.results}
+        rootProps={{className: cx(this.props.cssClasses.root, this.props.cssClasses.empty)}}
         templateKey="empty"
         {...this.props.templateProps}
       />

--- a/src/components/RefinementList/RefinementList.js
+++ b/src/components/RefinementList/RefinementList.js
@@ -13,6 +13,7 @@ class RefinementList extends React.Component {
       isShowMoreOpen: false
     };
     this.handleItemClick = this.handleItemClick.bind(this);
+    this.handleClickShowMore = this.handleClickShowMore.bind(this);
   }
 
   shouldComponentUpdate(nextProps, nextState) {
@@ -129,7 +130,7 @@ class RefinementList extends React.Component {
     const showMoreBtn =
       this.props.showMore ?
         <Template
-          onClick={() => this.handleClickShowMore()}
+          rootProps={{onClick: this.handleClickShowMore}}
           templateKey={'show-more-' + (this.state.isShowMoreOpen ? 'active' : 'inactive')}
           {...this.props.templateProps}
         /> :

--- a/src/components/Template.js
+++ b/src/components/Template.js
@@ -2,8 +2,6 @@ import React from 'react';
 
 import curry from 'lodash/function/curry';
 import cloneDeep from 'lodash/lang/cloneDeep';
-import keys from 'lodash/object/keys';
-import omit from 'lodash/object/omit';
 import mapValues from 'lodash/object/mapValues';
 
 import hogan from 'hogan.js';
@@ -37,12 +35,10 @@ class Template extends React.Component {
       return null;
     }
 
-    const otherProps = omit(this.props, keys(Template.propTypes));
-
     if (React.isValidElement(content)) {
       return (
         <div
-          {...otherProps}
+          {...this.props.rootProps}
           className={this.props.cssClass}
         >{content}</div>
       );
@@ -50,7 +46,7 @@ class Template extends React.Component {
 
     return (
       <div
-        {...otherProps}
+        {...this.props.rootProps}
         className={this.props.cssClass}
         dangerouslySetInnerHTML={{__html: content}}
       />

--- a/src/components/__tests__/Hits-test.js
+++ b/src/components/__tests__/Hits-test.js
@@ -43,15 +43,15 @@ describe('Hits', () => {
     expect(out).toEqualJSX(
       <div className="custom-root">
         <Template
-          cssClass="custom-item"
           data={results.hits[0]}
           key={results.hits[0].objectID}
+          rootProps={{className: 'custom-item'}}
           templateKey="item"
         />
         <Template
-          cssClass="custom-item"
           data={results.hits[1]}
           key={results.hits[1].objectID}
+          rootProps={{className: 'custom-item'}}
           templateKey="item"
         />
       </div>
@@ -86,8 +86,8 @@ describe('Hits', () => {
 
     expect(out).toEqualJSX(
       <Template
-        cssClass="custom-item"
         data={results}
+        rootProps={{className: 'custom-item'}}
         templateKey="allItems"
         {...templateProps2}
       />
@@ -111,8 +111,8 @@ describe('Hits', () => {
 
     expect(out).toEqualJSX(
       <Template
-        cssClass="custom-root custom-empty"
         data={results}
+        rootProps={{className: 'custom-root custom-empty'}}
         templateKey="empty"
       />
     );

--- a/src/components/__tests__/Template-test.js
+++ b/src/components/__tests__/Template-test.js
@@ -78,9 +78,6 @@ describe('Template', () => {
   });
 
   describe('using helpers', () => {
-    beforeEach(() => {
-    });
-
     it('call the relevant function', () => {
       const props = getProps({
         templates: {test: 'it supports {{#helpers.emphasis}}{{feature}}{{/helpers.emphasis}}'},
@@ -216,21 +213,19 @@ describe('Template', () => {
     });
   });
 
-  describe('misc feature', () => {
-    it('accepts props that are not defined in the proptypes', () => {
-      function fn() {}
+  it('forward rootProps to the first node', () => {
+    function fn() {}
 
-      const props = getProps({});
-      renderer.render(<Template onClick={fn} {...props}/>);
+    const props = getProps({});
+    renderer.render(<Template rootProps={{onClick: fn}} {...props}/>);
 
-      const out = renderer.getRenderOutput();
-      const expectedProps = {
-        className: undefined,
-        dangerouslySetInnerHTML: {__html: ''},
-        onClick: fn
-      };
-      expect(out).toEqualJSX(<div {...expectedProps}></div>);
-    });
+    const out = renderer.getRenderOutput();
+    const expectedProps = {
+      className: undefined,
+      dangerouslySetInnerHTML: {__html: ''},
+      onClick: fn
+    };
+    expect(out).toEqualJSX(<div {...expectedProps}></div>);
   });
 
   context('shouldComponentUpdate', () => {

--- a/src/decorators/__tests__/headerFooter-test.js
+++ b/src/decorators/__tests__/headerFooter-test.js
@@ -57,7 +57,7 @@ describe('headerFooter', () => {
     };
     expect(out).toEqualJSX(
       <div className="ais-root root">
-        <Template cssClass="ais-header" {...templateProps} onClick={null} />
+        <Template rootProps={{className: 'ais-header'}} {...templateProps} onClick={null} />
         <div className="ais-body body">
           <TestComponent {...defaultProps} />
         </div>
@@ -86,7 +86,7 @@ describe('headerFooter', () => {
         <div className="ais-body body">
           <TestComponent {...defaultProps} />
         </div>
-        <Template cssClass="ais-footer" {...templateProps} onClick={null} />
+        <Template rootProps={{className: 'ais-footer'}} {...templateProps} onClick={null} />
       </div>
     );
   });

--- a/src/decorators/headerFooter.js
+++ b/src/decorators/headerFooter.js
@@ -40,8 +40,8 @@ function headerFooter(ComposedComponent) {
       let className = cx(this.props.cssClasses[type], `ais-${type}`);
       return (
         <Template {...this.props.templateProps}
-          cssClass={className}
           onClick={handleClick}
+          rootProps={{className}}
           templateKey={type}
           transformData={null}
         />


### PR DESCRIPTION
Avoid `<div data="[object Object]">` being inserted in the DOM in
production builds.

The bug was introduced by
https://github.com/algolia/instantsearch.js/commit/fcfb990c9d059f59389b753b5abdecfba0dcd0f8
where we started using transform-react-remove-prop-types.

We cannot rely on PropTypes in production env because they are
removed.

We ask the dev to be explicit in what he's doing: use rootProps versus
forwarding everything a bit magically.

fixes #899