### PR TITLE
fix(lite): use lite algoliasearch build (js client)

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5,8 +5,8 @@
   "node-version": "v5.11.0",
   "dependencies": {
     "algoliasearch": {
-      "version": "3.14.4",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-3.14.4.tgz",
+      "version": "3.14.5",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-3.14.5.tgz",
       "dependencies": {
         "agentkeepalive": {
           "version": "2.1.1",
@@ -73,6 +73,26 @@
         "foreach": {
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
+        },
+        "global": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/global/-/global-4.3.0.tgz",
+          "dependencies": {
+            "min-document": {
+              "version": "2.18.0",
+              "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.18.0.tgz",
+              "dependencies": {
+                "dom-walk": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz"
+                }
+              }
+            },
+            "process": {
+              "version": "0.5.2",
+              "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz"
+            }
+          }
         },
         "inherits": {
           "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "webpack-dev-server": "^1.14.1"
   },
   "dependencies": {
-    "algoliasearch": "^3.14.4",
+    "algoliasearch": "^3.14.5",
     "algoliasearch-helper": "^2.9.0",
     "classnames": "^2.2.5",
     "events": "^1.1.0",

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -1,4 +1,4 @@
-import algoliasearch from 'algoliasearch';
+import algoliasearch from 'algoliasearch/lite';
 import algoliasearchHelper from 'algoliasearch-helper';
 import forEach from 'lodash/collection/forEach';
 import merge from 'lodash/object/merge';


### PR DESCRIPTION
fixes #1024 by forcing to load /lite and avoid bad resolve of the
browser field.

This could break if people were using search.client to do things like
indexing. But we do document this as an API entry. We only have an
infinite scroll tutorial using the client passed to the helper. Thus I
had to make browse and browseFrom part of the lite build.