### PR TITLE
feat(highlight): provide a function to use highligth in react

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,7 @@ module.exports = {
   "rules": {
     "comma-dangle": ["error", "always-multiline"],
     "no-multiple-empty-lines": ["error", {"max": 1}],
-    "react/jsx-key": ["error"]
+    "react/jsx-key": ["error"],
+    "no-prototype-builtins": 0
   }
 };

--- a/packages/react-instantsearch/index.js
+++ b/packages/react-instantsearch/index.js
@@ -1,5 +1,6 @@
 import InstantSearch from './src/core/InstantSearch';
 import createConnector from './src/core/createConnector';
+import highlight from './src/core/highlight.js';
 
 import Hits from './src/widgets/Hits/index.js';
 import HitsPerPage from './src/widgets/HitsPerPage/index.js';
@@ -45,4 +46,6 @@ export {
   Stats,
   Error,
   ScrollTo,
+
+  highlight,
 };

--- a/packages/react-instantsearch/src/core/highlight.js
+++ b/packages/react-instantsearch/src/core/highlight.js
@@ -1,0 +1,67 @@
+import React from 'react';
+
+function extractTagName(highlightedValue) {
+  const tagParse = (/<(.+?)>/).exec(highlightedValue);
+  return tagParse === null ? null : tagParse[1];
+}
+
+/**
+ * This function transforms an highlighted response
+ * to an array of React elements. This should be
+ * used in place of dangerouslySetInnerHTML when
+ * using the highlightReasult provided by Algolia.
+ *
+ * The function autodetects which tag is used in
+ * results to highlight, and creates the corresponding
+ * React element.
+ *
+ * It also creates keys on React elements to avoid warnings.
+ *
+ * The genegrated highlighted Elements use the `ais-hightlightedValue`
+ * class name attached.
+ *
+ * @param {string} attribute the name of the attribute for which we want the highlighted value
+ * @param {object} hit the hit from the algolia response
+ * @returns {Array.<string|ReactElement>} the array of react element
+ * @example
+ * const ProductHits = Hits.connect(({hits}) => {
+ *   const hitComponents = hits.map( hit =>
+ *     <div key={hit.objectID}>
+ *       <span className="hit-name">{hightlight('name', hit)}</span>
+ *     </div>
+ *   );
+ *
+ *   return <div className="hits">{hitComponents}</div>;
+ * });
+ */
+export default function hightlight(attribute, hit) {
+  if (!hit) throw new Error('The hit containing the attribute should be provided');
+  if (!hit.hasOwnProperty(attribute)) throw new Error(`${attribute} should be a retrievable attribute.`);
+  if (!hit._highlightResult ||
+      !hit._highlightResult.hasOwnProperty(attribute)){
+    throw new Error(`${attribute} should be an highlighted attribute`);
+  }
+
+  const highlightedValue = hit._highlightResult[attribute].value;
+  const tag = extractTagName(highlightedValue);
+  const firstPassSplit = highlightedValue.split(`<${tag}>`);
+  const firstValue = firstPassSplit.shift();
+  const elements = firstValue === '' ? [] : [firstValue];
+
+  firstPassSplit.forEach((split, i) => {
+    const s = split.split(`</${tag}>`);
+    elements.push(
+      React.createElement(
+        tag,
+        {
+          key: `split-${i}-${s[0]}`,
+          className: 'ais-highlightedValue',
+        },
+        s[0]
+      )
+    );
+    if (s[1] !== '') elements.push(s[1]);
+  });
+
+  return elements;
+}

