### PR TITLE
chore(docs): fix react hot loader

### DIFF
--- a/docgen/devServer.js
+++ b/docgen/devServer.js
@@ -18,6 +18,7 @@ export default function() {
     open: false,
     files: `${rootPath(process.env.DOCS_DIST || 'docs/react/')}**/*`,
     watchOptions: {
+      ignored: /\.js$/, // any change to a JavaScript file must be ignored, webpack handles it
       awaitWriteFinish: {
         stabilityThreshold: 150, // wait 150ms for the filesize to be stable (= write finished)
       },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react": "15.3.1",
     "react-docgen": "2.10.0",
     "react-dom": "15.3.1",
-    "react-hot-loader": "3.0.0-beta.3",
+    "react-hot-loader": "3.0.0-beta.4",
     "react-instantsearch": "file:./packages/react-instantsearch/",
     "recast": "0.11.14",
     "react-tap-event-plugin": "1.0.0",


### PR DESCRIPTION
Was failing since 6ee4d55e3e32718582612360bdd2e1269d38e956 because
browserSync would pick examples/.js files updates and reload the page
before react-hot-loader was able to hot reload it