### PR TITLE
fix(rootpath): remember rootpath option on 'back' button

### DIFF
--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -105,15 +105,14 @@ Usage: instantsearch({
   start() {
     if (!this.widgets) throw new Error('No widgets were added to instantsearch.js');
 
-    let syncWidget;
-
     if (this.urlSync) {
-      syncWidget = urlSyncWidget(this.urlSync);
+      let syncWidget = urlSyncWidget(this.urlSync);
       this._createURL = syncWidget.createURL.bind(syncWidget);
       this._onHistoryChange = syncWidget.onHistoryChange.bind(syncWidget);
+      this.widgets.push(syncWidget);
     } else {
       this._createURL = defaultCreateURL;
-      this._onHistoryChange = () => {};
+      this._onHistoryChange = function() {};
     }
 
     this.searchParameters = this.widgets.reduce(enhanceConfiguration, this.searchParameters);
@@ -132,11 +131,6 @@ Usage: instantsearch({
     this.helper = helper;
 
     this._init(helper.state, helper);
-
-    if (this.urlSync) {
-      helper.setState(enhanceConfiguration(helper.state, syncWidget));
-      this.widgets.push(syncWidget);
-    }
 
     helper.on('result', this._render.bind(this, helper));
     helper.search();

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -175,10 +175,8 @@ describe('InstantSearch lifecycle', () => {
 
       it('calls urlSync.getConfiguration after every widget', () => {
         expect(urlSync.getConfiguration.calledOnce).toBe(true, 'urlSync.getConfiguration called once');
-        expect(widget.init.calledAfter(widget.getConfiguration))
+        expect(urlSync.getConfiguration.calledAfter(widget.getConfiguration))
           .toBe(true, 'urlSync.getConfiguration was called after widget.init');
-        expect(urlSync.getConfiguration.getCall(0).args[0].sendMeToUrlSync)
-          .toBe(true, 'state modifications done in widget.init should be sent to urlSync.getConfiguration');
       });
 
       it('does not call widget.render', () => {

--- a/src/lib/url-sync.js
+++ b/src/lib/url-sync.js
@@ -98,7 +98,10 @@ class URLSync {
   }
 
   getConfiguration(currentConfiguration) {
-    this.originalConfig = currentConfiguration;
+    // we need to create a REAL helper to then get its state. Because some parameters
+    // like hierarchicalFacet.rootPath are then triggering a default refinement that would
+    // be not present if it was not going trough the SearchParameters constructor
+    this.originalConfig = algoliasearchHelper({}, currentConfiguration.index, currentConfiguration).state;
     let queryString = this.urlUtils.readUrl();
     let config = AlgoliaSearchHelper.getConfigurationFromQueryString(queryString, {mapping: this.mapping});
     return config;


### PR DESCRIPTION
Before this commit, when using the rootpath option and clicking on
backbutton after switching a page would result in the rootpath option
seeming "forgotten"

This was triggered because rootpath is a "magical" (BAD!!) option that
is triggering a refinement internally in the helper's SearchParameters
constructor.

Thus, in the urlSync widget, to determine the "original configuration"
(= all widgets getConfiguration before url sync) we need to go through
the SearchParameters constructor.

Also note that we originally wanted to understand the url sync
"original config" as being widget's getConfiguration + widget's init
but that's no doable because the way we implemented url sync. Indeed
there's no way to differentiate the state of the url from the state of
the widget's init action after all widget.init are called.

Thus when clicking back, we are not able to tell what are the
parameters we want to go back to.

In a V2 of instantsearch.js we should be able to have init({helper,
state, urlState}).

Or maybe there's another way. I will need to discuss this with
@bobylito :)