### PR TITLE
Metadata extractor

### DIFF
--- a/packages/instantsearch-react/.eslintrc
+++ b/packages/instantsearch-react/.eslintrc
@@ -3,5 +3,8 @@
   "parser": "babel-eslint",
   "rules": {
     "comma-dangle": ["error", "always-multiline"]
+  },
+  "globals": {
+    "__DOC__": true
   }
 }

--- a/packages/instantsearch-react/examples/webpack.config.babel.js
+++ b/packages/instantsearch-react/examples/webpack.config.babel.js
@@ -1,4 +1,5 @@
 import {resolve as r} from 'path';
+import webpack from 'webpack';
 
 const publicPath = 'http://localhost:8080/';
 
@@ -23,6 +24,7 @@ export default {
         test: /\.js$/,
         loaders: ['react-hot', 'babel'],
         include: [r('../src'), r('.'), r('../index.js')],
+        exclude: /node_modules/,
       },
     ],
   },
@@ -30,5 +32,8 @@ export default {
   plugins: [
     // Don't use --hot and this at the same time
     // new webpack.HotModuleReplacementPlugin(),
+    new webpack.DefinePlugin({
+      __DOC__: JSON.stringify(false),
+    }),
   ],
 };

--- a/packages/instantsearch-react/package.json
+++ b/packages/instantsearch-react/package.json
@@ -7,22 +7,27 @@
     "lint": "eslint \"**/*.js\" --ignore-path ../../.gitignore",
     "test": "jest --bail --no-cache",
     "test:watch": "jest --watch",
-    "test:update-snapshots": "jest -u"
+    "test:update-snapshots": "jest -u",
+    "extract-metadata": "babel-node src/extractMetadata > metadata.json"
   },
   "devDependencies": {
+    "babel-cli": "^6.11.4",
     "babel-eslint": "^6.1.2",
+    "babel-jest": "^13.2.2",
     "babel-loader": "^6.2.4",
     "babel-plugin-transform-class-properties": "^6.10.2",
     "babel-plugin-transform-object-rest-spread": "^6.8.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-0": "^6.5.0",
-    "babel-jest": "^13.2.2",
     "enzyme": "^2.4.1",
     "eslint": "^3.0.1",
     "jest-cli": "^13.2.3",
+    "memory-fs": "^0.3.0",
     "mockdate": "^1.0.4",
-    "webpack": "^1.13.1"
+    "require-from-string": "^1.2.0",
+    "webpack": "^1.13.1",
+    "webpack-externals-plugin": "^1.0.0"
   },
   "dependencies": {
     "algoliasearch": "^3.16.0",
@@ -48,6 +53,11 @@
     ],
     "setupFiles": [
       "src/silentWarnings.js"
-    ]
+    ],
+    "jest": {
+      "globals": {
+        "__DOC__": false
+      }
+    }
   }
 }

