### PR TITLE
feat(header): Pass count of current refined filters in header

### DIFF
--- a/src/decorators/__tests__/headerFooter-test.js
+++ b/src/decorators/__tests__/headerFooter-test.js
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import expect from 'expect';
+import {shallow} from 'enzyme';
 import TestUtils from 'react-addons-test-utils';
 import TestComponent from './TestComponent';
 import headerFooter from '../headerFooter';
@@ -13,6 +14,21 @@ expect.extend(expectJSX);
 describe('headerFooter', () => {
   let renderer;
   let defaultProps;
+
+  function render(props = {}) {
+    let HeaderFooter = headerFooter(TestComponent);
+    renderer.render(<HeaderFooter {...props} />);
+    return renderer.getRenderOutput();
+  }
+
+  function shallowRender(extraProps: {}) {
+    let props = {
+      templateProps: {},
+      ...extraProps
+    };
+    let componentWrappedInHeaderFooter = headerFooter(TestComponent);
+    return shallow(React.createElement(componentWrappedInHeaderFooter, props));
+  }
 
   beforeEach(() => {
     let {createRenderer} = TestUtils;
@@ -148,10 +164,34 @@ describe('headerFooter', () => {
     });
   });
 
-  function render(props = {}) {
-    let HeaderFooter = headerFooter(TestComponent);
-    renderer.render(<HeaderFooter {...props} />);
-    return renderer.getRenderOutput();
-  }
-});
+  describe('headerFooterData', () => {
+    it('should call the header and footer template with the given data', () => {
+      // Given
+      let props = {
+        headerFooterData: {
+          header: {
+            foo: 'bar'
+          },
+          footer: {
+            foo: 'baz'
+          }
+        },
+        templateProps: {
+          templates: {
+            header: 'header',
+            footer: 'footer'
+          }
+        }
+      };
 
+      // When
+      let actual = shallowRender(props);
+      let header = actual.find({templateKey: 'header'});
+      let footer = actual.find({templateKey: 'footer'});
+
+      // Then
+      expect(header.props().data.foo).toEqual('bar');
+      expect(footer.props().data.foo).toEqual('baz');
+    });
+  });
+});

--- a/src/decorators/headerFooter.js
+++ b/src/decorators/headerFooter.js
@@ -4,6 +4,7 @@
 import React from 'react';
 
 import cx from 'classnames';
+import getKey from 'lodash/object/get';
 
 import Template from '../components/Template.js';
 
@@ -16,11 +17,6 @@ function headerFooter(ComposedComponent) {
         collapsed: props.collapsible && props.collapsible.collapsed
       };
 