--- a/packages/react-instantsearch/src/core/highlight.test.js
+++ b/packages/react-instantsearch/src/core/highlight.test.js
@@ -1,0 +1,114 @@
+/* eslint-env jest, jasmine */
+import React from 'react';
+
+import highlight from './highlight.js';
+
+describe('highlight()', () => {
+  it('creates a single element when there is no tag', () => {
+    const value = 'foo bar baz';
+    const attribute = 'attr';
+    const out = highlight(attribute, createHit(attribute, value));
+    expect(out).toEqual([value]);
+  });
+
+  it('creates a single element when there is only a tag', () => {
+    const textValue = 'foo bar baz';
+    const value = `<em>${textValue}</em>`;
+    const attribute = 'attr';
+    const out = highlight(attribute, createHit(attribute, value));
+    expect(out).toEqual([<em className="ais-highlightedValue" key="split-0-foo bar baz">{textValue}</em>]);
+  });
+
+  it('creates two elements when there is a tag and some text', () => {
+    const textValue = 'foo bar baz';
+    const otherText = 'other text';
+    const value = `<em>${textValue}</em>${otherText}`;
+    const attribute = 'attr';
+    const out = highlight(attribute, createHit(attribute, value));
+    expect(out).toEqual(
+      [
+        <em className="ais-highlightedValue" key="split-0-foo bar baz">{textValue}</em>,
+        otherText,
+      ]
+    );
+  });
+
+  it('creates two elements when there is some text and a tag', () => {
+    const textValue = 'foo bar baz';
+    const otherText = 'other text';
+    const value = `${otherText}<em>${textValue}</em>`;
+    const attribute = 'attr';
+    const out = highlight(attribute, createHit(attribute, value));
+    expect(out).toEqual(
+      [
+        otherText,
+        <em className="ais-highlightedValue" key="split-0-foo bar baz">{textValue}</em>,
+      ]
+    );
+  });
+
+  it('creates four elements when there is some text, a tag, another tag, and some text', () => {
+    const textValue = 'foo bar baz';
+    const otherText = 'other text';
+    const value = `${otherText}<em>${textValue}</em><em>${textValue}</em>${otherText}`;
+    const attribute = 'attr';
+    const out = highlight(attribute, createHit(attribute, value));
+    expect(out).toEqual(
+      [
+        otherText,
+        <em className="ais-highlightedValue" key="split-0-foo bar baz">{textValue}</em>,
+        <em className="ais-highlightedValue" key="split-1-foo bar baz">{textValue}</em>,
+        otherText,
+      ]
+    );
+  });
+
+  it('creates three elements when there is a tag, some text and another tag', () => {
+    const textValue = 'foo bar baz';
+    const otherText = 'other text';
+    const value = `<em>${textValue}</em>${otherText}<em>${textValue}</em>`;
+    const attribute = 'attr';
+    const out = highlight(attribute, createHit(attribute, value));
+    expect(out).toEqual(
+      [
+        <em className="ais-highlightedValue" key="split-0-foo bar baz">{textValue}</em>,
+        otherText,
+        <em className="ais-highlightedValue" key="split-1-foo bar baz">{textValue}</em>,
+      ]
+    );
+  });
+
+  it('throws when the attribute is not returned in the hit', () => {
+    expect(highlight.bind(null, 'unknownAttribute', {}))
+      .toThrowError('unknownAttribute should be a retrievable attribute');
+  });
+
+  it('throws when the attribute is not highlighted in the hit', () => {
+    expect(highlight.bind(null, 'notHighlightedAttribute', {notHighlightedAttribute: ''}))
+      .toThrowError('notHighlightedAttribute should be an highlighted attribute');
+  });
+
+  it('throws when hit is `null`', () => {
+    expect(highlight.bind(null, 'unknownAttribute', null))
+      .toThrowError('The hit containing the attribute should be provided');
+  });
+
+  it('throws when hit is `undefined`', () => {
+    expect(highlight.bind(null, 'unknownAttribute', undefined))
+      .toThrowError('The hit containing the attribute should be provided');
+  });
+});
+
+function createHit(attribute, value) {
+  return {
+    [attribute]: value,
+    _highlightResult: {
+      [attribute]: {
+        value,
+        fullyHighlighted: true,
+        matchLevel: 'full',
+        matchedWords: [''],
+      },
+    },
+  };
+}


### PR DESCRIPTION
Usage in a custom hits widget:

```javascript
const ProductHits = Hits.connect(({hits}) => {
  const hitComponents = hits.map( hit =>
    <div key={hit.objectID}>
      <span className="hit-name">{hightlight('name', hit)}</span>
    </div>
  );

  return <div className="hits">{hitComponents}</div>;
});
```