### PR TITLE
fix(numericSelector): do not change state on init

### DIFF
--- a/docs/examples/tourism/search.js
+++ b/docs/examples/tourism/search.js
@@ -4,7 +4,8 @@
 var search = instantsearch({
   appId: 'latency',
   apiKey: '6be0576ff61c053d5f9a3225e2a90f76',
-  indexName: 'airbnb'
+  indexName: 'airbnb',
+  urlSync: true
 });
 
 search.addWidget(

--- a/src/widgets/numeric-selector/__tests__/numeric-selector-test.js
+++ b/src/widgets/numeric-selector/__tests__/numeric-selector-test.js
@@ -55,7 +55,6 @@ describe('numericSelector()', () => {
     helper = {
       addNumericRefinement: sinon.spy(),
       clearRefinements: sinon.spy(),
-      getRefinements: sinon.stub().returns([]),
       search: sinon.spy()
     };
     results = {
@@ -66,8 +65,31 @@ describe('numericSelector()', () => {
     helper.addNumericRefinement.reset();
   });
 
-  it('doesn\'t configure anything', () => {
-    expect(widget.getConfiguration).toEqual(undefined);
+  it('configures the right numericRefinement', () => {
+    expect(widget.getConfiguration({}, {})).toEqual({
+      numericRefinements: {
+        aNumAttr: {
+          '=': [1]
+        }
+      }
+    });
+  });
+
+  it('configures the right numericRefinement when present in the url', () => {
+    const urlState = {
+      numericRefinements: {
+        aNumAttr: {
+          '=': [2]
+        }
+      }
+    };
+    expect(widget.getConfiguration({}, urlState)).toEqual({
+      numericRefinements: {
+        aNumAttr: {
+          '=': [2]
+        }
+      }
+    });
   });
 
   it('calls twice ReactDOM.render(<Selector props />, container)', () => {
@@ -82,10 +104,13 @@ describe('numericSelector()', () => {
   });
 
   it('computes refined values and pass them to <Selector props />', () => {
-    helper.getRefinements = sinon.stub().returns([{
-      operator: '=',
-      value: [20]
-    }]);
+    helper.state = {
+      numericRefinements: {
+        aNumAttr: {
+          '=': [20]
+        }
+      }
+    };
     expectedProps.currentValue = 20;
     widget.render({helper, results, state: helper.state});
     expect(ReactDOM.render.firstCall.args[0]).toEqualJSX(<Selector {...expectedProps} />);


### PR DESCRIPTION
We were calling a helper method that was resetting the page to 0.

~~Tries to fix #1253~~

~~Basically the issue is that calling the helper.addNumericRefinement
upfront in init() will reset the page to 0 (linked issue)~~

~~@bobylito how could we solve that? Currently the fix will still fail,
because if I change the value of the tourism selector to 5 guest then
we will end up merging [1] with [5] in the IS init phase. This is not
what we want, The init() solution is the way to go but it has other
consequences.~~

UPDATE:
Done.