### PR TITLE
docs(transformData): Only document explicit objects for `transformData`

### DIFF
--- a/src/widgets/clear-all/clear-all.js
+++ b/src/widgets/clear-all/clear-all.js
@@ -21,9 +21,9 @@ let bem = bemHelper('ais-clear-all');
  * @function clearAll
  * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
  * @param  {Object} [options.templates] Templates to use for the widget
- * @param  {string|Function} [options.templates.header=''] Header template
+ * @param  {string|Function} [options.templates.header] Header template
  * @param  {string|Function} [options.templates.link] Link template
- * @param  {string|Function} [options.templates.footer=''] Footer template
+ * @param  {string|Function} [options.templates.footer] Footer template
  * @param  {boolean} [options.autoHideContainer=true] Hide the container when there's no refinement to clear
  * @param  {Object} [options.cssClasses] CSS classes to be added
  * @param  {string|string[]} [options.cssClasses.root] CSS class to add to the root element
@@ -39,7 +39,7 @@ const usage = `Usage:
 clearAll({
   container,
   [ cssClasses.{root,header,body,footer,link}={} ],
-  [ templates.{header,link,footer}={header: '', link: 'Clear all', footer: ''} ],
+  [ templates.{header,link,footer}={link: 'Clear all'} ],
   [ autoHideContainer=true ],
   [ collapsible=false ]
 })`;

