### PR TITLE
feat(pagination): Add CSS class denoting the number of pages

### DIFF
--- a/src/components/Pagination/Pagination.js
+++ b/src/components/Pagination/Pagination.js
@@ -1,12 +1,16 @@
 import React from 'react';
 import forEach from 'lodash/collection/forEach';
 import defaultsDeep from 'lodash/object/defaultsDeep';
-import {isSpecialClick} from '../../lib/utils.js';
-
+import {
+  bemHelper,
+  isSpecialClick
+} from '../../lib/utils.js';
 import Paginator from './Paginator.js';
 import PaginationLink from './PaginationLink.js';
 
 import cx from 'classnames';
+
+let bem = bemHelper('ais-pagination');
 
 class Pagination extends React.Component {
   constructor(props) {
@@ -123,8 +127,14 @@ class Pagination extends React.Component {
 
     let createURL = this.props.createURL;
 
+    // Mark the wrapper with a class denoting the number of pages
+    let cssClassRoot = cx(
+      this.props.cssClasses.root,
+      bem(null, `pagecount-${this.props.nbPages}`)
+    );
+
     return (
-      <ul className={this.props.cssClasses.root}>
+      <ul className={cssClassRoot}>
         {this.props.showFirstLast ? this.firstPageLink(pager, createURL) : null}
         {this.previousPageLink(pager, createURL)}
         {this.pages(pager, createURL)}

--- a/src/components/Pagination/__tests__/Pagination-test.js
+++ b/src/components/Pagination/__tests__/Pagination-test.js
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import expect from 'expect';
+import {shallow} from 'enzyme';
 import sinon from 'sinon';
 import TestUtils from 'react-addons-test-utils';
 import Pagination from '../Pagination';
@@ -12,6 +13,41 @@ expect.extend(expectJSX);
 
 describe('Pagination', () => {
   let renderer;
+
+  function render(extraProps = {}) {
+    let props = {
+      cssClasses: {
+        root: 'root',
+        item: 'item',
+        page: 'page',
+        previous: 'previous',
+        next: 'next',
+        first: 'first',
+        last: 'last',
+        active: 'active',
+        disabled: 'disabled'
+      },
+      labels: {first: '', last: '', next: '', previous: ''},
+      currentPage: 0,
+      nbHits: 200,
+      nbPages: 20,
+      padding: 3,
+      setCurrentPage: () => {},
+      ...extraProps
+    };
+
+    renderer.render(<Pagination {...props} />);
+    return renderer.getRenderOutput();
+  }
+
+  function shallowRender(extraProps: {}) {
+    let props = {
+      cssClasses: {},
+      labels: {},
+      ...extraProps
+    };
+    return shallow(React.createElement(Pagination, props));
+  }
 
   beforeEach(() => {
     let {createRenderer} = TestUtils;
@@ -127,29 +163,16 @@ describe('Pagination', () => {
     expect(preventDefault.calledOnce).toBe(true, 'preventDefault called once');
   });
 
-  function render(extraProps = {}) {
+  it('should add a CSS class denoting the number of pages', () => {
+    // Given
     let props = {
-      cssClasses: {
-        root: 'root',
-        item: 'item',
-        page: 'page',
-        previous: 'previous',
-        next: 'next',
-        first: 'first',
-        last: 'last',
-        active: 'active',
-        disabled: 'disabled'
-      },
-      labels: {first: '', last: '', next: '', previous: ''},
-      currentPage: 0,
-      nbHits: 200,
-      nbPages: 20,
-      padding: 3,
-      setCurrentPage: () => {},
-      ...extraProps
+      nbPages: 42
     };
 
-    renderer.render(<Pagination {...props} />);
-    return renderer.getRenderOutput();
-  }
+    // When
+    let actual = shallowRender(props);
+
+    // Then
+    expect(actual.hasClass('ais-pagination__pagecount-42')).toEqual(true);
+  });
 });

--- a/src/components/RefinementList/__tests__/RefinementList-test.js
+++ b/src/components/RefinementList/__tests__/RefinementList-test.js
@@ -8,9 +8,6 @@ import sinon from 'sinon';
 import RefinementList from '../RefinementList';
 import RefinementListItem from '../RefinementListItem';
 
-import expectJSX from 'expect-jsx';
-expect.extend(expectJSX);
-
 describe('RefinementList', () => {
   let createURL;
 

--- a/src/widgets/pagination/__tests__/pagination-test.js
+++ b/src/widgets/pagination/__tests__/pagination-test.js
@@ -11,182 +11,185 @@ expect.extend(expectJSX);
 import pagination from '../pagination';
 import Pagination from '../../../components/Pagination/Pagination';
 
-describe('pagination call', () => {
-  beforeEach(function() {this.jsdom = jsdom();});
-  afterEach(function() {this.jsdom();});
-
-  it('throws an exception when no container', () => {
-    expect(pagination.bind(null)).toThrow(/^Usage/);
-  });
-});
 describe('pagination()', () => {
-  beforeEach(function() {this.jsdom = jsdom();});
-  afterEach(function() {this.jsdom();});
-
-  let ReactDOM;
-  let container;
-  let widget;
-  let results;
-  let helper;
-  let cssClasses;
-
-  beforeEach(() => {
-    ReactDOM = {render: sinon.spy()};
-    pagination.__Rewire__('ReactDOM', ReactDOM);
-    pagination.__Rewire__('autoHideContainerHOC', sinon.stub().returns(Pagination));
-
-    container = document.createElement('div');
-    cssClasses = {
-      root: ['root', 'cx'],
-      item: 'item',
-      link: 'link',
-      page: 'page',
-      previous: 'previous',
-      next: 'next',
-      first: 'first',
-      last: 'last',
-      active: 'active',
-      disabled: 'disabled'
-    };
-    widget = pagination({container, scrollTo: false, cssClasses});
-    results = {hits: [{first: 'hit', second: 'hit'}], nbHits: 200, hitsPerPage: 10, nbPages: 20};
-    helper = {
-      setCurrentPage: sinon.spy(),
-      search: sinon.spy()
-    };
-    widget.init({helper});
+  beforeEach(function() {
+    this.jsdom = jsdom();
+  });
+  afterEach(function() {
+    this.jsdom();
   });
 
-  it('configures nothing', () => {
-    expect(widget.getConfiguration).toEqual(undefined);
+  describe('pagination call', () => {
+    it('throws an exception when no container', () => {
+      expect(pagination.bind(null)).toThrow(/^Usage/);
+    });
   });
 
-  it('sets the page', () => {
-    widget.setCurrentPage(helper, 42);
-    expect(helper.setCurrentPage.calledOnce).toBe(true);
-    expect(helper.search.calledOnce).toBe(true);
-  });
-
-  it('calls twice ReactDOM.render(<Pagination props />, container)', () => {
-    widget.render({results, helper});
-    widget.render({results, helper});
-
-    expect(ReactDOM.render.calledTwice).toBe(true, 'ReactDOM.render called twice');
-    expect(ReactDOM.render.firstCall.args[0]).toEqualJSX(<Pagination {...getProps()} />);
-    expect(ReactDOM.render.firstCall.args[1]).toEqual(container);
-    expect(ReactDOM.render.secondCall.args[0]).toEqualJSX(<Pagination {...getProps()} />);
-    expect(ReactDOM.render.secondCall.args[1]).toEqual(container);
-  });
-
-  context('mocking getContainerNode', function() {
-    let scrollIntoView;
+  describe('pagination()', () => {
+    let ReactDOM;
+    let container;
+    let widget;
+    let results;
+    let helper;
+    let cssClasses;
 
     beforeEach(() => {
-      scrollIntoView = sinon.spy();
-      const getContainerNode = sinon.stub().returns({
-        scrollIntoView: scrollIntoView
+      ReactDOM = {render: sinon.spy()};
+      pagination.__Rewire__('ReactDOM', ReactDOM);
+      pagination.__Rewire__('autoHideContainerHOC', sinon.stub().returns(Pagination));
+
+      container = document.createElement('div');
+      cssClasses = {
+        root: ['root', 'cx'],
+        item: 'item',
+        link: 'link',
+        page: 'page',
+        previous: 'previous',
+        next: 'next',
+        first: 'first',
+        last: 'last',
+        active: 'active',
+        disabled: 'disabled'
+      };
+      widget = pagination({container, scrollTo: false, cssClasses});
+      results = {hits: [{first: 'hit', second: 'hit'}], nbHits: 200, hitsPerPage: 10, nbPages: 20};
+      helper = {
+        setCurrentPage: sinon.spy(),
+        search: sinon.spy()
+      };
+      widget.init({helper});
+    });
+
+    it('configures nothing', () => {
+      expect(widget.getConfiguration).toEqual(undefined);
+    });
+
+    it('sets the page', () => {
+      widget.setCurrentPage(helper, 42);
+      expect(helper.setCurrentPage.calledOnce).toBe(true);
+      expect(helper.search.calledOnce).toBe(true);
+    });
+
+    it('calls twice ReactDOM.render(<Pagination props />, container)', () => {
+      widget.render({results, helper});
+      widget.render({results, helper});
+
+      expect(ReactDOM.render.calledTwice).toBe(true, 'ReactDOM.render called twice');
+      expect(ReactDOM.render.firstCall.args[0]).toEqualJSX(<Pagination {...getProps()} />);
+      expect(ReactDOM.render.firstCall.args[1]).toEqual(container);
+      expect(ReactDOM.render.secondCall.args[0]).toEqualJSX(<Pagination {...getProps()} />);
+      expect(ReactDOM.render.secondCall.args[1]).toEqual(container);
+    });
+
+    context('mocking getContainerNode', function() {
+      let scrollIntoView;
+
+      beforeEach(() => {
+        scrollIntoView = sinon.spy();
+        const getContainerNode = sinon.stub().returns({
+          scrollIntoView: scrollIntoView
+        });
+        pagination.__Rewire__('getContainerNode', getContainerNode);
       });
-      pagination.__Rewire__('getContainerNode', getContainerNode);
-    });
 
-    it('should not scroll', () => {
-      widget = pagination({container, scrollTo: false});
-      widget.init({helper});
-      widget.setCurrentPage(helper, 2);
-      expect(scrollIntoView.calledOnce).toBe(false, 'scrollIntoView never called');
-    });
+      it('should not scroll', () => {
+        widget = pagination({container, scrollTo: false});
+        widget.init({helper});
+        widget.setCurrentPage(helper, 2);
+        expect(scrollIntoView.calledOnce).toBe(false, 'scrollIntoView never called');
+      });
 
-    it('should scroll to body', () => {
-      widget = pagination({container});
-      widget.init({helper});
-      widget.setCurrentPage(helper, 2);
-      expect(scrollIntoView.calledOnce).toBe(true, 'scrollIntoView called once');
+      it('should scroll to body', () => {
+        widget = pagination({container});
+        widget.init({helper});
+        widget.setCurrentPage(helper, 2);
+        expect(scrollIntoView.calledOnce).toBe(true, 'scrollIntoView called once');
+      });
+
+      afterEach(() => {
+        pagination.__ResetDependency__('utils');
+      });
     });
 
     afterEach(() => {
-      pagination.__ResetDependency__('utils');
+      pagination.__ResetDependency__('ReactDOM');
+      pagination.__ResetDependency__('autoHideContainerHOC');
+    });
+
+    function getProps() {
+      return {
+        cssClasses: {
+          root: 'ais-pagination root cx',
+          item: 'ais-pagination--item item',
+          link: 'ais-pagination--link link',
+          page: 'ais-pagination--item__page page',
+          previous: 'ais-pagination--item__previous previous',
+          next: 'ais-pagination--item__next next',
+          first: 'ais-pagination--item__first first',
+          last: 'ais-pagination--item__last last',
+          active: 'ais-pagination--item__active active',
+          disabled: 'ais-pagination--item__disabled disabled'
+        },
+        currentPage: 0,
+        shouldAutoHideContainer: false,
+        labels: {first: '«', last: '»', next: '›', previous: '‹'},
+        nbHits: results.nbHits,
+        nbPages: results.nbPages,
+        padding: 3,
+        setCurrentPage: () => {},
+        showFirstLast: true,
+        createURL: () => '#'
+      };
+    }
+  });
+
+  describe('pagination MaxPage', () => {
+    let ReactDOM;
+    let container;
+    let widget;
+    let results;
+    let cssClasses;
+    let paginationOptions;
+
+    beforeEach(() => {
+      ReactDOM = {render: sinon.spy()};
+      pagination.__Rewire__('ReactDOM', ReactDOM);
+      pagination.__Rewire__('autoHideContainerHOC', sinon.stub().returns(Pagination));
+
+      container = document.createElement('div');
+      cssClasses = {
+        root: 'root',
+        item: 'item',
+        link: 'link',
+        page: 'page',
+        previous: 'previous',
+        next: 'next',
+        first: 'first',
+        last: 'last',
+        active: 'active',
+        disabled: 'disabled'
+      };
+      results = {hits: [{first: 'hit', second: 'hit'}], nbHits: 300, hitsPerPage: 10, nbPages: 30};
+      paginationOptions = {container, scrollTo: false, cssClasses};
+    });
+
+    it('does to have any default', () => {
+      widget = pagination(paginationOptions);
+      expect(widget.getMaxPage(results)).toEqual(30);
+    });
+
+    it('does reduce the number of page if lower than nbPages', () => {
+      paginationOptions.maxPages = 20;
+      widget = pagination(paginationOptions);
+      expect(widget.getMaxPage(results)).toEqual(20);
+    });
+
+    it('does not reduce the number of page if greater than nbPages', () => {
+      paginationOptions.maxPages = 40;
+      widget = pagination(paginationOptions);
+      expect(widget.getMaxPage(results)).toEqual(30);
     });
   });
-
-  afterEach(() => {
-    pagination.__ResetDependency__('ReactDOM');
-    pagination.__ResetDependency__('autoHideContainerHOC');
-  });
-
-  function getProps() {
-    return {
-      cssClasses: {
-        root: 'ais-pagination root cx',
-        item: 'ais-pagination--item item',
-        link: 'ais-pagination--link link',
-        page: 'ais-pagination--item__page page',
-        previous: 'ais-pagination--item__previous previous',
-        next: 'ais-pagination--item__next next',
-        first: 'ais-pagination--item__first first',
-        last: 'ais-pagination--item__last last',
-        active: 'ais-pagination--item__active active',
-        disabled: 'ais-pagination--item__disabled disabled'
-      },
-      currentPage: 0,
-      shouldAutoHideContainer: false,
-      labels: {first: '«', last: '»', next: '›', previous: '‹'},
-      nbHits: results.nbHits,
-      nbPages: results.nbPages,
-      padding: 3,
-      setCurrentPage: () => {},
-      showFirstLast: true,
-      createURL: () => '#'
-    };
-  }
 });
 
-describe('pagination MaxPage', () => {
-  beforeEach(function() {this.jsdom = jsdom();});
-  afterEach(function() {this.jsdom();});
 
-  let ReactDOM;
-  let container;
-  let widget;
-  let results;
-  let cssClasses;
-  let paginationOptions;
-
-  beforeEach(() => {
-    ReactDOM = {render: sinon.spy()};
-    pagination.__Rewire__('ReactDOM', ReactDOM);
-    pagination.__Rewire__('autoHideContainerHOC', sinon.stub().returns(Pagination));
-
-    container = document.createElement('div');
-    cssClasses = {
-      root: 'root',
-      item: 'item',
-      link: 'link',
-      page: 'page',
-      previous: 'previous',
-      next: 'next',
-      first: 'first',
-      last: 'last',
-      active: 'active',
-      disabled: 'disabled'
-    };
-    results = {hits: [{first: 'hit', second: 'hit'}], nbHits: 300, hitsPerPage: 10, nbPages: 30};
-    paginationOptions = {container, scrollTo: false, cssClasses};
-  });
-
-  it('does to have any default', () => {
-    widget = pagination(paginationOptions);
-    expect(widget.getMaxPage(results)).toEqual(30);
-  });
-
-  it('does reduce the number of page if lower than nbPages', () => {
-    paginationOptions.maxPages = 20;
-    widget = pagination(paginationOptions);
-    expect(widget.getMaxPage(results)).toEqual(20);
-  });
-
-  it('does not reduce the number of page if greater than nbPages', () => {
-    paginationOptions.maxPages = 40;
-    widget = pagination(paginationOptions);
-    expect(widget.getMaxPage(results)).toEqual(30);
-  });
-});


### PR DESCRIPTION
Fixes #1039

The pagination widget wrapper now has a CSS class of
`ais-pagination__pagecount-42`, if there are 42 possibles pages of
results.

![image](https://cloud.githubusercontent.com/assets/283419/15696103/4eb4c106-2762-11e6-96a5-6d7206e2c390.png)


I've used enzyme for the tests, and refactored a bit an unrelated test
file (just moved the duplicate `beforeEach`/`afterEach` one level
higher).

Two issues:

- The class name is not configurable. Do you think it should be? and
  if so, what name would you suggest for the `cssClasses` option.
- It uses the `nbPages`, not the actual number of pages displayed in
  the UI. Do you think it's an issue?