### PR TITLE
docs(examples): ensure the YAML header is first in the file

### DIFF
--- a/docs/examples/e-commerce/main.scss
+++ b/docs/examples/e-commerce/main.scss
@@ -1,7 +1,7 @@
-@charset 'utf-8';
 ---
 # this ensures Jekyll reads the file to be transformed into CSS later
 ---
+@charset 'utf-8';
 
 $gray-light: #EEE;
 $gray: #888;

--- a/docs/examples/media/main.scss
+++ b/docs/examples/media/main.scss
@@ -1,7 +1,7 @@
-@charset 'utf-8';
 ---
 # this ensures Jekyll reads the file to be transformed into CSS later
 ---
+@charset 'utf-8';
 
 $white: #FFFFFF;
 $media-red: #E91D00;

--- a/docs/examples/tourism/main.scss
+++ b/docs/examples/tourism/main.scss
@@ -1,7 +1,7 @@
-@charset 'utf-8';
 ---
 # this ensures Jekyll reads the file to be transformed into CSS later
 ---
+@charset 'utf-8';
 
 /* VARIABLES
 // ------------------------- */


### PR DESCRIPTION
Otherwise, the SCSS files are not considered by Jekyll's assets pipeline