--- a/src/widgets/current-refined-values/__tests__/current-refined-values-test.js
+++ b/src/widgets/current-refined-values/__tests__/current-refined-values-test.js
@@ -35,7 +35,9 @@ describe('currentRefinedValues()', () => {
         onlyListedAttributes: false,
         clearAll: 'after',
         templates: {},
-        transformData: (data) => data,
+        transformData: {
+          item: (data) => data
+        },
         autoHideContainer: false,
         cssClasses: {}
       };
@@ -250,6 +252,13 @@ describe('currentRefinedValues()', () => {
 
       it('doesn\'t throw usage with a function', () => {
         parameters.transformData = (data) => data;
+        expect(boundWidget).toNotThrow();
+      });
+
+      it('doesn\'t throw usage with an object of functions', () => {
+        parameters.transformData = {
+          item: (data) => data
+        };
         expect(boundWidget).toNotThrow();
       });
 

--- a/src/widgets/current-refined-values/current-refined-values.js
+++ b/src/widgets/current-refined-values/current-refined-values.js
@@ -39,11 +39,11 @@ let bem = bemHelper('ais-current-refined-values');
  * @param  {boolean|string}    [option.clearAll='before'] Clear all position (one of ('before', 'after', false))
  * @param  {boolean}           [options.onlyListedAttributes=false] Only use declared attributes
  * @param  {Object}            [options.templates] Templates to use for the widget
- * @param  {string|Function}   [options.templates.header=''] Header template
+ * @param  {string|Function}   [options.templates.header] Header template
  * @param  {string|Function}   [options.templates.item] Item template
  * @param  {string|Function}   [options.templates.clearAll] Clear all template
- * @param  {string|Function}   [options.templates.footer=''] Footer template
- * @param  {Function}          [options.transformData] Function to change the object passed to the `body` template
+ * @param  {string|Function}   [options.templates.footer] Footer template
+ * @param  {Function}          [options.transformData.item] Function to change the object passed to the `item` template
  * @param  {boolean}           [options.autoHideContainer=true] Hide the container when no current refinements
  * @param  {Object}            [options.cssClasses] CSS classes to be added
  * @param  {string}            [options.cssClasses.root] CSS classes added to the root element
@@ -65,8 +65,8 @@ currentRefinedValues({
   [ attributes: [{name[, label, template, transformData]}] ],
   [ onlyListedAttributes = false ],
   [ clearAll = 'before' ] // One of ['before', 'after', false]
-  [ templates.{header = '', item, clearAll, footer = ''} ],
-  [ transformData ],
+  [ templates.{header,item,clearAll,footer} ],
+  [ transformData.{item} ],
   [ autoHideContainer = true ],
   [ cssClasses.{root, header, body, clearAll, list, item, link, count, footer} = {} ],
   [ collapsible=false ]
@@ -108,6 +108,10 @@ function currentRefinedValues({
        isString(val) || isArray(val);
     }, true);
 
+  const transformDataOK = isUndefined(transformData) ||
+    isFunction(transformData) ||
+    (isPlainObject(transformData) && isFunction(transformData.item));
+
   const showUsage = false ||
     !(isString(container) || isDomElement(container)) ||
     !isArray(attributes) ||
@@ -116,7 +120,7 @@ function currentRefinedValues({
     [false, 'before', 'after'].indexOf(clearAll) === -1 ||
     !isPlainObject(templates) ||
     !templatesOK ||
-    !(isUndefined(transformData) || isFunction(transformData)) ||
+    !transformDataOK ||
     !isBoolean(autoHideContainer) ||
     !userCssClassesOK;
 
@@ -157,6 +161,7 @@ function currentRefinedValues({
       };
 
       let templateProps = prepareTemplateProps({
+        transformData,
         defaultTemplates,
         templatesConfig,
         templates

--- a/src/widgets/hierarchical-menu/hierarchical-menu.js
+++ b/src/widgets/hierarchical-menu/hierarchical-menu.js
@@ -27,7 +27,7 @@ let bem = bemHelper('ais-hierarchical-menu');
  * @param  {string|Function} [options.templates.header=''] Header template (root level only)
  * @param  {string|Function} [options.templates.item] Item template, provided with `name`, `count`, `isRefined`, `url` data properties
  * @param  {string|Function} [options.templates.footer=''] Footer template (root level only)
- * @param  {Function} [options.transformData] Method to change the object passed to the item template
+ * @param  {Function} [options.transformData.item] Method to change the object passed to the `item` template
  * @param  {boolean} [options.autoHideContainer=true] Hide the container when there are no items in the menu
  * @param  {Object} [options.cssClasses] CSS classes to add to the wrapping elements
  * @param  {string|string[]} [options.cssClasses.root] CSS class to add to the root element
@@ -55,7 +55,7 @@ hierarchicalMenu({
   [ sortBy=['name:asc'] ],
   [ cssClasses.{root , header, body, footer, list, depth, item, active, link}={} ],
   [ templates.{header, item, footer} ],
-  [ transformData ],
+  [ transformData.{item} ],
   [ autoHideContainer=true ],
   [ collapsible=false ]
 })`;

--- a/src/widgets/hits/hits.js
+++ b/src/widgets/hits/hits.js
@@ -20,9 +20,9 @@ let bem = bemHelper('ais-hits');
  * @param  {string|Function} [options.templates.item=''] Template to use for each result. This template will receive an object containing a single record.
  * @param  {string|Function} [options.templates.allItems=''] Template to use for the list of all results. (Can't be used with `item` template). This template will receive a complete SearchResults result object, this object contains the key hits that contains all the records retrieved.
  * @param  {Object} [options.transformData] Method to change the object passed to the templates
- * @param  {Function} [options.transformData.empty=identity] Method used to change the object passed to the `empty` template
- * @param  {Function} [options.transformData.item=identity] Method used to change the object passed to the `item` template
- * @param  {Function} [options.transformData.allItems=identity] Method used to change the object passed to the `allItems` template
+ * @param  {Function} [options.transformData.empty] Method used to change the object passed to the `empty` template
+ * @param  {Function} [options.transformData.item] Method used to change the object passed to the `item` template
+ * @param  {Function} [options.transformData.allItems] Method used to change the object passed to the `allItems` template
  * @param  {number} [hitsPerPage=20] The number of hits to display per page
  * @param  {Object} [options.cssClasses] CSS classes to add
  * @param  {string|string[]} [options.cssClasses.root] CSS class to add to the wrapping element
@@ -36,7 +36,7 @@ hits({
   container,
   [ cssClasses.{root,empty,item}={} ],
   [ templates.{empty,item} | templates.{empty, allItems} ],
-  [ transformData.{empty=identity,item=identity} | transformData.{empty, allItems} ],
+  [ transformData.{empty,item} | transformData.{empty, allItems} ],
   [ hitsPerPage=20 ]
 })`;
 function hits({

--- a/src/widgets/menu/menu.js
+++ b/src/widgets/menu/menu.js
@@ -28,10 +28,10 @@ let bem = bemHelper('ais-menu');
  * @param  {object} [options.showMore.templates.inactive] Template used when showMore not clicked
  * @param  {object} [options.showMore.limit] Max number of facets values to display when showMore is clicked
  * @param  {Object} [options.templates] Templates to use for the widget
- * @param  {string|Function} [options.templates.header=''] Header template
+ * @param  {string|Function} [options.templates.header] Header template
  * @param  {string|Function} [options.templates.item] Item template, provided with `name`, `count`, `isRefined`, `url` data properties
- * @param  {string|Function} [options.templates.footer=''] Footer template
- * @param  {Function} [options.transformData] Method to change the object passed to the item template
+ * @param  {string|Function} [options.templates.footer] Footer template
+ * @param  {Function} [options.transformData.item] Method to change the object passed to the `item` template
  * @param  {boolean} [options.autoHideContainer=true] Hide the container when there are no items in the menu
  * @param  {Object} [options.cssClasses] CSS classes to add to the wrapping elements
  * @param  {string|string[]} [options.cssClasses.root] CSS class to add to the root element
@@ -55,7 +55,7 @@ menu({
   [ limit=10 ],
   [ cssClasses.{root,list,item} ],
   [ templates.{header,item,footer} ],
-  [ transformData ],
+  [ transformData.{item} ],
   [ autoHideContainer ],
   [ showMore.{templates: {active, inactive}, limit} ],
   [ collapsible=false ]

--- a/src/widgets/numeric-refinement-list/numeric-refinement-list.js
+++ b/src/widgets/numeric-refinement-list/numeric-refinement-list.js
@@ -25,7 +25,7 @@ let bem = bemHelper('ais-refinement-list');
  * @param  {string|Function} [options.templates.header] Header template
  * @param  {string|Function} [options.templates.item] Item template, provided with `name`, `isRefined`, `url` data properties
  * @param  {string|Function} [options.templates.footer] Footer template
- * @param  {Function} [options.transformData] Function to change the object passed to the item template
+ * @param  {Function} [options.transformData.item] Function to change the object passed to the `item` template
  * @param  {boolean} [options.autoHideContainer=true] Hide the container when no results match
  * @param  {Object} [options.cssClasses] CSS classes to add to the wrapping elements
  * @param  {string|string[]} [options.cssClasses.root] CSS class to add to the root element
@@ -48,7 +48,7 @@ numericRefinementList({
   options,
   [ cssClasses.{root,header,body,footer,list,item,active,label,checkbox,count} ],
   [ templates.{header,item,footer} ],
-  [ transformData ],
+  [ transformData.{item} ],
   [ autoHideContainer ],
   [ collapsible=false ]
 })`;

--- a/src/widgets/refinement-list/refinement-list.js
+++ b/src/widgets/refinement-list/refinement-list.js
@@ -31,7 +31,7 @@ let bem = bemHelper('ais-refinement-list');
  * @param  {string|Function} [options.templates.header] Header template
  * @param  {string|Function} [options.templates.item] Item template, provided with `name`, `count`, `isRefined`, `url` data properties
  * @param  {string|Function} [options.templates.footer] Footer template
- * @param  {Function} [options.transformData] Function to change the object passed to the item template
+ * @param  {Function} [options.transformData.item] Function to change the object passed to the `item` template
  * @param  {boolean} [options.autoHideContainer=true] Hide the container when no items in the refinement list
  * @param  {Object} [options.cssClasses] CSS classes to add to the wrapping elements
  * @param  {string|string[]} [options.cssClasses.root] CSS class to add to the root element
@@ -57,7 +57,7 @@ refinementList({
   [ limit=10 ],
   [ cssClasses.{root, header, body, footer, list, item, active, label, checkbox, count}],
   [ templates.{header,item,footer} ],
-  [ transformData ],
+  [ transformData.{item} ],
   [ autoHideContainer=true ],
   [ collapsible=false ],
   [ showMore.{templates: {active, inactive}, limit} ],

--- a/src/widgets/star-rating/star-rating.js
+++ b/src/widgets/star-rating/star-rating.js
@@ -14,19 +14,6 @@ import RefinementListComponent from '../../components/RefinementList/RefinementL
 
 let bem = bemHelper('ais-star-rating');
 
-const usage = `Usage:
-starRating({
-  container,
-  attributeName,
-  [ max=5 ],
-  [ cssClasses.{root,header,body,footer,list,item,active,link,disabledLink,star,emptyStar,count} ],
-  [ templates.{header,item,footer} ],
-  [ labels.{andUp} ],
-  [ transformData ],
-  [ autoHideContainer=true ],
-  [ collapsible=false ]
-})`;
-
 /**
  * Instantiate a list of refinements based on a rating attribute
  * The ratings must be integer values. You can still keep the precise float value in another attribute
@@ -41,7 +28,7 @@ starRating({
  * @param  {string|Function} [options.templates.header] Header template
  * @param  {string|Function} [options.templates.item] Item template, provided with `name`, `count`, `isRefined`, `url` data properties
  * @param  {string|Function} [options.templates.footer] Footer template
- * @param  {Function} [options.transformData] Function to change the object passed to the item template
+ * @param  {Function} [options.transformData.item] Function to change the object passed to the `item` template
  * @param  {boolean} [options.autoHideContainer=true] Hide the container when no results match
  * @param  {Object} [options.cssClasses] CSS classes to add to the wrapping elements
  * @param  {string|string[]} [options.cssClasses.root] CSS class to add to the root element
@@ -59,6 +46,18 @@ starRating({
  * @param  {boolean} [options.collapsible.collapsed] Initial collapsed state of a collapsible widget
  * @return {Object}
  */
+const usage = `Usage:
+starRating({
+  container,
+  attributeName,
+  [ max=5 ],
+  [ cssClasses.{root,header,body,footer,list,item,active,link,disabledLink,star,emptyStar,count} ],
+  [ templates.{header,item,footer} ],
+  [ transformData.{item} ],
+  [ labels.{andUp} ],
+  [ autoHideContainer=true ],
+  [ collapsible=false ]
+})`;
 function starRating({
     container,
     attributeName,

--- a/src/widgets/stats/stats.js
+++ b/src/widgets/stats/stats.js
@@ -22,7 +22,7 @@ let bem = bemHelper('ais-stats');
  * @param  {string|Function} [options.templates.body] Body template, provided with `hasManyResults`,
  * `hasNoResults`, `hasOneResult`, `hitsPerPage`, `nbHits`, `nbPages`, `page`, `processingTimeMS`, `query`
  * @param  {string|Function} [options.templates.footer=''] Footer template
- * @param  {Function} [options.transformData] Function to change the object passed to the `body` template
+ * @param  {Function} [options.transformData.body] Function to change the object passed to the `body` template
  * @param  {boolean} [options.autoHideContainer=true] Hide the container when no results match
  * @param  {Object} [options.cssClasses] CSS classes to add
  * @param  {string|string[]} [options.cssClasses.root] CSS class to add to the root element
@@ -35,8 +35,8 @@ let bem = bemHelper('ais-stats');
 const usage = `Usage:
 stats({
   container,
-  [ template ],
-  [ transformData ],
+  [ templates.{header,body,footer} ],
+  [ transformData.{body} ],
   [ autoHideContainer]
 })`;
 function stats({

--- a/src/widgets/toggle/toggle.js
+++ b/src/widgets/toggle/toggle.js
@@ -25,10 +25,10 @@ let bem = bemHelper('ais-toggle');
  * @param  {string|number|boolean} [options.values.off] Value to filter on when unchecked
  * element (when using the default template)
  * @param  {Object} [options.templates] Templates to use for the widget
- * @param  {string|Function} [options.templates.header=''] Header template
+ * @param  {string|Function} [options.templates.header] Header template
  * @param  {string|Function} [options.templates.item] Item template
- * @param  {string|Function} [options.templates.footer=''] Footer template
- * @param  {Function} [options.transformData] Function to change the object passed to the item template
+ * @param  {string|Function} [options.templates.footer] Footer template
+ * @param  {Function} [options.transformData.item] Function to change the object passed to the `item` template
  * @param  {boolean} [options.autoHideContainer=true] Hide the container when there's no results
  * @param  {Object} [options.cssClasses] CSS classes to add
  * @param  {string|string[]} [options.cssClasses.root] CSS class to add to the root element
@@ -55,7 +55,7 @@ toggle({
   [ userValues={on: true, off: undefined} ],
   [ cssClasses.{root,header,body,footer,list,item,active,label,checkbox,count} ],
   [ templates.{header,item,footer} ],
-  [ transformData ],
+  [ transformData.{item} ],
   [ autoHideContainer=true ],
   [ collapsible=false ]
 })`;


### PR DESCRIPTION
We can currently pass for `transformData` either an object or
a function. If passed a function, it will be applied on every
template, while if passing an object, each key function will only be
applied to the template with a matching name.

We think the "top level" call to a function creates more issues than
an explicit definition. It usually creates weird effects when the
method is applied to a "no result" set, resulting in errors. To avoid
that, we will stop documenting the feature, and remove it completely
in a next major version.

I've updated the documentation to reflect this change, ie always
documenting `transformData.item` instead of just `transformData` as
the place to put the custom method. I've updated the `usage` errors
accordingly as well. It should still silently accept the top level function, but at least it is no longer documented and will be easier to deprecate in the future.

I also fixed a few errors in the docs, like removing empty default
values (it was only adding noise to the docs, and was not consistent).

I've also fixed an inconsistency between the documentation and the
code in the `currentRefinedValues` widget. It was previously not
possible to pass a `transformData.item` (this resulted in an error),
while passing a `transformData` directly was accepted, but didn't
produce any effect. We can now correctly pass `transformData.item`.