-      this._headerElement = this._getElement({
-        type: 'header',
-        handleClick: props.collapsible ? this.handleHeaderClick : null
-      });
-
       this._cssClasses = {
         root: cx('ais-root', this.props.cssClasses.root),
         body: cx('ais-body', this.props.cssClasses.body)
@@ -28,18 +24,18 @@ function headerFooter(ComposedComponent) {
 
       this._footerElement = this._getElement({type: 'footer'});
     }
-    shouldComponentUpdate(nextProps, nextState) {
-      return nextState.collapsed === false ||
-        nextState !== this.state;
-    }
     _getElement({type, handleClick = null}) {
       let templates = this.props.templateProps.templates;
       if (!templates || !templates[type]) {
         return null;
       }
       let className = cx(this.props.cssClasses[type], `ais-${type}`);
+
+      let templateData = getKey(this.props, `headerFooterData.${type}`);
+
       return (
         <Template {...this.props.templateProps}
+          data={templateData}
           rootProps={{className, onClick: handleClick}}
           templateKey={type}
           transformData={null}
@@ -67,9 +63,14 @@ function headerFooter(ComposedComponent) {
         root: cx(rootCssClasses)
       };
 
+      let headerElement = this._getElement({
+        type: 'header',
+        handleClick: this.props.collapsible ? this.handleHeaderClick : null
+      });
+
       return (
         <div className={cssClasses.root}>
-          {this._headerElement}
+          {headerElement}
           <div
             className={cssClasses.body}
           >

--- a/src/widgets/refinement-list/__tests__/refinement-list-test.js
+++ b/src/widgets/refinement-list/__tests__/refinement-list-test.js
@@ -258,6 +258,62 @@ describe('refinementList()', () => {
         expect(actual).toBe(true);
       });
     });
+
+    describe('header', () => {
+      it('should pass the refined count to the header data', () => {
+        // Given
+        let facetValues = [{
+          name: 'foo',
+          isRefined: true
+        }, {
+          name: 'bar',
+          isRefined: true
+        }, {
+          name: 'baz',
+          isRefined: false
+        }];
+        results.getFacetValues = sinon.stub().returns(facetValues);
+
+        // When
+        renderWidget();
+        let props = ReactDOM.render.firstCall.args[0].props;
+
+        // Then
+        expect(props.headerFooterData.header.count).toEqual(2);
+      });
+
+      it('should dynamically update the header template on subsequent renders', () => {
+        // Given
+        let widgetOptions = {container, attributeName: 'type'};
+        let initOptions = {helper, createURL};
+        let facetValues = [{
+          name: 'foo',
+          isRefined: true
+        }, {
+          name: 'bar',
+          isRefined: false
+        }];
+        results.getFacetValues = sinon.stub().returns(facetValues);
+        let renderOptions = {results, helper, templatesConfig, state};
+
+        // When
+        widget = refinementList(widgetOptions);
+        widget.init(initOptions);
+        widget.render(renderOptions);
+
+        // Then
+        let props = ReactDOM.render.firstCall.args[0].props;
+        expect(props.headerFooterData.header.count).toEqual(1);
+
+        // When... second render call
+        facetValues[1].isRefined = true;
+        widget.render(renderOptions);
+
+        // Then
+        props = ReactDOM.render.secondCall.args[0].props;
+        expect(props.headerFooterData.header.count).toEqual(2);
+      });
+    });
   });
 
   context('toggleRefinement', () => {
@@ -280,8 +336,6 @@ describe('refinementList()', () => {
 
       // Then
       expect(helper.toggleRefinement.calledWith('attributeName', 'facetValue'));
-
-      // Then
     });
     it('should start a search on refinement', () => {
       // Given
@@ -293,8 +347,6 @@ describe('refinementList()', () => {
 
       // Then
       expect(helper.search.called);
-
-      // Then
     });
   });
 

--- a/src/widgets/refinement-list/refinement-list.js
+++ b/src/widgets/refinement-list/refinement-list.js
@@ -7,6 +7,7 @@ import {
   prefixKeys
 } from '../../lib/utils.js';
 import cx from 'classnames';
+import filter from 'lodash/collection/filter';
 import autoHideContainerHOC from '../../decorators/autoHideContainer.js';
 import headerFooterHOC from '../../decorators/headerFooter.js';
 import getShowMoreConfig from '../../lib/show-more/getShowMoreConfig.js';
@@ -152,12 +153,19 @@ function refinementList({
         return createURL(state.toggleRefinement(attributeName, facetValue));
       }
 
+      // Pass count of currently selected items to the header template
+      let refinedCount = filter(facetValues, {isRefined: true}).length;
+      let headerFooterData = {
+        header: {count: refinedCount}
+      };
+
       ReactDOM.render(
         <RefinementList
           collapsible={collapsible}
           createURL={_createURL}
           cssClasses={cssClasses}
           facetValues={facetValues}
+          headerFooterData={headerFooterData}
           limitMax={widgetMaxValuesPerFacet}
           limitMin={limit}
           shouldAutoHideContainer={facetValues.length === 0}


### PR DESCRIPTION
Partially fixes #1013

The goal of the PR was to make the `count` variable accessible to the
header template of the `refinementList` widget. This `count` is the
number of active filters applied to the facet.

![2016-06-03_15h47m14](https://cloud.githubusercontent.com/assets/283419/15794795/7d8339d0-29a2-11e6-98a6-73fa3dc51deb.gif)
_(I click on the header in this demo to show that it works with `collapsible` as well)_

```javascript
        templates: {
          header: (data) => {
            if (data.count === 0) {
              return `<h3 class="facet--title">Teams</h3>`;
            }
            return `<h3 class="facet--title">Teams (${data.count})</h3>`;
          }
        },
```

To do so the first step was to make the `header` template dynamic.
Before the PR, it was static, meaning that it was defined at the
widget init and never updated. I changed that part so the header
template is re-rendered on every render of its component.

It also meant that I had to remove the custom `shouldComponentUpdate`
method. The method was checking if the component was collapsed or not
before triggering the render. As we now always need to update the
render of the header, being collapsed or not, I removed the check.
I think it might even fix #1041 as well.

To pass template data to the header, you now need to pass the
`headerFooterData` prop to the component that is wrapped by
`headerFooterHOC`. It's an object with a key `header` containing the
data you want to pass. It could also potentially have a key
`footer`, but the footer part is not implemented yet because we had no
need for it.

Improvements and discussions:

- The `footer` template is still static. It would be trivial to set it
  as dynamic, but I left it like this until we have a use-case.
- Only the `refinementList` widget takes advantage of this feature. It
  would not be too hard to pass dynamic data to headers in other
  widgets, but I left that to other PRs.
- I will tackle the other issue of adding a CSS class on the root on
  another PR.