### PR TITLE
docs(codebox): the options tab is now the default

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -117,7 +117,7 @@ var search = instantsearch({
 });
 {% endhighlight %}
   </div>
-  <div class="jsdoc js-toggle-jsdoc" style="display: none">
+  <div class="jsdoc js-toggle-jsdoc">
 {% highlight javascript %}
 instantsearch(options);
 {% endhighlight %}
@@ -171,7 +171,7 @@ To build your search results page, you need to combine several widgets. Start by
 </script>
 {% endhighlight %}
   </div>
-  <div class="jsdoc js-toggle-jsdoc" style="display: none">
+  <div class="jsdoc js-toggle-jsdoc">
 {% highlight javascript %}
 search.addWidget(widget)
 {% endhighlight %}
@@ -323,7 +323,7 @@ search.addWidget(
 );
 {% endhighlight %}
   </div>
-  <div class="jsdoc js-toggle-jsdoc" style="display: none">
+  <div class="jsdoc js-toggle-jsdoc">
 {% highlight javascript %}
 instantsearch.widgets.searchBox(options)
 {% endhighlight %}
@@ -368,7 +368,7 @@ search.addWidget(
 {% endraw %}
 {% endhighlight %}
   </div>
-  <div class="jsdoc js-toggle-jsdoc" style='display:none'>
+  <div class="jsdoc js-toggle-jsdoc">
 {% highlight javascript %}
 {% raw %}
 instantsearch.widgets.hits(options);
@@ -417,7 +417,7 @@ search.addWidget(
 {% endraw %}
 {% endhighlight %}
   </div>
-  <div class="jsdoc js-toggle-jsdoc" style='display:none'>
+  <div class="jsdoc js-toggle-jsdoc">
 {% highlight javascript %}
 {% raw %}
 instantsearch.widgets.hitsPerPageSelector(options);
@@ -461,7 +461,7 @@ search.addWidget(
 );
     {% endhighlight %}
   </div>
-  <div class="jsdoc js-toggle-jsdoc" style='display:none'>
+  <div class="jsdoc js-toggle-jsdoc">
 {% highlight javascript %}
 instantsearch.widgets.pagination(options);
 {% endhighlight %}
@@ -500,7 +500,7 @@ search.addWidget(
 {% endhighlight %}
   </div>
 
-  <div class="jsdoc js-toggle-jsdoc" style='display:none'>
+  <div class="jsdoc js-toggle-jsdoc">
 {% highlight javascript %}
 instantsearch.widgets.menu(options);
 {% endhighlight %}
@@ -542,7 +542,7 @@ search.addWidget(
 {% endhighlight %}
   </div>
 
-  <div class="jsdoc js-toggle-jsdoc" style='display:none'>
+  <div class="jsdoc js-toggle-jsdoc">
 {% highlight javascript %}
 instantsearch.widgets.hierarchicalMenu(options);
 {% endhighlight %}
@@ -603,7 +603,7 @@ search.addWidget(
 );
 {% endhighlight %}
   </div>
-  <div class="jsdoc js-toggle-jsdoc" style='display:none'>
+  <div class="jsdoc js-toggle-jsdoc">
 {% highlight javascript %}
 instantsearch.widgets.refinementList(options);
 {% endhighlight %}
@@ -648,7 +648,7 @@ search.addWidget(
 );
 {% endhighlight %}
   </div>
-  <div class="jsdoc js-toggle-jsdoc" style='display:none'>
+  <div class="jsdoc js-toggle-jsdoc">
 {% highlight javascript %}
 instantsearch.widgets.numericRefinementList(options);
 {% endhighlight %}
@@ -694,7 +694,7 @@ search.addWidget(
 );
 {% endhighlight %}
   </div>
-  <div class="jsdoc js-toggle-jsdoc" style='display:none'>
+  <div class="jsdoc js-toggle-jsdoc">
 {% highlight javascript %}
 instantsearch.widgets.toggle(options);
 {% endhighlight %}
@@ -737,7 +737,7 @@ search.addWidget(
 );
 {% endhighlight %}
   </div>
-  <div class="jsdoc js-toggle-jsdoc" style='display:none'>
+  <div class="jsdoc js-toggle-jsdoc">
 {% highlight javascript %}
 instantsearch.widgets.rangeSlider(options);
 {% endhighlight %}
@@ -779,7 +779,7 @@ search.addWidget(
 );
 {% endhighlight %}
   </div>
-  <div class="jsdoc js-toggle-jsdoc" style='display:none'>
+  <div class="jsdoc js-toggle-jsdoc">
 {% highlight javascript %}
 instantsearch.widgets.priceRanges(options);
 {% endhighlight %}
@@ -821,7 +821,7 @@ search.addWidget(
 );
 {% endhighlight %}
   </div>
-  <div class="jsdoc js-toggle-jsdoc" style='display:none'>
+  <div class="jsdoc js-toggle-jsdoc">
 {% highlight javascript %}
 instantsearch.widgets.numericSelector(options);
 {% endhighlight %}
@@ -861,7 +861,7 @@ search.addWidget(
 );
 {% endhighlight %}
   </div>
-  <div class="jsdoc js-toggle-jsdoc" style='display:none'>
+  <div class="jsdoc js-toggle-jsdoc">
 {% highlight javascript %}
 instantsearch.widgets.starRating(options);
 {% endhighlight %}
@@ -899,7 +899,7 @@ search.addWidget(
 );
 {% endhighlight %}
   </div>
-  <div class="jsdoc js-toggle-jsdoc" style='display:none'>
+  <div class="jsdoc js-toggle-jsdoc">
 {% highlight javascript %}
 instantsearch.widgets.clearAll(options);
 {% endhighlight %}
@@ -932,7 +932,7 @@ search.addWidget(
 );
 {% endhighlight %}
   </div>
-  <div class="jsdoc js-toggle-jsdoc" style='display:none'>
+  <div class="jsdoc js-toggle-jsdoc">
 {% highlight javascript %}
 instantsearch.widgets.currentRefinedValues(options);
 {% endhighlight %}
@@ -971,7 +971,7 @@ search.addWidget(
 );
 {% endhighlight %}
   </div>
-  <div class="jsdoc js-toggle-jsdoc" style='display:none'>
+  <div class="jsdoc js-toggle-jsdoc">
 {% highlight javascript %}
 instantsearch.widgets.sortBySelector(options);
 {% endhighlight %}
@@ -1010,7 +1010,7 @@ search.addWidget(
 );
 {% endhighlight %}
   </div>
-  <div class="jsdoc js-toggle-jsdoc" style='display:none'>
+  <div class="jsdoc js-toggle-jsdoc">
 {% highlight javascript %}
 instantsearch.widgets.stats(options);
 {% endhighlight %}
@@ -1169,7 +1169,7 @@ search.addWidget(customWidget);
 {% endhighlight %}
 
   </div>
-  <div class="jsdoc js-toggle-jsdoc" style='display:none'>
+  <div class="jsdoc js-toggle-jsdoc">
 
 {% highlight javascript %}
 search.addWidget(widget)

--- a/docs/js/doc.js
+++ b/docs/js/doc.js
@@ -57,15 +57,21 @@
         return $button;
       }
       var $btnGroup = $('<div class="btn-group js-doc-toggle"></div>');
-      $btnGroup.append(getButton('Snippet', 'snippet').addClass('active'));
+      var $snippetButton = getButton('Example', 'snippet');
       if (hasJsdoc) {
-        $btnGroup.append(getButton('All options', 'jsdoc'));
+        $btnGroup.append(getButton('Usage', 'jsdoc').addClass('active'));
+      } else {
+        $snippetButton.addClass('active');
       }
       if (hasRequirements) {
         $btnGroup.append(getButton('Requirements', 'requirements'));
       }
+      $btnGroup.append($snippetButton);
 
       $this.prepend($btnGroup);
+      setTimeout(function() {
+        $btnGroup.find('button:first-child').click();
+      }, 1);
     });
     $(document).on('click', '.toggle-doc-button', function() {
       var $this = $(this);


### PR DESCRIPTION
- Renamed "All Options" to "Usage"
 - Renamed "Snippet" to "Example"
 - Moved "Requirements" at the 2nd position
 - do not use display:none in the raw HTML code

Fix #966 

![screen shot 2016-04-04 at 12 01 37](https://cloud.githubusercontent.com/assets/29529/14244738/01026f9e-fa5d-11e5-99af-3a6f19488bc1.png)