### PR TITLE
feat(connectors API): consistent default/current refinement naming

### DIFF
--- a/docgen/src/examples/e-commerce/App.js
+++ b/docgen/src/examples/e-commerce/App.js
@@ -163,13 +163,13 @@ const ColorItem = ({item, selectedItems, createURL, refine}) => {
   );
 };
 
-const CustomColorRefinementList = ({items, selectedItems, refine, createURL}) =>
+const CustomColorRefinementList = ({items, currentRefinement, refine, createURL}) =>
     <div>
       {items.map(item =>
         <ColorItem
           key={item.value}
           item={item}
-          selectedItems={selectedItems}
+          selectedItems={currentRefinement}
           refine={refine}
           createURL={createURL}
         />
@@ -237,7 +237,7 @@ const CustomResults = createConnector({
                 {value: 'ikea_price_asc', label: 'Price asc.'},
                 {value: 'ikea_price_desc', label: 'Price desc.'},
               ]}
-              defaultSelectedIndex="ikea"
+              defaultRefinement="ikea"
             />
           </div>
           <Stats />

--- a/docgen/src/examples/material-ui/App.js
+++ b/docgen/src/examples/material-ui/App.js
@@ -78,7 +78,7 @@ const Content = React.createClass({
         <div className="Header">
           <AppBar
             title="AMAZING"
-            iconElementRight={<ConnectedSortBy defaultSelectedIndex="ikea"/>}
+            iconElementRight={<ConnectedSortBy defaultRefinement="ikea"/>}
             onLeftIconButtonTouchTap={this.drawerAction}
             className="Header__appBar"
           />
@@ -160,14 +160,14 @@ const CheckBoxItem = ({item, selectedItems, refine}) => {
     ;
 };
 
-const MaterialUiCheckBoxRefinementList = ({items, attributeName, selectedItems, refine, createURL}) =>
+const MaterialUiCheckBoxRefinementList = ({items, attributeName, currentRefinement, refine, createURL}) =>
     <List>
       <Subheader style={{fontSize: 18}}>{attributeName.toUpperCase()}</Subheader>
       {items.map(item =>
         <CheckBoxItem
           key={item.value}
           item={item}
-          selectedItems={selectedItems}
+          selectedItems={currentRefinement}
           refine={refine}
           createURL={createURL}
         />
@@ -175,7 +175,7 @@ const MaterialUiCheckBoxRefinementList = ({items, attributeName, selectedItems, 
     </List>
   ;
 
-const MaterialUiNestedList = function ({id, items, refine, selectedItem}) {
+const MaterialUiNestedList = function ({id, items, refine, currentRefinement}) {
   return <List>
     <Subheader style={{fontSize: 18}}>{id.toUpperCase()}</Subheader>
     {items.map((item, idx) => {
@@ -187,7 +187,7 @@ const MaterialUiNestedList = function ({id, items, refine, selectedItem}) {
             e.preventDefault();
             refine(child.value);
           }}
-          style={selectedItem && selectedItem.includes(child.value) ? {fontWeight: 700} : {}}
+          style={currentRefinement && currentRefinement.includes(child.value) ? {fontWeight: 700} : {}}
         />
       ) : [];
       return <ListItem
@@ -199,7 +199,7 @@ const MaterialUiNestedList = function ({id, items, refine, selectedItem}) {
           e.preventDefault();
           refine(item.value);
         }}
-        style={selectedItem && selectedItem.includes(item.value) ? {fontWeight: 700} : {}}
+        style={currentRefinement && currentRefinement.includes(item.value) ? {fontWeight: 700} : {}}
       />;
     }
     )}
@@ -209,7 +209,7 @@ const MaterialUiNestedList = function ({id, items, refine, selectedItem}) {
 const MaterialUiSortBy = React.createClass({
 
   getInitialState() {
-    return {value: this.props.defaultSelectedIndex};
+    return {value: this.props.defaultRefinement};
   },
 
   handleChange (ev, index, value) {

--- a/docgen/src/examples/tourism/App.js
+++ b/docgen/src/examples/tourism/App.js
@@ -173,13 +173,13 @@ OptionCapacity.propTypes = {
   value: PropTypes.string,
 };
 
-const CapacitySelector = MultiRange.connect(({items, selectedItem, refine}) => {
+const CapacitySelector = MultiRange.connect(({items, currentRefinement, refine}) => {
   const selectValue = e => refine(e.target.value);
 
-  const allOption = <OptionCapacity label="" value="" isSelected={Boolean(selectedItem)} key="all"/>;
+  const allOption = <OptionCapacity label="" value="" isSelected={Boolean(currentRefinement)} key="all"/>;
 
   const options = items.map(item => {
-    const isSelected = item.value === selectedItem;
+    const isSelected = item.value === currentRefinement;
     const val = parseFloat(item.value.split(':')[0]);
     const label = `${val} person${val > 1 ? 's' : ''}`;
     return <OptionCapacity label={label} value={item.value} isSelected={isSelected} key={item.value}/>;
@@ -189,7 +189,7 @@ const CapacitySelector = MultiRange.connect(({items, selectedItem, refine}) => {
 
   return (
     <div className="capacity-menu-wrapper">
-      <select defaultValue={selectedItem} onChange={selectValue}>
+      <select defaultValue={currentRefinement} onChange={selectValue}>
         {options}
       </select>
     </div>
@@ -207,12 +207,12 @@ function DatesAndGuest() {
   );
 }
 
-const RoomType = RefinementList.connect(({items, refine, selectedItems}) => {
+const RoomType = RefinementList.connect(({items, refine, currentRefinement}) => {
   const itemComponents = items.map(item => {
-    const isSelected = selectedItems.indexOf(item.value) !== -1;
+    const isSelected = currentRefinement.indexOf(item.value) !== -1;
     const value = isSelected ?
-      selectedItems.filter(v => v !== item.value) :
-      selectedItems.concat([item.value]);
+      currentRefinement.filter(v => v !== item.value) :
+      currentRefinement.concat([item.value]);
     const selectedClassName = isSelected ? ' ais-refinement-list--item__active' : '';
     const itemClassName = `ais-refinement-list--item col-sm-3 ${selectedClassName}`;
     return (

--- a/packages/examples/Search.js
+++ b/packages/examples/Search.js
@@ -85,7 +85,7 @@ class Search extends Component {
                 value: 'instant_search_price_desc',
               },
             ]}
-            defaultSelectedIndex="instant_search"
+            defaultRefinement="instant_search"
           />
           <HitsPerPage items={[10, 20, 30]} defaultHitsPerPage={20} />
           <Range
@@ -117,7 +117,7 @@ class Search extends Component {
           />
           <RefinementList
             attributeName="categories"
-            defaultSelectedItems={['Audio']}
+            defaultRefinement={['Audio']}
           />
           <Menu
             attributeName="brand"

--- a/packages/react-instantsearch/src/widgets/HierarchicalMenu/HierarchicalMenu.js
+++ b/packages/react-instantsearch/src/widgets/HierarchicalMenu/HierarchicalMenu.js
@@ -23,7 +23,7 @@ class HierarchicalMenu extends Component {
     refine: PropTypes.func.isRequired,
     createURL: PropTypes.func.isRequired,
     items: itemsPropType,
-    selectedItem: PropTypes.string,
+    currentRefinement: PropTypes.string,
     showMore: PropTypes.bool,
     limitMin: PropTypes.number,
     limitMax: PropTypes.number,
@@ -63,7 +63,7 @@ class HierarchicalMenu extends Component {
       <List
         renderItem={this.renderItem}
         selectedItems={
-          this.props.selectedItem === null ? [] : [this.props.selectedItem]
+          this.props.currentRefinement === null ? [] : [this.props.currentRefinement]
         }
         {...pick(this.props, [
           'applyTheme',

--- a/packages/react-instantsearch/src/widgets/HierarchicalMenu/README.md
+++ b/packages/react-instantsearch/src/widgets/HierarchicalMenu/README.md
@@ -85,7 +85,7 @@ function MyHierarchicalMenu(props) {
       {props.items.map(item =>
         <Item
           item={item}
-          selectedItems={props.selectedItems}
+          selectedItems={props.currentRefinement}
           createURL={props.createURL}
           refine={props.refine}
         />
@@ -95,7 +95,7 @@ function MyHierarchicalMenu(props) {
 }
 
 // `HierarchicalMenu.connect` accepts the same `name`, `attributes`, `showMore`,
-// `limitMin`, `limitMax`, `defaultSelectedItem`, `separator`, `rootPath`,
+// `limitMin`, `limitMax`, `defaultRefinement`, `separator`, `rootPath`,
 // `showParentLevel` and `sortBy` props as `HierarchicalMenu`.
 // When `showMore === true`, `limitMax` facet values will be retrieved.
 // Otherwise, `limitMin` facet values will be retrieved.

--- a/packages/react-instantsearch/src/widgets/HierarchicalMenu/connect.js
+++ b/packages/react-instantsearch/src/widgets/HierarchicalMenu/connect.js
@@ -10,8 +10,8 @@ function getSelectedItem(props, state) {
     }
     return state[id];
   }
-  if (props.defaultSelectedItem) {
-    return props.defaultSelectedItem;
+  if (props.defaultRefinement) {
+    return props.defaultRefinement;
   }
   return null;
 }
@@ -77,7 +77,7 @@ export default createConnector({
      * Default state of this widget.
      * @public
      */
-    defaultSelectedItem: PropTypes.string,
+    defaultRefinement: PropTypes.string,
 
     /**
      * Display a show more button for increasing the number of refinement values
@@ -126,7 +126,7 @@ export default createConnector({
     const value = results.getFacetValues(id, {sortBy});
     return {
       items: value.data ? transformValue(value.data, limit) : [],
-      selectedItem: getSelectedItem(props, state),
+      currentRefinement: getSelectedItem(props, state),
     };
   },
 

--- a/packages/react-instantsearch/src/widgets/HierarchicalMenu/connect.test.js
+++ b/packages/react-instantsearch/src/widgets/HierarchicalMenu/connect.test.js
@@ -24,15 +24,15 @@ describe('HierarchicalMenu.connect', () => {
 
     results.getFacetValues.mockImplementationOnce(() => ({}));
     props = getProps({id: 'ok'}, {ok: 'wat'}, {results});
-    expect(props).toEqual({items: [], selectedItem: 'wat'});
+    expect(props).toEqual({items: [], currentRefinement: 'wat'});
 
     results.getFacetValues.mockImplementationOnce(() => ({}));
-    props = getProps({id: 'ok', defaultSelectedItem: 'wat'}, {}, {results});
-    expect(props).toEqual({items: [], selectedItem: 'wat'});
+    props = getProps({id: 'ok', defaultRefinement: 'wat'}, {}, {results});
+    expect(props).toEqual({items: [], currentRefinement: 'wat'});
 
     results.getFacetValues.mockImplementationOnce(() => ({}));
     props = getProps({id: 'ok'}, {}, {results});
-    expect(props).toEqual({items: [], selectedItem: null});
+    expect(props).toEqual({items: [], currentRefinement: null});
 
     results.getFacetValues.mockClear();
     results.getFacetValues.mockImplementationOnce(() => ({}));

--- a/packages/react-instantsearch/src/widgets/HitsPerPage/HitsPerPage.enzyme.test.js
+++ b/packages/react-instantsearch/src/widgets/HitsPerPage/HitsPerPage.enzyme.test.js
@@ -16,7 +16,7 @@ describe('HitsPerPage', () => {
         createURL={() => '#'}
         items={[111, 333, 666]}
         refine={refine}
-        hitsPerPage={111}
+        currentRefinement={111}
       />
     );
 

--- a/packages/react-instantsearch/src/widgets/HitsPerPage/HitsPerPage.js
+++ b/packages/react-instantsearch/src/widgets/HitsPerPage/HitsPerPage.js
@@ -9,7 +9,7 @@ import theme from './HitsPerPage.css';
 class HitsPerPage extends Component {
   static propTypes = {
     refine: PropTypes.func.isRequired,
-    hitsPerPage: PropTypes.number.isRequired,
+    currentRefinement: PropTypes.number.isRequired,
     applyTheme: PropTypes.func.isRequired,
     createURL: PropTypes.func.isRequired,
 
@@ -39,7 +39,7 @@ class HitsPerPage extends Component {
 
   render() {
     const {
-      hitsPerPage,
+      currentRefinement,
       refine,
       items,
       applyTheme,
@@ -52,7 +52,7 @@ class HitsPerPage extends Component {
           typeof item === 'number' ? {value: item, label: item} : item
         )}
         onSelect={refine}
-        selectedItem={hitsPerPage}
+        selectedItem={currentRefinement}
         applyTheme={applyTheme}
         createURL={createURL}
       />

--- a/packages/react-instantsearch/src/widgets/HitsPerPage/HitsPerPage.test.js
+++ b/packages/react-instantsearch/src/widgets/HitsPerPage/HitsPerPage.test.js
@@ -12,7 +12,7 @@ describe('HitsPerPage', () => {
         createURL={() => '#'}
         refine={() => null}
         items={[111, 333, 666]}
-        hitsPerPage={111}
+        currentRefinement={111}
       />
     ).toJSON();
     expect(tree).toMatchSnapshot();
@@ -28,7 +28,7 @@ describe('HitsPerPage', () => {
           {label: '333 items', value: 333},
           {label: '666 items', value: 666},
         ]}
-        hitsPerPage={111}
+        currentRefinement={111}
       />
     ).toJSON();
     expect(tree).toMatchSnapshot();
@@ -44,7 +44,7 @@ describe('HitsPerPage', () => {
           label: 'HITS_LABEL',
           value: v => `HITS_VALUE_${v}`,
         }}
-        hitsPerPage={111}
+        currentRefinement={111}
       />
     ).toJSON();
     expect(tree).toMatchSnapshot();

--- a/packages/react-instantsearch/src/widgets/HitsPerPage/HitsPerPageSelect.js
+++ b/packages/react-instantsearch/src/widgets/HitsPerPage/HitsPerPageSelect.js
@@ -10,7 +10,7 @@ class HitsPerPageSelect extends Component {
   static propTypes = {
     refine: PropTypes.func.isRequired,
     applyTheme: PropTypes.func.isRequired,
-    hitsPerPage: PropTypes.number.isRequired,
+    currentRefinement: PropTypes.number.isRequired,
 
     /**
      * List of hits per page options.
@@ -36,7 +36,7 @@ class HitsPerPageSelect extends Component {
 
   render() {
     const {
-      hitsPerPage,
+      currentRefinement,
       refine,
       items,
       applyTheme,
@@ -45,7 +45,7 @@ class HitsPerPageSelect extends Component {
     return (
       <Select
         onSelect={refine}
-        selectedItem={hitsPerPage}
+        selectedItem={currentRefinement}
         items={items}
         applyTheme={applyTheme}
       />

--- a/packages/react-instantsearch/src/widgets/HitsPerPage/connect.js
+++ b/packages/react-instantsearch/src/widgets/HitsPerPage/connect.js
@@ -9,7 +9,7 @@ function getHitsPerPage(props, state) {
     }
     return state[props.id];
   }
-  return props.defaultHitsPerPage;
+  return props.defaultRefinement;
 }
 
 export default createConnector({
@@ -25,7 +25,7 @@ export default createConnector({
      * Default state of the widget.
      * @public
      */
-    defaultHitsPerPage: PropTypes.number.isRequired,
+    defaultRefinement: PropTypes.number.isRequired,
   },
 
   defaultProps: {
@@ -34,7 +34,7 @@ export default createConnector({
 
   getProps(props, state) {
     return {
-      hitsPerPage: getHitsPerPage(props, state),
+      currentRefinement: getHitsPerPage(props, state),
     };
   },
 

--- a/packages/react-instantsearch/src/widgets/HitsPerPage/connect.test.js
+++ b/packages/react-instantsearch/src/widgets/HitsPerPage/connect.test.js
@@ -18,13 +18,13 @@ let params;
 describe('HitsPerPage.connect', () => {
   it('provides the correct props to the component', () => {
     props = getProps({id: 'hPP'}, {hPP: 10});
-    expect(props).toEqual({hitsPerPage: 10});
+    expect(props).toEqual({currentRefinement: 10});
 
     props = getProps({id: 'hPP'}, {hPP: '10'});
-    expect(props).toEqual({hitsPerPage: 10});
+    expect(props).toEqual({currentRefinement: 10});
 
-    props = getProps({id: 'hPP', defaultHitsPerPage: 20}, {});
-    expect(props).toEqual({hitsPerPage: 20});
+    props = getProps({id: 'hPP', defaultRefinement: 20}, {});
+    expect(props).toEqual({currentRefinement: 20});
   });
 
   it('calling refine updates the widget\'s state', () => {
@@ -44,7 +44,7 @@ describe('HitsPerPage.connect', () => {
     params = getSP(sp, {id: 'hPP'}, {hPP: '10'});
     expect(params).toEqual(sp.setQueryParameter('hitsPerPage', 10));
 
-    params = getSP(sp, {id: 'hPP', defaultHitsPerPage: 20}, {});
+    params = getSP(sp, {id: 'hPP', defaultRefinement: 20}, {});
     expect(params).toEqual(sp.setQueryParameter('hitsPerPage', 20));
   });
 

--- a/packages/react-instantsearch/src/widgets/Menu/Menu.js
+++ b/packages/react-instantsearch/src/widgets/Menu/Menu.js
@@ -19,7 +19,7 @@ class Menu extends Component {
       value: PropTypes.string.isRequired,
       count: PropTypes.number.isRequired,
     })),
-    selectedItem: PropTypes.string,
+    currentRefinement: PropTypes.string,
     showMore: PropTypes.bool,
     limitMin: PropTypes.number,
     limitMax: PropTypes.number,
@@ -49,7 +49,7 @@ class Menu extends Component {
     return (
       <List
         renderItem={this.renderItem}
-        selectedItems={[this.props.selectedItem]}
+        selectedItems={[this.props.currentRefinement]}
         {...pick(this.props, [
           'applyTheme',
           'translate',

--- a/packages/react-instantsearch/src/widgets/Menu/MenuSelect.js
+++ b/packages/react-instantsearch/src/widgets/Menu/MenuSelect.js
@@ -16,16 +16,16 @@ class MenuSelect extends Component {
       value: PropTypes.string.isRequired,
       count: PropTypes.number.isRequired,
     })).isRequired,
-    selectedItem: PropTypes.string.isRequired,
+    currentRefinement: PropTypes.string.isRequired,
   };
 
   render() {
-    const {applyTheme, refine, items, selectedItem, translate} = this.props;
+    const {applyTheme, refine, items, currentRefinement, translate} = this.props;
 
     return (
       <Select
         applyTheme={applyTheme}
-        selectedItem={selectedItem || ''}
+        selectedItem={currentRefinement || ''}
         onSelect={refine}
         items={[
           {label: translate('none'), value: ''},

--- a/packages/react-instantsearch/src/widgets/Menu/README.md
+++ b/packages/react-instantsearch/src/widgets/Menu/README.md
@@ -60,7 +60,7 @@ function MyMenu(props) {
 }
 
 // `Menu.connect` accepts the same `id`, `attributeName`, `sortBy`,
-// `defaultSelectedItems`, `showMore`, `limitMin` and `limitMax` props
+// `defaultRefinement`, `showMore`, `limitMin` and `limitMax` props
 // as `Menu`.
 // When `showMore === true`, `limitMax` facet values will be retrieved.
 // Otherwise, `limitMin` facet values will be retrieved.

--- a/packages/react-instantsearch/src/widgets/Menu/connect.js
+++ b/packages/react-instantsearch/src/widgets/Menu/connect.js
@@ -14,8 +14,8 @@ function getSelectedItem(props, state) {
     }
     return state[id];
   }
-  if (props.defaultSelectedItem) {
-    return props.defaultSelectedItem;
+  if (props.defaultRefinement) {
+    return props.defaultRefinement;
   }
   return null;
 }
@@ -64,7 +64,7 @@ export default createConnector({
      * The default state of this widget.
      * @public
      */
-    defaultSelectedItem: PropTypes.string,
+    defaultRefinement: PropTypes.string,
   },
 
   defaultProps: {
@@ -95,7 +95,7 @@ export default createConnector({
         count: v.count,
       }));
 
-    return {items, selectedItem: getSelectedItem(props, state)};
+    return {items, currentRefinement: getSelectedItem(props, state)};
   },
 
   refine(props, state, nextSelectedItem) {

--- a/packages/react-instantsearch/src/widgets/Menu/connect.test.js
+++ b/packages/react-instantsearch/src/widgets/Menu/connect.test.js
@@ -24,16 +24,16 @@ describe('Menu.connect', () => {
     };
 
     props = getProps({id: 'ok'}, {ok: 'wat'}, {results});
-    expect(props).toEqual({items: [], selectedItem: 'wat'});
+    expect(props).toEqual({items: [], currentRefinement: 'wat'});
 
     props = getProps({attributeName: 'ok'}, {ok: 'wat'}, {results});
-    expect(props).toEqual({items: [], selectedItem: 'wat'});
+    expect(props).toEqual({items: [], currentRefinement: 'wat'});
 
-    props = getProps({id: 'ok', defaultSelectedItem: 'wat'}, {}, {results});
-    expect(props).toEqual({items: [], selectedItem: 'wat'});
+    props = getProps({id: 'ok', defaultRefinement: 'wat'}, {}, {results});
+    expect(props).toEqual({items: [], currentRefinement: 'wat'});
 
     props = getProps({id: 'ok'}, {}, {results});
-    expect(props).toEqual({items: [], selectedItem: null});
+    expect(props).toEqual({items: [], currentRefinement: null});
 
     results.getFacetValues.mockClear();
     const sortBy = ['my:custom:sort'];

--- a/packages/react-instantsearch/src/widgets/MultiRange/MultiRange.enzyme.test.js
+++ b/packages/react-instantsearch/src/widgets/MultiRange/MultiRange.enzyme.test.js
@@ -19,7 +19,7 @@ describe('RangeInput', () => {
           {label: 'label', value: '20:30'},
           {label: 'label', value: '30:'},
         ]}
-        selectedItem=""
+        currentRefinement=""
       />
     );
 

--- a/packages/react-instantsearch/src/widgets/MultiRange/MultiRange.js
+++ b/packages/react-instantsearch/src/widgets/MultiRange/MultiRange.js
@@ -13,7 +13,7 @@ class MultiRange extends Component {
       label: PropTypes.node.isRequired,
       value: PropTypes.string.isRequired,
     })).isRequired,
-    selectedItem: PropTypes.string.isRequired,
+    currentRefinement: PropTypes.string.isRequired,
     refine: PropTypes.func.isRequired,
   };
 
@@ -36,7 +36,7 @@ class MultiRange extends Component {
   };
 
   render() {
-    const {items, selectedItem, applyTheme} = this.props;
+    const {items, currentRefinement, applyTheme} = this.props;
 
     return (
       <List
@@ -44,7 +44,7 @@ class MultiRange extends Component {
         showMore={false}
         applyTheme={applyTheme}
         items={items}
-        selectedItems={[selectedItem]}
+        selectedItems={[currentRefinement]}
       />
     );
   }

--- a/packages/react-instantsearch/src/widgets/MultiRange/MultiRange.test.js
+++ b/packages/react-instantsearch/src/widgets/MultiRange/MultiRange.test.js
@@ -17,7 +17,7 @@ describe('RangeInput', () => {
           {label: 'label', value: '20:30'},
           {label: 'label', value: '30:'},
         ]}
-        selectedItem=""
+        currentRefinement=""
       />
     ).toJSON();
     expect(tree).toMatchSnapshot();
@@ -34,7 +34,7 @@ describe('RangeInput', () => {
           {label: 'label', value: '20:30'},
           {label: 'label', value: '30:'},
         ]}
-        selectedItem="10:20"
+        currentRefinement="10:20"
       />
     ).toJSON();
     expect(tree).toMatchSnapshot();

--- a/packages/react-instantsearch/src/widgets/MultiRange/connect.js
+++ b/packages/react-instantsearch/src/widgets/MultiRange/connect.js
@@ -30,8 +30,8 @@ function getSelectedItem(props, state) {
   if (typeof state[id] !== 'undefined') {
     return state[id];
   }
-  if (props.defaultSelectedItem) {
-    return props.defaultSelectedItem;
+  if (props.defaultRefinement) {
+    return props.defaultRefinement;
   }
   return '';
 }
@@ -82,14 +82,14 @@ export default createConnector({
 
   getProps(props, state) {
     const {items} = props;
-    const selectedItem = getSelectedItem(props, state);
+    const currentRefinement = getSelectedItem(props, state);
 
     return {
       items: items.map(item => ({
         label: item.label,
         value: stringifyItem(item),
       })),
-      selectedItem,
+      currentRefinement,
     };
   },
 

--- a/packages/react-instantsearch/src/widgets/MultiRange/connect.test.js
+++ b/packages/react-instantsearch/src/widgets/MultiRange/connect.test.js
@@ -26,7 +26,7 @@ describe('MultiRange.connect', () => {
       items: [
         {label: 'All', value: ''},
       ],
-      selectedItem: '',
+      currentRefinement: '',
     });
 
     props = getProps({
@@ -40,7 +40,7 @@ describe('MultiRange.connect', () => {
         {label: 'All', value: ''},
         {label: 'Ok', value: '100:'},
       ],
-      selectedItem: '',
+      currentRefinement: '',
     });
 
     props = getProps({
@@ -54,7 +54,7 @@ describe('MultiRange.connect', () => {
         {label: 'All', value: ''},
         {label: 'Not ok', value: ':200'},
       ],
-      selectedItem: '',
+      currentRefinement: '',
     });
 
     props = getProps({
@@ -72,17 +72,17 @@ describe('MultiRange.connect', () => {
         {label: 'Not ok', value: ':200'},
         {label: 'Maybe ok?', value: '100:200'},
       ],
-      selectedItem: '',
+      currentRefinement: '',
     });
 
     props = getProps({id: 'ok', items: []}, {ok: 'wat'});
-    expect(props).toEqual({items: [], selectedItem: 'wat'});
+    expect(props).toEqual({items: [], currentRefinement: 'wat'});
 
     props = getProps({attributeName: 'ok', items: []}, {ok: 'wat'});
-    expect(props).toEqual({items: [], selectedItem: 'wat'});
+    expect(props).toEqual({items: [], currentRefinement: 'wat'});
 
-    props = getProps({id: 'ok', items: [], defaultSelectedItem: 'wat'}, {});
-    expect(props).toEqual({items: [], selectedItem: 'wat'});
+    props = getProps({id: 'ok', items: [], defaultRefinement: 'wat'}, {});
+    expect(props).toEqual({items: [], currentRefinement: 'wat'});
   });
 
   it('calling refine updates the widget\'s state', () => {

--- a/packages/react-instantsearch/src/widgets/Range/connect.js
+++ b/packages/react-instantsearch/src/widgets/Range/connect.js
@@ -18,8 +18,8 @@ function getValue(props, state) {
     }
     return {min, max};
   }
-  if (typeof props.defaultValue !== 'undefined') {
-    return props.defaultValue;
+  if (typeof props.defaultRefinement !== 'undefined') {
+    return props.defaultRefinement;
   }
   return {};
 }
@@ -45,7 +45,7 @@ export default createConnector({
      * @public
      * @defines RangeState
      */
-    defaultValue: PropTypes.shape({
+    defaultRefinement: PropTypes.shape({
       /**
        * Start of the range
        */

--- a/packages/react-instantsearch/src/widgets/Range/connect.test.js
+++ b/packages/react-instantsearch/src/widgets/Range/connect.test.js
@@ -72,7 +72,7 @@ describe('Range.connect', () => {
       attributeName: 'ok',
       min: 5,
       max: 10,
-      defaultValue: {min: 6, max: 9},
+      defaultRefinement: {min: 6, max: 9},
     }, {}, {});
     expect(props).toEqual({
       min: 5,

--- a/packages/react-instantsearch/src/widgets/RefinementList/README.md
+++ b/packages/react-instantsearch/src/widgets/RefinementList/README.md
@@ -59,7 +59,7 @@ function MyRefinementList(props) {
       {props.items.map(item =>
         <Item
           item={item}
-          selectedItems={props.selectedItems}
+          selectedItems={props.currentRefinement}
           refine={props.refine}
           createURL={props.createURL}
         />
@@ -69,7 +69,7 @@ function MyRefinementList(props) {
 }
 
 // `RefinementList.connect` accepts the same `id`, `attributeName`, `operator`,
-// `sortBy`, `defaultSelectedItems`, `showMore`, `limitMin` and `limitMax` props
+// `sortBy`, `defaultRefinement`, `showMore`, `limitMin` and `limitMax` props
 // as `RefinementList`.
 // When `showMore === true`, `limitMax` facet values will be retrieved.
 // Otherwise, `limitMin` facet values will be retrieved.

--- a/packages/react-instantsearch/src/widgets/RefinementList/RefinementList.js
+++ b/packages/react-instantsearch/src/widgets/RefinementList/RefinementList.js
@@ -18,15 +18,15 @@ class RefinementList extends Component {
       value: PropTypes.string.isRequired,
       count: PropTypes.number.isRequired,
     })),
-    selectedItems: PropTypes.arrayOf(PropTypes.string),
+    currentRefinement: PropTypes.arrayOf(PropTypes.string),
     showMore: PropTypes.bool,
     limitMin: PropTypes.number,
     limitMax: PropTypes.number,
   };
 
   onItemChange = (item, e) => {
-    const {selectedItems} = this.props;
-    const nextSelectedItems = selectedItems.slice();
+    const {currentRefinement} = this.props;
+    const nextSelectedItems = currentRefinement.slice();
     const idx = nextSelectedItems.indexOf(item.value);
     if (e.target.checked && idx === -1) {
       nextSelectedItems.push(item.value);
@@ -62,11 +62,11 @@ class RefinementList extends Component {
     return (
       <List
         renderItem={this.renderItem}
+        selectedItems={this.props.currentRefinement}
         {...pick(this.props, [
           'applyTheme',
           'translate',
           'items',
-          'selectedItems',
           'showMore',
           'limitMin',
           'limitMax',

--- a/packages/react-instantsearch/src/widgets/RefinementList/RefinementListLinks.js
+++ b/packages/react-instantsearch/src/widgets/RefinementList/RefinementListLinks.js
@@ -19,15 +19,15 @@ class RefinementListLinks extends Component {
       value: PropTypes.string.isRequired,
       count: PropTypes.number.isRequired,
     })),
-    selectedItems: PropTypes.arrayOf(PropTypes.string),
+    currentRefinement: PropTypes.arrayOf(PropTypes.string),
     showMore: PropTypes.bool,
     limitMin: PropTypes.number,
     limitMax: PropTypes.number,
   };
 
   getSelectedItems = item => {
-    const {selectedItems} = this.props;
-    const nextSelectedItems = selectedItems.slice();
+    const {currentRefinement} = this.props;
+    const nextSelectedItems = currentRefinement.slice();
     const idx = nextSelectedItems.indexOf(item.value);
     if (idx === -1) {
       nextSelectedItems.push(item.value);
@@ -61,11 +61,11 @@ class RefinementListLinks extends Component {
     return (
       <List
         renderItem={this.renderItem}
+        selectedItems={this.props.currentRefinement}
         {...pick(this.props, [
           'applyTheme',
           'translate',
           'items',
-          'selectedItems',
           'showMore',
           'limitMin',
           'limitMax',

--- a/packages/react-instantsearch/src/widgets/RefinementList/connect.js
+++ b/packages/react-instantsearch/src/widgets/RefinementList/connect.js
@@ -15,8 +15,8 @@ function getSelectedItems(props, state) {
     }
     return state[id];
   }
-  if (props.defaultSelectedItems) {
-    return props.defaultSelectedItems;
+  if (props.defaultRefinement) {
+    return props.defaultRefinement;
   }
   return [];
 }
@@ -78,7 +78,7 @@ export default createConnector({
      * The default state of this widget, as an array of facet values.
      * @public
      */
-    defaultSelectedItems: PropTypes.arrayOf(PropTypes.string),
+    defaultRefinement: PropTypes.arrayOf(PropTypes.string),
   },
 
   defaultProps: {
@@ -110,7 +110,7 @@ export default createConnector({
         count: v.count,
       }));
 
-    return {items, selectedItems: getSelectedItems(props, state)};
+    return {items, currentRefinement: getSelectedItems(props, state)};
   },
 
   refine(props, state, nextSelected) {
@@ -119,7 +119,7 @@ export default createConnector({
       ...state,
       // Setting the value to an empty string ensures that it is persisted in
       // the URL as an empty value.
-      // This is necessary in the case where `defaultSelectedItems` contains one
+      // This is necessary in the case where `defaultRefinement` contains one
       // item and we try to deselect it. `nextSelected` would be an empty array,
       // which would not be persisted to the URL.
       // {foo: ['bar']} => "foo[0]=bar"

--- a/packages/react-instantsearch/src/widgets/RefinementList/connect.test.js
+++ b/packages/react-instantsearch/src/widgets/RefinementList/connect.test.js
@@ -24,16 +24,16 @@ describe('RefinementList.connect', () => {
     };
 
     props = getProps({id: 'ok'}, {ok: ['wat']}, {results});
-    expect(props).toEqual({items: [], selectedItems: ['wat']});
+    expect(props).toEqual({items: [], currentRefinement: ['wat']});
 
     props = getProps({attributeName: 'ok'}, {ok: ['wat']}, {results});
-    expect(props).toEqual({items: [], selectedItems: ['wat']});
+    expect(props).toEqual({items: [], currentRefinement: ['wat']});
 
-    props = getProps({id: 'ok', defaultSelectedItems: ['wat']}, {}, {results});
-    expect(props).toEqual({items: [], selectedItems: ['wat']});
+    props = getProps({id: 'ok', defaultRefinement: ['wat']}, {}, {results});
+    expect(props).toEqual({items: [], currentRefinement: ['wat']});
 
     props = getProps({id: 'ok'}, {}, {results});
-    expect(props).toEqual({items: [], selectedItems: []});
+    expect(props).toEqual({items: [], currentRefinement: []});
 
     results.getFacetValues.mockClear();
     const sortBy = ['my:custom:sort'];

--- a/packages/react-instantsearch/src/widgets/SortBy/README.md
+++ b/packages/react-instantsearch/src/widgets/SortBy/README.md
@@ -65,7 +65,7 @@ function MySortBy(props) {
   );
 }
 
-// `SortBy.connect` accepts the same `id` and `defaultSelectedIndex` props as
+// `SortBy.connect` accepts the same `id` and `defaultRefinement` props as
 // `SortBy`.
 export default SortBy.connect(MySortBy);
 ```

--- a/packages/react-instantsearch/src/widgets/SortBy/SortBy.js
+++ b/packages/react-instantsearch/src/widgets/SortBy/SortBy.js
@@ -27,7 +27,7 @@ class SortBy extends Component {
       value: PropTypes.string.isRequired,
     })).isRequired,
 
-    selectedIndex: PropTypes.string.isRequired,
+    currentRefinement: PropTypes.string.isRequired,
   };
 
   onChange = e => {
@@ -35,11 +35,11 @@ class SortBy extends Component {
   }
 
   render() {
-    const {applyTheme, refine, items, selectedIndex} = this.props;
+    const {applyTheme, refine, items, currentRefinement} = this.props;
     return (
       <Select
         applyTheme={applyTheme}
-        selectedItem={selectedIndex}
+        selectedItem={currentRefinement}
         onSelect={refine}
         items={items}
       />

--- a/packages/react-instantsearch/src/widgets/SortBy/connect.js
+++ b/packages/react-instantsearch/src/widgets/SortBy/connect.js
@@ -7,8 +7,8 @@ function getSelectedIndex(props, state) {
   if (state[id]) {
     return state[id];
   }
-  if (props.defaultSelectedIndex) {
-    return props.defaultSelectedIndex;
+  if (props.defaultRefinement) {
+    return props.defaultRefinement;
   }
   return null;
 }
@@ -29,7 +29,7 @@ export default createConnector({
      * The default selected index.
      * @public
      */
-    defaultSelectedIndex: PropTypes.string,
+    defaultRefinement: PropTypes.string,
   },
 
   defaultProps: {
@@ -37,8 +37,8 @@ export default createConnector({
   },
 
   getProps(props, state) {
-    const selectedIndex = getSelectedIndex(props, state);
-    return {selectedIndex};
+    const currentRefinement = getSelectedIndex(props, state);
+    return {currentRefinement};
   },
 
   refine(props, state, nextSelectedIndex) {

--- a/packages/react-instantsearch/src/widgets/SortBy/connect.test.js
+++ b/packages/react-instantsearch/src/widgets/SortBy/connect.test.js
@@ -18,13 +18,13 @@ let params;
 describe('SortBy.connect', () => {
   it('provides the correct props to the component', () => {
     props = getProps({id: 'i'}, {});
-    expect(props).toEqual({selectedIndex: null});
+    expect(props).toEqual({currentRefinement: null});
 
     props = getProps({id: 'i'}, {i: 'yep'});
-    expect(props).toEqual({selectedIndex: 'yep'});
+    expect(props).toEqual({currentRefinement: 'yep'});
 
-    props = getProps({id: 'i', defaultSelectedIndex: 'yep'}, {});
-    expect(props).toEqual({selectedIndex: 'yep'});
+    props = getProps({id: 'i', defaultRefinement: 'yep'}, {});
+    expect(props).toEqual({currentRefinement: 'yep'});
   });
 
   it('calling refine updates the widget\'s state', () => {


### PR DESCRIPTION
Goal: provide a more consistent and smaller connector API surface by defining only two way to: define default refinement, access current refinement.

Move from:
- Accessing current refined value: selectedItem, selectedItems, selectedIndex, hitsPerPage (forwarded props)
- Providing default refined value: defaultSelectedIndex, defaultRefinement, defaultSelectedItems, defaultHitsPerPage (connector props)

=> __8 API entries__

To:
- Accessing current refined value: currentRefinement (forwarded prop)
- Providing default refined value: defaultRefinement (connector prop)

=> __2 API entries__

Linked to #1305

Still missing:
- forwarded consistent `items` (+ isRefined)
- forwarded `toggleRefinement` method to easily toggle one refinement
- forwarded `clearRefinement` method to easily remove all refinements

Questions:
I think I will remove the "currentRefinement" forwarded prop once we have proper `items` (with isRefined) and toggle method. Then we will see if people need it, we will add it.

About the "refine" method, it allows to refine multiple values at once,  should we make toggleRefinement works with multiple values just like the helper allows it (if I remember well?) or should we just remove it?

Should we name `items` `refinements`? To be in line with the other API entries? (toggleRefinement, clearRefinement, defaultRefinement)