### PR TITLE
fix(nouislider): fix the slider for nouislider 8.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "lodash": "^3.10.1",
     "react": "^15.2.1",
     "react-dom": "^15.2.1",
-    "react-nouislider": "^1.11.0",
+    "react-nouislider": "^1.13.0",
     "to-factory": "^1.0.0"
   },
   "license": "MIT"

--- a/src/components/Slider/Slider.js
+++ b/src/components/Slider/Slider.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import omit from 'lodash/object/omit';
 
 import Nouislider from 'react-nouislider';
 
@@ -48,7 +49,9 @@ class Slider extends React.Component {
 
     return (
       <Nouislider
-        {...this.props}
+        // NoUiSlider also accepts a cssClasses prop, but we don't want to
+        // provide one.
+        {...omit(this.props, 'cssClasses')}
         animate={false}
         behaviour={'snap'}
         connect


### PR DESCRIPTION
NoUiSlider added a `cssClasses` option in 8.5.0. Since we also have a `cssClasses` prop on our Slider component that is consumed by the higher order components (but still forwarded), we were passing an invalid option to the underlying NoUiSlider.