### PR TITLE
docs(header): Fix the header when scrolling

### DIFF
--- a/docs/_assets/stylesheets/_header.scss
+++ b/docs/_assets/stylesheets/_header.scss
@@ -3,6 +3,8 @@
 
 .site-header {
   width: 100%;
+  position: fixed;
+  z-index: 999;
 
   .navbar {
     border-radius: 0;

--- a/docs/_assets/stylesheets/_home.scss
+++ b/docs/_assets/stylesheets/_home.scss
@@ -59,7 +59,7 @@ h2 {
 }
 
 .hero {
-  padding-top: 100px;
+  padding-top: 170px;
   opacity: 1;
 }
 

--- a/docs/_assets/stylesheets/_page.scss
+++ b/docs/_assets/stylesheets/_page.scss
@@ -1,3 +1,6 @@
+.main-content {
+  padding-top: 70px;
+}
 .page-content {
   font-size: 1.1em;
   line-height: 1.5em;


### PR DESCRIPTION
I've had feedbacks that when discovering instantsearch.js for the
first time, people scroll down on the home page and once they are at
the bottom they don't know where to go because the menu disappeared.
They thought it was just a promo page, with no more content, so they
closed it.

I've set the header as `position: fixed` like on the documentation
page. Seems like a recent commit did remove the fixed header by
mistake.

| Before | After |
|---------- | --------- |
| ![2016-05-25_15h33m39](https://cloud.githubusercontent.com/assets/283419/15558342/2bdd7340-228e-11e6-972a-7ed52c0f3ba3.gif) | ![2016-05-25_15h36m18](https://cloud.githubusercontent.com/assets/283419/15558370/7a611c6a-228e-11e6-9869-63386795945e.gif) |


cc @Shipow 