### PR TITLE
fix(showMore): hide showMore when no more facet values to show

### DIFF
--- a/src/components/RefinementList/RefinementList.js
+++ b/src/components/RefinementList/RefinementList.js
@@ -129,9 +129,11 @@ class RefinementList extends React.Component {
 
     const limit = this.state.isShowMoreOpen ? this.props.limitMax : this.props.limitMin;
     let displayedFacetValues = this.props.facetValues.slice(0, limit);
+    const displayShowMore = this.props.showMore === true &&
+      this.props.facetValues.length > displayedFacetValues.length ||
+      this.state.isShowMoreOpen === true;
 
-    const showMoreBtn =
-      this.props.showMore ?
+    const showMoreBtn = displayShowMore ?
         <Template
           rootProps={{onClick: this.handleClickShowMore}}
           templateKey={'show-more-' + (this.state.isShowMoreOpen ? 'active' : 'inactive')}


### PR DESCRIPTION
If number of facet values is 5 and limit is 5 then we were still
displaying the showMore button.

Now fixed, no added tests, waiting for
#948