### PR TITLE
fix(documentation): Change instantsearch.widgets.stats typo 

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1183,7 +1183,7 @@ search.addWidget(
     templates: {
       body: function(data) {
         return '<div>You have ' + data.nbHits + ' results, fetched in ' +
-          data.processingTimMS +'ms.</div>'
+          data.processingTimeMS +'ms.</div>'
       }
     }
   })


### PR DESCRIPTION
Instant Search has typo on widget stats.

Reference :
https://community.algolia.com/instantsearch.js/documentation/#stats
`
// Function template example
search.addWidget(
  instantsearch.widgets.stats({
    container: '#stats',
    templates: {
      body: function(data) {
        return '<div>You have ' + data.nbHits + ' results, fetched in ' +
          data.processingTimMS +'ms.</div>'
      }
    }
  })
);
`
While api data object contains these properties : 
`
hasManyResults: true, hasNoResults: false, hasOneResult: false, hitsPerPage: 10, nbHits: 2446, nbPages: 100, page: 0, processingTimeMS: 1,
`

TYPO is data.processingTimMS should be data.processingTimeMS