### PR TITLE
fix(lifecycle): save configuration done in widget.init

### DIFF
--- a/dev/app.js
+++ b/dev/app.js
@@ -305,6 +305,7 @@ search.addWidget(
       link: 'facet-value',
       count: 'facet-count pull-right'
     },
+    rootPath: 'Cameras & Camcorders > Digital Camera Accessories',
     templates: {
       header: 'Hierarchical categories'
     }

--- a/dev/index.html
+++ b/dev/index.html
@@ -67,11 +67,11 @@
               </div>
             </div>
           </div>
+          <div id="pagination" class="text-center"></div>
           <h3>Results overview</h3>
           <div id="hits-table"></div>
           <h3>Results</h3>
           <div id="hits"></div>
-          <div id="pagination" class="text-center"></div>
         </div>
       </div>
     </div>

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -102,14 +102,15 @@ Usage: instantsearch({
   start() {
     if (!this.widgets) throw new Error('No widgets were added to instantsearch.js');
 
+    let syncWidget;
+
     if (this.urlSync) {
-      let syncWidget = urlSyncWidget(this.urlSync);
+      syncWidget = urlSyncWidget(this.urlSync);
       this._createURL = syncWidget.createURL.bind(syncWidget);
       this._onHistoryChange = syncWidget.onHistoryChange.bind(syncWidget);
-      this.widgets.push(syncWidget);
     } else {
       this._createURL = defaultCreateURL;
-      this._onHistoryChange = function() {};
+      this._onHistoryChange = () => {};
     }
 
     this.searchParameters = this.widgets.reduce(enhanceConfiguration, this.searchParameters);
@@ -128,6 +129,12 @@ Usage: instantsearch({
     this.helper = helper;
 
     this._init(helper.state, helper);
+
+    if (this.urlSync) {
+      helper.setState(enhanceConfiguration(helper.state, syncWidget));
+      syncWidget.init({helper});
+    }
+
     helper.on('result', this._render.bind(this, helper));
     helper.search();
   }


### PR DESCRIPTION
Before this commit, every configuration done in widget.init would not
be remembered when going back in the browser history.

Scenario: You built a custom widget using helper.setQueryParameter in
widget.init. Then you load "/", widget.init() sets some helper params,
you go to page 2, you click on <= back. Before this commit we would
forget what was done in widget.init(). Now it works.

This was needed to fix the "rootPath" option of the hierarchicalMenu.
The rootPath option triggers a state change from inside the helper
(which may have been a bad idea after all) => it was not remembered
when going back to empty url.

Thanks to @maxiloc for the bug report and big help solving this!