### PR TITLE
feat(hits): Add a `__position` attribute to data passed to items

### DIFF
--- a/src/components/Hits.js
+++ b/src/components/Hits.js
@@ -3,6 +3,7 @@ import map from 'lodash/collection/map';
 
 import Template from './Template.js';
 
+import hasKey from 'lodash/object/has';
 import isEqual from 'lodash/lang/isEqual';
 import cx from 'classnames';
 
@@ -14,11 +15,15 @@ class Hits extends React.Component {
   }
 
   renderWithResults() {
-    let renderedHits = map(this.props.results.hits, hit => {
+    let renderedHits = map(this.props.results.hits, (hit, position) => {
+      let data = {
+        ...hit,
+        __position: position
+      };
       return (
         <Template
-          data={hit}
-          key={hit.objectID}
+          data={data}
+          key={data.objectID}
           rootProps={{className: this.props.cssClasses.item}}
           templateKey="item"
           {...this.props.templateProps}
@@ -30,10 +35,15 @@ class Hits extends React.Component {
   }
 
   renderAllResults() {
+    let className = cx(
+      this.props.cssClasses.root,
+      this.props.cssClasses.allItems
+    );
+
     return (
       <Template
         data={this.props.results}
-        rootProps={{className: this.props.cssClasses.allItems}}
+        rootProps={{className}}
         templateKey="allItems"
         {...this.props.templateProps}
       />
@@ -41,10 +51,14 @@ class Hits extends React.Component {
   }
 
   renderNoResults() {
+    let className = cx(
+      this.props.cssClasses.root,
+      this.props.cssClasses.empty
+    );
     return (
       <Template
         data={this.props.results}
-        rootProps={{className: cx(this.props.cssClasses.root, this.props.cssClasses.empty)}}
+        rootProps={{className}}
         templateKey="empty"
         {...this.props.templateProps}
       />
@@ -52,17 +66,20 @@ class Hits extends React.Component {
   }
 
   render() {
-    if (this.props.results.hits.length > 0) {
-      const useAllItemsTemplate =
-        this.props.templateProps &&
-        this.props.templateProps.templates &&
-        this.props.templateProps.templates.allItems;
-      if (useAllItemsTemplate) {
-        return this.renderAllResults();
-      }
-      return this.renderWithResults();
+    let hasResults = this.props.results.hits.length > 0;
+    let hasAllItemsTemplate = hasKey(this.props, 'templateProps.templates.allItems');
+
+    if (!hasResults) {
+      return this.renderNoResults();
     }
-    return this.renderNoResults();
+
+    // If a allItems template is defined, it takes precedence over our looping
+    // through hits
+    if (hasAllItemsTemplate) {
+      return this.renderAllResults();
+    }
+
+    return this.renderWithResults();
   }
 }
 

--- a/src/components/__tests__/Hits-test.js
+++ b/src/components/__tests__/Hits-test.js
@@ -2,119 +2,284 @@
 
 import React from 'react';
 import expect from 'expect';
-import TestUtils from 'react-addons-test-utils';
+import {shallow} from 'enzyme';
 import Hits from '../Hits';
 import Template from '../Template';
 
-import expectJSX from 'expect-jsx';
-expect.extend(expectJSX);
-
 describe('Hits', () => {
-  let renderer;
-  let results;
-  let templateProps;
+  function shallowRender(extraProps: {}) {
+    let props = {
+      cssClasses: {},
+      ...extraProps
+    };
+    return shallow(React.createElement(Hits, props));
+  }
 
-  beforeEach(() => {
-    let {createRenderer} = TestUtils;
-    renderer = createRenderer();
-    results = {hits: []};
-    templateProps = {};
+  describe('no results', () => {
+    it('should use the empty template if no results', () => {
+      // Given
+      let props = {
+        results: {
+          hits: []
+        }
+      };
+
+      // When
+      let actual = shallowRender(props);
+
+      // Then
+      expect(actual.props().templateKey).toEqual('empty');
+    });
+
+    it('should set the empty CSS class when no results', () => {
+      // Given
+      let props = {
+        results: {
+          hits: []
+        },
+        cssClasses: {
+          root: 'my_root',
+          empty: 'my_empty'
+        }
+      };
+
+      // When
+      let actual = shallowRender(props);
+
+      // Then
+      expect(actual.props().rootProps.className).toContain('my_empty');
+      expect(actual.props().rootProps.className).toContain('my_root');
+    });
   });
 
-  it('render hits when present (item template)', () => {
-    results = {hits: [{
-      objectID: 'hello'
-    }, {
-      objectID: 'mom'
-    }]};
+  describe('allItems template', () => {
+    it('should use the allItems template if defined', () => {
+      // Given
+      let props = {
+        results: {
+          hits: [{
+            foo: 'bar'
+          }]
+        },
+        templateProps: {
+          templates: {
+            allItems: 'all items'
+          }
+        }
+      };
 
-    let props = {
-      results,
-      templateProps,
-      cssClasses: {
-        root: 'custom-root',
-        item: 'custom-item',
-        empty: 'custom-empty'
-      }
-    };
-    renderer.render(<Hits {...props} />);
-    let out = renderer.getRenderOutput();
+      // When
+      let actual = shallowRender(props);
 
-    expect(out).toEqualJSX(
-      <div className="custom-root">
-        <Template
-          data={results.hits[0]}
-          key={results.hits[0].objectID}
-          rootProps={{className: 'custom-item'}}
-          templateKey="item"
-        />
-        <Template
-          data={results.hits[1]}
-          key={results.hits[1].objectID}
-          rootProps={{className: 'custom-item'}}
-          templateKey="item"
-        />
-      </div>
-    );
+      // Then
+      expect(actual.props().templateKey).toEqual('allItems');
+    });
+
+    it('should set the allItems CSS class to the template', () => {
+      // Given
+      let props = {
+        results: {
+          hits: [{
+            foo: 'bar'
+          }]
+        },
+        templateProps: {
+          templates: {
+            allItems: 'all items'
+          }
+        },
+        cssClasses: {
+          root: 'my_root',
+          allItems: 'my_all_items'
+        }
+      };
+
+      // When
+      let actual = shallowRender(props);
+
+      // Then
+      expect(actual.props().rootProps.className).toContain('my_all_items');
+      expect(actual.props().rootProps.className).toContain('my_root');
+    });
+
+    it('should pass the list of all results to the template', () => {
+      // Given
+      let results = {
+        hits: [{
+          foo: 'bar'
+        }]
+      };
+      let props = {
+        results,
+        templateProps: {
+          templates: {
+            allItems: 'all items'
+          }
+        }
+      };
+
+      // When
+      let actual = shallowRender(props);
+
+      // Then
+      expect(actual.props().data).toEqual(results);
+    });
   });
 
-  it('render hits when present (allItems template)', () => {
-    results = {hits: [{
-      objectID: 'hello'
-    }, {
-      objectID: 'mom'
-    }]};
+  describe('individual item templates', () => {
+    it('should add an item template for each hit', () => {
+      // Given
+      let props = {
+        results: {
+          hits: [{
+            foo: 'bar'
+          }, {
+            foo: 'baz'
+          }]
+        },
+        templateProps: {
+          templates: {
+            item: 'one item'
+          }
+        }
+      };
 
-    const templateProps2 = {
-      ...templateProps,
-      templates: {
-        allItems: 'all items'
-      }
-    };
+      // When
+      let actual = shallowRender(props).find(Template);
 
-    let props = {
-      results,
-      templateProps: templateProps2,
-      cssClasses: {
-        root: 'custom-root',
-        allItems: 'custom-item',
-        empty: 'custom-empty'
-      }
-    };
-    renderer.render(<Hits {...props} />);
-    let out = renderer.getRenderOutput();
+      // Then
+      expect(actual.length).toEqual(2);
+      expect(actual.at(0).props().templateKey).toEqual('item');
+    });
 
-    expect(out).toEqualJSX(
-      <Template
-        data={results}
-        rootProps={{className: 'custom-item'}}
-        templateKey="allItems"
-        {...templateProps2}
-      />
-    );
-  });
+    it('should set the item class to each item', () => {
+      // Given
+      let props = {
+        results: {
+          hits: [{
+            foo: 'bar'
+          }]
+        },
+        templateProps: {
+          templates: {
+            item: 'one item'
+          }
+        },
+        cssClasses: {
+          item: 'my_item'
+        }
+      };
 
-  it('renders a specific template when no results', () => {
-    results = {hits: []};
+      // When
+      let actual = shallowRender(props).find(Template);
 
-    let props = {
-      results,
-      templateProps,
-      cssClasses: {
-        root: 'custom-root',
-        item: 'custom-item',
-        empty: 'custom-empty'
-      }
-    };
-    renderer.render(<Hits {...props} />);
-    let out = renderer.getRenderOutput();
+      // Then
+      expect(actual.props().rootProps.className).toContain('my_item');
+    });
 
-    expect(out).toEqualJSX(
-      <Template
-        data={results}
-        rootProps={{className: 'custom-root custom-empty'}}
-        templateKey="empty"
-      />
-    );
+    it('should wrap the items in a root div element', () => {
+      // Given
+      let props = {
+        results: {
+          hits: [{
+            foo: 'bar'
+          }, {
+            foo: 'baz'
+          }]
+        },
+        templateProps: {
+          templates: {
+            item: 'one item'
+          }
+        },
+        cssClasses: {
+          root: 'my_root'
+        }
+      };
+
+      // When
+      let actual = shallowRender(props);
+
+      // Then
+      expect(actual.name()).toEqual('div');
+      expect(actual.props().className).toContain('my_root');
+    });
+
+    it('should pass each result data to each item template', () => {
+      // Given
+      let props = {
+        results: {
+          hits: [{
+            foo: 'bar'
+          }, {
+            foo: 'baz'
+          }]
+        },
+        templateProps: {
+          templates: {
+            item: 'one item'
+          }
+        }
+      };
+
+      // When
+      let actual = shallowRender(props).find({templateKey: 'item'});
+
+      // Then
+      expect(actual.at(0).props().data.foo).toEqual('bar');
+      expect(actual.at(1).props().data.foo).toEqual('baz');
+    });
+
+    it('should add the __position in the list to each item', () => {
+      // Given
+      let props = {
+        results: {
+          hits: [{
+            foo: 'bar'
+          }, {
+            foo: 'baz'
+          }]
+        },
+        templateProps: {
+          templates: {
+            item: 'one item'
+          }
+        }
+      };
+
+      // When
+      let actual = shallowRender(props).find({templateKey: 'item'});
+
+      // Then
+      expect(actual.at(0).props().data.__position).toEqual(0);
+      expect(actual.at(1).props().data.__position).toEqual(1);
+    });
+
+    it('should use the objectID as the DOM key', () => {
+      // Given
+      let props = {
+        results: {
+          hits: [{
+            objectID: 'BAR',
+            foo: 'bar'
+          }, {
+            objectID: 'BAZ',
+            foo: 'baz'
+          }]
+        },
+        templateProps: {
+          templates: {
+            item: 'one item'
+          }
+        }
+      };
+
+      // When
+      let actual = shallowRender(props).find({templateKey: 'item'});
+
+      // Then
+      expect(actual.at(0).key()).toEqual('BAR');
+      expect(actual.at(1).key()).toEqual('BAZ');
+    });
   });
 });


### PR DESCRIPTION
Fixes #903

The change itself was easy to do, but it broke all the tests because
we were testing a full JSX output and we now had one more key passed
to the `data`.

It took this as an opportunity to refactor the Hits tests uzing enzyme
to make them easier to read. It allow me to spot one or two
inconsistencies in the way the `root` class was added or not depending
on the kind of template used.