### PR TITLE
fix(toggle) make autoHide check facetValue.count

### DIFF
--- a/src/widgets/toggle/implementations/currentToggle.js
+++ b/src/widgets/toggle/implementations/currentToggle.js
@@ -76,11 +76,11 @@ const currentToggle = ({
       isRefined: onData !== undefined ? onData.isRefined : false,
       count: onData === undefined ? null : onData.count
     };
-    const offData = find(allFacetValues, {name: offValue.toString()});
+    const offData = hasAnOffValue ? find(allFacetValues, {name: offValue.toString()}) : undefined;
     const offFacetValue = {
       name: label,
       isRefined: offData !== undefined ? offData.isRefined : false,
-      count: offData === undefined ? null : offData.count
+      count: offData === undefined ? results.nbHits : offData.count
     };
 
         // what will we show by default,

--- a/src/widgets/toggle/implementations/currentToggle.js
+++ b/src/widgets/toggle/implementations/currentToggle.js
@@ -111,7 +111,7 @@ const currentToggle = ({
             createURL={_createURL}
             cssClasses={cssClasses}
             facetValues={[facetValue]}
-            shouldAutoHideContainer={results.nbHits === 0}
+            shouldAutoHideContainer={(facetValue.count === 0 || facetValue.count === null)}
             templateProps={this._templateProps}
             toggleRefinement={this.toggleRefinement}
           />,

--- a/src/widgets/toggle/implementations/legacyToggle.js
+++ b/src/widgets/toggle/implementations/legacyToggle.js
@@ -91,7 +91,7 @@ export default function currentToggle({
           createURL={_createURL}
           cssClasses={cssClasses}
           facetValues={[facetValue]}
-          shouldAutoHideContainer={(facetValue.count === 0 || facetValue.count === null)}
+          shouldAutoHideContainer={results.nbHits === 0}
           templateProps={this._templateProps}
           toggleRefinement={this.toggleRefinement}
         />,

--- a/src/widgets/toggle/implementations/legacyToggle.js
+++ b/src/widgets/toggle/implementations/legacyToggle.js
@@ -91,7 +91,7 @@ export default function currentToggle({
           createURL={_createURL}
           cssClasses={cssClasses}
           facetValues={[facetValue]}
-          shouldAutoHideContainer={results.nbHits === 0}
+          shouldAutoHideContainer={(facetValue.count === 0 || facetValue.count === null)}
           templateProps={this._templateProps}
           toggleRefinement={this.toggleRefinement}
         />,


### PR DESCRIPTION
Activating a toggle with 0 hits puts the user in a state where they can't get back to the previous state.  The toggle and many other widgets autoHide when no results are found.  This change will autoHide the toggle if changing it's state would result in 0 hits.

Issue #1185