### PR TITLE
docs(examples): add titles on widget icons

### DIFF
--- a/docs/examples.haml
+++ b/docs/examples.haml
@@ -19,12 +19,12 @@ permalink: /examples/
         %h3 Media
       %p Browsing video, music and other media becomes much more intuitive with instant search.
       .built-with.m-b
-        {% img 'icon-widget-searchbox.svg' width:30 %}
-        {% img 'icon-widget-results.svg' width:30 %}
-        {% img 'icon-widget-stats.svg' width:30 %}
-        {% img 'icon-widget-pagination.svg' width:30 %}
-        {% img 'icon-widget-refinement.svg' width:30 %}
-        {% img 'icon-widget-slider.svg' width:30 %}
+       {% img 'icon-widget-searchbox.svg' title:'searchBox' width:30 %}
+        {% img 'icon-widget-results.svg' title:'hits' width:30 %}
+        {% img 'icon-widget-stats.svg' title:'stats' width:30 %}
+        {% img 'icon-widget-pagination.svg' title:'pagination' width:30 %}
+        {% img 'icon-widget-refinement.svg' title:'refinementList' width:30 %}
+        {% img 'icon-widget-slider.svg' title:'rangeSlider' width:30 %}
       %a{href: '{{ "https://github.com/algolia/instantsearch.js/tree/master/docs/examples/media" }}'} View code <i class="fa fa-github"></i>
       %span or
       %a{href: '{{ "/examples/media.zip" | prepend: site.baseurl }}'} download
@@ -37,16 +37,16 @@ permalink: /examples/
         %h3 E-commerce
       %p An instant-search experience helps shoppers more easily find and buy what they want.
       .built-with.m-b
-        {% img 'icon-widget-searchbox.svg' width:30 %}
-        {% img 'icon-widget-results.svg' width:30 %}
-        {% img 'icon-widget-stats.svg' width:30 %}
-        {% img 'icon-widget-clearall.svg' width:30 %}
-        {% img 'icon-widget-index.svg' width:30 %}
-        {% img 'icon-widget-pagination.svg' width:30 %}
-        {% img 'icon-widget-hierarchical.svg' width:30 %}
-        {% img 'icon-widget-refinement.svg' width:30 %}
-        {% img 'icon-widget-pricerange.svg' width:30 %}
-        {% img 'icon-widget-star-rating.svg' width:30 %}
+        {% img 'icon-widget-searchbox.svg' title:'searchBox' width:30 %}
+        {% img 'icon-widget-results.svg' title:'hits' width:30 %}
+        {% img 'icon-widget-stats.svg' title:'stats' width:30 %}
+        {% img 'icon-widget-clearall.svg' title:'clearAll' width:30 %}
+        {% img 'icon-widget-index.svg' title:'sortBySelector' width:30 %}
+        {% img 'icon-widget-pagination.svg' title:'pagination' width:30 %}
+        {% img 'icon-widget-hierarchical.svg' title:'hierarchicalMenu' width:30 %}
+        {% img 'icon-widget-refinement.svg' title:'refinementList' width:30 %}
+        {% img 'icon-widget-pricerange.svg' title:'priceRanges' width:30 %}
+        {% img 'icon-widget-star-rating.svg' title:'starRating' width:30 %}
       %a{href: '{{ "https://github.com/algolia/instantsearch.js/tree/master/docs/examples/e-commerce" }}'} View code <i class="fa fa-github"></i>
       %span or
       %a{href: '{{ "/examples/e-commerce.zip" | prepend: site.baseurl }}'} download
@@ -59,14 +59,14 @@ permalink: /examples/
         %h3 Tourism
       %p Travel the world at the speed of search with instant results.
       .built-with.m-b
-        {% img 'icon-widget-searchbox.svg' width:30 %}
-        {% img 'icon-widget-stats.svg' width:30 %}
-        {% img 'icon-widget-pagination.svg' width:30 %}
-        {% img 'icon-widget-results.svg' width:30 %}
-        {% img 'icon-widget-slider.svg' width:30 %}
-        {% img 'icon-widget-refinement.svg' width:30 %}
-        {% img 'icon-widget-numerical.svg' width:30 %}
-        {% img 'icon-widget-custom.svg' width:30 %}
+        {% img 'icon-widget-searchbox.svg' title:'searchBox' width:30 %}
+        {% img 'icon-widget-stats.svg' title:'stats' width:30 %}
+        {% img 'icon-widget-pagination.svg' title:'pagination' width:30 %}
+        {% img 'icon-widget-results.svg' title:'hits' width:30 %}
+        {% img 'icon-widget-slider.svg' title:'rangeSlider' width:30 %}
+        {% img 'icon-widget-refinement.svg' title:'refinementList' width:30 %}
+        {% img 'icon-widget-numerical.svg' title:'numericRefinementList' width:30 %}
+        {% img 'icon-widget-custom.svg' title:'custom' width:30 %}
       %a{href: '{{ "https://github.com/algolia/instantsearch.js/tree/master/docs/examples/tourism" }}'} View code <i class="fa fa-github"></i>
       %span or
       %a{href: '{{ "/examples/tourism.zip" | prepend: site.baseurl }}'} download


### PR DESCRIPTION
Unless you are familiar with the icons of each widget, the current images are hard to understand. I added the title so you at least get a tooltip - making it easier to find the widget in the doc afterwards.