### PR TITLE
docs(nav): small reorg

### DIFF
--- a/docgen/layouts/api.pug
+++ b/docgen/layouts/api.pug
@@ -4,7 +4,7 @@ mixin nav(currentPath, nav)
       - var className = navItem.path === currentPath ? 'navItem--active' : 'navItem';
       li(class=className)
         a(href=h.publicPath(navItem.path))=navItem.file.title
-        if(navItem.children.length > 0) 
+        if(navItem.children.length > 0)
           nav(currentPath, navItem.children)
 
 doctype html
@@ -25,11 +25,13 @@ html
         +nav(nav_path, navs.core)
       .nav.widgets
         +nav(nav_path, navs.widgets)
-      .nav.headings
-        ul
-          for heading in headings
-            - var headingType = heading.type === 'h2' ? 'title' : 'subtitle';
-            li(class=headingType)
-              a(href=heading.id)=heading.text
+      .nav.examples
+        +nav(nav_path, navs.examples)
+      //- .nav.headings
+      //-   ul
+      //-     for heading in headings
+      //-       - var headingType = heading.type === 'h2' ? 'title' : 'subtitle';
+      //-       li(class=headingType)
+      //-         a(href=heading.id)=heading.text
     .content!=contents
     script(src=webpack.assets['assets/js/api.js'])

--- a/docgen/middlewares.js
+++ b/docgen/middlewares.js
@@ -63,6 +63,10 @@ const common = [
       sortBy: 'nav_sort',
       filterProperty: 'nav_groups',
     },
+    examples: {
+      sortBy: 'nav_sort',
+      filterProperty: 'nav_groups',
+    },
   }, {
     navListProperty: 'navs',
   }),

--- a/docgen/src/InstantSearch.md
+++ b/docgen/src/InstantSearch.md
@@ -2,7 +2,7 @@
 title: InstantSearch
 layout: api.pug
 nav_groups:
-  - core
+  - widgets
 nav_sort: 1
 ---
 

--- a/docgen/src/ecommerce.html
+++ b/docgen/src/ecommerce.html
@@ -3,7 +3,7 @@ title: E-commerce example
 layout: example.pug
 name: ecommerce
 nav_groups:
-  - core
+  - examples
 stylesheets:
   - https://cdn.jsdelivr.net/bootstrap/3.3.5/css/bootstrap.min.css
   - https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css

--- a/docgen/src/materialui.html
+++ b/docgen/src/materialui.html
@@ -3,7 +3,7 @@ title: Material-UI example
 layout: example.pug
 name: material-ui
 nav_groups:
-  - core
+  - examples
 stylesheets:
   - https://fonts.googleapis.com/icon?family=Material+Icons
 ---

--- a/docgen/src/media.html
+++ b/docgen/src/media.html
@@ -3,6 +3,6 @@ title: Media example
 layout: example.pug
 name: media
 nav_groups:
-  - core
+  - examples
 ---
 <div id="app"></div>

--- a/docgen/src/tourism.html
+++ b/docgen/src/tourism.html
@@ -3,7 +3,7 @@ title: Tourism example
 layout: example.pug
 name: tourism
 nav_groups:
-  - core
+  - examples
 stylesheets:
   - https://cdn.jsdelivr.net/bootstrap/3.3.5/css/bootstrap.min.css
   - https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css


### PR DESCRIPTION
added an examples section,
commented out the headers#, I feel like it's not useful for now and
hard to understand.

Preview:
![2016-09-14-230336_592x1249_scrot](https://cloud.githubusercontent.com/assets/123822/18530165/8233e69e-7ad0-11e6-8e12-3d5281224245.png)
