### PR TITLE
refactor(enzyme): Moved tests of RefinementList component to enzyme

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,15 +2,15 @@
   "name": "instantsearch.js",
   "version": "1.4.3",
   "npm-shrinkwrap-version": "200.5.1",
-  "node-version": "v5.9.1",
+  "node-version": "v4.0.0",
   "dependencies": {
     "algoliasearch": {
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-3.13.1.tgz",
       "dependencies": {
         "agentkeepalive": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-2.0.5.tgz"
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-2.1.1.tgz"
         },
         "debug": {
           "version": "2.2.0",
@@ -117,16 +117,16 @@
       }
     },
     "autoprefixer": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.3.5.tgz",
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.3.6.tgz",
       "dependencies": {
         "browserslist": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.3.0.tgz"
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.3.1.tgz"
         },
         "caniuse-db": {
-          "version": "1.0.30000437",
-          "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000437.tgz"
+          "version": "1.0.30000452",
+          "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000452.tgz"
         },
         "normalize-range": {
           "version": "0.1.2",
@@ -1155,12 +1155,12 @@
       }
     },
     "babel-core": {
-      "version": "6.7.4",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.7.4.tgz",
+      "version": "6.7.6",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.7.6.tgz",
       "dependencies": {
         "babel-code-frame": {
-          "version": "6.7.4",
-          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.4.tgz",
+          "version": "6.7.5",
+          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.5.tgz",
           "dependencies": {
             "chalk": {
               "version": "1.1.3",
@@ -1227,8 +1227,8 @@
           }
         },
         "babel-generator": {
-          "version": "6.7.2",
-          "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.7.2.tgz",
+          "version": "6.7.5",
+          "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.7.5.tgz",
           "dependencies": {
             "detect-indent": {
               "version": "3.0.1",
@@ -1301,8 +1301,8 @@
           }
         },
         "babel-traverse": {
-          "version": "6.7.4",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.4.tgz",
+          "version": "6.7.6",
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
           "dependencies": {
             "globals": {
               "version": "8.18.0",
@@ -1987,8 +1987,8 @@
       }
     },
     "babel-plugin-transform-react-remove-prop-types": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.2.4.tgz"
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.2.5.tgz"
     },
     "babel-preset-es2015": {
       "version": "6.6.0",
@@ -3827,8 +3827,8 @@
           }
         },
         "core-js": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.2.1.tgz"
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.2.2.tgz"
         },
         "home-or-tmp": {
           "version": "1.0.0",
@@ -3881,12 +3881,12 @@
           }
         },
         "babel-traverse": {
-          "version": "6.7.4",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.4.tgz",
+          "version": "6.7.6",
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
           "dependencies": {
             "babel-code-frame": {
-              "version": "6.7.4",
-              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.4.tgz",
+              "version": "6.7.5",
+              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.5.tgz",
               "dependencies": {
                 "chalk": {
                   "version": "1.1.3",
@@ -4009,12 +4009,12 @@
           }
         },
         "babel-traverse": {
-          "version": "6.7.4",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.4.tgz",
+          "version": "6.7.6",
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.7.6.tgz",
           "dependencies": {
             "babel-code-frame": {
-              "version": "6.7.4",
-              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.4.tgz",
+              "version": "6.7.5",
+              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.7.5.tgz",
               "dependencies": {
                 "chalk": {
                   "version": "1.1.3",
@@ -5501,8 +5501,8 @@
               }
             },
             "core-js": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.2.1.tgz"
+              "version": "2.2.2",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.2.2.tgz"
             },
             "feature-detect-es6": {
               "version": "1.2.0",
@@ -5533,8 +5533,8 @@
           "resolved": "https://registry.npmjs.org/ddata/-/ddata-0.1.25.tgz",
           "dependencies": {
             "core-js": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.2.1.tgz"
+              "version": "2.2.2",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.2.2.tgz"
             },
             "handlebars": {
               "version": "4.0.5",
@@ -5749,12 +5749,12 @@
           "resolved": "https://registry.npmjs.org/reduce-unique/-/reduce-unique-1.0.0.tgz"
         },
         "reduce-without": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/reduce-without/-/reduce-without-1.0.0.tgz",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/reduce-without/-/reduce-without-1.0.1.tgz",
           "dependencies": {
             "test-value": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.0.0.tgz",
               "dependencies": {
                 "typical": {
                   "version": "2.4.2",
@@ -6277,6 +6277,100 @@
         "update-section": {
           "version": "0.3.3",
           "resolved": "https://registry.npmjs.org/update-section/-/update-section-0.3.3.tgz"
+        }
+      }
+    },
+    "enzyme": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-2.2.0.tgz",
+      "dependencies": {
+        "is-subset": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz"
+        },
+        "lodash": {
+          "version": "4.6.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.6.1.tgz"
+        },
+        "object.assign": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.3.tgz",
+          "dependencies": {
+            "define-properties": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+              "dependencies": {
+                "foreach": {
+                  "version": "2.0.5",
+                  "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
+                }
+              }
+            },
+            "function-bind": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
+            },
+            "object-keys": {
+              "version": "1.0.9",
+              "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz"
+            }
+          }
+        },
+        "object.values": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.3.tgz",
+          "dependencies": {
+            "define-properties": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+              "dependencies": {
+                "foreach": {
+                  "version": "2.0.5",
+                  "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
+                },
+                "object-keys": {
+                  "version": "1.0.9",
+                  "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz"
+                }
+              }
+            },
+            "es-abstract": {
+              "version": "1.5.0",
+              "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.5.0.tgz",
+              "dependencies": {
+                "es-to-primitive": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+                  "dependencies": {
+                    "is-date-object": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz"
+                    },
+                    "is-symbol": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz"
+                    }
+                  }
+                },
+                "is-callable": {
+                  "version": "1.1.3",
+                  "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz"
+                },
+                "is-regex": {
+                  "version": "1.0.3",
+                  "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.3.tgz"
+                }
+              }
+            },
+            "function-bind": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
+            },
+            "has": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz"
+            }
+          }
         }
       }
     },
