### PR TITLE
fix(toggle): add backward compatibility for previous toggle implem

### DIFF
--- a/scripts/jsdom.js
+++ b/scripts/jsdom.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+
+beforeEach(function () {
+  this.jsdom = require('jsdom-global')();
+});
+
+afterEach(function () {
+  this.jsdom();
+});

--- a/scripts/mocha.opts
+++ b/scripts/mocha.opts
@@ -1,3 +1,2 @@
 --compilers js:babel-register
---require jsdom-global/register
-@(src)/**/__tests__/**/*-test.js
+@(src)/**/__tests__/**/*-test.js scripts/jsdom.js

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -157,7 +157,7 @@ describe('InstantSearch lifecycle', () => {
       });
 
       it('calls widget.getConfiguration(searchParameters)', () => {
-        expect(widget.getConfiguration.args[0]).toEqual([searchParameters]);
+        expect(widget.getConfiguration.args[0]).toEqual([searchParameters, undefined]);
       });
 
       it('calls algoliasearchHelper(client, indexName, searchParameters)', () => {

--- a/src/lib/url-sync.js
+++ b/src/lib/url-sync.js
@@ -96,6 +96,12 @@ class URLSync {
     this.getHistoryState = options.getHistoryState || (() => null);
     this.threshold = options.threshold || 700;
     this.trackedParameters = options.trackedParameters || ['query', 'attribute:*', 'index', 'page', 'hitsPerPage'];
+
+    this.searchParametersFromUrl = AlgoliaSearchHelper
+      .getConfigurationFromQueryString(
+        this.urlUtils.readUrl(),
+        {mapping: this.mapping}
+      );
   }
 
   getConfiguration(currentConfiguration) {
@@ -103,9 +109,7 @@ class URLSync {
     // like hierarchicalFacet.rootPath are then triggering a default refinement that would
     // be not present if it was not going trough the SearchParameters constructor
     this.originalConfig = algoliasearchHelper({}, currentConfiguration.index, currentConfiguration).state;
-    const queryString = this.urlUtils.readUrl();
-    const config = AlgoliaSearchHelper.getConfigurationFromQueryString(queryString, {mapping: this.mapping});
-    return config;
+    return this.searchParametersFromUrl;
   }
 
   render({helper}) {

--- a/src/widgets/toggle/__tests__/toggle-test.js
+++ b/src/widgets/toggle/__tests__/toggle-test.js
@@ -1,24 +1,13 @@
 /* eslint-env mocha */
 
-import React from 'react';
 import expect from 'expect';
 import sinon from 'sinon';
-
-import {createRenderer} from 'react-addons-test-utils';
-
 import toggle from '../toggle';
-import defaultTemplates from '../defaultTemplates.js';
-import RefinementList from '../../../components/RefinementList/RefinementList';
-import Template from '../../../components/Template';
 
 import expectJSX from 'expect-jsx';
 expect.extend(expectJSX);
-import createHelpers from '../../../lib/createHelpers.js';
 
 describe('toggle()', () => {
-  const helpers = createHelpers('en-US');
-  const renderer = createRenderer();
-
   context('bad usage', () => {
     it('throws when no container', () => {
       expect(() => {
@@ -40,21 +29,29 @@ describe('toggle()', () => {
   });
 
   context('good usage', () => {
-    let ReactDOM;
     let autoHideContainer;
     let headerFooter;
     let container;
     let widget;
     let attributeName;
     let label;
+    let currentToggleImplem;
+    let currentToggle;
+    let legacyToggleImplem;
+    let legacyToggle;
 
     beforeEach(() => {
-      ReactDOM = {render: sinon.spy()};
-      autoHideContainer = sinon.stub().returns(RefinementList);
-      headerFooter = sinon.stub().returns(RefinementList);
+      autoHideContainer = sinon.stub();
+      headerFooter = sinon.stub();
 
-      toggle.__Rewire__('ReactDOM', ReactDOM);
+      currentToggleImplem = {getConfiguration: sinon.spy(), init: sinon.spy(), render: sinon.spy()};
+      legacyToggleImplem = {getConfiguration: sinon.spy(), init: sinon.spy(), render: sinon.spy()};
+      currentToggle = sinon.stub().returns(currentToggleImplem);
+      legacyToggle = sinon.stub().returns(legacyToggleImplem);
+
       toggle.__Rewire__('autoHideContainerHOC', autoHideContainer);
+      toggle.__Rewire__('currentToggle', currentToggle);
+      toggle.__Rewire__('legacyToggle', legacyToggle);
       toggle.__Rewire__('headerFooterHOC', headerFooter);
 
       container = document.createElement('div');
@@ -63,8 +60,36 @@ describe('toggle()', () => {
       widget = toggle({container, attributeName, label});
     });
 
-    it('configures hitsPerPage', () => {
-      expect(widget.getConfiguration()).toEqual({disjunctiveFacets: ['world!']});
+    it('uses currentToggle implementation by default', () => {
+      widget.getConfiguration(1, 2);
+      expect(currentToggle.calledOnce).toBe(true);
+      expect(currentToggleImplem.getConfiguration.calledWithExactly(1, 2)).toBe(true);
+      widget.init(1);
+      widget.render(2);
+      expect(currentToggleImplem.init.calledWithExactly(1)).toBe(true);
+      expect(currentToggleImplem.render.calledWithExactly(2)).toBe(true);
+    });
+
+    it('uses legacyToggle implementation when corresponding facetsRefinements set previously', () => {
+      const currentSearchParameters = {facetsRefinements: {[attributeName]: ['yes']}};
+      widget.getConfiguration(currentSearchParameters, 2);
+      expect(legacyToggle.calledOnce).toBe(true);
+      expect(legacyToggleImplem.getConfiguration.calledWithExactly(currentSearchParameters, 2)).toBe(true);
+      widget.init(1);
+      expect(legacyToggleImplem.init.calledWithExactly(1)).toBe(true);
+      widget.render(2);
+      expect(legacyToggleImplem.render.calledWithExactly(2)).toBe(true);
+    });
+
+    it('uses legacyToggle implementation when corresponding facetsRefinements set in the url', () => {
+      const searchParametersFromUrl = {facetsRefinements: {[attributeName]: ['yes']}};
+      widget.getConfiguration(1, searchParametersFromUrl);
+      expect(legacyToggle.calledOnce).toBe(true);
+      expect(legacyToggleImplem.getConfiguration.calledWithExactly(1, searchParametersFromUrl)).toBe(true);
+      widget.init(1);
+      expect(legacyToggleImplem.init.calledWithExactly(1)).toBe(true);
+      widget.render(2);
+      expect(legacyToggleImplem.render.calledWithExactly(2)).toBe(true);
     });
 
     it('uses autoHideContainer() and headerFooter()', () => {
@@ -73,343 +98,11 @@ describe('toggle()', () => {
       expect(headerFooter.calledBefore(autoHideContainer)).toBe(true);
     });
 
-    context('render', () => {
-      let templateProps;
-      let results;
-      let helper;
-      let state;
-      let props;
-      let createURL;
-
-      beforeEach(() => {
-        templateProps = {
-          templatesConfig: undefined,
-          templates: defaultTemplates,
-          useCustomCompileOptions: {header: false, item: false, footer: false},
-          transformData: undefined
-        };
-        helper = {
-          state: {
-            isDisjunctiveFacetRefined: sinon.stub().returns(false)
-          },
-          removeDisjunctiveFacetRefinement: sinon.spy(),
-          addDisjunctiveFacetRefinement: sinon.spy(),
-          search: sinon.spy()
-        };
-        state = {
-          removeDisjunctiveFacetRefinement: sinon.spy(),
-          addDisjunctiveFacetRefinement: sinon.spy(),
-          isDisjunctiveFacetRefined: sinon.stub().returns(false)
-        };
-        props = {
-          cssClasses: {
-            root: 'ais-toggle',
-            header: 'ais-toggle--header',
-            body: 'ais-toggle--body',
-            footer: 'ais-toggle--footer',
-            list: 'ais-toggle--list',
-            item: 'ais-toggle--item',
-            active: 'ais-toggle--item__active',
-            label: 'ais-toggle--label',
-            checkbox: 'ais-toggle--checkbox',
-            count: 'ais-toggle--count'
-          },
-          collapsible: false,
-          templateProps,
-          createURL() {},
-          toggleRefinement() {}
-        };
-        createURL = () => '#';
-        widget.init({state});
-      });
-
-      it('calls twice ReactDOM.render', () => {
-        results = {
-          hits: [{Hello: ', world!'}],
-          nbHits: 1,
-          getFacetValues: sinon.stub().returns([{name: 'true', count: 2}, {name: 'false', count: 1}])
-        };
-        widget = toggle({container, attributeName, label});
-        widget.render({results, helper, state, createURL});
-        widget.render({results, helper, state, createURL});
-        expect(ReactDOM.render.calledTwice).toBe(true, 'ReactDOM.render called twice');
-        expect(ReactDOM.render.firstCall.args[1]).toEqual(container);
-        expect(ReactDOM.render.secondCall.args[1]).toEqual(container);
-      });
-
-      it('formats counts', () => {
-        templateProps.templatesConfig = {helpers};
-        renderer.render(<Template data={{count: 1000}} {...templateProps} templateKey="item" />);
-        const out = renderer.getRenderOutput();
-        // eslint-disable-next-line max-len
-        expect(out).toEqualJSX(<div dangerouslySetInnerHTML={{__html: '<label class="">\n <input type="checkbox" class="" value="" />\n <span class="">1,000</span>\n</label>'}} />);
-      });
-
-      it('understands cssClasses', () => {
-        results = {
-          hits: [{Hello: ', world!'}],
-          nbHits: 1,
-          getFacetValues: sinon.stub().returns([
-            {name: 'true', count: 2, isRefined: false},
-            {name: 'false', count: 1, isRefined: true}
-          ])
-        };
-        props.cssClasses.root += ' root cx';
-        props = {
-          facetValues: [{
-            count: 2,
-            isRefined: false,
-            name: label,
-            offFacetValue: {count: 1, name: 'Hello, ', isRefined: true},
-            onFacetValue: {count: 2, name: 'Hello, ', isRefined: false}
-          }],
-          shouldAutoHideContainer: false,
-          ...props
-        };
-        const cssClasses = {root: ['root', 'cx']};
-        widget = toggle({container, attributeName, label, cssClasses});
-        widget.init({state, helper});
-        widget.render({results, helper, state, createURL});
-        expect(ReactDOM.render.firstCall.args[0]).toEqualJSX(<RefinementList {...props} />);
-      });
-
-      it('with facet values', () => {
-        results = {
-          hits: [{Hello: ', world!'}],
-          nbHits: 1,
-          getFacetValues: sinon.stub().returns([
-            {name: 'true', count: 2, isRefined: false},
-            {name: 'false', count: 1, isRefined: true}
-          ])
-        };
-        widget = toggle({container, attributeName, label});
-        widget.init({state, helper});
-        widget.render({results, helper, state, createURL});
-        widget.render({results, helper, state, createURL});
-
-        props = {
-          facetValues: [{
-            count: 2,
-            isRefined:
-            false,
-            name: label,
-            offFacetValue: {count: 1, name: 'Hello, ', isRefined: true},
-            onFacetValue: {count: 2, name: 'Hello, ', isRefined: false}
-          }],
-          shouldAutoHideContainer: false,
-          ...props
-        };
-
-        expect(ReactDOM.render.firstCall.args[0]).toEqualJSX(<RefinementList {...props} />);
-        expect(ReactDOM.render.secondCall.args[0]).toEqualJSX(<RefinementList {...props} />);
-      });
-
-      it('without facet values', () => {
-        results = {
-          hits: [],
-          nbHits: 0,
-          getFacetValues: sinon.stub().returns([])
-        };
-        widget = toggle({container, attributeName, label});
-        widget.init({state, helper});
-        widget.render({results, helper, state, createURL});
-        widget.render({results, helper, state, createURL});
-
-        props = {
-          facetValues: [{
-            name: label,
-            isRefined: false,
-            count: null,
-            onFacetValue: {name: label, isRefined: false, count: null},
-            offFacetValue: {name: label, isRefined: false, count: null}
-          }],
-          shouldAutoHideContainer: true,
-          ...props
-        };
-
-        expect(ReactDOM.render.firstCall.args[0]).toEqualJSX(<RefinementList {...props} />);
-        expect(ReactDOM.render.secondCall.args[0]).toEqualJSX(<RefinementList {...props} />);
-      });
-
-      it('when refined', () => {
-        helper = {
-          state: {
-            isDisjunctiveFacetRefined: sinon.stub().returns(true)
-          }
-        };
-        results = {
-          hits: [{Hello: ', world!'}],
-          nbHits: 1,
-          getFacetValues: sinon.stub().returns([
-            {name: 'true', count: 2, isRefined: true},
-            {name: 'false', count: 1, isRefined: false}
-          ])
-        };
-        widget = toggle({container, attributeName, label});
-        widget.init({state, helper});
-        widget.render({results, helper, state, createURL});
-        widget.render({results, helper, state, createURL});
-
-        props = {
-          facetValues: [{
-            count: 1,
-            isRefined: true,
-            name: label,
-            onFacetValue: {name: label, isRefined: true, count: 2},
-            offFacetValue: {name: label, isRefined: false, count: 1}
-          }],
-          shouldAutoHideContainer: false,
-          ...props
-        };
-
-        expect(ReactDOM.render.firstCall.args[0]).toEqualJSX(<RefinementList {...props} />);
-        expect(ReactDOM.render.secondCall.args[0]).toEqualJSX(<RefinementList {...props} />);
-      });
-
-      it('using props.toggleRefinement', () => {
-        results = {
-          hits: [{Hello: ', world!'}],
-          nbHits: 1,
-          getFacetValues: sinon.stub().returns([{name: 'true', count: 2}, {name: 'false', count: 1}])
-        };
-        widget = toggle({container, attributeName, label});
-        widget.init({state, helper});
-        widget.render({results, helper, state, createURL});
-        const toggleRefinement = ReactDOM.render.firstCall.args[0].props.toggleRefinement;
-        expect(toggleRefinement).toBeA('function');
-        toggleRefinement();
-        expect(helper.addDisjunctiveFacetRefinement.calledOnce).toBe(true);
-        expect(helper.addDisjunctiveFacetRefinement.calledWithExactly(attributeName, true));
-        helper.hasRefinements = sinon.stub().returns(true);
-      });
-    });
-
-    context('toggleRefinement', () => {
-      let helper;
-      let values;
-
-      function toggleOn() {
-        widget.toggleRefinement(helper, 'facetValueToRefine', false);
-      }
-      function toggleOff() {
-        widget.toggleRefinement(helper, 'facetValueToRefine', true);
-      }
-
-      beforeEach(() => {
-        helper = {
-          removeDisjunctiveFacetRefinement: sinon.spy(),
-          addDisjunctiveFacetRefinement: sinon.spy(),
-          search: sinon.spy()
-        };
-      });
-
-      context('default values', () => {
-        it('toggle on should add filter to true', () => {
-          // Given
-          widget = toggle({container, attributeName, label});
-
-          // When
-          toggleOn();
-
-          // Then
-          expect(helper.addDisjunctiveFacetRefinement.calledWith(attributeName, true)).toBe(true);
-          expect(helper.removeDisjunctiveFacetRefinement.called).toBe(false);
-        });
-        it('toggle off should remove all filters', () => {
-          // Given
-          widget = toggle({container, attributeName, label});
-
-          // When
-          toggleOff();
-
-          // Then
-          expect(helper.removeDisjunctiveFacetRefinement.calledWith(attributeName, true)).toBe(true);
-          expect(helper.addDisjunctiveFacetRefinement.called).toBe(false);
-        });
-      });
-      context('specific values', () => {
-        it('toggle on should change the refined value', () => {
-          // Given
-          values = {on: 'on', off: 'off'};
-          widget = toggle({container, attributeName, label, values});
-
-          // When
-          toggleOn();
-
-          // Then
-          expect(helper.removeDisjunctiveFacetRefinement.calledWith(attributeName, 'off')).toBe(true);
-          expect(helper.addDisjunctiveFacetRefinement.calledWith(attributeName, 'on')).toBe(true);
-        });
-        it('toggle off should change the refined value', () => {
-          // Given
-          values = {on: 'on', off: 'off'};
-          widget = toggle({container, attributeName, label, values});
-
-          // When
-          toggleOff();
-
-          // Then
-          expect(helper.removeDisjunctiveFacetRefinement.calledWith(attributeName, 'on')).toBe(true);
-          expect(helper.addDisjunctiveFacetRefinement.calledWith(attributeName, 'off')).toBe(true);
-        });
-      });
-    });
-
-    context('custom off value', () => {
-      it('should add a refinement for custom off value on init', () => {
-        // Given
-        const values = {on: 'on', off: 'off'};
-        widget = toggle({container, attributeName, label, values});
-        const state = {
-          isDisjunctiveFacetRefined: sinon.stub().returns(false)
-        };
-        const helper = {
-          addDisjunctiveFacetRefinement: sinon.spy()
-        };
-
-        // When
-        widget.init({state, helper});
-
-        // Then
-        expect(helper.addDisjunctiveFacetRefinement.calledWith(attributeName, 'off')).toBe(true);
-      });
-      it('should not add a refinement for custom off value on init if already checked', () => {
-        // Given
-        const values = {on: 'on', off: 'off'};
-        widget = toggle({container, attributeName, label, values});
-        const state = {
-          isDisjunctiveFacetRefined: sinon.stub().returns(true)
-        };
-        const helper = {
-          addDisjunctiveFacetRefinement: sinon.spy()
-        };
-
-        // When
-        widget.init({state, helper});
-
-        // Then
-        expect(helper.addDisjunctiveFacetRefinement.called).toBe(false);
-      });
-      it('should not add a refinement for no custom off value on init', () => {
-        // Given
-        widget = toggle({container, attributeName, label});
-        const state = {};
-        const helper = {
-          addDisjunctiveFacetRefinement: sinon.spy()
-        };
-
-        // When
-        widget.init({state, helper});
-
-        // Then
-        expect(helper.addDisjunctiveFacetRefinement.called).toBe(false);
-      });
-    });
-
     afterEach(() => {
-      toggle.__ResetDependency__('ReactDOM');
       toggle.__ResetDependency__('autoHideContainerHOC');
       toggle.__ResetDependency__('headerFooterHOC');
+      toggle.__ResetDependency__('currentToggle');
+      toggle.__ResetDependency__('legacyToggle');
     });
   });
 });

--- a/src/widgets/toggle/implementations/__tests__/currentToggle-test.js
+++ b/src/widgets/toggle/implementations/__tests__/currentToggle-test.js
@@ -1,0 +1,429 @@
+/* eslint-env mocha */
+
+import React from 'react';
+import expect from 'expect';
+import sinon from 'sinon';
+
+import {createRenderer} from 'react-addons-test-utils';
+
+import currentToggle from '../currentToggle.js';
+import defaultTemplates from '../../defaultTemplates.js';
+import Template from '../../../../components/Template';
+
+import expectJSX from 'expect-jsx';
+expect.extend(expectJSX);
+import createHelpers from '../../../../lib/createHelpers.js';
+
+describe('currentToggle()', () => {
+  const helpers = createHelpers('en-US');
+  const renderer = createRenderer();
+
+  context('good usage', () => {
+    let ReactDOM;
+    let containerNode;
+    let widget;
+    let attributeName;
+    let label;
+    let userValues;
+    let RefinementList;
+    let collapsible;
+    let cssClasses;
+
+    beforeEach(() => {
+      ReactDOM = {render: sinon.spy()};
+
+      currentToggle.__Rewire__('ReactDOM', ReactDOM);
+
+      containerNode = document.createElement('div');
+      label = 'Hello, ';
+      attributeName = 'world!';
+      cssClasses = {};
+      collapsible = false;
+      userValues = {on: true, off: undefined};
+      RefinementList = () => <div></div>;
+      widget = currentToggle({containerNode, attributeName, label});
+    });
+
+    it('configures disjunctiveFacets', () => {
+      expect(widget.getConfiguration()).toEqual({disjunctiveFacets: ['world!']});
+    });
+
+    context('render', () => {
+      let templateProps;
+      let results;
+      let helper;
+      let state;
+      let props;
+      let createURL;
+
+      beforeEach(() => {
+        templateProps = {
+          templatesConfig: undefined,
+          templates: defaultTemplates,
+          useCustomCompileOptions: {header: false, item: false, footer: false},
+          transformData: undefined
+        };
+        helper = {
+          state: {
+            isDisjunctiveFacetRefined: sinon.stub().returns(false)
+          },
+          removeDisjunctiveFacetRefinement: sinon.spy(),
+          addDisjunctiveFacetRefinement: sinon.spy(),
+          search: sinon.spy()
+        };
+        state = {
+          removeDisjunctiveFacetRefinement: sinon.spy(),
+          addDisjunctiveFacetRefinement: sinon.spy(),
+          isDisjunctiveFacetRefined: sinon.stub().returns(false)
+        };
+        props = {
+          cssClasses: {},
+          collapsible: false,
+          templateProps,
+          createURL() {},
+          toggleRefinement() {}
+        };
+        createURL = () => '#';
+        widget.init({state});
+      });
+
+      it('calls twice ReactDOM.render', () => {
+        results = {
+          hits: [{Hello: ', world!'}],
+          nbHits: 1,
+          getFacetValues: sinon.stub().returns([{name: 'true', count: 2}, {name: 'false', count: 1}])
+        };
+        widget = currentToggle({containerNode, attributeName, label, userValues});
+        widget.getConfiguration();
+        widget.render({results, helper, state, createURL});
+        widget.render({results, helper, state, createURL});
+        expect(ReactDOM.render.calledTwice).toBe(true, 'ReactDOM.render called twice');
+        expect(ReactDOM.render.firstCall.args[1]).toEqual(containerNode);
+        expect(ReactDOM.render.secondCall.args[1]).toEqual(containerNode);
+      });
+
+      it('formats counts', () => {
+        templateProps.templatesConfig = {helpers};
+        renderer.render(<Template data={{count: 1000}} {...templateProps} templateKey="item" />);
+        const out = renderer.getRenderOutput();
+        // eslint-disable-next-line max-len
+        expect(out).toEqualJSX(<div dangerouslySetInnerHTML={{__html: '<label class="">\n <input type="checkbox" class="" value="" />\n <span class="">1,000</span>\n</label>'}} />);
+      });
+
+      it('understands cssClasses', () => {
+        results = {
+          hits: [{Hello: ', world!'}],
+          nbHits: 1,
+          getFacetValues: sinon.stub().returns([
+            {name: 'true', count: 2, isRefined: false},
+            {name: 'false', count: 1, isRefined: true}
+          ])
+        };
+        props.cssClasses.root = 'test';
+        props = {
+          facetValues: [{
+            count: 2,
+            isRefined: false,
+            name: label,
+            offFacetValue: {count: 1, name: 'Hello, ', isRefined: true},
+            onFacetValue: {count: 2, name: 'Hello, ', isRefined: false}
+          }],
+          shouldAutoHideContainer: false,
+          ...props
+        };
+        cssClasses = {root: 'test'};
+        widget = currentToggle({
+          containerNode,
+          attributeName,
+          label,
+          cssClasses,
+          userValues,
+          RefinementList,
+          collapsible
+        });
+        widget.getConfiguration();
+        widget.init({state, helper});
+        widget.render({results, helper, state, createURL});
+        expect(ReactDOM.render.firstCall.args[0]).toEqualJSX(<RefinementList {...props} />);
+      });
+
+      it('with facet values', () => {
+        results = {
+          hits: [{Hello: ', world!'}],
+          nbHits: 1,
+          getFacetValues: sinon.stub().returns([
+            {name: 'true', count: 2, isRefined: false},
+            {name: 'false', count: 1, isRefined: true}
+          ])
+        };
+        widget = currentToggle({
+          containerNode,
+          attributeName,
+          label,
+          cssClasses,
+          userValues,
+          RefinementList,
+          collapsible
+        });
+        widget.getConfiguration();
+        widget.init({state, helper});
+        widget.render({results, helper, state, createURL});
+        widget.render({results, helper, state, createURL});
+
+        props = {
+          facetValues: [{
+            count: 2,
+            isRefined:
+            false,
+            name: label,
+            offFacetValue: {count: 1, name: 'Hello, ', isRefined: true},
+            onFacetValue: {count: 2, name: 'Hello, ', isRefined: false}
+          }],
+          shouldAutoHideContainer: false,
+          ...props
+        };
+
+        expect(ReactDOM.render.firstCall.args[0]).toEqualJSX(<RefinementList {...props} />);
+        expect(ReactDOM.render.secondCall.args[0]).toEqualJSX(<RefinementList {...props} />);
+      });
+
+      it('without facet values', () => {
+        results = {
+          hits: [],
+          nbHits: 0,
+          getFacetValues: sinon.stub().returns([])
+        };
+        widget = currentToggle({
+          containerNode,
+          attributeName,
+          label,
+          cssClasses,
+          userValues,
+          RefinementList,
+          collapsible
+        });
+        widget.getConfiguration();
+        widget.init({state, helper});
+        widget.render({results, helper, state, createURL});
+        widget.render({results, helper, state, createURL});
+
+        props = {
+          facetValues: [{
+            name: label,
+            isRefined: false,
+            count: null,
+            onFacetValue: {name: label, isRefined: false, count: null},
+            offFacetValue: {name: label, isRefined: false, count: null}
+          }],
+          shouldAutoHideContainer: true,
+          ...props
+        };
+
+        expect(ReactDOM.render.firstCall.args[0]).toEqualJSX(<RefinementList {...props} />);
+        expect(ReactDOM.render.secondCall.args[0]).toEqualJSX(<RefinementList {...props} />);
+      });
+
+      it('when refined', () => {
+        helper = {
+          state: {
+            isDisjunctiveFacetRefined: sinon.stub().returns(true)
+          }
+        };
+        results = {
+          hits: [{Hello: ', world!'}],
+          nbHits: 1,
+          getFacetValues: sinon.stub().returns([
+            {name: 'true', count: 2, isRefined: true},
+            {name: 'false', count: 1, isRefined: false}
+          ])
+        };
+        widget = currentToggle({
+          containerNode,
+          attributeName,
+          label,
+          cssClasses,
+          userValues,
+          RefinementList,
+          collapsible
+        });
+        widget.getConfiguration();
+        widget.init({state, helper});
+        widget.render({results, helper, state, createURL});
+        widget.render({results, helper, state, createURL});
+
+        props = {
+          facetValues: [{
+            count: 1,
+            isRefined: true,
+            name: label,
+            onFacetValue: {name: label, isRefined: true, count: 2},
+            offFacetValue: {name: label, isRefined: false, count: 1}
+          }],
+          shouldAutoHideContainer: false,
+          ...props
+        };
+
+        expect(ReactDOM.render.firstCall.args[0]).toEqualJSX(<RefinementList {...props} />);
+        expect(ReactDOM.render.secondCall.args[0]).toEqualJSX(<RefinementList {...props} />);
+      });
+
+      it('using props.toggleRefinement', () => {
+        results = {
+          hits: [{Hello: ', world!'}],
+          nbHits: 1,
+          getFacetValues: sinon.stub().returns([{name: 'true', count: 2}, {name: 'false', count: 1}])
+        };
+        widget = currentToggle({
+          containerNode,
+          attributeName,
+          label,
+          cssClasses,
+          userValues,
+          RefinementList,
+          collapsible
+        });
+        widget.getConfiguration();
+        widget.init({state, helper});
+        widget.render({results, helper, state, createURL});
+        const toggleRefinement = ReactDOM.render.firstCall.args[0].props.toggleRefinement;
+        expect(toggleRefinement).toBeA('function');
+        toggleRefinement();
+        expect(helper.addDisjunctiveFacetRefinement.calledOnce).toBe(true);
+        expect(helper.addDisjunctiveFacetRefinement.calledWithExactly(attributeName, true));
+        helper.hasRefinements = sinon.stub().returns(true);
+      });
+    });
+
+    context('toggleRefinement', () => {
+      let helper;
+
+      function toggleOn() {
+        widget.toggleRefinement(helper, 'facetValueToRefine', false);
+      }
+      function toggleOff() {
+        widget.toggleRefinement(helper, 'facetValueToRefine', true);
+      }
+
+      beforeEach(() => {
+        helper = {
+          removeDisjunctiveFacetRefinement: sinon.spy(),
+          addDisjunctiveFacetRefinement: sinon.spy(),
+          search: sinon.spy()
+        };
+      });
+
+      context('default values', () => {
+        it('toggle on should add filter to true', () => {
+          // Given
+          widget = currentToggle({containerNode, attributeName, label, userValues});
+          widget.getConfiguration();
+
+          // When
+          toggleOn();
+
+          // Then
+          expect(helper.addDisjunctiveFacetRefinement.calledWith(attributeName, true)).toBe(true);
+          expect(helper.removeDisjunctiveFacetRefinement.called).toBe(false);
+        });
+        it('toggle off should remove all filters', () => {
+          // Given
+          widget = currentToggle({containerNode, attributeName, label, userValues});
+          widget.getConfiguration();
+
+          // When
+          toggleOff();
+
+          // Then
+          expect(helper.removeDisjunctiveFacetRefinement.calledWith(attributeName, true)).toBe(true);
+          expect(helper.addDisjunctiveFacetRefinement.called).toBe(false);
+        });
+      });
+      context('specific values', () => {
+        it('toggle on should change the refined value', () => {
+          // Given
+          userValues = {on: 'on', off: 'off'};
+          widget = currentToggle({containerNode, attributeName, label, userValues, hasAnOffValue: true});
+          widget.getConfiguration();
+
+          // When
+          toggleOn();
+
+          // Then
+          expect(helper.removeDisjunctiveFacetRefinement.calledWith(attributeName, 'off')).toBe(true);
+          expect(helper.addDisjunctiveFacetRefinement.calledWith(attributeName, 'on')).toBe(true);
+        });
+        it('toggle off should change the refined value', () => {
+          // Given
+          userValues = {on: 'on', off: 'off'};
+          widget = currentToggle({containerNode, attributeName, label, userValues, hasAnOffValue: true});
+          widget.getConfiguration();
+
+          // When
+          toggleOff();
+
+          // Then
+          expect(helper.removeDisjunctiveFacetRefinement.calledWith(attributeName, 'on')).toBe(true);
+          expect(helper.addDisjunctiveFacetRefinement.calledWith(attributeName, 'off')).toBe(true);
+        });
+      });
+    });
+
+    context('custom off value', () => {
+      it('should add a refinement for custom off value on init', () => {
+        // Given
+        userValues = {on: 'on', off: 'off'};
+        widget = currentToggle({containerNode, attributeName, label, hasAnOffValue: true, userValues});
+        widget.getConfiguration();
+        const state = {
+          isDisjunctiveFacetRefined: sinon.stub().returns(false)
+        };
+        const helper = {
+          addDisjunctiveFacetRefinement: sinon.spy()
+        };
+
+        // When
+        widget.init({state, helper});
+
+        // Then
+        expect(helper.addDisjunctiveFacetRefinement.calledWith(attributeName, 'off')).toBe(true);
+      });
+      it('should not add a refinement for custom off value on init if already checked', () => {
+        // Given
+        userValues = {on: 'on', off: 'off'};
+        widget = currentToggle({containerNode, attributeName, label, userValues, hasAnOffValue: true});
+        widget.getConfiguration();
+        const state = {
+          isDisjunctiveFacetRefined: sinon.stub().returns(true)
+        };
+        const helper = {
+          addDisjunctiveFacetRefinement: sinon.spy()
+        };
+
+        // When
+        widget.init({state, helper});
+
+        // Then
+        expect(helper.addDisjunctiveFacetRefinement.called).toBe(false);
+      });
+      it('should not add a refinement for no custom off value on init', () => {
+        // Given
+        widget = currentToggle({containerNode, attributeName, label, hasAnOffValue: false, userValues});
+        widget.getConfiguration();
+        const state = {};
+        const helper = {
+          addDisjunctiveFacetRefinement: sinon.spy()
+        };
+
+        // When
+        widget.init({state, helper});
+
+        // Then
+        expect(helper.addDisjunctiveFacetRefinement.called).toBe(false);
+      });
+    });
+
+    afterEach(() => {
+      currentToggle.__ResetDependency__('ReactDOM');
+    });
+  });
+});

--- a/src/widgets/toggle/implementations/currentToggle.js
+++ b/src/widgets/toggle/implementations/currentToggle.js
@@ -1,0 +1,123 @@
+import find from 'lodash/collection/find';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import defaultTemplates from '../defaultTemplates.js';
+import {
+  prepareTemplateProps
+} from '../../../lib/utils.js';
+
+// cannot use a function declaration because of
+// https://github.com/speedskater/babel-plugin-rewire/issues/109#issuecomment-227917555
+const currentToggle = ({
+  attributeName,
+  label,
+  userValues,
+  templates,
+  collapsible,
+  transformData,
+  hasAnOffValue,
+  containerNode,
+  RefinementList,
+  cssClasses
+} = {}) => ({
+  getConfiguration() {
+    return {
+      disjunctiveFacets: [attributeName]
+    };
+  },
+  toggleRefinement(helper, facetValue, isRefined) {
+    const on = userValues.on;
+    const off = userValues.off;
+
+    // Checking
+    if (!isRefined) {
+      if (hasAnOffValue) {
+        helper.removeDisjunctiveFacetRefinement(attributeName, off);
+      }
+      helper.addDisjunctiveFacetRefinement(attributeName, on);
+    } else {
+      // Unchecking
+      helper.removeDisjunctiveFacetRefinement(attributeName, on);
+      if (hasAnOffValue) {
+        helper.addDisjunctiveFacetRefinement(attributeName, off);
+      }
+    }
+
+    helper.search();
+  },
+  init({state, helper, templatesConfig}) {
+    this._templateProps = prepareTemplateProps({
+      transformData,
+      defaultTemplates,
+      templatesConfig,
+      templates
+    });
+
+    this.toggleRefinement = this.toggleRefinement.bind(this, helper);
+
+        // no need to refine anything at init if no custom off values
+    if (!hasAnOffValue) {
+      return;
+    }
+        // Add filtering on the 'off' value if set
+    const isRefined = state.isDisjunctiveFacetRefined(attributeName, userValues.on);
+    if (!isRefined) {
+      helper.addDisjunctiveFacetRefinement(attributeName, userValues.off);
+    }
+  },
+  render({helper, results, state, createURL}) {
+    const isRefined = helper.state.isDisjunctiveFacetRefined(attributeName, userValues.on);
+    const onValue = userValues.on;
+    const offValue = userValues.off === undefined ? false : userValues.off;
+    const allFacetValues = results.getFacetValues(attributeName);
+    const onData = find(allFacetValues, {name: onValue.toString()});
+    const onFacetValue = {
+      name: label,
+      isRefined: onData !== undefined ? onData.isRefined : false,
+      count: onData === undefined ? null : onData.count
+    };
+    const offData = find(allFacetValues, {name: offValue.toString()});
+    const offFacetValue = {
+      name: label,
+      isRefined: offData !== undefined ? offData.isRefined : false,
+      count: offData === undefined ? null : offData.count
+    };
+
+        // what will we show by default,
+        // if checkbox is not checked, show: [ ] free shipping (countWhenChecked)
+        // if checkbox is checked, show: [x] free shipping (countWhenNotChecked)
+    const nextRefinement = isRefined ? offFacetValue : onFacetValue;
+
+    const facetValue = {
+      name: label,
+      isRefined,
+      count: nextRefinement === undefined ? null : nextRefinement.count,
+      onFacetValue,
+      offFacetValue
+    };
+
+        // Bind createURL to this specific attribute
+    function _createURL() {
+      return createURL(
+            state
+              .removeDisjunctiveFacetRefinement(attributeName, isRefined ? onValue : userValues.off)
+              .addDisjunctiveFacetRefinement(attributeName, isRefined ? userValues.off : onValue)
+          );
+    }
+
+    ReactDOM.render(
+          <RefinementList
+            collapsible={collapsible}
+            createURL={_createURL}
+            cssClasses={cssClasses}
+            facetValues={[facetValue]}
+            shouldAutoHideContainer={results.nbHits === 0}
+            templateProps={this._templateProps}
+            toggleRefinement={this.toggleRefinement}
+          />,
+          containerNode
+        );
+  }
+});
+
+export default currentToggle;

--- a/src/widgets/toggle/implementations/legacyToggle.js
+++ b/src/widgets/toggle/implementations/legacyToggle.js
@@ -1,0 +1,102 @@
+import find from 'lodash/collection/find';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import defaultTemplates from '../defaultTemplates.js';
+import {
+  prepareTemplateProps
+} from '../../../lib/utils.js';
+
+export default function currentToggle({
+  attributeName,
+  label,
+  userValues,
+  templates,
+  collapsible,
+  transformData,
+  hasAnOffValue,
+  containerNode,
+  RefinementList,
+  cssClasses
+} = {}) {
+  return {
+    getConfiguration() {
+      return {
+        facets: [attributeName]
+      };
+    },
+    toggleRefinement(helper, facetValue, isRefined) {
+      const on = userValues.on;
+      const off = userValues.off;
+
+      // Checking
+      if (!isRefined) {
+        if (hasAnOffValue) {
+          helper.removeFacetRefinement(attributeName, off);
+        }
+        helper.addFacetRefinement(attributeName, on);
+      } else {
+        // Unchecking
+        helper.removeFacetRefinement(attributeName, on);
+        if (hasAnOffValue) {
+          helper.addFacetRefinement(attributeName, off);
+        }
+      }
+
+      helper.search();
+    },
+    init({state, helper, templatesConfig}) {
+      this._templateProps = prepareTemplateProps({
+        transformData,
+        defaultTemplates,
+        templatesConfig,
+        templates
+      });
+      this.toggleRefinement = this.toggleRefinement.bind(this, helper);
+
+      // no need to refine anything at init if no custom off values
+      if (!hasAnOffValue) {
+        return;
+      }
+      // Add filtering on the 'off' value if set
+      const isRefined = state.isFacetRefined(attributeName, userValues.on);
+      if (!isRefined) {
+        helper.addFacetRefinement(attributeName, userValues.off);
+      }
+    },
+    render({helper, results, state, createURL}) {
+      const isRefined = helper.state.isFacetRefined(attributeName, userValues.on);
+      const currentRefinement = isRefined ? userValues.on : userValues.off;
+      let count;
+      if (typeof currentRefinement === 'number') {
+        count = results.getFacetStats(attributeName).sum;
+      } else {
+        const facetData = find(results.getFacetValues(attributeName), {name: isRefined.toString()});
+        count = facetData !== undefined ? facetData.count : null;
+      }
+
+      const facetValue = {
+        name: label,
+        isRefined,
+        count
+      };
+
+      // Bind createURL to this specific attribute
+      function _createURL() {
+        return createURL(state.toggleRefinement(attributeName, isRefined));
+      }
+
+      ReactDOM.render(
+        <RefinementList
+          collapsible={collapsible}
+          createURL={_createURL}
+          cssClasses={cssClasses}
+          facetValues={[facetValue]}
+          shouldAutoHideContainer={results.nbHits === 0}
+          templateProps={this._templateProps}
+          toggleRefinement={this.toggleRefinement}
+        />,
+        containerNode
+      );
+    }
+  };
+}

--- a/src/widgets/toggle/toggle.js
+++ b/src/widgets/toggle/toggle.js
@@ -1,18 +1,22 @@
-import find from 'lodash/collection/find';
-import React from 'react';
-import ReactDOM from 'react-dom';
 import {
   bemHelper,
-  prepareTemplateProps,
   getContainerNode
 } from '../../lib/utils.js';
+import defaultTemplates from './defaultTemplates.js';
 import cx from 'classnames';
 import autoHideContainerHOC from '../../decorators/autoHideContainer.js';
 import headerFooterHOC from '../../decorators/headerFooter.js';
-import defaultTemplates from './defaultTemplates.js';
 import RefinementListComponent from '../../components/RefinementList/RefinementList.js';
+import currentToggle from './implementations/currentToggle';
+import legacyToggle from './implementations/legacyToggle';
 
 const bem = bemHelper('ais-toggle');
+
+// we cannot use helper. because the facet is not yet declared in the helper
+const hasFacetsRefinementsFor = (attributeName, searchParameters) =>
+  searchParameters &&
+  searchParameters.facetsRefinements &&
+  searchParameters.facetsRefinements[attributeName] !== undefined;
 
 /**
  * Instantiate the toggling of a boolean facet filter on and off.
@@ -76,18 +80,18 @@ function toggle({
   } = {}) {
   const containerNode = getContainerNode(container);
 
+  if (!container || !attributeName || !label) {
+    throw new Error(usage);
+  }
+
   let RefinementList = headerFooterHOC(RefinementListComponent);
   if (autoHideContainer === true) {
     RefinementList = autoHideContainerHOC(RefinementList);
   }
 
-  if (!container || !attributeName || !label) {
-    throw new Error(usage);
-  }
-
   const hasAnOffValue = userValues.off !== undefined;
 
-  let cssClasses = {
+  const cssClasses = {
     root: cx(bem(null), userCssClasses.root),
     header: cx(bem('header'), userCssClasses.header),
     body: cx(bem('body'), userCssClasses.body),
@@ -100,104 +104,37 @@ function toggle({
     count: cx(bem('count'), userCssClasses.count)
   };
 
+  // store the computed options for usage in the two toggle implementations
+  const implemOptions = {
+    attributeName,
+    label,
+    userValues,
+    templates,
+    collapsible,
+    transformData,
+    hasAnOffValue,
+    containerNode,
+    RefinementList,
+    cssClasses
+  };
+
   return {
-    getConfiguration: () => ({
-      disjunctiveFacets: [attributeName]
-    }),
-    init({state, helper, templatesConfig}) {
-      this._templateProps = prepareTemplateProps({
-        transformData,
-        defaultTemplates,
-        templatesConfig,
-        templates
-      });
-      this.toggleRefinement = this.toggleRefinement.bind(this, helper);
+    getConfiguration(currentSearchParameters, searchParametersFromUrl) {
+      const useLegacyToggle =
+        hasFacetsRefinementsFor(attributeName, currentSearchParameters) ||
+        hasFacetsRefinementsFor(attributeName, searchParametersFromUrl);
 
-      // no need to refine anything at init if no custom off values
-      if (!hasAnOffValue) {
-        return;
-      }
-      // Add filtering on the 'off' value if set
-      const isRefined = state.isDisjunctiveFacetRefined(attributeName, userValues.on);
-      if (!isRefined) {
-        helper.addDisjunctiveFacetRefinement(attributeName, userValues.off);
-      }
+      const toggleImplementation = useLegacyToggle ?
+        legacyToggle(implemOptions) :
+        currentToggle(implemOptions);
+
+      this.init = toggleImplementation.init.bind(toggleImplementation);
+      this.render = toggleImplementation.render.bind(toggleImplementation);
+      return toggleImplementation.getConfiguration(currentSearchParameters, searchParametersFromUrl);
     },
-    toggleRefinement: (helper, facetValue, isRefined) => {
-      const on = userValues.on;
-      const off = userValues.off;
-
-      // Checking
-      if (!isRefined) {
-        if (hasAnOffValue) {
-          helper.removeDisjunctiveFacetRefinement(attributeName, off);
-        }
-        helper.addDisjunctiveFacetRefinement(attributeName, on);
-      } else {
-        // Unchecking
-        helper.removeDisjunctiveFacetRefinement(attributeName, on);
-        if (hasAnOffValue) {
-          helper.addDisjunctiveFacetRefinement(attributeName, off);
-        }
-      }
-
-      helper.search();
-    },
-    render({helper, results, state, createURL}) {
-      const isRefined = helper.state.isDisjunctiveFacetRefined(attributeName, userValues.on);
-      const onValue = userValues.on;
-      const offValue = userValues.off === undefined ? false : userValues.off;
-      const allFacetValues = results.getFacetValues(attributeName);
-      const onData = find(allFacetValues, {name: onValue.toString()});
-      const onFacetValue = {
-        name: label,
-        isRefined: onData !== undefined ? onData.isRefined : false,
-        count: onData === undefined ? null : onData.count
-      };
-      const offData = find(allFacetValues, {name: offValue.toString()});
-      const offFacetValue = {
-        name: label,
-        isRefined: offData !== undefined ? offData.isRefined : false,
-        count: offData === undefined ? null : offData.count
-      };
-
-      // what will we show by default,
-      // if checkbox is not checked, show: [ ] free shipping (countWhenChecked)
-      // if checkbox is checked, show: [x] free shipping (countWhenNotChecked)
-      const nextRefinement = isRefined ? offFacetValue : onFacetValue;
-
-      const facetValue = {
-        name: label,
-        isRefined,
-        count: nextRefinement === undefined ? null : nextRefinement.count,
-        onFacetValue,
-        offFacetValue
-      };
-
-      // Bind createURL to this specific attribute
-      function _createURL() {
-        return createURL(
-          state
-            .removeDisjunctiveFacetRefinement(attributeName, isRefined ? onValue : userValues.off)
-            .addDisjunctiveFacetRefinement(attributeName, isRefined ? userValues.off : onValue)
-        );
-      }
-
-      ReactDOM.render(
-        <RefinementList
-          collapsible={collapsible}
-          createURL={_createURL}
-          cssClasses={cssClasses}
-          facetValues={[facetValue]}
-          shouldAutoHideContainer={results.nbHits === 0}
-          templateProps={this._templateProps}
-          toggleRefinement={this.toggleRefinement}
-        />,
-        containerNode
-      );
-    }
+    init() {},
+    render() {}
   };
 }
-
 
 export default toggle;


### PR DESCRIPTION
Context: I upgrade the default toggle behavior in #1146.
To do this, I switched from using a facet to a disjunctive facet. Which
led to inconsistencies with the already public instantsearch websites urls using
facetRefinements for toggle.

So now, if there's a matching facetRefinement for the attributeName used
in the toggle, I will switch to a legacy implementation.

Otherwise, I will switch to the current implementation.

I wrote some tests around this but this is very messy. Our whole test
stack has evolved in a monster, mostly because of the way we are writing
our own code.

This should get better with instantsearch-react and so I did not spend
my whole day on this. Tested this multiple times: it works.