### PR TITLE
Docs: makes parameter descriptions collapsible

### DIFF
--- a/docs/_assets/javascripts/doc.js
+++ b/docs/_assets/javascripts/doc.js
@@ -181,6 +181,15 @@
     });
   }
 
+  function foldableDetails() {
+    $('.attr-name').on('click', function() {
+      var $descriptionParagraph = $(this).next('.attr-description')
+      var isVisible = $descriptionParagraph.is(':visible');
+      $('.attr-description').hide();
+      if(!isVisible) $descriptionParagraph.show();
+    });
+  }
+
   search();
   codeTabs();
   htmlTabs();
@@ -188,4 +197,5 @@
   copyButtons();
   tocMenu();
   scrollToRightAnchor();
+  foldableDetails();
 })(window.jQuery);

--- a/docs/_assets/stylesheets/_documentation.scss
+++ b/docs/_assets/stylesheets/_documentation.scss
@@ -340,6 +340,19 @@ code {
     code {
       background-color: #0A1724;
     }
+    .attr-name {
+      margin: 10px 0 0;
+      cursor: help;
+      .show-description {
+        padding: 0 6px;
+        background: #132F49;
+        margin-left: 3px;
+        font-weight: bold;
+      }
+      &:hover .show-description {
+        color: #FFF;
+      }
+    }
     .attr-optional code {
       color: #46AEDA;
     }
@@ -347,9 +360,14 @@ code {
       color: $success-color;
     }
     .attr-infos {
-      display: block;
       font-size: .8em;
       margin-left: 10px;
+      float: right;
+    }
+    .attr-description {
+      margin: -5px 0 0;
+      display: none;
+      clear: both;
     }
     h5 {
       text-decoration: underline;

--- a/docs/_includes/widget-jsdoc/addWidget.md
+++ b/docs/_includes/widget-jsdoc/addWidget.md
@@ -1,8 +1,23 @@
-| Param | Description |
-| --- | --- |
-| <span class='attr-optional'>`widget`</span><span class="attr-infos">Type: <code>Object</code></span> | The widget to add |
-| <span class='attr-optional'>`widget.render`</span><span class="attr-infos">Type: <code>function</code></span> | Called after each search response has been received |
-| <span class='attr-optional'>`widget.getConfiguration`</span><span class="attr-infos">Type: <code>function</code></span> | Let the widget update the configuration of the search with new parameters |
-| <span class='attr-optional'>`widget.init`</span><span class="attr-infos">Type: <code>function</code></span> | Called once before the first search |
+<h4>Parameters</h4>
+<p class="attr-name">
+<span class='attr-optional'>`widget`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">The widget to add</p>
+<p class="attr-name">
+<span class='attr-optional'>`widget.render`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>function</code>)</span> 
+</p>
+<p class="attr-description">Called after each search response has been received</p>
+<p class="attr-name">
+<span class='attr-optional'>`widget.getConfiguration`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>function</code>)</span> 
+</p>
+<p class="attr-description">Let the widget update the configuration of the search with new parameters</p>
+<p class="attr-name">
+<span class='attr-optional'>`widget.init`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>function</code>)</span> 
+</p>
+<p class="attr-description">Called once before the first search</p>
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/clearAll.md
+++ b/docs/_includes/widget-jsdoc/clearAll.md
@@ -1,18 +1,73 @@
-| Param | Description |
-| --- | --- |
-| <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
-| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
-| <span class='attr-optional'>`options.templates.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Header template |
-| <span class='attr-optional'>`options.templates.link`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Link template |
-| <span class='attr-optional'>`options.templates.footer`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Footer template |
-| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when there's no refinement to clear |
-| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to be added |
-| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the root element |
-| <span class='attr-optional'>`options.cssClasses.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the header element |
-| <span class='attr-optional'>`options.cssClasses.body`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the body element |
-| <span class='attr-optional'>`options.cssClasses.footer`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the footer element |
-| <span class='attr-optional'>`options.cssClasses.link`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the link element |
-| <span class='attr-optional'>`options.collapsible`</span><span class="attr-infos">Default:<code class="attr-default">false</code><br />Type: <code>object</code> &#124; <code>boolean</code></span> | Hide the widget body and footer when clicking on header |
-| <span class='attr-optional'>`options.collapsible.collapsed`</span><span class="attr-infos">Type: <code>boolean</code></span> | Initial collapsed state of a collapsible widget |
+<h4>Parameters</h4>
+<p class="attr-name">
+<span class='attr-required'>`options.container`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>DOMElement</code>)</span> 
+</p>
+<p class="attr-description">CSS Selector or DOMElement to insert the widget</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">Templates to use for the widget</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates.header`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Header template</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates.link`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Link template</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates.footer`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Footer template</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.autoHideContainer`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">true</code>(<code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Hide the container when there's no refinement to clear</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">CSS classes to be added</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.root`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the root element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.header`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the header element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.body`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the body element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.footer`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the footer element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.link`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the link element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.collapsible`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">false</code>(<code>object</code> &#124; <code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Hide the widget body and footer when clicking on header</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.collapsible.collapsed`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Initial collapsed state of a collapsible widget</p>
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/currentRefinedValues.md
+++ b/docs/_includes/widget-jsdoc/currentRefinedValues.md
@@ -1,31 +1,138 @@
-| Param | Description |
-| --- | --- |
-| <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
-| <span class='attr-optional'>`option.attributes`</span><span class="attr-infos">Type: <code>Array</code></span> | Attributes configuration |
-| <span class='attr-optional'>`option.attributes[].name`</span><span class="attr-infos">Type: <code>string</code></span> | Required attribute name |
-| <span class='attr-optional'>`option.attributes[].label`</span><span class="attr-infos">Type: <code>string</code></span> | Attribute label (passed to the item template) |
-| <span class='attr-optional'>`option.attributes[].template`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Attribute specific template |
-| <span class='attr-optional'>`option.attributes[].transformData`</span><span class="attr-infos">Type: <code>function</code></span> | Attribute specific transformData |
-| <span class='attr-optional'>`option.clearAll`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;before&#x27;</code><br />Type: <code>boolean</code> &#124; <code>string</code></span> | Clear all position (one of ('before', 'after', false)) |
-| <span class='attr-optional'>`options.onlyListedAttributes`</span><span class="attr-infos">Default:<code class="attr-default">false</code><br />Type: <code>boolean</code></span> | Only use declared attributes |
-| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
-| <span class='attr-optional'>`options.templates.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Header template |
-| <span class='attr-optional'>`options.templates.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Item template |
-| <span class='attr-optional'>`options.templates.clearAll`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Clear all template |
-| <span class='attr-optional'>`options.templates.footer`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Footer template |
-| <span class='attr-optional'>`options.transformData.item`</span><span class="attr-infos">Type: <code>function</code></span> | Function to change the object passed to the `item` template |
-| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when no current refinements |
-| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to be added |
-| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code></span> | CSS classes added to the root element |
-| <span class='attr-optional'>`options.cssClasses.header`</span><span class="attr-infos">Type: <code>string</code></span> | CSS classes added to the header element |
-| <span class='attr-optional'>`options.cssClasses.body`</span><span class="attr-infos">Type: <code>string</code></span> | CSS classes added to the body element |
-| <span class='attr-optional'>`options.cssClasses.clearAll`</span><span class="attr-infos">Type: <code>string</code></span> | CSS classes added to the clearAll element |
-| <span class='attr-optional'>`options.cssClasses.list`</span><span class="attr-infos">Type: <code>string</code></span> | CSS classes added to the list element |
-| <span class='attr-optional'>`options.cssClasses.item`</span><span class="attr-infos">Type: <code>string</code></span> | CSS classes added to the item element |
-| <span class='attr-optional'>`options.cssClasses.link`</span><span class="attr-infos">Type: <code>string</code></span> | CSS classes added to the link element |
-| <span class='attr-optional'>`options.cssClasses.count`</span><span class="attr-infos">Type: <code>string</code></span> | CSS classes added to the count element |
-| <span class='attr-optional'>`options.cssClasses.footer`</span><span class="attr-infos">Type: <code>string</code></span> | CSS classes added to the footer element |
-| <span class='attr-optional'>`options.collapsible`</span><span class="attr-infos">Default:<code class="attr-default">false</code><br />Type: <code>object</code> &#124; <code>boolean</code></span> | Hide the widget body and footer when clicking on header |
-| <span class='attr-optional'>`options.collapsible.collapsed`</span><span class="attr-infos">Type: <code>boolean</code></span> | Initial collapsed state of a collapsible widget |
+<h4>Parameters</h4>
+<p class="attr-name">
+<span class='attr-required'>`options.container`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>DOMElement</code>)</span> 
+</p>
+<p class="attr-description">CSS Selector or DOMElement to insert the widget</p>
+<p class="attr-name">
+<span class='attr-optional'>`option.attributes`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Array</code>)</span> 
+</p>
+<p class="attr-description">Attributes configuration</p>
+<p class="attr-name">
+<span class='attr-optional'>`option.attributes[].name`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">Required attribute name</p>
+<p class="attr-name">
+<span class='attr-optional'>`option.attributes[].label`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">Attribute label (passed to the item template)</p>
+<p class="attr-name">
+<span class='attr-optional'>`option.attributes[].template`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Attribute specific template</p>
+<p class="attr-name">
+<span class='attr-optional'>`option.attributes[].transformData`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>function</code>)</span> 
+</p>
+<p class="attr-description">Attribute specific transformData</p>
+<p class="attr-name">
+<span class='attr-optional'>`option.clearAll`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">&#x27;before&#x27;</code>(<code>boolean</code> &#124; <code>string</code>)</span> 
+</p>
+<p class="attr-description">Clear all position (one of ('before', 'after', false))</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.onlyListedAttributes`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">false</code>(<code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Only use declared attributes</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">Templates to use for the widget</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates.header`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Header template</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates.item`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Item template</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates.clearAll`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Clear all template</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates.footer`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Footer template</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.transformData.item`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>function</code>)</span> 
+</p>
+<p class="attr-description">Function to change the object passed to the `item` template</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.autoHideContainer`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">true</code>(<code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Hide the container when no current refinements</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">CSS classes to be added</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.root`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">CSS classes added to the root element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.header`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">CSS classes added to the header element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.body`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">CSS classes added to the body element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.clearAll`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">CSS classes added to the clearAll element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.list`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">CSS classes added to the list element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.item`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">CSS classes added to the item element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.link`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">CSS classes added to the link element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.count`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">CSS classes added to the count element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.footer`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">CSS classes added to the footer element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.collapsible`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">false</code>(<code>object</code> &#124; <code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Hide the widget body and footer when clicking on header</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.collapsible.collapsed`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Initial collapsed state of a collapsible widget</p>
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/hierarchicalMenu.md
+++ b/docs/_includes/widget-jsdoc/hierarchicalMenu.md
@@ -1,30 +1,133 @@
-| Param | Description |
-| --- | --- |
-| <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
-| <span class='attr-required'>`options.attributes`</span><span class="attr-infos">Type: <code>Array.&lt;string&gt;</code></span> | Array of attributes to use to generate the hierarchy of the menu. Refer to [the readme](https://github.com/algolia/algoliasearch-helper-js#hierarchical-facets) for the convention to follow. |
-| <span class='attr-optional'>`options.separator`</span><span class="attr-infos">Default:<code class="attr-default">&#x27; &gt; &#x27;</code><br />Type: <code>string</code></span> | Separator used in the attributes to separate level values. |
-| <span class='attr-optional'>`options.rootPath`</span><span class="attr-infos">Type: <code>string</code></span> | Prefix path to use if the first level is not the root level. |
-| <span class='attr-optional'>`options.showParentLevel`</span><span class="attr-infos">Default:<code class="attr-default">false</code><br />Type: <code>string</code></span> | Show the parent level of the current refined value |
-| <span class='attr-optional'>`options.limit`</span><span class="attr-infos">Default:<code class="attr-default">10</code><br />Type: <code>number</code></span> | How much facet values to get |
-| <span class='attr-optional'>`options.sortBy`</span><span class="attr-infos">Default:<code class="attr-default">[&#x27;name:asc&#x27;]</code><br />Type: <code>Array.&lt;string&gt;</code> &#124; <code>function</code></span> | How to sort refinements. Possible values: `count|isRefined|name:asc|desc` |
-| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
-| <span class='attr-optional'>`options.templates.header`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Header template (root level only) |
-| <span class='attr-optional'>`options.templates.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Item template, provided with `name`, `count`, `isRefined`, `url` data properties |
-| <span class='attr-optional'>`options.templates.footer`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Footer template (root level only) |
-| <span class='attr-optional'>`options.transformData.item`</span><span class="attr-infos">Type: <code>function</code></span> | Method to change the object passed to the `item` template |
-| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when there are no items in the menu |
-| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add to the wrapping elements |
-| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the root element |
-| <span class='attr-optional'>`options.cssClasses.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the header element |
-| <span class='attr-optional'>`options.cssClasses.body`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the body element |
-| <span class='attr-optional'>`options.cssClasses.footer`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the footer element |
-| <span class='attr-optional'>`options.cssClasses.list`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the list element |
-| <span class='attr-optional'>`options.cssClasses.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each item element |
-| <span class='attr-optional'>`options.cssClasses.depth`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each item element to denote its depth. The actual level will be appended to the given class name (ie. if `depth` is given, the widget will add `depth0`, `depth1`, ... according to the level of each item). |
-| <span class='attr-optional'>`options.cssClasses.active`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each active element |
-| <span class='attr-optional'>`options.cssClasses.link`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each link (when using the default template) |
-| <span class='attr-optional'>`options.cssClasses.count`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each count element (when using the default template) |
-| <span class='attr-optional'>`options.collapsible`</span><span class="attr-infos">Default:<code class="attr-default">false</code><br />Type: <code>object</code> &#124; <code>boolean</code></span> | Hide the widget body and footer when clicking on header |
-| <span class='attr-optional'>`options.collapsible.collapsed`</span><span class="attr-infos">Type: <code>boolean</code></span> | Initial collapsed state of a collapsible widget |
+<h4>Parameters</h4>
+<p class="attr-name">
+<span class='attr-required'>`options.container`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>DOMElement</code>)</span> 
+</p>
+<p class="attr-description">CSS Selector or DOMElement to insert the widget</p>
+<p class="attr-name">
+<span class='attr-required'>`options.attributes`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">Array of attributes to use to generate the hierarchy of the menu. Refer to [the readme](https://github.com/algolia/algoliasearch-helper-js#hierarchical-facets) for the convention to follow.</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.separator`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">&#x27; &gt; &#x27;</code>(<code>string</code>)</span> 
+</p>
+<p class="attr-description">Separator used in the attributes to separate level values.</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.rootPath`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">Prefix path to use if the first level is not the root level.</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.showParentLevel`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">false</code>(<code>string</code>)</span> 
+</p>
+<p class="attr-description">Show the parent level of the current refined value</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.limit`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">10</code>(<code>number</code>)</span> 
+</p>
+<p class="attr-description">How much facet values to get</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.sortBy`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">[&#x27;name:asc&#x27;]</code>(<code>Array.&lt;string&gt;</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">How to sort refinements. Possible values: `count|isRefined|name:asc|desc`</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">Templates to use for the widget</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates.header`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code>(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Header template (root level only)</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates.item`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Item template, provided with `name`, `count`, `isRefined`, `url` data properties</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates.footer`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code>(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Footer template (root level only)</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.transformData.item`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>function</code>)</span> 
+</p>
+<p class="attr-description">Method to change the object passed to the `item` template</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.autoHideContainer`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">true</code>(<code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Hide the container when there are no items in the menu</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">CSS classes to add to the wrapping elements</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.root`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the root element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.header`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the header element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.body`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the body element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.footer`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the footer element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.list`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the list element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.item`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to each item element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.depth`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to each item element to denote its depth. The actual level will be appended to the given class name (ie. if `depth` is given, the widget will add `depth0`, `depth1`, ... according to the level of each item).</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.active`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to each active element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.link`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to each link (when using the default template)</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.count`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to each count element (when using the default template)</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.collapsible`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">false</code>(<code>object</code> &#124; <code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Hide the widget body and footer when clicking on header</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.collapsible.collapsed`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Initial collapsed state of a collapsible widget</p>
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/hits.md
+++ b/docs/_includes/widget-jsdoc/hits.md
@@ -1,18 +1,73 @@
-| Param | Description |
-| --- | --- |
-| <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
-| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
-| <span class='attr-optional'>`options.templates.empty`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Template to use when there are no results. |
-| <span class='attr-optional'>`options.templates.item`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Template to use for each result. This template will receive an object containing a single record. |
-| <span class='attr-optional'>`options.templates.allItems`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Template to use for the list of all results. (Can't be used with `item` template). This template will receive a complete SearchResults result object, this object contains the key hits that contains all the records retrieved. |
-| <span class='attr-optional'>`options.transformData`</span><span class="attr-infos">Type: <code>Object</code></span> | Method to change the object passed to the templates |
-| <span class='attr-optional'>`options.transformData.empty`</span><span class="attr-infos">Type: <code>function</code></span> | Method used to change the object passed to the `empty` template |
-| <span class='attr-optional'>`options.transformData.item`</span><span class="attr-infos">Type: <code>function</code></span> | Method used to change the object passed to the `item` template |
-| <span class='attr-optional'>`options.transformData.allItems`</span><span class="attr-infos">Type: <code>function</code></span> | Method used to change the object passed to the `allItems` template |
-| <span class='attr-optional'>`hitsPerPage`</span><span class="attr-infos">Default:<code class="attr-default">20</code><br />Type: <code>number</code></span> | The number of hits to display per page |
-| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add |
-| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the wrapping element |
-| <span class='attr-optional'>`options.cssClasses.empty`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the wrapping element when no results |
-| <span class='attr-optional'>`options.cssClasses.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each result |
+<h4>Parameters</h4>
+<p class="attr-name">
+<span class='attr-required'>`options.container`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>DOMElement</code>)</span> 
+</p>
+<p class="attr-description">CSS Selector or DOMElement to insert the widget</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">Templates to use for the widget</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates.empty`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code>(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Template to use when there are no results.</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates.item`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code>(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Template to use for each result. This template will receive an object containing a single record.</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates.allItems`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code>(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Template to use for the list of all results. (Can't be used with `item` template). This template will receive a complete SearchResults result object, this object contains the key hits that contains all the records retrieved.</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.transformData`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">Method to change the object passed to the templates</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.transformData.empty`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>function</code>)</span> 
+</p>
+<p class="attr-description">Method used to change the object passed to the `empty` template</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.transformData.item`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>function</code>)</span> 
+</p>
+<p class="attr-description">Method used to change the object passed to the `item` template</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.transformData.allItems`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>function</code>)</span> 
+</p>
+<p class="attr-description">Method used to change the object passed to the `allItems` template</p>
+<p class="attr-name">
+<span class='attr-optional'>`hitsPerPage`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">20</code>(<code>number</code>)</span> 
+</p>
+<p class="attr-description">The number of hits to display per page</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">CSS classes to add</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.root`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the wrapping element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.empty`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the wrapping element when no results</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.item`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to each result</p>
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/hitsPerPageSelector.md
+++ b/docs/_includes/widget-jsdoc/hitsPerPageSelector.md
@@ -1,12 +1,43 @@
-| Param | Description |
-| --- | --- |
-| <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
-| <span class='attr-required'>`options.options`</span><span class="attr-infos">Type: <code>Array</code></span> | Array of objects defining the different values and labels |
-| <span class='attr-required'>`options.options[0].value`</span><span class="attr-infos">Type: <code>number</code></span> | number of hits to display per page |
-| <span class='attr-required'>`options.options[0].label`</span><span class="attr-infos">Type: <code>string</code></span> | Label to display in the option |
-| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">false</code><br />Type: <code>boolean</code></span> | Hide the container when no results match |
-| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to be added |
-| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS classes added to the parent `<select>` |
-| <span class='attr-optional'>`options.cssClasses.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS classes added to each `<option>` |
+<h4>Parameters</h4>
+<p class="attr-name">
+<span class='attr-required'>`options.container`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>DOMElement</code>)</span> 
+</p>
+<p class="attr-description">CSS Selector or DOMElement to insert the widget</p>
+<p class="attr-name">
+<span class='attr-required'>`options.options`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Array</code>)</span> 
+</p>
+<p class="attr-description">Array of objects defining the different values and labels</p>
+<p class="attr-name">
+<span class='attr-required'>`options.options[0].value`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>number</code>)</span> 
+</p>
+<p class="attr-description">number of hits to display per page</p>
+<p class="attr-name">
+<span class='attr-required'>`options.options[0].label`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">Label to display in the option</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.autoHideContainer`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">false</code>(<code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Hide the container when no results match</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">CSS classes to be added</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.root`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS classes added to the parent `<select>`</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.item`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS classes added to each `<option>`</p>
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/instantsearch.md
+++ b/docs/_includes/widget-jsdoc/instantsearch.md
@@ -1,16 +1,63 @@
-| Param | Description |
-| --- | --- |
-| <span class='attr-required'>`options.appId`</span><span class="attr-infos">Type: <code>string</code></span> | The Algolia application ID |
-| <span class='attr-required'>`options.apiKey`</span><span class="attr-infos">Type: <code>string</code></span> | The Algolia search-only API key |
-| <span class='attr-required'>`options.indexName`</span><span class="attr-infos">Type: <code>string</code></span> | The name of the main index |
-| <span class='attr-optional'>`options.numberLocale`</span><span class="attr-infos">Type: <code>string</code></span> | The locale used to display numbers. This will be passed to Number.prototype.toLocaleString() |
-| <span class='attr-optional'>`options.searchFunction`</span><span class="attr-infos">Type: <code>function</code></span> | A hook that will be called each time a search needs to be done, with the helper as a parameter. It's your responsibility to call helper.search(). This option allows you to avoid doing searches at page load for example. |
-| <span class='attr-optional'>`options.searchParameters`</span><span class="attr-infos">Type: <code>Object</code></span> | Additional parameters to pass to the Algolia API. [Full documentation](https://community.algolia.com/algoliasearch-helper-js/docs/SearchParameters.html) |
-| <span class='attr-optional'>`options.urlSync`</span><span class="attr-infos">Type: <code>Object</code> &#124; <code>boolean</code></span> | Url synchronization configuration. Setting to `true` will synchronize the needed search parameters with the browser url. |
-| <span class='attr-optional'>`options.urlSync.mapping`</span><span class="attr-infos">Type: <code>Object</code></span> | Object used to define replacement query parameter to use in place of another. Keys are current query parameters and value the new value, e.g. `{ q: 'query' }`. |
-| <span class='attr-optional'>`options.urlSync.threshold`</span><span class="attr-infos">Type: <code>number</code></span> | Idle time in ms after which a new state is created in the browser history. The default value is 700. The url is always updated at each keystroke but we only create a "previous search state" (activated when click on back button) every 700ms of idle time. |
-| <span class='attr-optional'>`options.urlSync.trackedParameters`</span><span class="attr-infos">Type: <code>Array.&lt;string&gt;</code></span> | Parameters that will be synchronized in the URL. By default, it will track the query, all the refinable attribute (facets and numeric filters), the index and the page. [Full documentation](https://community.algolia.com/algoliasearch-helper-js/docs/SearchParameters.html) |
-| <span class='attr-optional'>`options.urlSync.useHash`</span><span class="attr-infos">Type: <code>boolean</code></span> | If set to true, the url will be hash based. Otherwise, it'll use the query parameters using the modern history API. |
-| <span class='attr-optional'>`options.urlSync.getHistoryState`</span><span class="attr-infos">Type: <code>function</code></span> | Pass this function to override the default history API state we set to `null`. For example this could be used to force passing {turbolinks: true} to the history API every time we update it. |
+<h4>Parameters</h4>
+<p class="attr-name">
+<span class='attr-required'>`options.appId`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">The Algolia application ID</p>
+<p class="attr-name">
+<span class='attr-required'>`options.apiKey`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">The Algolia search-only API key</p>
+<p class="attr-name">
+<span class='attr-required'>`options.indexName`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">The name of the main index</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.numberLocale`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">The locale used to display numbers. This will be passed to Number.prototype.toLocaleString()</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.searchFunction`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>function</code>)</span> 
+</p>
+<p class="attr-description">A hook that will be called each time a search needs to be done, with the helper as a parameter. It's your responsibility to call helper.search(). This option allows you to avoid doing searches at page load for example.</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.searchParameters`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">Additional parameters to pass to the Algolia API. [Full documentation](https://community.algolia.com/algoliasearch-helper-js/docs/SearchParameters.html)</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.urlSync`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code> &#124; <code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Url synchronization configuration. Setting to `true` will synchronize the needed search parameters with the browser url.</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.urlSync.mapping`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">Object used to define replacement query parameter to use in place of another. Keys are current query parameters and value the new value, e.g. `{ q: 'query' }`.</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.urlSync.threshold`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>number</code>)</span> 
+</p>
+<p class="attr-description">Idle time in ms after which a new state is created in the browser history. The default value is 700. The url is always updated at each keystroke but we only create a "previous search state" (activated when click on back button) every 700ms of idle time.</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.urlSync.trackedParameters`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">Parameters that will be synchronized in the URL. By default, it will track the query, all the refinable attribute (facets and numeric filters), the index and the page. [Full documentation](https://community.algolia.com/algoliasearch-helper-js/docs/SearchParameters.html)</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.urlSync.useHash`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>boolean</code>)</span> 
+</p>
+<p class="attr-description">If set to true, the url will be hash based. Otherwise, it'll use the query parameters using the modern history API.</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.urlSync.getHistoryState`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>function</code>)</span> 
+</p>
+<p class="attr-description">Pass this function to override the default history API state we set to `null`. For example this could be used to force passing {turbolinks: true} to the history API every time we update it.</p>
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/menu.md
+++ b/docs/_includes/widget-jsdoc/menu.md
@@ -1,31 +1,138 @@
-| Param | Description |
-| --- | --- |
-| <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
-| <span class='attr-required'>`options.attributeName`</span><span class="attr-infos">Type: <code>string</code></span> | Name of the attribute for faceting |
-| <span class='attr-optional'>`options.sortBy`</span><span class="attr-infos">Default:<code class="attr-default">[&#x27;count:desc&#x27;, &#x27;name:asc&#x27;]</code><br />Type: <code>Array.&lt;string&gt;</code> &#124; <code>function</code></span> | How to sort refinements. Possible values: `count|isRefined|name:asc|desc` |
-| <span class='attr-optional'>`options.limit`</span><span class="attr-infos">Default:<code class="attr-default">10</code><br />Type: <code>string</code></span> | How many facets values to retrieve |
-| <span class='attr-optional'>`options.showMore`</span><span class="attr-infos">Default:<code class="attr-default">false</code><br />Type: <code>object</code> &#124; <code>boolean</code></span> | Limit the number of results and display a showMore button |
-| <span class='attr-optional'>`options.showMore.templates`</span><span class="attr-infos">Type: <code>object</code></span> | Templates to use for showMore |
-| <span class='attr-optional'>`options.showMore.templates.active`</span><span class="attr-infos">Type: <code>object</code></span> | Template used when showMore was clicked |
-| <span class='attr-optional'>`options.showMore.templates.inactive`</span><span class="attr-infos">Type: <code>object</code></span> | Template used when showMore not clicked |
-| <span class='attr-optional'>`options.showMore.limit`</span><span class="attr-infos">Type: <code>object</code></span> | Max number of facets values to display when showMore is clicked |
-| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
-| <span class='attr-optional'>`options.templates.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Header template |
-| <span class='attr-optional'>`options.templates.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Item template, provided with `name`, `count`, `isRefined`, `url` data properties |
-| <span class='attr-optional'>`options.templates.footer`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Footer template |
-| <span class='attr-optional'>`options.transformData.item`</span><span class="attr-infos">Type: <code>function</code></span> | Method to change the object passed to the `item` template |
-| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when there are no items in the menu |
-| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add to the wrapping elements |
-| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the root element |
-| <span class='attr-optional'>`options.cssClasses.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the header element |
-| <span class='attr-optional'>`options.cssClasses.body`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the body element |
-| <span class='attr-optional'>`options.cssClasses.footer`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the footer element |
-| <span class='attr-optional'>`options.cssClasses.list`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the list element |
-| <span class='attr-optional'>`options.cssClasses.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each item element |
-| <span class='attr-optional'>`options.cssClasses.active`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each active element |
-| <span class='attr-optional'>`options.cssClasses.link`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each link (when using the default template) |
-| <span class='attr-optional'>`options.cssClasses.count`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each count element (when using the default template) |
-| <span class='attr-optional'>`options.collapsible`</span><span class="attr-infos">Default:<code class="attr-default">false</code><br />Type: <code>object</code> &#124; <code>boolean</code></span> | Hide the widget body and footer when clicking on header |
-| <span class='attr-optional'>`options.collapsible.collapsed`</span><span class="attr-infos">Type: <code>boolean</code></span> | Initial collapsed state of a collapsible widget |
+<h4>Parameters</h4>
+<p class="attr-name">
+<span class='attr-required'>`options.container`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>DOMElement</code>)</span> 
+</p>
+<p class="attr-description">CSS Selector or DOMElement to insert the widget</p>
+<p class="attr-name">
+<span class='attr-required'>`options.attributeName`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">Name of the attribute for faceting</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.sortBy`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">[&#x27;count:desc&#x27;, &#x27;name:asc&#x27;]</code>(<code>Array.&lt;string&gt;</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">How to sort refinements. Possible values: `count|isRefined|name:asc|desc`</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.limit`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">10</code>(<code>string</code>)</span> 
+</p>
+<p class="attr-description">How many facets values to retrieve</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.showMore`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">false</code>(<code>object</code> &#124; <code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Limit the number of results and display a showMore button</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.showMore.templates`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>object</code>)</span> 
+</p>
+<p class="attr-description">Templates to use for showMore</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.showMore.templates.active`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>object</code>)</span> 
+</p>
+<p class="attr-description">Template used when showMore was clicked</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.showMore.templates.inactive`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>object</code>)</span> 
+</p>
+<p class="attr-description">Template used when showMore not clicked</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.showMore.limit`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>object</code>)</span> 
+</p>
+<p class="attr-description">Max number of facets values to display when showMore is clicked</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">Templates to use for the widget</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates.header`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Header template</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates.item`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Item template, provided with `name`, `count`, `isRefined`, `url` data properties</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates.footer`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Footer template</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.transformData.item`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>function</code>)</span> 
+</p>
+<p class="attr-description">Method to change the object passed to the `item` template</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.autoHideContainer`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">true</code>(<code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Hide the container when there are no items in the menu</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">CSS classes to add to the wrapping elements</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.root`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the root element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.header`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the header element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.body`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the body element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.footer`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the footer element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.list`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the list element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.item`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to each item element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.active`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to each active element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.link`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to each link (when using the default template)</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.count`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to each count element (when using the default template)</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.collapsible`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">false</code>(<code>object</code> &#124; <code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Hide the widget body and footer when clicking on header</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.collapsible.collapsed`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Initial collapsed state of a collapsible widget</p>
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/numericRefinementList.md
+++ b/docs/_includes/widget-jsdoc/numericRefinementList.md
@@ -1,25 +1,108 @@
-| Param | Description |
-| --- | --- |
-| <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
-| <span class='attr-required'>`options.attributeName`</span><span class="attr-infos">Type: <code>string</code></span> | Name of the attribute for filtering |
-| <span class='attr-required'>`options.options`</span><span class="attr-infos">Type: <code>Array.&lt;Object&gt;</code></span> | List of all the options |
-| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
-| <span class='attr-optional'>`options.templates.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Header template |
-| <span class='attr-optional'>`options.templates.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Item template, provided with `name`, `isRefined`, `url` data properties |
-| <span class='attr-optional'>`options.templates.footer`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Footer template |
-| <span class='attr-optional'>`options.transformData.item`</span><span class="attr-infos">Type: <code>function</code></span> | Function to change the object passed to the `item` template |
-| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when no results match |
-| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add to the wrapping elements |
-| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the root element |
-| <span class='attr-optional'>`options.cssClasses.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the header element |
-| <span class='attr-optional'>`options.cssClasses.body`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the body element |
-| <span class='attr-optional'>`options.cssClasses.footer`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the footer element |
-| <span class='attr-optional'>`options.cssClasses.list`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the list element |
-| <span class='attr-optional'>`options.cssClasses.label`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each link element |
-| <span class='attr-optional'>`options.cssClasses.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each item element |
-| <span class='attr-optional'>`options.cssClasses.radio`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each radio element (when using the default template) |
-| <span class='attr-optional'>`options.cssClasses.active`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each active element |
-| <span class='attr-optional'>`options.collapsible`</span><span class="attr-infos">Default:<code class="attr-default">false</code><br />Type: <code>object</code> &#124; <code>boolean</code></span> | Hide the widget body and footer when clicking on header |
-| <span class='attr-optional'>`options.collapsible.collapsed`</span><span class="attr-infos">Type: <code>boolean</code></span> | Initial collapsed state of a collapsible widget |
+<h4>Parameters</h4>
+<p class="attr-name">
+<span class='attr-required'>`options.container`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>DOMElement</code>)</span> 
+</p>
+<p class="attr-description">CSS Selector or DOMElement to insert the widget</p>
+<p class="attr-name">
+<span class='attr-required'>`options.attributeName`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">Name of the attribute for filtering</p>
+<p class="attr-name">
+<span class='attr-required'>`options.options`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Array.&lt;Object&gt;</code>)</span> 
+</p>
+<p class="attr-description">List of all the options</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">Templates to use for the widget</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates.header`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Header template</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates.item`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Item template, provided with `name`, `isRefined`, `url` data properties</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates.footer`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Footer template</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.transformData.item`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>function</code>)</span> 
+</p>
+<p class="attr-description">Function to change the object passed to the `item` template</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.autoHideContainer`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">true</code>(<code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Hide the container when no results match</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">CSS classes to add to the wrapping elements</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.root`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the root element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.header`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the header element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.body`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the body element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.footer`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the footer element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.list`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the list element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.label`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to each link element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.item`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to each item element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.radio`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to each radio element (when using the default template)</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.active`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to each active element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.collapsible`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">false</code>(<code>object</code> &#124; <code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Hide the widget body and footer when clicking on header</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.collapsible.collapsed`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Initial collapsed state of a collapsible widget</p>
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/numericSelector.md
+++ b/docs/_includes/widget-jsdoc/numericSelector.md
@@ -1,14 +1,53 @@
-| Param | Description |
-| --- | --- |
-| <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
-| <span class='attr-required'>`options.attributeName`</span><span class="attr-infos">Type: <code>string</code></span> | Name of the numeric attribute to use |
-| <span class='attr-required'>`options.options`</span><span class="attr-infos">Type: <code>Array</code></span> | Array of objects defining the different values and labels |
-| <span class='attr-required'>`options.options[i].value`</span><span class="attr-infos">Type: <code>number</code></span> | The numerical value to refine with |
-| <span class='attr-required'>`options.options[i].label`</span><span class="attr-infos">Type: <code>string</code></span> | Label to display in the option |
-| <span class='attr-optional'>`options.operator`</span><span class="attr-infos">Type: <code>string</code></span> | The operator to use to refine |
-| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">false</code><br />Type: <code>boolean</code></span> | Hide the container when no results match |
-| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to be added |
-| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS classes added to the parent `<select>` |
-| <span class='attr-optional'>`options.cssClasses.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS classes added to each `<option>` |
+<h4>Parameters</h4>
+<p class="attr-name">
+<span class='attr-required'>`options.container`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>DOMElement</code>)</span> 
+</p>
+<p class="attr-description">CSS Selector or DOMElement to insert the widget</p>
+<p class="attr-name">
+<span class='attr-required'>`options.attributeName`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">Name of the numeric attribute to use</p>
+<p class="attr-name">
+<span class='attr-required'>`options.options`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Array</code>)</span> 
+</p>
+<p class="attr-description">Array of objects defining the different values and labels</p>
+<p class="attr-name">
+<span class='attr-required'>`options.options[i].value`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>number</code>)</span> 
+</p>
+<p class="attr-description">The numerical value to refine with</p>
+<p class="attr-name">
+<span class='attr-required'>`options.options[i].label`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">Label to display in the option</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.operator`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">The operator to use to refine</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.autoHideContainer`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">false</code>(<code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Hide the container when no results match</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">CSS classes to be added</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.root`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS classes added to the parent `<select>`</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.item`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS classes added to each `<option>`</p>
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/pagination.md
+++ b/docs/_includes/widget-jsdoc/pagination.md
@@ -1,26 +1,113 @@
-| Param | Description |
-| --- | --- |
-| <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
-| <span class='attr-optional'>`options.labels`</span><span class="attr-infos">Type: <code>Object</code></span> | Text to display in the various links (prev, next, first, last) |
-| <span class='attr-optional'>`options.labels.previous`</span><span class="attr-infos">Type: <code>string</code></span> | Label for the Previous link |
-| <span class='attr-optional'>`options.labels.next`</span><span class="attr-infos">Type: <code>string</code></span> | Label for the Next link |
-| <span class='attr-optional'>`options.labels.first`</span><span class="attr-infos">Type: <code>string</code></span> | Label for the First link |
-| <span class='attr-optional'>`options.labels.last`</span><span class="attr-infos">Type: <code>string</code></span> | Label for the Last link |
-| <span class='attr-optional'>`options.maxPages`</span><span class="attr-infos">Type: <code>number</code></span> | The max number of pages to browse |
-| <span class='attr-optional'>`options.padding`</span><span class="attr-infos">Default:<code class="attr-default">3</code><br />Type: <code>number</code></span> | The number of pages to display on each side of the current page |
-| <span class='attr-optional'>`options.scrollTo`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;body&#x27;</code><br />Type: <code>string</code> &#124; <code>DOMElement</code> &#124; <code>boolean</code></span> | Where to scroll after a click, set to `false` to disable |
-| <span class='attr-optional'>`options.showFirstLast`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Define if the First and Last links should be displayed |
-| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when no results match |
-| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to be added |
-| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS classes added to the parent `<ul>` |
-| <span class='attr-optional'>`options.cssClasses.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS classes added to each `<li>` |
-| <span class='attr-optional'>`options.cssClasses.link`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS classes added to each link |
-| <span class='attr-optional'>`options.cssClasses.page`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS classes added to page `<li>` |
-| <span class='attr-optional'>`options.cssClasses.previous`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS classes added to the previous `<li>` |
-| <span class='attr-optional'>`options.cssClasses.next`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS classes added to the next `<li>` |
-| <span class='attr-optional'>`options.cssClasses.first`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS classes added to the first `<li>` |
-| <span class='attr-optional'>`options.cssClasses.last`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS classes added to the last `<li>` |
-| <span class='attr-optional'>`options.cssClasses.active`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS classes added to the active `<li>` |
-| <span class='attr-optional'>`options.cssClasses.disabled`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS classes added to the disabled `<li>` |
+<h4>Parameters</h4>
+<p class="attr-name">
+<span class='attr-required'>`options.container`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>DOMElement</code>)</span> 
+</p>
+<p class="attr-description">CSS Selector or DOMElement to insert the widget</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.labels`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">Text to display in the various links (prev, next, first, last)</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.labels.previous`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">Label for the Previous link</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.labels.next`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">Label for the Next link</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.labels.first`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">Label for the First link</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.labels.last`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">Label for the Last link</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.maxPages`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>number</code>)</span> 
+</p>
+<p class="attr-description">The max number of pages to browse</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.padding`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">3</code>(<code>number</code>)</span> 
+</p>
+<p class="attr-description">The number of pages to display on each side of the current page</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.scrollTo`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">&#x27;body&#x27;</code>(<code>string</code> &#124; <code>DOMElement</code> &#124; <code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Where to scroll after a click, set to `false` to disable</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.showFirstLast`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">true</code>(<code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Define if the First and Last links should be displayed</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.autoHideContainer`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">true</code>(<code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Hide the container when no results match</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">CSS classes to be added</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.root`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS classes added to the parent `<ul>`</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.item`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS classes added to each `<li>`</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.link`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS classes added to each link</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.page`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS classes added to page `<li>`</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.previous`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS classes added to the previous `<li>`</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.next`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS classes added to the next `<li>`</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.first`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS classes added to the first `<li>`</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.last`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS classes added to the last `<li>`</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.active`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS classes added to the active `<li>`</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.disabled`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS classes added to the disabled `<li>`</p>
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/priceRanges.md
+++ b/docs/_includes/widget-jsdoc/priceRanges.md
@@ -1,30 +1,133 @@
-| Param | Description |
-| --- | --- |
-| <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | Valid CSS Selector as a string or DOMElement |
-| <span class='attr-required'>`options.attributeName`</span><span class="attr-infos">Type: <code>string</code></span> | Name of the attribute for faceting |
-| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
-| <span class='attr-optional'>`options.templates.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Item template. Template data: `from`, `to` and `currency` |
-| <span class='attr-optional'>`options.currency`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;$&#x27;</code><br />Type: <code>string</code></span> | The currency to display |
-| <span class='attr-optional'>`options.labels`</span><span class="attr-infos">Type: <code>Object</code></span> | Labels to use for the widget |
-| <span class='attr-optional'>`options.labels.separator`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Separator label, between min and max |
-| <span class='attr-optional'>`options.labels.button`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Button label |
-| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when no refinements available |
-| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add |
-| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the root element |
-| <span class='attr-optional'>`options.cssClasses.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the header element |
-| <span class='attr-optional'>`options.cssClasses.body`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the body element |
-| <span class='attr-optional'>`options.cssClasses.list`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the wrapping list element |
-| <span class='attr-optional'>`options.cssClasses.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each item element |
-| <span class='attr-optional'>`options.cssClasses.active`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the active item element |
-| <span class='attr-optional'>`options.cssClasses.link`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each link element |
-| <span class='attr-optional'>`options.cssClasses.form`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the form element |
-| <span class='attr-optional'>`options.cssClasses.label`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each wrapping label of the form |
-| <span class='attr-optional'>`options.cssClasses.input`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each input of the form |
-| <span class='attr-optional'>`options.cssClasses.currency`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each currency element of the form |
-| <span class='attr-optional'>`options.cssClasses.separator`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the separator of the form |
-| <span class='attr-optional'>`options.cssClasses.button`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the submit button of the form |
-| <span class='attr-optional'>`options.cssClasses.footer`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the footer element |
-| <span class='attr-optional'>`options.collapsible`</span><span class="attr-infos">Default:<code class="attr-default">false</code><br />Type: <code>object</code> &#124; <code>boolean</code></span> | Hide the widget body and footer when clicking on header |
-| <span class='attr-optional'>`options.collapsible.collapsed`</span><span class="attr-infos">Type: <code>boolean</code></span> | Initial collapsed state of a collapsible widget |
+<h4>Parameters</h4>
+<p class="attr-name">
+<span class='attr-required'>`options.container`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>DOMElement</code>)</span> 
+</p>
+<p class="attr-description">Valid CSS Selector as a string or DOMElement</p>
+<p class="attr-name">
+<span class='attr-required'>`options.attributeName`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">Name of the attribute for faceting</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">Templates to use for the widget</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates.item`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Item template. Template data: `from`, `to` and `currency`</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.currency`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">&#x27;$&#x27;</code>(<code>string</code>)</span> 
+</p>
+<p class="attr-description">The currency to display</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.labels`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">Labels to use for the widget</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.labels.separator`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Separator label, between min and max</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.labels.button`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Button label</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.autoHideContainer`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">true</code>(<code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Hide the container when no refinements available</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">CSS classes to add</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.root`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the root element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.header`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the header element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.body`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the body element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.list`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the wrapping list element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.item`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to each item element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.active`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the active item element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.link`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to each link element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.form`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the form element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.label`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to each wrapping label of the form</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.input`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to each input of the form</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.currency`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to each currency element of the form</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.separator`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the separator of the form</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.button`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the submit button of the form</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.footer`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the footer element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.collapsible`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">false</code>(<code>object</code> &#124; <code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Hide the widget body and footer when clicking on header</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.collapsible.collapsed`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Initial collapsed state of a collapsible widget</p>
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/rangeSlider.md
+++ b/docs/_includes/widget-jsdoc/rangeSlider.md
@@ -1,20 +1,83 @@
-| Param | Description |
-| --- | --- |
-| <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
-| <span class='attr-required'>`options.attributeName`</span><span class="attr-infos">Type: <code>string</code></span> | Name of the attribute for faceting |
-| <span class='attr-optional'>`options.tooltips`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code> &#124; <code>Object</code></span> | Should we show tooltips or not. The default tooltip will show the formatted corresponding value without any other token. You can also provide `tooltips: {format: function(formattedValue, rawValue) {return '$' + formattedValue}}` So that you can format the tooltip display value as you want |
-| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
-| <span class='attr-optional'>`options.templates.header`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Header template |
-| <span class='attr-optional'>`options.templates.footer`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Footer template |
-| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when no refinements available |
-| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add to the wrapping elements |
-| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the root element |
-| <span class='attr-optional'>`options.cssClasses.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the header element |
-| <span class='attr-optional'>`options.cssClasses.body`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the body element |
-| <span class='attr-optional'>`options.cssClasses.footer`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the footer element |
-| <span class='attr-optional'>`options.collapsible`</span><span class="attr-infos">Default:<code class="attr-default">false</code><br />Type: <code>object</code> &#124; <code>boolean</code></span> | Hide the widget body and footer when clicking on header |
-| <span class='attr-optional'>`options.collapsible.collapsed`</span><span class="attr-infos">Type: <code>boolean</code></span> | Initial collapsed state of a collapsible widget |
-| <span class='attr-optional'>`options.min`</span><span class="attr-infos">Type: <code>number</code></span> | Minimal slider value, default to automatically computed from the result set |
-| <span class='attr-optional'>`options.max`</span><span class="attr-infos">Type: <code>number</code></span> | Maximal slider value, defaults to automatically computed from the result set |
+<h4>Parameters</h4>
+<p class="attr-name">
+<span class='attr-required'>`options.container`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>DOMElement</code>)</span> 
+</p>
+<p class="attr-description">CSS Selector or DOMElement to insert the widget</p>
+<p class="attr-name">
+<span class='attr-required'>`options.attributeName`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">Name of the attribute for faceting</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.tooltips`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">true</code>(<code>boolean</code> &#124; <code>Object</code>)</span> 
+</p>
+<p class="attr-description">Should we show tooltips or not. The default tooltip will show the formatted corresponding value without any other token. You can also provide `tooltips: {format: function(formattedValue, rawValue) {return '$' + formattedValue}}` So that you can format the tooltip display value as you want</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">Templates to use for the widget</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates.header`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code>(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Header template</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates.footer`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code>(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Footer template</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.autoHideContainer`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">true</code>(<code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Hide the container when no refinements available</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">CSS classes to add to the wrapping elements</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.root`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the root element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.header`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the header element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.body`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the body element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.footer`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the footer element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.collapsible`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">false</code>(<code>object</code> &#124; <code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Hide the widget body and footer when clicking on header</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.collapsible.collapsed`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Initial collapsed state of a collapsible widget</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.min`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>number</code>)</span> 
+</p>
+<p class="attr-description">Minimal slider value, default to automatically computed from the result set</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.max`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>number</code>)</span> 
+</p>
+<p class="attr-description">Maximal slider value, defaults to automatically computed from the result set</p>
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/refinementList.md
+++ b/docs/_includes/widget-jsdoc/refinementList.md
@@ -1,33 +1,148 @@
-| Param | Description |
-| --- | --- |
-| <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
-| <span class='attr-required'>`options.attributeName`</span><span class="attr-infos">Type: <code>string</code></span> | Name of the attribute for faceting |
-| <span class='attr-optional'>`options.operator`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;or&#x27;</code><br />Type: <code>string</code></span> | How to apply refinements. Possible values: `or`, `and` |
-| <span class='attr-optional'>`options.sortBy`</span><span class="attr-infos">Default:<code class="attr-default">[&#x27;count:desc&#x27;, &#x27;name:asc&#x27;]</code><br />Type: <code>Array.&lt;string&gt;</code> &#124; <code>function</code></span> | How to sort refinements. Possible values: `count:asc|count:desc|name:asc|name:desc|isRefined` |
-| <span class='attr-optional'>`options.limit`</span><span class="attr-infos">Default:<code class="attr-default">10</code><br />Type: <code>string</code></span> | How much facet values to get. When the show more feature is activated this is the minimun number of facets requested (the show more button is not in active state). |
-| <span class='attr-optional'>`options.showMore`</span><span class="attr-infos">Default:<code class="attr-default">false</code><br />Type: <code>object</code> &#124; <code>boolean</code></span> | Limit the number of results and display a showMore button |
-| <span class='attr-optional'>`options.showMore.templates`</span><span class="attr-infos">Type: <code>object</code></span> | Templates to use for showMore |
-| <span class='attr-optional'>`options.showMore.templates.active`</span><span class="attr-infos">Type: <code>object</code></span> | Template used when showMore was clicked |
-| <span class='attr-optional'>`options.showMore.templates.inactive`</span><span class="attr-infos">Type: <code>object</code></span> | Template used when showMore not clicked |
-| <span class='attr-optional'>`options.showMore.limit`</span><span class="attr-infos">Type: <code>object</code></span> | Max number of facets values to display when showMore is clicked |
-| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
-| <span class='attr-optional'>`options.templates.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Header template |
-| <span class='attr-optional'>`options.templates.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Item template, provided with `name`, `count`, `isRefined`, `url` data properties |
-| <span class='attr-optional'>`options.templates.footer`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Footer template |
-| <span class='attr-optional'>`options.transformData.item`</span><span class="attr-infos">Type: <code>function</code></span> | Function to change the object passed to the `item` template |
-| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when no items in the refinement list |
-| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add to the wrapping elements |
-| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the root element |
-| <span class='attr-optional'>`options.cssClasses.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the header element |
-| <span class='attr-optional'>`options.cssClasses.body`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the body element |
-| <span class='attr-optional'>`options.cssClasses.footer`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the footer element |
-| <span class='attr-optional'>`options.cssClasses.list`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the list element |
-| <span class='attr-optional'>`options.cssClasses.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each item element |
-| <span class='attr-optional'>`options.cssClasses.active`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each active element |
-| <span class='attr-optional'>`options.cssClasses.label`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each label element (when using the default template) |
-| <span class='attr-optional'>`options.cssClasses.checkbox`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each checkbox element (when using the default template) |
-| <span class='attr-optional'>`options.cssClasses.count`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each count element (when using the default template) |
-| <span class='attr-optional'>`options.collapsible`</span><span class="attr-infos">Default:<code class="attr-default">false</code><br />Type: <code>object</code> &#124; <code>boolean</code></span> | Hide the widget body and footer when clicking on header |
-| <span class='attr-optional'>`options.collapsible.collapsed`</span><span class="attr-infos">Type: <code>boolean</code></span> | Initial collapsed state of a collapsible widget |
+<h4>Parameters</h4>
+<p class="attr-name">
+<span class='attr-required'>`options.container`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>DOMElement</code>)</span> 
+</p>
+<p class="attr-description">CSS Selector or DOMElement to insert the widget</p>
+<p class="attr-name">
+<span class='attr-required'>`options.attributeName`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">Name of the attribute for faceting</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.operator`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">&#x27;or&#x27;</code>(<code>string</code>)</span> 
+</p>
+<p class="attr-description">How to apply refinements. Possible values: `or`, `and`</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.sortBy`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">[&#x27;count:desc&#x27;, &#x27;name:asc&#x27;]</code>(<code>Array.&lt;string&gt;</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">How to sort refinements. Possible values: `count:asc|count:desc|name:asc|name:desc|isRefined`</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.limit`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">10</code>(<code>string</code>)</span> 
+</p>
+<p class="attr-description">How much facet values to get. When the show more feature is activated this is the minimun number of facets requested (the show more button is not in active state).</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.showMore`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">false</code>(<code>object</code> &#124; <code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Limit the number of results and display a showMore button</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.showMore.templates`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>object</code>)</span> 
+</p>
+<p class="attr-description">Templates to use for showMore</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.showMore.templates.active`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>object</code>)</span> 
+</p>
+<p class="attr-description">Template used when showMore was clicked</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.showMore.templates.inactive`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>object</code>)</span> 
+</p>
+<p class="attr-description">Template used when showMore not clicked</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.showMore.limit`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>object</code>)</span> 
+</p>
+<p class="attr-description">Max number of facets values to display when showMore is clicked</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">Templates to use for the widget</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates.header`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Header template</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates.item`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Item template, provided with `name`, `count`, `isRefined`, `url` data properties</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates.footer`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Footer template</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.transformData.item`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>function</code>)</span> 
+</p>
+<p class="attr-description">Function to change the object passed to the `item` template</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.autoHideContainer`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">true</code>(<code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Hide the container when no items in the refinement list</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">CSS classes to add to the wrapping elements</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.root`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the root element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.header`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the header element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.body`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the body element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.footer`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the footer element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.list`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the list element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.item`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to each item element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.active`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to each active element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.label`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to each label element (when using the default template)</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.checkbox`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to each checkbox element (when using the default template)</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.count`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to each count element (when using the default template)</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.collapsible`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">false</code>(<code>object</code> &#124; <code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Hide the widget body and footer when clicking on header</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.collapsible.collapsed`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Initial collapsed state of a collapsible widget</p>
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/searchBox.md
+++ b/docs/_includes/widget-jsdoc/searchBox.md
@@ -1,15 +1,58 @@
-| Param | Description |
-| --- | --- |
-| <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
-| <span class='attr-optional'>`options.placeholder`</span><span class="attr-infos">Type: <code>string</code></span> | Input's placeholder |
-| <span class='attr-optional'>`options.poweredBy`</span><span class="attr-infos">Default:<code class="attr-default">false</code><br />Type: <code>boolean</code></span> | Show a powered by Algolia link below the input |
-| <span class='attr-optional'>`options.wrapInput`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Wrap the input in a `div.ais-search-box` |
-| <span class='attr-optional'>`autofocus`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;auto&#x27;</code><br />Type: <code>boolean</code> &#124; <code>string</code></span> | autofocus on the input |
-| <span class='attr-optional'>`options.searchOnEnterKeyPressOnly`</span><span class="attr-infos">Default:<code class="attr-default">false</code><br />Type: <code>boolean</code></span> | If set, trigger the search once `<Enter>` is pressed only |
-| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add |
-| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the wrapping div (if `wrapInput` set to `true`) |
-| <span class='attr-optional'>`options.cssClasses.input`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the input |
-| <span class='attr-optional'>`options.cssClasses.poweredBy`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the poweredBy element |
-| <span class='attr-optional'>`options.queryHook`</span><span class="attr-infos">Type: <code>function</code></span> | A function that will be called everytime a new search would be done. You will get the query as first parameter and a search(query) function to call as the second parameter. This queryHook can be used to debounce the number of searches done from the searchBox. |
+<h4>Parameters</h4>
+<p class="attr-name">
+<span class='attr-required'>`options.container`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>DOMElement</code>)</span> 
+</p>
+<p class="attr-description">CSS Selector or DOMElement to insert the widget</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.placeholder`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">Input's placeholder</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.poweredBy`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">false</code>(<code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Show a powered by Algolia link below the input</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.wrapInput`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">true</code>(<code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Wrap the input in a `div.ais-search-box`</p>
+<p class="attr-name">
+<span class='attr-optional'>`autofocus`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">&#x27;auto&#x27;</code>(<code>boolean</code> &#124; <code>string</code>)</span> 
+</p>
+<p class="attr-description">autofocus on the input</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.searchOnEnterKeyPressOnly`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">false</code>(<code>boolean</code>)</span> 
+</p>
+<p class="attr-description">If set, trigger the search once `<Enter>` is pressed only</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">CSS classes to add</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.root`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the wrapping div (if `wrapInput` set to `true`)</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.input`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the input</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.poweredBy`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the poweredBy element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.queryHook`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>function</code>)</span> 
+</p>
+<p class="attr-description">A function that will be called everytime a new search would be done. You will get the query as first parameter and a search(query) function to call as the second parameter. This queryHook can be used to debounce the number of searches done from the searchBox.</p>
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/sortBySelector.md
+++ b/docs/_includes/widget-jsdoc/sortBySelector.md
@@ -1,12 +1,43 @@
-| Param | Description |
-| --- | --- |
-| <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
-| <span class='attr-required'>`options.indices`</span><span class="attr-infos">Type: <code>Array</code></span> | Array of objects defining the different indices to choose from. |
-| <span class='attr-required'>`options.indices[0].name`</span><span class="attr-infos">Type: <code>string</code></span> | Name of the index to target |
-| <span class='attr-required'>`options.indices[0].label`</span><span class="attr-infos">Type: <code>string</code></span> | Label displayed in the dropdown |
-| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">false</code><br />Type: <code>boolean</code></span> | Hide the container when no results match |
-| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to be added |
-| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS classes added to the parent <select> |
-| <span class='attr-optional'>`options.cssClasses.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS classes added to each <option> |
+<h4>Parameters</h4>
+<p class="attr-name">
+<span class='attr-required'>`options.container`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>DOMElement</code>)</span> 
+</p>
+<p class="attr-description">CSS Selector or DOMElement to insert the widget</p>
+<p class="attr-name">
+<span class='attr-required'>`options.indices`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Array</code>)</span> 
+</p>
+<p class="attr-description">Array of objects defining the different indices to choose from.</p>
+<p class="attr-name">
+<span class='attr-required'>`options.indices[0].name`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">Name of the index to target</p>
+<p class="attr-name">
+<span class='attr-required'>`options.indices[0].label`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">Label displayed in the dropdown</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.autoHideContainer`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">false</code>(<code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Hide the container when no results match</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">CSS classes to be added</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.root`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS classes added to the parent <select></p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.item`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS classes added to each <option></p>
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/starRating.md
+++ b/docs/_includes/widget-jsdoc/starRating.md
@@ -1,29 +1,128 @@
-| Param | Description |
-| --- | --- |
-| <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
-| <span class='attr-required'>`options.attributeName`</span><span class="attr-infos">Type: <code>string</code></span> | Name of the attribute for filtering |
-| <span class='attr-optional'>`options.max`</span><span class="attr-infos">Type: <code>number</code></span> | The maximum rating value |
-| <span class='attr-optional'>`options.labels`</span><span class="attr-infos">Type: <code>Object</code></span> | Labels used by the default template |
-| <span class='attr-optional'>`options.labels.andUp`</span><span class="attr-infos">Type: <code>string</code></span> | The label suffixed after each line |
-| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
-| <span class='attr-optional'>`options.templates.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Header template |
-| <span class='attr-optional'>`options.templates.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Item template, provided with `name`, `count`, `isRefined`, `url` data properties |
-| <span class='attr-optional'>`options.templates.footer`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Footer template |
-| <span class='attr-optional'>`options.transformData.item`</span><span class="attr-infos">Type: <code>function</code></span> | Function to change the object passed to the `item` template |
-| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when no results match |
-| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add to the wrapping elements |
-| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the root element |
-| <span class='attr-optional'>`options.cssClasses.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the header element |
-| <span class='attr-optional'>`options.cssClasses.body`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the body element |
-| <span class='attr-optional'>`options.cssClasses.footer`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the footer element |
-| <span class='attr-optional'>`options.cssClasses.list`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the list element |
-| <span class='attr-optional'>`options.cssClasses.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each item element |
-| <span class='attr-optional'>`options.cssClasses.link`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each link element |
-| <span class='attr-optional'>`options.cssClasses.disabledLink`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each disabled link (when using the default template) |
-| <span class='attr-optional'>`options.cssClasses.star`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each star element (when using the default template) |
-| <span class='attr-optional'>`options.cssClasses.emptyStar`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each empty star element (when using the default template) |
-| <span class='attr-optional'>`options.cssClasses.active`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each active element |
-| <span class='attr-optional'>`options.collapsible`</span><span class="attr-infos">Default:<code class="attr-default">false</code><br />Type: <code>object</code> &#124; <code>boolean</code></span> | Hide the widget body and footer when clicking on header |
-| <span class='attr-optional'>`options.collapsible.collapsed`</span><span class="attr-infos">Type: <code>boolean</code></span> | Initial collapsed state of a collapsible widget |
+<h4>Parameters</h4>
+<p class="attr-name">
+<span class='attr-required'>`options.container`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>DOMElement</code>)</span> 
+</p>
+<p class="attr-description">CSS Selector or DOMElement to insert the widget</p>
+<p class="attr-name">
+<span class='attr-required'>`options.attributeName`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">Name of the attribute for filtering</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.max`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>number</code>)</span> 
+</p>
+<p class="attr-description">The maximum rating value</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.labels`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">Labels used by the default template</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.labels.andUp`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">The label suffixed after each line</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">Templates to use for the widget</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates.header`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Header template</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates.item`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Item template, provided with `name`, `count`, `isRefined`, `url` data properties</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates.footer`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Footer template</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.transformData.item`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>function</code>)</span> 
+</p>
+<p class="attr-description">Function to change the object passed to the `item` template</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.autoHideContainer`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">true</code>(<code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Hide the container when no results match</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">CSS classes to add to the wrapping elements</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.root`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the root element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.header`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the header element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.body`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the body element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.footer`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the footer element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.list`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the list element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.item`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to each item element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.link`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to each link element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.disabledLink`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to each disabled link (when using the default template)</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.star`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to each star element (when using the default template)</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.emptyStar`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to each empty star element (when using the default template)</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.active`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to each active element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.collapsible`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">false</code>(<code>object</code> &#124; <code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Hide the widget body and footer when clicking on header</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.collapsible.collapsed`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Initial collapsed state of a collapsible widget</p>
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/stats.md
+++ b/docs/_includes/widget-jsdoc/stats.md
@@ -1,17 +1,68 @@
-| Param | Description |
-| --- | --- |
-| <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
-| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
-| <span class='attr-optional'>`options.templates.header`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Header template |
-| <span class='attr-optional'>`options.templates.body`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Body template, provided with `hasManyResults`, `hasNoResults`, `hasOneResult`, `hitsPerPage`, `nbHits`, `nbPages`, `page`, `processingTimeMS`, `query` |
-| <span class='attr-optional'>`options.templates.footer`</span><span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code><br />Type: <code>string</code> &#124; <code>function</code></span> | Footer template |
-| <span class='attr-optional'>`options.transformData.body`</span><span class="attr-infos">Type: <code>function</code></span> | Function to change the object passed to the `body` template |
-| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when no results match |
-| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add |
-| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the root element |
-| <span class='attr-optional'>`options.cssClasses.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the header element |
-| <span class='attr-optional'>`options.cssClasses.body`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the body element |
-| <span class='attr-optional'>`options.cssClasses.footer`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the footer element |
-| <span class='attr-optional'>`options.cssClasses.time`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the element wrapping the time processingTimeMs |
+<h4>Parameters</h4>
+<p class="attr-name">
+<span class='attr-required'>`options.container`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>DOMElement</code>)</span> 
+</p>
+<p class="attr-description">CSS Selector or DOMElement to insert the widget</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">Templates to use for the widget</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates.header`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code>(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Header template</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates.body`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Body template, provided with `hasManyResults`, `hasNoResults`, `hasOneResult`, `hitsPerPage`, `nbHits`, `nbPages`, `page`, `processingTimeMS`, `query`</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates.footer`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">&#x27;&#x27;</code>(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Footer template</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.transformData.body`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>function</code>)</span> 
+</p>
+<p class="attr-description">Function to change the object passed to the `body` template</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.autoHideContainer`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">true</code>(<code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Hide the container when no results match</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">CSS classes to add</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.root`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the root element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.header`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the header element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.body`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the body element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.footer`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the footer element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.time`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the element wrapping the time processingTimeMs</p>
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/docs/_includes/widget-jsdoc/toggle.md
+++ b/docs/_includes/widget-jsdoc/toggle.md
@@ -1,29 +1,128 @@
-| Param | Description |
-| --- | --- |
-| <span class='attr-required'>`options.container`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>DOMElement</code></span> | CSS Selector or DOMElement to insert the widget |
-| <span class='attr-required'>`options.attributeName`</span><span class="attr-infos">Type: <code>string</code></span> | Name of the attribute for faceting (eg. "free_shipping") |
-| <span class='attr-required'>`options.label`</span><span class="attr-infos">Type: <code>string</code></span> | Human-readable name of the filter (eg. "Free Shipping") |
-| <span class='attr-optional'>`options.values`</span><span class="attr-infos">Type: <code>Object</code></span> | Lets you define the values to filter on when toggling |
-| <span class='attr-optional'>`options.values.on`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>number</code> &#124; <code>boolean</code></span> | Value to filter on when checked |
-| <span class='attr-optional'>`options.values.off`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>number</code> &#124; <code>boolean</code></span> | Value to filter on when unchecked element (when using the default template) |
-| <span class='attr-optional'>`options.templates`</span><span class="attr-infos">Type: <code>Object</code></span> | Templates to use for the widget |
-| <span class='attr-optional'>`options.templates.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Header template |
-| <span class='attr-optional'>`options.templates.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Item template |
-| <span class='attr-optional'>`options.templates.footer`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>function</code></span> | Footer template |
-| <span class='attr-optional'>`options.transformData.item`</span><span class="attr-infos">Type: <code>function</code></span> | Function to change the object passed to the `item` template |
-| <span class='attr-optional'>`options.autoHideContainer`</span><span class="attr-infos">Default:<code class="attr-default">true</code><br />Type: <code>boolean</code></span> | Hide the container when there's no results |
-| <span class='attr-optional'>`options.cssClasses`</span><span class="attr-infos">Type: <code>Object</code></span> | CSS classes to add |
-| <span class='attr-optional'>`options.cssClasses.root`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the root element |
-| <span class='attr-optional'>`options.cssClasses.header`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the header element |
-| <span class='attr-optional'>`options.cssClasses.body`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the body element |
-| <span class='attr-optional'>`options.cssClasses.footer`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the footer element |
-| <span class='attr-optional'>`options.cssClasses.list`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to the list element |
-| <span class='attr-optional'>`options.cssClasses.item`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each item element |
-| <span class='attr-optional'>`options.cssClasses.active`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each active element |
-| <span class='attr-optional'>`options.cssClasses.label`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each label element (when using the default template) |
-| <span class='attr-optional'>`options.cssClasses.checkbox`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each checkbox element (when using the default template) |
-| <span class='attr-optional'>`options.cssClasses.count`</span><span class="attr-infos">Type: <code>string</code> &#124; <code>Array.&lt;string&gt;</code></span> | CSS class to add to each count |
-| <span class='attr-optional'>`options.collapsible`</span><span class="attr-infos">Default:<code class="attr-default">false</code><br />Type: <code>object</code> &#124; <code>boolean</code></span> | Hide the widget body and footer when clicking on header |
-| <span class='attr-optional'>`options.collapsible.collapsed`</span><span class="attr-infos">Type: <code>boolean</code></span> | Initial collapsed state of a collapsible widget |
+<h4>Parameters</h4>
+<p class="attr-name">
+<span class='attr-required'>`options.container`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>DOMElement</code>)</span> 
+</p>
+<p class="attr-description">CSS Selector or DOMElement to insert the widget</p>
+<p class="attr-name">
+<span class='attr-required'>`options.attributeName`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">Name of the attribute for faceting (eg. "free_shipping")</p>
+<p class="attr-name">
+<span class='attr-required'>`options.label`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code>)</span> 
+</p>
+<p class="attr-description">Human-readable name of the filter (eg. "Free Shipping")</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.values`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">Lets you define the values to filter on when toggling</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.values.on`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>number</code> &#124; <code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Value to filter on when checked</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.values.off`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>number</code> &#124; <code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Value to filter on when unchecked element (when using the default template)</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">Templates to use for the widget</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates.header`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Header template</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates.item`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Item template</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.templates.footer`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>function</code>)</span> 
+</p>
+<p class="attr-description">Footer template</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.transformData.item`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>function</code>)</span> 
+</p>
+<p class="attr-description">Function to change the object passed to the `item` template</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.autoHideContainer`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">true</code>(<code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Hide the container when there's no results</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>Object</code>)</span> 
+</p>
+<p class="attr-description">CSS classes to add</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.root`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the root element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.header`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the header element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.body`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the body element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.footer`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the footer element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.list`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to the list element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.item`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to each item element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.active`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to each active element</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.label`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to each label element (when using the default template)</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.checkbox`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to each checkbox element (when using the default template)</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.cssClasses.count`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>string</code> &#124; <code>Array.&lt;string&gt;</code>)</span> 
+</p>
+<p class="attr-description">CSS class to add to each count</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.collapsible`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">false</code>(<code>object</code> &#124; <code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Hide the widget body and footer when clicking on header</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.collapsible.collapsed`<span class="show-description">…</span></span>
+  <span class="attr-infos">(<code>boolean</code>)</span> 
+</p>
+<p class="attr-description">Initial collapsed state of a collapsible widget</p>
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/scripts/docs/widgetTemplate.hbs
+++ b/scripts/docs/widgetTemplate.hbs
@@ -1,7 +1,11 @@
 {{#function name="%s"}}
-{{tableHead params "name|Param" "description|Description" ~}}
+<h4>Parameters</h4>
 {{#tableRow params "name" "type" "defaultvalue" "description" ~}}
-| {{#if optional}}<span class='attr-optional'>{{else}}<span class='attr-required'>{{/if}}`{{name}}`</span><span class="attr-infos">{{#unless (equal defaultvalue undefined)}}Default:<code class="attr-default">{{defaultvalue}}</code><br />{{/unless}}Type: {{>linked-type-list types=type.names delimiter=" &#124; " }}</span> | {{{stripNewlines (inlineLinks description)}}} |
+<p class="attr-name">
+{{#if optional}}<span class='attr-optional'>{{else}}<span class='attr-required'>{{/if}}`{{name}}`<span class="show-description">…</span></span>
+  <span class="attr-infos">{{#unless (equal defaultvalue undefined)}}Default:<code class="attr-default">{{defaultvalue}}</code>{{/unless}}({{>linked-type-list types=type.names delimiter=" &#124; " }})</span> 
+</p>
+<p class="attr-description">{{{stripNewlines (inlineLinks description)}}}</p>
 {{/tableRow}}
 {{/function}}
 


### PR DESCRIPTION
Proposition to enhance the readability of the parameters in the documentation. All the descriptions are hidden by default, this let the user have a better overview of the parameters, makes the list of parameters less daunting.

Updated based on @Shipow feedback :) (thanks man :))

Demo:

![collapsibledesc-demo-3](https://cloud.githubusercontent.com/assets/393765/15674805/1986c7cc-273f-11e6-9e25-7fe2cc2bd7dc.gif)