--- a/packages/instantsearch-react/src/createConnector.js
+++ b/packages/instantsearch-react/src/createConnector.js
@@ -16,7 +16,9 @@ export default function createConnector(connectorDesc) {
 
   return Composed => class Connector extends Component {
     static displayName = `${connectorDesc.displayName}(${getDisplayName(Composed)})`;
-    static propTypes = connectorDesc.propTypes;
+    static propTypes = __DOC__ ?
+      {...Composed.propTypes, ...connectorDesc.propTypes} :
+      connectorDesc.propTypes;
     static defaultProps = connectorDesc.defaultProps;
 
     static contextTypes = {

--- a/packages/instantsearch-react/src/createConnector.js
+++ b/packages/instantsearch-react/src/createConnector.js
@@ -1,7 +1,7 @@
 import React, {PropTypes, Component} from 'react';
 import {has} from 'lodash';
 
-import {shallowEqual} from './utils';
+import {shallowEqual, getDisplayName} from './utils';
 
 export default function createConnector(connectorDesc) {
   if (!connectorDesc.displayName) {
@@ -15,7 +15,7 @@ export default function createConnector(connectorDesc) {
   const hasMetadata = has(connectorDesc, 'getMetadata');
 
   return Composed => class Connector extends Component {
-    static displayName = connectorDesc.displayName;
+    static displayName = `${connectorDesc.displayName}(${getDisplayName(Composed)})`;
     static propTypes = connectorDesc.propTypes;
     static defaultProps = connectorDesc.defaultProps;
 

--- a/packages/instantsearch-react/src/createConnector.js
+++ b/packages/instantsearch-react/src/createConnector.js
@@ -1,5 +1,5 @@
 import React, {PropTypes, Component} from 'react';
-import {has} from 'lodash';
+import {omit, has} from 'lodash';
 
 import {shallowEqual, getDisplayName} from './utils';
 
@@ -17,7 +17,10 @@ export default function createConnector(connectorDesc) {
   return Composed => class Connector extends Component {
     static displayName = `${connectorDesc.displayName}(${getDisplayName(Composed)})`;
     static propTypes = __DOC__ ?
-      {...Composed.propTypes, ...connectorDesc.propTypes} :
+      {
+        ...omit(Composed.propTypes, 'refine', 'createURL'),
+        ...connectorDesc.propTypes,
+      } :
       connectorDesc.propTypes;
     static defaultProps = connectorDesc.defaultProps;
 

--- a/packages/instantsearch-react/src/extractMetadata.js
+++ b/packages/instantsearch-react/src/extractMetadata.js
@@ -1,0 +1,73 @@
+import webpack from 'webpack';
+import fs from 'fs';
+import MemoryFS from 'memory-fs';
+import path from 'path';
+import ExternalsPlugin from 'webpack-externals-plugin';
+import requireFromString from 'require-from-string';
+
+import {getDisplayName} from './utils';
+
+const folder = path.resolve(__dirname, 'widgets');
+const entries = fs.readdirSync(folder)
+  .filter(filename =>
+    filename.match(/.js$/) && !filename.match(/\.test\.js$/)
+  )
+  .reduce((res, filename) => ({
+    ...res,
+    [filename]: path.resolve(folder, filename),
+  }), {});
+const compiler = webpack({
+  entry: entries,
+
+  output: {
+    filename: '[name]',
+    path: '/',
+    libraryTarget: 'commonjs2',
+  },
+
+  module: {
+    loaders: [
+      {
+        test: /\.js$/,
+        include: __dirname,
+        loaders: [
+          'babel',
+          path.resolve(__dirname, 'inlinePropsLoader.js'),
+        ],
+      },
+    ],
+  },
+
+  plugins: [
+    new ExternalsPlugin({
+      type: 'commonjs',
+      test: /node_modules/,
+    }),
+    new webpack.DefinePlugin({
+      __DOC__: JSON.stringify(true),
+    }),
+  ],
+});
+
+const mfs = new MemoryFS();
+compiler.outputFileSystem = mfs;
+
+compiler.run(err => {
+  if (err) {
+    throw err;
+  }
+
+  const output = Object.keys(entries).reduce((res, entry) => {
+    const str = mfs.readFileSync(path.resolve('/', entry), 'utf8');
+    const Component = requireFromString(str).default;
+    return {
+      ...res,
+      [entry]: {
+        displayName: getDisplayName(Component),
+        props: Component.propTypes,
+      },
+    };
+  }, {});
+
+  console.log(JSON.stringify(output, null, '  '));
+});

--- a/packages/instantsearch-react/src/impl/SearchBox.js
+++ b/packages/instantsearch-react/src/impl/SearchBox.js
@@ -20,7 +20,7 @@ class SearchBox extends Component {
 
   static defaultProps = {
     query: '',
-    poweredBy: false,
+    // poweredBy: false,
     focusShortcuts: ['s', '/'],
     autoFocus: false,
     searchAsYouType: true,

--- a/packages/instantsearch-react/src/inlineProps.js
+++ b/packages/instantsearch-react/src/inlineProps.js
@@ -1,0 +1,61 @@
+import {handlers, resolver, utils, parse} from 'react-docgen';
+import r from 'recast';
+import fs from 'fs';
+
+function findPropTypesDefinitions(ast, recast) {
+  const definitions = resolver.findAllComponentDefinitions(ast, recast);
+
+  function objectVisitor(path) {
+    // Just check that `propTypes` is present on the object.
+    const propTypes = utils.getPropertyValuePath(path, 'propTypes');
+    if (propTypes) {
+      definitions.push(path);
+    }
+    return false;
+  }
+
+  recast.visit(ast, {
+    visitObjectExpression: objectVisitor,
+  });
+
+  return definitions;
+}
+
+function propLocHandler(documentation, path) {
+  let propTypesPath = utils.getMemberValuePath(path, 'propTypes');
+  if (!propTypesPath) {
+    return;
+  }
+  propTypesPath = utils.resolveToValue(propTypesPath);
+  if (!propTypesPath || !r.types.namedTypes.ObjectExpression.check(propTypesPath.node)) {
+    return;
+  }
+
+  propTypesPath.get('properties').each(propertyPath => {
+    if (r.types.namedTypes.Property.check(propertyPath.node)) {
+      const propName = utils.getPropertyName(propertyPath);
+      const propDescriptor = documentation.getPropDescriptor(propName);
+      propDescriptor.loc = {
+        start: propertyPath.get('value').value.start,
+        end: propertyPath.get('value').value.end,
+      };
+    }
+  });
+}
+
+export default function inlineProps(code) {
+  const result = parse(code, findPropTypesDefinitions, [
+    handlers.propTypeHandler,
+    propLocHandler,
+    handlers.propDocBlockHandler,
+    handlers.defaultPropsHandler,
+  ]);
+
+  return result.slice().reverse().reduce((res, info) =>
+    Object.keys(info.props).slice().reverse().reduce((res2, propName) =>
+      res2.slice(0, info.props[propName].loc.start) +
+      JSON.stringify(info.props[propName]) +
+      res2.slice(info.props[propName].loc.end)
+    , res)
+  , code);
+}

--- a/packages/instantsearch-react/src/inlinePropsLoader.js
+++ b/packages/instantsearch-react/src/inlinePropsLoader.js
@@ -1,0 +1,9 @@
+import inlineProps from './inlineProps';
+
+module.exports = function inlinePropsLoader(content) {
+  try {
+    return inlineProps(content);
+  } catch (e) {
+    return content;
+  }
+};

--- a/packages/instantsearch-react/src/themeable.js
+++ b/packages/instantsearch-react/src/themeable.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import reactThemeable from 'react-themeable';
 
+import {getDisplayName} from './utils';
 import {withKeysPropType} from './propTypes';
 
 export default function themeable(defaultTheme) {
@@ -11,6 +12,8 @@ export default function themeable(defaultTheme) {
 
       return <Composed {...otherProps} applyTheme={applyTheme} />;
     }
+
+    Themeable.displayName = `Themeable(${getDisplayName(Composed)})`;
 
     Themeable.propTypes = {
       theme: withKeysPropType(Object.keys(defaultTheme)),

--- a/packages/instantsearch-react/src/themeable.js
+++ b/packages/instantsearch-react/src/themeable.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import reactThemeable from 'react-themeable';
+import {omit} from 'lodash';
 
 import {getDisplayName} from './utils';
 import {withKeysPropType} from './propTypes';
@@ -16,8 +17,17 @@ export default function themeable(defaultTheme) {
     Themeable.displayName = `Themeable(${getDisplayName(Composed)})`;
 
     Themeable.propTypes = {
-      theme: withKeysPropType(Object.keys(defaultTheme)),
+      theme: __DOC__ ?
+        {type: {name: 'theme', value: defaultTheme}} :
+        withKeysPropType(Object.keys(defaultTheme)),
     };
+
+    if (__DOC__) {
+      Themeable.propTypes = {
+        ...omit(Composed.propTypes, 'applyTheme'),
+        ...Themeable.propTypes,
+      };
+    }
 
     return Themeable;
   };

--- a/packages/instantsearch-react/src/translatable.js
+++ b/packages/instantsearch-react/src/translatable.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import has from 'lodash/object/has';
+import {omit, has} from 'lodash';
 
 import {getDisplayName} from './utils';
 import {withKeysPropType} from './propTypes';
@@ -25,8 +25,17 @@ export default function translatable(defaultTranslations) {
     Translatable.displayName = `Translatable(${getDisplayName(Composed)})`;
 
     Translatable.propTypes = {
-      translations: withKeysPropType(Object.keys(defaultTranslations)),
+      translations: __DOC__ ?
+        {type: {name: 'translations', value: defaultTranslations}} :
+        withKeysPropType(Object.keys(defaultTranslations)),
     };
+
+    if (__DOC__) {
+      Translatable.propTypes = {
+        ...omit(Composed.propTypes, 'translate'),
+        ...Translatable.propTypes,
+      };
+    }
 
     return Translatable;
   };

--- a/packages/instantsearch-react/src/translatable.js
+++ b/packages/instantsearch-react/src/translatable.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import has from 'lodash/object/has';
 
+import {getDisplayName} from './utils';
 import {withKeysPropType} from './propTypes';
 
 export default function translatable(defaultTranslations) {
@@ -20,6 +21,8 @@ export default function translatable(defaultTranslations) {
 
       return <Composed {...otherProps} translate={translate} />;
     }
+
+    Translatable.displayName = `Translatable(${getDisplayName(Composed)})`;
 
     Translatable.propTypes = {
       translations: withKeysPropType(Object.keys(defaultTranslations)),

--- a/packages/instantsearch-react/src/utils.js
+++ b/packages/instantsearch-react/src/utils.js
@@ -54,3 +54,7 @@ export function assertFacetDefined(searchParameters, searchResults, facet) {
     );
   }
 }
+
+export function getDisplayName(Component) {
+  return Component.displayName || Component.name || 'UnknownComponent';
+}

--- a/packages/instantsearch-react/src/utils.test.js
+++ b/packages/instantsearch-react/src/utils.test.js
@@ -1,10 +1,12 @@
 /* eslint-env jest, jasmine */
 /* eslint-disable no-console */
+import React, {Component} from 'react';
 
 import {
   isSpecialClick,
   capitalize,
   assertFacetDefined,
+  getDisplayName,
 } from './utils';
 jest.unmock('./utils');
 import {SearchParameters, SearchResults} from 'algoliasearch-helper';
@@ -60,6 +62,42 @@ describe('utils', () => {
         'index settings.'
       );
       console.warn = warn;
+    });
+  });
+
+  describe('getDisplayName', () => {
+    it('gets the right displayName from classes', () => {
+      class SuperComponent extends Component {
+        render() {
+          return null;
+        }
+      }
+
+      expect(getDisplayName(SuperComponent)).toBe('SuperComponent');
+    });
+
+    // this works because babel turns arrows functions to named function expressions
+    it('gets the right displayName from stateless components', () => {
+      const SuperComponent = () => null; // => var SuperComponent = function SuperComponent() {}
+      expect(getDisplayName(SuperComponent)).toBe('SuperComponent');
+    });
+
+    it('gets the right displayName from React.createClass', () => {
+      const SuperComponent = React.createClass({
+        render() { return null; },
+        displayName: 'SuperComponent',
+      });
+
+      expect(getDisplayName(SuperComponent)).toBe('SuperComponent');
+    });
+
+    it('sets a default displayName when not able to find one', () => {
+      const SuperComponent = React.createClass({
+        render() { return null; },
+        displayName: undefined, // latest babel
+      });
+
+      expect(getDisplayName(SuperComponent)).toBe('UnknownComponent');
     });
   });
 });


### PR DESCRIPTION
Depends on #1208.

This PR adds an `extractMetadata` script that is able to infer the `displayName` and `propTypes` of widgets using both static analysis (with react-docgen) and dynamic composition of props at runtime.

WIP as this isn't being used in the docs yet.