### PR TITLE
docs(urlSync): Explicitly display the trackedParameters default value

### DIFF
--- a/docs/_includes/widget-jsdoc/instantsearch.md
+++ b/docs/_includes/widget-jsdoc/instantsearch.md
@@ -48,7 +48,7 @@
 <span class='attr-optional'>`options.urlSync.trackedParameters`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>Array.&lt;string&gt;</code>)</span>
 </p>
-<p class="attr-description">Parameters that will be synchronized in the URL. By default, it will track the query, all the refinable attribute (facets and numeric filters), the index and the page. [Full documentation](https://community.algolia.com/algoliasearch-helper-js/docs/SearchParameters.html)</p>
+<p class="attr-description">Parameters that will be synchronized in the URL. Default value is `['query', 'attribute:*', 'index', 'page', 'hitsPerPage']`. Refer to the [full documentation](https://community.algolia.com/algoliasearch-helper-js/docs/SearchParameters.html) for more details.</p>
 <p class="attr-name">
 <span class='attr-optional'>`options.urlSync.useHash`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>boolean</code>)</span>

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -35,9 +35,10 @@ function defaultCreateURL() { return '#'; }
  * state is created in the browser history. The default value is 700. The url is always updated at each keystroke
  * but we only create a "previous search state" (activated when click on back button) every 700ms of idle time.
  * @param  {string[]} [options.urlSync.trackedParameters] Parameters that will
- * be synchronized in the URL. By default, it will track the query, all the
- * refinable attribute (facets and numeric filters), the index and the page.
- * [Full documentation](https://community.algolia.com/algoliasearch-helper-js/docs/SearchParameters.html)
+ * be synchronized in the URL. Default value is `['query', 'attribute:*',
+ * 'index', 'page', 'hitsPerPage']`. Refer to the [full
+ * documentation](https://community.algolia.com/algoliasearch-helper-js/docs/SearchParameters.html)
+ * for more details.
  * @param  {boolean} [options.urlSync.useHash] If set to true, the url will be
  * hash based. Otherwise, it'll use the query parameters using the modern
  * history API.


### PR DESCRIPTION
I had to stop `urlSync` tracking the index. I could a simple way to remove one element except redefining the whole list. I had to dig in the source code to find the default value, so I thought it would be easier to just put the default value in the documentation.