### PR TITLE
fix(urlSync): urls should be safe by default

### DIFF
--- a/src/lib/url-sync.js
+++ b/src/lib/url-sync.js
@@ -134,7 +134,8 @@ class URLSync {
       state.filter(this.trackedParameters),
       {
         moreAttributes: foreignConfig,
-        mapping: this.mapping
+        mapping: this.mapping,
+        safe: true
       }
     );
 


### PR DESCRIPTION
tl;dr; Urls stored in the browser bar were made to look not too bad by omitting to encode some characters. Turns out it was a bad idea, copy pasting the url from browser bar to slack or github failed.

Fixes #982 #848 by using the new safe: true option from the helper when asking for a state as a url (https://github.com/algolia/algoliasearch-helper-js/pull/317).

This seems to be backward compatible (instantsearch wise):
- for current implementations, urls in the browser bar will move from `&hRF[color]` to `&hRF%05Bcolor%05D`
- urls sent to the server (if it happen people were reading them) will move from `&hRF[color]` to `&hRF%05Bcolor%05D` but I believe most server side code is already using decodeURI
- no change to current urls, they will be properly decoded (no change was needed on the decoding part)

If you have any idea how this might break people's website, please add a comment.

cc @olance 