### PR TITLE
fix(urlSync): only start watching for changes at first render

### DIFF
--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -135,7 +135,7 @@ Usage: instantsearch({
 
     if (this.urlSync) {
       helper.setState(enhanceConfiguration(helper.state, syncWidget));
-      syncWidget.init({helper});
+      this.widgets.push(syncWidget);
     }
 
     helper.on('result', this._render.bind(this, helper));

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -43,7 +43,7 @@ describe('InstantSearch lifecycle', () => {
       createURL: sinon.spy(),
       onHistoryChange: () => {},
       getConfiguration: sinon.spy(),
-      init: () => {}
+      render: () => {}
     };
 
     algoliasearch = sinon.stub().returns(client);

--- a/src/lib/url-sync.js
+++ b/src/lib/url-sync.js
@@ -6,6 +6,7 @@ import merge from 'lodash/object/merge';/**/
 
 let AlgoliaSearchHelper = algoliasearchHelper.AlgoliaSearchHelper;
 let majorVersionNumber = version.split('.')[0];
+let firstRender = true;
 
 function timerMaker(t0) {
   let t = t0;
@@ -103,11 +104,12 @@ class URLSync {
     return config;
   }
 
-  init({helper}) {
-    helper.on('change', (state) => {
-      this.renderURLFromState(state);
-    });
-    this.onHistoryChange(this.onPopState.bind(this, helper));
+  render({helper}) {
+    if (firstRender) {
+      firstRender = false;
+      this.onHistoryChange(this.onPopState.bind(this, helper));
+      helper.on('change', state => this.renderURLFromState(state));
+    }
   }
 
   onPopState(helper, fullState) {

--- a/src/widgets/search-box/__tests__/search-box-test.js
+++ b/src/widgets/search-box/__tests__/search-box-test.js
@@ -209,12 +209,18 @@ describe('searchBox()', () => {
       container = document.body.appendChild(document.createElement('input'));
     });
 
-    function simulateInputEvent(query) {
+    function simulateInputEvent(query, stateQuery) {
       if (query === undefined) {
         query = 'test';
       }
+
       // Given
-      helper.state.query = 'tes';
+      if (stateQuery !== undefined) {
+        helper.state.query = stateQuery;
+      } else {
+        helper.state.query = 'tes';
+      }
+
       // When
       widget.init({state, helper, onHistoryChange});
       // Then
@@ -236,6 +242,12 @@ describe('searchBox()', () => {
       it('sets the query on any change', () => {
         simulateInputEvent();
         expect(helper.setQuery.calledOnce).toBe(true);
+      });
+
+      it('does nothing when query is the same as state', () => {
+        simulateInputEvent('test', 'test');
+        expect(helper.setQuery.calledOnce).toBe(false);
+        expect(helper.search.called).toBe(false);
       });
     });
 

--- a/src/widgets/search-box/search-box.js
+++ b/src/widgets/search-box/search-box.js
@@ -155,6 +155,10 @@ function searchBox({
       }
 
       function maybeSearch(query) {
+        if (query === helper.state.query) {
+          return;
+        }
+
         if (queryHook) {
           queryHook(query, search);
           return;


### PR DESCRIPTION
Before this commit, if one of the widget was making helper changes in
his init(), we would trigger a change event that would update the url.

What we want is that everything done before the first render should be
considered as start configuration and not synced into the url UNLESS
there are new differences (user changes the query).

It also fixed a nasty IE10/11 bug where the input event would be
triggered as soon as a placeholder is set into the DOM or
programmatically.