### PR TITLE
fix(pagination): reset on other filter + no toggle

### DIFF
--- a/packages/react-instantsearch/src/components/LinkList.js
+++ b/packages/react-instantsearch/src/components/LinkList.js
@@ -24,6 +24,7 @@ export default class LinkList extends Component {
         value: PropTypes.oneOfType([
           PropTypes.string,
           PropTypes.number,
+          PropTypes.object,
         ]).isRequired,
 
         /**
@@ -50,6 +51,7 @@ export default class LinkList extends Component {
     selectedItem: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.number,
+      PropTypes.object,
     ]),
     onSelect: PropTypes.func.isRequired,
   };
@@ -63,7 +65,8 @@ export default class LinkList extends Component {
             {...applyTheme(
               has(item, 'key') ? item.key : item.value,
               'item',
-              item.value === selectedItem && 'itemSelected',
+              // eslint-disable-next-line
+              item.value == selectedItem && 'itemSelected',
               item.disabled && 'itemDisabled',
               item.modifier
             )}

--- a/packages/react-instantsearch/src/widgets/Pagination/Pagination.enzyme.test.js
+++ b/packages/react-instantsearch/src/widgets/Pagination/Pagination.enzyme.test.js
@@ -40,7 +40,9 @@ describe('Pagination', () => {
       .filterWhere(e => e.text() === '10')
       .simulate('click');
     expect(refine.mock.calls.length).toBe(2);
-    expect(refine.mock.calls[1][0]).toEqual(9);
+    const parameters = refine.mock.calls[1][0];
+    expect(parameters.isSamePage).toBe(true);
+    expect(parameters.valueOf()).toBe(9);
     wrapper
       .find('.Pagination__item--previous')
       .find('.Pagination__item__link')

--- a/packages/react-instantsearch/src/widgets/Pagination/Pagination.js
+++ b/packages/react-instantsearch/src/widgets/Pagination/Pagination.js
@@ -170,12 +170,18 @@ class Pagination extends Component {
         ariaLabel: translate('ariaPrevious'),
       });
     }
+
+    const samePage = {
+      valueOf: () => page,
+      isSamePage: true,
+    };
+
     items = items.concat(
       getPages(page, totalPages, pagesPadding).map(value => ({
         key: value,
         modifier: 'itemPage',
         label: translate('page', value),
-        value,
+        value: value === page ? samePage : value,
         ariaLabel: translate('ariaPage', value),
       }))
     );

--- a/packages/react-instantsearch/src/widgets/Pagination/connect.js
+++ b/packages/react-instantsearch/src/widgets/Pagination/connect.js
@@ -1,4 +1,5 @@
 import {PropTypes} from 'react';
+import {omit} from 'lodash';
 
 import createConnector from '../../core/createConnector';
 
@@ -49,6 +50,14 @@ export default createConnector({
   },
 
   transitionState(props, prevState, nextState) {
+    if (nextState[props.id] && nextState[props.id].isSamePage) {
+      return {
+        ...nextState,
+        [props.id]: prevState[props.id],
+      };
+    } else if (prevState[props.id] === nextState[props.id]) {
+      return omit(nextState, props.id);
+    }
     return nextState;
   },
 

--- a/packages/react-instantsearch/src/widgets/Pagination/connect.test.js
+++ b/packages/react-instantsearch/src/widgets/Pagination/connect.test.js
@@ -48,14 +48,20 @@ describe('Pagination.connect', () => {
     expect(params.page).toBe(666);
   });
 
-  it('Transition state whatever the value', () => {
+  it('Transition state when the value is identical and does not contain isSamePage flag', () => {
     state = transitionState({id: 'ok'}, {ok: 1}, {ok: 1});
-    expect(state).toEqual({
-      ok: 1,
-    });
+    expect(state).toEqual({});
     state = transitionState({id: 'ok'}, {ok: 1}, {ok: 2});
     expect(state).toEqual({
       ok: 2,
+    });
+    const newSameValue = {
+      valueOf: () => 1,
+      isSamePage: true,
+    };
+    state = transitionState({id: 'ok'}, {ok: 1}, {ok: newSameValue});
+    expect(state).toEqual({
+      ok: 1,
     });
   });
 


### PR DESCRIPTION
The bug is caused by the use of two conflicting semantics
with the same set of changes. Previously we had "if the value for the
page, reset the page number", which led to reseting the pager to 0
if we were selecting the same page (the toggle effect). I previously
removed this behaviour, but it introduced the impossibility to reset
the pager to 0 when changing any other filter (setting the value was
the trigger).

In order to fix this issue I introduce a new type of value to
express the intent of using the same value without changing the page.
This way we have two distinctly defined intents and values:
 - same value as numbers -> reset to 0
 - value with isSamePage flag -> change to page value

It relies on `valuesOf`, which is not that nice and introduces the use
of the dreaded `==`. At least, I can say that I found a legit use case
for it. Bottom line, I'm open to suggestion here :)