### PR TITLE
feat(serve): Adding `npm run serve` command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ Hi (future) collaborator!
 - [New API proposal](#new-api-proposal)
 - [How to write issues](#how-to-write-issues)
 - [Development workflow](#development-workflow)
+- [Serving the build](#serving-the-build)
 - [Adding/Updating a package](#addingupdating-a-package)
 - [Removing a package](#removing-a-package)
 - [Commit message guidelines](#commit-message-guidelines)
@@ -82,6 +83,19 @@ Launch the website docs dev tool:
 npm run dev:docs
 ```
 
+# Serving the build
+
+For some use cases like building a demo, you may want to serve the current build
+on an http endpoint.
+
+To do so:
+
+```sh
+npm run serve
+```
+
+Will build, watch for changes and serve instantsearch.css and instantsearch.js on http://localhost:8080.
+
 # Adding/Updating a package
 
 We use a [specific shrinkwrapping tool](https://github.com/uber/npm-shrinkwrap) and npm@2.
@@ -96,6 +110,7 @@ npm run shrinkwrap
 
 ```sh
 npm install
+npm prune
 npm remove package --save[-dev]
 npm run shrinkwrap
 ```

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -7640,6 +7640,94 @@
         }
       }
     },
+    "http-server": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-0.9.0.tgz",
+      "dependencies": {
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
+        },
+        "corser": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.0.tgz"
+        },
+        "ecstatic": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-1.4.0.tgz",
+          "dependencies": {
+            "he": {
+              "version": "0.5.0",
+              "resolved": "https://registry.npmjs.org/he/-/he-0.5.0.tgz"
+            },
+            "mime": {
+              "version": "1.3.4",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+            },
+            "minimist": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+            },
+            "url-join": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz"
+            }
+          }
+        },
+        "http-proxy": {
+          "version": "1.13.2",
+          "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.13.2.tgz",
+          "dependencies": {
+            "eventemitter3": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz"
+            },
+            "requires-port": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
+            }
+          }
+        },
+        "opener": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.1.tgz"
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.10",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+            },
+            "wordwrap": {
+              "version": "0.0.3",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+            }
+          }
+        },
+        "portfinder": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-0.4.0.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.9.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+            }
+          }
+        },
+        "union": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/union/-/union-0.4.4.tgz",
+          "dependencies": {
+            "qs": {
+              "version": "2.3.3",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+            }
+          }
+        }
+      }
+    },
     "is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:functional": "wdio functional-tests/wdio.conf.js",
     "test:functional:dev": "babel-node scripts/dev-functional-tests",
     "test:functional:dev:debug-server": "PORT=9090 babel-node scripts/dev-functional-tests-debug-server",
+    "serve": "./scripts/serve.sh",
     "shrinkwrap": "npm-shrinkwrap --dev"
   },
   "repository": "algolia/instantsearch.js",
@@ -65,6 +66,7 @@
     "expose-loader": "^0.7.1",
     "express": "^4.13.4",
     "gh-pages": "^0.11.0",
+    "http-server": "^0.9.0",
     "jsdoc-to-markdown": "^1.3.3",
     "jsdom": "^8.2.0",
     "jsdom-global": "^1.7.0",

--- a/scripts/karma.conf.babel.js
+++ b/scripts/karma.conf.babel.js
@@ -15,11 +15,10 @@ let baseConfig = {
     // enzyme does not work well with webpack:
     // https://github.com/airbnb/enzyme/issues/47#issuecomment-165430136
     externals: {
-      jsdom: 'window',
       cheerio: 'window',
+      'react/addons': true,
       'react/lib/ExecutionEnvironment': true,
-      'react/lib/ReactContext': 'window',
-      'text-encoding': 'window'
+      'react/lib/ReactContext': true
     }
   },
   webpackMiddleware: {noInfo: true}

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Serves the current build version on a local server available (by default) on
+# http://127.0.0.1:8080/instantsearch.js
+#
+# This is useful when you want to test the latest instantsearch.js version
+# (including your own branches) on a specific local project. Just run `npm run
+# serve` in the instantsearch repository, on link the file in your project.
+#
+# This works by running webpack in watch mode as well as simply serving the dist
+# folder through a local web server.
+
+npm install
+node-sass -o ./dist/ ./src/css --output-style expanded
+node-sass -o ./dist/ --watch ./src/css --output-style expanded &
+NODE_ENV=production webpack --config ./scripts/webpack.config.serve.babel.js -w &
+sleep 3 &&
+http-server dist/ &
+wait

--- a/scripts/webpack.config.serve.babel.js
+++ b/scripts/webpack.config.serve.babel.js
@@ -1,0 +1,14 @@
+import webpack from 'webpack';
+import baseConfig from './webpack.config.jsdelivr.babel.js';
+
+export default {
+  ...baseConfig,
+  plugins: [
+    ...baseConfig.plugins,
+    new webpack.optimize.UglifyJsPlugin({
+      compress: {
+        warnings: false
+      }
+    })
+  ]
+};


### PR DESCRIPTION
`npm run serve` will build the current instantsearch and expose the
file on http://127.0.0.1:8080/instantsearch.js. It will get
automatically updated in each change.

This is useful when you want to test your branch in a specific
project. Just run `npm run serve` in the instantsearch repo and link
to the file in your project.

I've regenerated the shrinkwrap but had to run a `npm prune` before
shrinkwrap allowed me to do it, so I updated the doc accordingly.