@@ -7159,8 +7253,8 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-algolia/-/eslint-plugin-algolia-1.5.0.tgz"
     },
     "eslint-plugin-react": {
-      "version": "3.16.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-3.16.1.tgz"
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-4.3.0.tgz"
     },
     "events": {
       "version": "1.1.0",
@@ -7257,8 +7351,8 @@
           "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.3.tgz"
         },
         "object-inspect": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.1.0.tgz"
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.2.1.tgz"
         }
       }
     },
@@ -7269,84 +7363,6 @@
         "collapse-white-space": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.0.tgz"
-        },
-        "react": {
-          "version": "0.14.8",
-          "resolved": "https://registry.npmjs.org/react/-/react-0.14.8.tgz",
-          "dependencies": {
-            "envify": {
-              "version": "3.4.0",
-              "resolved": "https://registry.npmjs.org/envify/-/envify-3.4.0.tgz",
-              "dependencies": {
-                "jstransform": {
-                  "version": "10.1.0",
-                  "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-10.1.0.tgz",
-                  "dependencies": {
-                    "base62": {
-                      "version": "0.1.1",
-                      "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz"
-                    },
-                    "esprima-fb": {
-                      "version": "13001.1001.0-dev-harmony-fb",
-                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1001.0-dev-harmony-fb.tgz"
-                    },
-                    "source-map": {
-                      "version": "0.1.31",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
-                      "dependencies": {
-                        "amdefine": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "through": {
-                  "version": "2.3.8",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-                }
-              }
-            },
-            "fbjs": {
-              "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.6.1.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "1.2.6",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                },
-                "loose-envify": {
-                  "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
-                  "dependencies": {
-                    "js-tokens": {
-                      "version": "1.0.3",
-                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
-                    }
-                  }
-                },
-                "promise": {
-                  "version": "7.1.1",
-                  "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
-                  "dependencies": {
-                    "asap": {
-                      "version": "2.0.3",
-                      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz"
-                    }
-                  }
-                },
-                "ua-parser-js": {
-                  "version": "0.7.10",
-                  "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.10.tgz"
-                },
-                "whatwg-fetch": {
-                  "version": "0.9.0",
-                  "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz"
-                }
-              }
-            }
-          }
         },
         "react-element-to-jsx-string": {
           "version": "2.5.0",
@@ -7685,8 +7701,8 @@
               "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
             },
             "pinkie-promise": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
               "dependencies": {
                 "pinkie": {
                   "version": "2.0.4",
@@ -8295,8 +8311,8 @@
       }
     },
     "jsdom": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-8.2.0.tgz",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-8.3.1.tgz",
       "dependencies": {
         "abab": {
           "version": "1.0.3",
@@ -8389,8 +8405,8 @@
           "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz"
         },
         "request": {
-          "version": "2.69.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.69.0.tgz",
+          "version": "2.71.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.71.0.tgz",
           "dependencies": {
             "aws-sign2": {
               "version": "0.6.0",
@@ -8417,8 +8433,8 @@
               }
             },
             "bl": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.6",
@@ -8565,8 +8581,8 @@
                   }
                 },
                 "pinkie-promise": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                   "dependencies": {
                     "pinkie": {
                       "version": "2.0.4",
@@ -8693,8 +8709,8 @@
               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
             },
             "qs": {
-              "version": "6.0.2",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz"
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz"
             },
             "stringstream": {
               "version": "0.0.5",
@@ -8931,8 +8947,14 @@
                       }
                     },
                     "expand-brackets": {
-                      "version": "0.1.4",
-                      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz"
+                      "version": "0.1.5",
+                      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+                      "dependencies": {
+                        "is-posix-bracket": {
+                          "version": "0.1.1",
+                          "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
+                        }
+                      }
                     },
                     "extglob": {
                       "version": "0.3.2",
@@ -8995,8 +9017,8 @@
                       }
                     },
                     "regex-cache": {
-                      "version": "0.4.2",
-                      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
+                      "version": "0.4.3",
+                      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
                       "dependencies": {
                         "is-equal-shallow": {
                           "version": "0.1.3",
@@ -9073,12 +9095,60 @@
                   }
                 },
                 "readable-stream": {
-                  "version": "2.0.6",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                  "version": "2.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.0.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "inline-process-browser": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/inline-process-browser/-/inline-process-browser-2.0.1.tgz",
+                      "dependencies": {
+                        "falafel": {
+                          "version": "1.2.0",
+                          "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
+                          "dependencies": {
+                            "acorn": {
+                              "version": "1.2.2",
+                              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+                            },
+                            "foreach": {
+                              "version": "2.0.5",
+                              "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "object-keys": {
+                              "version": "1.0.9",
+                              "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz"
+                            }
+                          }
+                        },
+                        "through2": {
+                          "version": "0.6.5",
+                          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                          "dependencies": {
+                            "readable-stream": {
+                              "version": "1.0.34",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                              "dependencies": {
+                                "isarray": {
+                                  "version": "0.0.1",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                }
+                              }
+                            },
+                            "xtend": {
+                              "version": "4.0.1",
+                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
                     },
                     "isarray": {
                       "version": "1.0.0",
@@ -9091,6 +9161,34 @@
                     "string_decoder": {
                       "version": "0.10.31",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "unreachable-branch-transform": {
+                      "version": "0.5.1",
+                      "resolved": "https://registry.npmjs.org/unreachable-branch-transform/-/unreachable-branch-transform-0.5.1.tgz",
+                      "dependencies": {
+                        "esmangle-evaluator": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/esmangle-evaluator/-/esmangle-evaluator-1.0.0.tgz"
+                        },
+                        "recast": {
+                          "version": "0.11.5",
+                          "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.5.tgz",
+                          "dependencies": {
+                            "ast-types": {
+                              "version": "0.8.16",
+                              "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.16.tgz"
+                            },
+                            "esprima": {
+                              "version": "2.7.2",
+                              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
+                            },
+                            "private": {
+                              "version": "0.1.6",
+                              "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+                            }
+                          }
+                        }
+                      }
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
@@ -9155,8 +9253,8 @@
           }
         },
         "core-js": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.2.1.tgz"
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.2.2.tgz"
         },
         "di": {
           "version": "0.0.1",
@@ -9279,8 +9377,8 @@
           "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.33.tgz",
           "dependencies": {
             "readable-stream": {
-              "version": "1.0.33",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "version": "1.0.34",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
@@ -12657,8 +12755,8 @@
           }
         },
         "npm": {
-          "version": "2.15.2",
-          "resolved": "https://registry.npmjs.org/npm/-/npm-2.15.2.tgz",
+          "version": "2.15.3",
+          "resolved": "https://registry.npmjs.org/npm/-/npm-2.15.3.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.7",
@@ -13063,12 +13161,12 @@
               "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-0.1.2.tgz"
             },
             "npmlog": {
-              "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.2.tgz",
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.3.tgz",
               "dependencies": {
                 "are-we-there-yet": {
-                  "version": "1.0.6",
-                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz",
+                  "version": "1.1.2",
+                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
                   "dependencies": {
                     "delegates": {
                       "version": "1.0.0",
@@ -13077,40 +13175,52 @@
                   }
                 },
                 "gauge": {
-                  "version": "1.2.5",
-                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.5.tgz",
+                  "version": "1.2.7",
+                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
                   "dependencies": {
                     "has-unicode": {
                       "version": "2.0.0",
                       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz"
                     },
-                    "lodash._basetostring": {
-                      "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
-                    },
-                    "lodash._createpadding": {
-                      "version": "3.6.1",
-                      "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz"
-                    },
                     "lodash.pad": {
-                      "version": "3.2.2",
-                      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.2.2.tgz"
-                    },
-                    "lodash.padleft": {
-                      "version": "3.1.1",
-                      "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz"
-                    },
-                    "lodash.padright": {
-                      "version": "3.1.1",
-                      "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz"
-                    },
-                    "lodash.repeat": {
-                      "version": "3.2.0",
-                      "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.2.0.tgz",
+                      "version": "4.1.0",
+                      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.1.0.tgz",
                       "dependencies": {
-                        "lodash._root": {
-                          "version": "3.0.1",
-                          "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
+                        "lodash.repeat": {
+                          "version": "4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.0.0.tgz"
+                        },
+                        "lodash.tostring": {
+                          "version": "4.1.2",
+                          "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.2.tgz"
+                        }
+                      }
+                    },
+                    "lodash.padend": {
+                      "version": "4.2.0",
+                      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.2.0.tgz",
+                      "dependencies": {
+                        "lodash.repeat": {
+                          "version": "4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.0.0.tgz"
+                        },
+                        "lodash.tostring": {
+                          "version": "4.1.2",
+                          "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.2.tgz"
+                        }
+                      }
+                    },
+                    "lodash.padstart": {
+                      "version": "4.2.0",
+                      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.2.0.tgz",
+                      "dependencies": {
+                        "lodash.repeat": {
+                          "version": "4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.0.0.tgz"
+                        },
+                        "lodash.tostring": {
+                          "version": "4.1.2",
+                          "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.2.tgz"
                         }
                       }
                     }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "conventional-changelog": "^0.5.3",
     "dmd": "^1.3.11",
     "doctoc": "^1.0.0",
+    "enzyme": "2.2.0",
     "eslint": "^1.10.3",
     "eslint-config-airbnb": "^0.1.0",
     "eslint-config-algolia": "^4.5.0",

--- a/scripts/karma.conf.babel.js
+++ b/scripts/karma.conf.babel.js
@@ -11,6 +11,15 @@ let baseConfig = {
       loaders: [{
         test: /\.js$/, exclude: /node_modules/, loader: 'babel'
       }]
+    },
+    // enzyme does not work well with webpack:
+    // https://github.com/airbnb/enzyme/issues/47#issuecomment-165430136
+    externals: {
+      jsdom: 'window',
+      cheerio: 'window',
+      'react/lib/ExecutionEnvironment': true,
+      'react/lib/ReactContext': 'window',
+      'text-encoding': 'window'
     }
   },
   webpackMiddleware: {noInfo: true}

--- a/src/components/RefinementList/__tests__/RefinementList-test.js
+++ b/src/components/RefinementList/__tests__/RefinementList-test.js
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 
 import React from 'react';
+import {shallow} from 'enzyme';
 import expect from 'expect';
-import TestUtils from 'react-addons-test-utils';
 import RefinementList from '../RefinementList';
 import RefinementListItem from '../RefinementListItem';
 
@@ -10,176 +10,318 @@ import expectJSX from 'expect-jsx';
 expect.extend(expectJSX);
 
 describe('RefinementList', () => {
-  let renderer;
-  let parentListProps;
-  let itemProps;
-
-  beforeEach(() => {
-    let {createRenderer} = TestUtils;
-    let cssClasses = {
-      list: 'list',
-      item: 'item',
-      active: 'active'
+  function shallowRender(extraProps: {}) {
+    let props = {
+      createURL: () => 'url',
+      facetValues: [],
+      ...extraProps
     };
-    let templateData = {
-      cssClasses,
-      url: 'url'
-    };
-    let commonItemProps = {
-      handleClick: () => {},
-      itemClassName: 'item',
-      subItems: undefined,
-      templateKey: 'item',
-      templateProps: {}
-    };
+    return shallow(React.createElement(RefinementList, props));
+  }
 
-    parentListProps = {className: 'list'};
-    itemProps = [{
-      ...commonItemProps,
-      itemClassName: 'item active',
-      facetValueToRefine: 'facet1',
-      isRefined: true,
-      templateData: {
-        ...templateData,
-        name: 'facet1',
-        isRefined: true
-      }
-    }, {
-      ...commonItemProps,
-      facetValueToRefine: 'facet2',
-      isRefined: false,
-      templateData: {
-        ...templateData,
-        name: 'facet2',
-        isRefined: false
-      }
-    }];
-    renderer = createRenderer();
-  });
-
-
-  it('should render default list', () => {
-    let out = render();
-
-    expect(out).toEqualJSX(
-      <div {...parentListProps}>
-        <RefinementListItem
-          {...itemProps[0]}
-        />
-        <RefinementListItem
-          {...itemProps[1]}
-        />
-      </div>
-    );
-    expect(out.props.children[0][0].key).toEqual('facet1/true');
-    expect(out.props.children[0][1].key).toEqual('facet2/false');
-  });
-
-  it('should render default list highlighted', () => {
-    let out = render({facetValues: [{name: 'facet1', isRefined: true, count: 42}]});
-    itemProps[0].templateData = {
-      ...itemProps[0].templateData,
-      count: 42,
-      isRefined: true
-    };
-    expect(out).toEqualJSX(
-      <div {...parentListProps}>
-        <RefinementListItem
-          {...itemProps[0]}
-        />
-      </div>
-    );
-    expect(out.props.children[0][0].key).toEqual('facet1/true/42');
-  });
-
-  context('showMore', () => {
-    it('should display the number accordingly to the state : closed', () => {
-      const out = render({
-        facetValues: [
-          {name: 'facet1', isRefined: false, count: 42},
-          {name: 'facet2', isRefined: false, count: 42}
-        ],
-        showMore: true,
-        limitMin: 1,
-        limitMax: 2
-      });
-      expect(out.props.children.length).toBe(2);
-    });
-
-    it('should display the number accordingly to the state : open', () => {
-      // FIXME find a way to test this state...
-    });
-  });
-
-  context('sublist', () => {
-    it('works', () => {
-      let customProps = {
+  describe('cssClasses', () => {
+    it('should add the `list` class to the root element', () => {
+      // Given
+      let props = {
         cssClasses: {
-          depth: 'depth',
-          item: 'item',
-          list: 'list',
+          list: 'list'
+        }
+      };
+
+      // When
+      let actual = shallowRender(props);
+
+      // Then
+      expect(actual.hasClass('list')).toEqual(true);
+    });
+
+    it('should set item classes to the refinements', () => {
+      // Given
+      let props = {
+        cssClasses: {
+          item: 'item'
+        },
+        facetValues: [
+          {name: 'foo', isRefined: true}
+        ]
+      };
+
+      // When
+      let actual = shallowRender(props).find(RefinementListItem);
+
+      // Then
+      expect(actual.props().itemClassName).toContain('item');
+    });
+
+    it('should set active classes to the active refinements', () => {
+      // Given
+      let props = {
+        cssClasses: {
           active: 'active'
         },
         facetValues: [
+          {name: 'foo', isRefined: true},
+          {name: 'bar', isRefined: false}
+        ]
+      };
+
+      // When
+      let activeItem = shallowRender(props).find({isRefined: true});
+      let inactiveItem = shallowRender(props).find({isRefined: false});
+
+      // Then
+      expect(activeItem.props().itemClassName).toContain('active');
+      expect(inactiveItem.props().itemClassName).toNotContain('active');
+    });
+  });
+
+  describe('items', () => {
+    it('should have the correct names', () => {
+      // Given
+      let props = {
+        facetValues: [
+          {name: 'foo', isRefined: false},
+          {name: 'bar', isRefined: false}
+        ]
+      };
+
+      // When
+      let items = shallowRender(props).find(RefinementListItem);
+      let firstItem = items.at(0);
+      let secondItem = items.at(1);
+
+      // Then
+      expect(firstItem.props().facetValueToRefine).toEqual('foo');
+      expect(secondItem.props().facetValueToRefine).toEqual('bar');
+    });
+
+    it('should correctly set if refined or not', () => {
+      // Given
+      let props = {
+        facetValues: [
+          {name: 'foo', isRefined: false},
+          {name: 'bar', isRefined: true}
+        ]
+      };
+
+      // When
+      let items = shallowRender(props).find(RefinementListItem);
+      let firstItem = items.at(0);
+      let secondItem = items.at(1);
+
+      // Then
+      expect(firstItem.props().isRefined).toEqual(false);
+      expect(secondItem.props().isRefined).toEqual(true);
+    });
+  });
+
+  describe('count', () => {
+    it('should pass the count to the templateData', () => {
+      // Given
+      let props = {
+        facetValues: [
+          {name: 'foo', count: 42},
+          {name: 'bar', count: 16}
+        ]
+      };
+
+      // When
+      let items = shallowRender(props).find(RefinementListItem);
+      let firstItem = items.at(0);
+      let secondItem = items.at(1);
+
+      // Then
+      expect(firstItem.props().templateData.count).toEqual(42);
+      expect(secondItem.props().templateData.count).toEqual(16);
+    });
+  });
+
+  describe('showMore', () => {
+    it('displays a number of items equal to the limit when showMore: false', () => {
+      // Given
+      let props = {
+        facetValues: [
+          {name: 'foo'},
+          {name: 'bar'},
+          {name: 'baz'}
+        ],
+        showMore: false,
+        limitMin: 2
+      };
+
+      // When
+      let actual = shallowRender(props).find(RefinementListItem);
+
+      // Then
+      expect(actual.length).toEqual(2);
+    });
+
+    it('displays a number of items equal to the limit when showMore: true but not enabled', () => {
+      // Given
+      let props = {
+        facetValues: [
+          {name: 'foo'},
+          {name: 'bar'},
+          {name: 'baz'}
+        ],
+        showMore: true,
+        limitMin: 2,
+        limitMax: 3
+      };
+
+      // When
+      let actual = shallowRender(props).find(RefinementListItem);
+
+      // Then
+      expect(actual.length).toEqual(2);
+    });
+
+    it('displays a number of items equal to the showMore limit when showMore: true and enabled', () => {
+      // Given
+      let props = {
+        facetValues: [
+          {name: 'foo'},
+          {name: 'bar'},
+          {name: 'baz'}
+        ],
+        limitMin: 2,
+        limitMax: 3,
+        showMore: true
+      };
+
+      // When
+      let root = shallowRender(props);
+      root.setState({isShowMoreOpen: true});
+      let actual = root.find(RefinementListItem);
+
+      // Then
+      expect(actual.length).toEqual(3);
+    });
+
+    it('adds a showMore link when the feature is enabled', () => {
+      // Given
+      let props = {
+        facetValues: [
+          {name: 'foo'},
+          {name: 'bar'},
+          {name: 'baz'}
+        ],
+        showMore: true,
+        limitMin: 2,
+        limitMax: 3
+      };
+
+      // When
+      let root = shallowRender(props);
+      let actual = root.find('Template').filter({templateKey: 'show-more-inactive'});
+
+      // Then
+      expect(actual.length).toEqual(1);
+    });
+
+    it('does not add a showMore link when the feature is disabled', () => {
+      // Given
+      let props = {
+        facetValues: [
+          {name: 'foo'},
+          {name: 'bar'},
+          {name: 'baz'}
+        ],
+        showMore: false,
+        limitMin: 2,
+        limitMax: 3
+      };
+
+      // When
+      let root = shallowRender(props);
+      let actual = root.find('Template').filter({templateKey: 'show-more-inactive'});
+
+      // Then
+      expect(actual.length).toEqual(0);
+    });
+
+    it('changing the state will toggle the number of items displayed', () => {
+      // Given
+      let props = {
+        facetValues: [
+          {name: 'foo'},
+          {name: 'bar'},
+          {name: 'baz'}
+        ],
+        limitMin: 2,
+        limitMax: 3,
+        showMore: true
+      };
+
+      // When
+      let root = shallowRender(props);
+
+      // Then: Not opened, initial number displayed
+      expect(root.find(RefinementListItem).length).toEqual(2);
+
+      // Then: Toggling the state, display the limitMax
+      root.setState({isShowMoreOpen: true});
+      expect(root.find(RefinementListItem).length).toEqual(3);
+
+      // Then: Toggling the state again, back to the limitMin
+      root.setState({isShowMoreOpen: false});
+      expect(root.find(RefinementListItem).length).toEqual(2);
+    });
+  });
+
+  describe('sublist', () => {
+    it('should create a subList with the sub values', () => {
+      // Given
+      let props = {
+        facetValues: [
           {
-            name: 'facet1',
-            isRefined: true,
+            name: 'foo',
             data: [
-              {name: 'subfacet1'},
-              {name: 'subfacet2'}
+              {name: 'bar'},
+              {name: 'baz'}
             ]
           }
         ]
       };
-      parentListProps = {
-        className: 'list depth0'
+
+      // When
+      let root = shallowRender(props);
+      let mainItem = root.find(RefinementListItem).at(0);
+      let subList = shallow(mainItem.props().subItems);
+      let subItems = subList.find(RefinementListItem);
+
+      // Then
+      expect(mainItem.props().facetValueToRefine).toEqual('foo');
+      expect(subItems.at(0).props().facetValueToRefine).toEqual('bar');
+      expect(subItems.at(1).props().facetValueToRefine).toEqual('baz');
+    });
+
+    it('should add depth class for each depth', () => {
+      // Given
+      let props = {
+        cssClasses: {
+          depth: 'depth-'
+        },
+        facetValues: [
+          {
+            name: 'foo',
+            data: [
+              {name: 'bar'},
+              {name: 'baz'}
+            ]
+          }
+        ]
       };
-      itemProps[0].templateData.cssClasses = customProps.cssClasses;
-      itemProps[0].templateData = {
-        ...itemProps[0].templateData,
-        data: customProps.facetValues[0].data
-      };
-      itemProps[0].subItems = (
-        <RefinementList
-          attributeNameKey="name"
-          createURL={() => {}}
-          cssClasses={customProps.cssClasses}
-          depth={1}
-          facetValues={customProps.facetValues[0].data}
-          templateProps={{}}
-        />
-      );
-      let out = render(customProps);
-      expect(out).toEqualJSX(
-        <div {...parentListProps}>
-          <RefinementListItem
-            {...itemProps[0]}
-          />
-        </div>
-      );
+
+      // When
+      let root = shallowRender(props);
+      let mainItem = root.find(RefinementListItem).at(0);
+      let subList = shallow(mainItem.props().subItems);
+
+      // Then
+      expect(root.props().className).toContain('depth-0');
+      expect(subList.props().className).toContain('depth-1');
     });
   });
-
-  function render(extraProps = {}) {
-    let props = getProps(extraProps);
-    renderer.render(<RefinementList {...props} ref="list" templateProps={{}} />);
-    return renderer.getRenderOutput();
-  }
-
-  function getProps(extraProps = {}) {
-    return {
-      cssClasses: {
-        list: 'list',
-        item: 'item',
-        active: 'active'
-      },
-      facetValues: [
-        {name: 'facet1', isRefined: true},
-        {name: 'facet2', isRefined: false}
-      ],
-      createURL: () => 'url',
-      ...extraProps
-    };
-  }
 });
 

--- a/src/widgets/stats/stats.js
+++ b/src/widgets/stats/stats.js
@@ -19,7 +19,8 @@ let bem = bemHelper('ais-stats');
  * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
  * @param  {Object} [options.templates] Templates to use for the widget
  * @param  {string|Function} [options.templates.header=''] Header template
- * @param  {string|Function} [options.templates.body] Body template
+ * @param  {string|Function} [options.templates.body] Body template, provided with `hasManyResults`,
+ * `hasNoResults`, `hasOneResult`, `hitsPerPage`, `nbHits`, `nbPages`, `page`, `processingTimeMS`, `query`
  * @param  {string|Function} [options.templates.footer=''] Footer template
  * @param  {Function} [options.transformData] Function to change the object passed to the `body` template
  * @param  {boolean} [options.autoHideContainer=true] Hide the container when no results match


### PR DESCRIPTION
So what is this PR about?

In the process of fixing #934, I tried to add a test to assert that we did not generated more urls than needed in the RefinementList component. 

By doing so I discovered in the test file that we had no test to test the `showMore` feature (we had a comment saying basically "I don't know how to test that") and most of our tests where actually testing a whole bunch of fonctionnalities at once (using full JSX diff) instead of just tiny parts of it.

This resulted in a lot of boilerplate (we needed to copy the whole props in each tests), and made the tests very brittle because they needed both an internal knowledge of the components and were all very dependent. Adding a new prop would break all tests, even those that are not relevant.

I then looked for a more granular way to test React components. At first I found [skin-deep](https://github.com/glenjamin/skin-deep) (through [this blogpost](http://simonsmith.io/unit-testing-react-components-without-a-dom/)) which in essence a set of utils to ease shallow rendering testing.

Then, after discussing with @vvo, we decided that if we were to change the testing tool, we should go with [enzyme](https://github.com/airbnb/enzyme) that does the same thing, but is created by airbnb and has many more followers and stars.

So, I tried to refactor our test file with enzyme, as a POC, to see if it was wortht it. Here are my findings:

The logic we had with our custom `render` method in the tests is the same, but all the small details are now integrated into `enzyme`. We no longer need to expose global `itemProps` to pass them to each `JSX` we need to test, we can focus on defining only the props we need to test.

This is a huge win in my opinion, because we can now create, for example, 4 different tests to test the 4 different custom CSS classes we add to generated content instead of one big test testing all possible outcomes.

`enzyme` provides a few utilities that help keeping the tests shorts. You start by _shallow rendering_ your component (not rendering the inner sub components). You can then do basic selection with `.find('RefinementListItem')` or `.find({isRefined: true})` to select only a few sub-nodes that you'd like to test.

You have access to the number of matching elements through the `.length` property, and you can access individual results with the `.at(index)` call. Once you have a component, you can read and write its props and state with `.props()`, `setProps()`, `.state()` and `.setState()`. This is also a big win, especially considering that updating the state does trigger all the dynamic modifications. It my example I can toggle the `state.isShowMoreOpen` from `true` to `false` and having the number of `.find(RefinementListItem).length` automatically updated.

`enzyme` is also supposed to let you simulate events (click, etc). But in our case, I couldn't use it because we are using components to do the templating, so the shallow rendering does not display the content of the templates. And our click events are not bound on the template but on the root element generated **inside** the template. Long story short, I couldn't find a way to test click events with our current templating system (and trust me, I tried!).

So in the end, instead of testing that we could click on the "Show More" link to toggle the number of element displayed, I simply tested that a change of the state changed the number of element displayed. This is not ideal. As Vincent suggested, it might be better to extract the "ShowMoreButton" into its own component and test it in isolation there.

I did not use the `mount` and full `render` capabilities of `enzyme`. I tried them, but shallow rendering seemed to always be a best usage in my cases.

In the end, I feel like this approach is better as it lets us do smaller tests that are in turn more readable and more robust.

All feedbacks welcome!