### PR TITLE
fix(merge): merge only plain object from searchParameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "classnames": "^2.2.5",
     "events": "^1.1.0",
     "hogan.js": "^3.0.2",
-    "lodash": "4.15.0",
+    "lodash": "^4.16.4",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
     "react-nouislider": "^1.13.0",

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -6,7 +6,7 @@ import forEach from 'lodash/forEach';
 import mergeWith from 'lodash/mergeWith';
 import union from 'lodash/union';
 import clone from 'lodash/clone';
-import isObject from 'lodash/isObject';
+import isPlainObject from 'lodash/isPlainObject';
 import {EventEmitter} from 'events';
 import urlSyncWidget from './url-sync.js';
 import version from './version.js';
@@ -208,7 +208,7 @@ function enhanceConfiguration(searchParametersFromUrl) {
       }
 
       // avoid mutating objects
-      if (isObject(a)) {
+      if (isPlainObject(a)) {
         return mergeWith({}, a, b, customizer);
       }
 


### PR DESCRIPTION
We got an infinite loop on objects created by Ember which had weird
functions attached to it.

Not even able to completely udnerstand it, I would have to dig a lot
more. This is just plain easy solving.

cc @rayrutjes