### PR TITLE
feat(CurrentFilters): remove `key`, remove `hide`, rename filters to `items`

### DIFF
--- a/packages/react-instantsearch/src/widgets/CurrentFilters/CurrentFilters.css
+++ b/packages/react-instantsearch/src/widgets/CurrentFilters/CurrentFilters.css
@@ -1,16 +1,16 @@
 .root {
 }
 
-.filters {
+.items {
 }
 
-.filter {
+.item {
 }
 
-.filterLabel {
+.itemLabel {
 }
 
-.filterClear {
+.itemClear {
 }
 
 .clearAll {

--- a/packages/react-instantsearch/src/widgets/CurrentFilters/CurrentFilters.js
+++ b/packages/react-instantsearch/src/widgets/CurrentFilters/CurrentFilters.js
@@ -9,42 +9,41 @@ class CurrentFilters extends Component {
   static propTypes = {
     translate: PropTypes.func.isRequired,
     applyTheme: PropTypes.func.isRequired,
-    filters: PropTypes.arrayOf(PropTypes.shape({
-      key: PropTypes.string,
+    items: PropTypes.arrayOf(PropTypes.shape({
       label: PropTypes.string,
     })).isRequired,
     refine: PropTypes.func.isRequired,
   };
 
   render() {
-    const {applyTheme, translate, filters, refine} = this.props;
-    const displayedFilters = filters.filter(filter => !filter.hide);
-    if (displayedFilters.length === 0) {
+    const {applyTheme, translate, items, refine} = this.props;
+
+    if (items.length === 0) {
       return null;
     }
 
     return (
       <div {...applyTheme('root', 'root')}>
-        <div {...applyTheme('filters', 'filters')}>
-          {displayedFilters.map(filter =>
+        <div {...applyTheme('items', 'items')}>
+          {items.map(item =>
             <div // eslint-disable-line react/jsx-key, automatically done by themeable
-              {...applyTheme(filter.key, 'filter')}
+              {...applyTheme(item.label, 'item')}
             >
-              <span {...applyTheme('filterLabel', 'filterLabel')}>
-                {filter.label}
+              <span {...applyTheme('itemLabel', 'itemLabel')}>
+                {item.label}
               </span>
               <button
-                {...applyTheme('filterClear', 'filterClear')}
-                onClick={refine.bind(null, [filter])}
+                {...applyTheme('itemClear', 'itemClear')}
+                onClick={refine.bind(null, [item])}
               >
-                {translate('clearFilter', filter)}
+                {translate('clearFilter', item)}
               </button>
             </div>
           )}
         </div>
         <button
           {...applyTheme('clearAll', 'clearAll')}
-          onClick={refine.bind(null, displayedFilters)}
+          onClick={refine.bind(null, items)}
         >
           {translate('clearAll')}
         </button>

--- a/packages/react-instantsearch/src/widgets/CurrentFilters/connect.js
+++ b/packages/react-instantsearch/src/widgets/CurrentFilters/connect.js
@@ -5,7 +5,7 @@ export default createConnector({
 
   getProps(props, state, search, metadata) {
     return {
-      filters: metadata.reduce((res, meta) =>
+      items: metadata.reduce((res, meta) =>
         typeof meta.filters !== 'undefined' ? res.concat(meta.filters) : res
       , []),
     };

--- a/packages/react-instantsearch/src/widgets/CurrentFilters/connect.test.js
+++ b/packages/react-instantsearch/src/widgets/CurrentFilters/connect.test.js
@@ -12,7 +12,7 @@ describe('CurrentFilters.connect', () => {
       {filters: ['two']},
       {filters: ['three']},
     ]);
-    expect(props.filters).toEqual(['one', 'two', 'three']);
+    expect(props.items).toEqual(['one', 'two', 'three']);
   });
 
   it('refine applies the selected filters clear method on state', () => {

--- a/packages/react-instantsearch/src/widgets/HierarchicalMenu/connect.js
+++ b/packages/react-instantsearch/src/widgets/HierarchicalMenu/connect.js
@@ -182,7 +182,6 @@ export default createConnector({
     return {
       id,
       filters: !selectedItem ? [] : [{
-        key: `${id}.${selectedItem}`,
         label: `${id}: ${selectedItem}`,
         clear: nextState => ({
           ...nextState,

--- a/packages/react-instantsearch/src/widgets/HierarchicalMenu/connect.test.js
+++ b/packages/react-instantsearch/src/widgets/HierarchicalMenu/connect.test.js
@@ -204,7 +204,6 @@ describe('HierarchicalMenu.connect', () => {
     expect(metadata).toEqual({
       id: 'ok',
       filters: [{
-        key: 'ok.wat',
         label: 'ok: wat',
         // Ignore clear, we test it later
         clear: metadata.filters[0].clear,

--- a/packages/react-instantsearch/src/widgets/Menu/connect.js
+++ b/packages/react-instantsearch/src/widgets/Menu/connect.js
@@ -136,7 +136,6 @@ export default createConnector({
     return {
       id,
       filters: selectedItem === null ? [] : [{
-        key: `${id}.${selectedItem}`,
         label: `${props.attributeName}: ${selectedItem}`,
         clear: nextState => ({
           ...nextState,

--- a/packages/react-instantsearch/src/widgets/Menu/connect.test.js
+++ b/packages/react-instantsearch/src/widgets/Menu/connect.test.js
@@ -148,7 +148,6 @@ describe('Menu.connect', () => {
     expect(metadata).toEqual({
       id: 'ok',
       filters: [{
-        key: 'ok.wat',
         label: 'wot: wat',
         // Ignore clear, we test it later
         clear: metadata.filters[0].clear,

--- a/packages/react-instantsearch/src/widgets/MultiRange/connect.js
+++ b/packages/react-instantsearch/src/widgets/MultiRange/connect.js
@@ -128,7 +128,6 @@ export default createConnector({
     if (value !== '') {
       const {label} = find(props.items, item => stringifyItem(item) === value);
       filters.push({
-        key: `${id}.${value}`,
         label: `${props.attributeName}: ${label}`,
         clear: nextState => ({
           ...nextState,

--- a/packages/react-instantsearch/src/widgets/MultiRange/connect.test.js
+++ b/packages/react-instantsearch/src/widgets/MultiRange/connect.test.js
@@ -136,7 +136,6 @@ describe('MultiRange.connect', () => {
     expect(metadata).toEqual({
       id: 'wot',
       filters: [{
-        key: 'wot.100:200',
         label: 'wot: YAY',
         // Ignore clear, we test it later
         clear: metadata.filters[0].clear,

--- a/packages/react-instantsearch/src/widgets/Range/connect.js
+++ b/packages/react-instantsearch/src/widgets/Range/connect.js
@@ -157,7 +157,6 @@ export default createConnector({
         filterLabel += ` <= ${value.max}`;
       }
       filter = {
-        key: `${id}.${filterLabel}`,
         label: filterLabel,
         clear: nextState => ({
           ...nextState,

--- a/packages/react-instantsearch/src/widgets/Range/connect.test.js
+++ b/packages/react-instantsearch/src/widgets/Range/connect.test.js
@@ -110,7 +110,6 @@ describe('Range.connect', () => {
     expect(metadata).toEqual({
       id: 'wot',
       filters: [{
-        key: 'wot.5 <= wot',
         label: '5 <= wot',
         // Ignore clear, we test it later
         clear: metadata.filters[0].clear,
@@ -127,7 +126,6 @@ describe('Range.connect', () => {
     expect(metadata).toEqual({
       id: 'wot',
       filters: [{
-        key: 'wot.wot <= 10',
         label: 'wot <= 10',
         clear: metadata.filters[0].clear,
       }],
@@ -140,7 +138,6 @@ describe('Range.connect', () => {
     expect(metadata).toEqual({
       id: 'wot',
       filters: [{
-        key: 'wot.5 <= wot <= 10',
         label: '5 <= wot <= 10',
         clear: metadata.filters[0].clear,
       }],

--- a/packages/react-instantsearch/src/widgets/RefinementList/connect.js
+++ b/packages/react-instantsearch/src/widgets/RefinementList/connect.js
@@ -155,7 +155,6 @@ export default createConnector({
     return {
       id,
       filters: getSelectedItems(props, state).map(item => ({
-        key: `${id}.${item}`,
         label: `${props.attributeName}: ${item}`,
         clear: nextState => {
           const nextSelectedItems = getSelectedItems(props, nextState).filter(

--- a/packages/react-instantsearch/src/widgets/RefinementList/connect.test.js
+++ b/packages/react-instantsearch/src/widgets/RefinementList/connect.test.js
@@ -165,13 +165,11 @@ describe('RefinementList.connect', () => {
       id: 'ok',
       filters: [
         {
-          key: 'ok.wat',
           label: 'wot: wat',
           // Ignore clear, we test it later
           clear: metadata.filters[0].clear,
         },
         {
-          key: 'ok.wut',
           label: 'wot: wut',
           clear: metadata.filters[1].clear,
         },

--- a/packages/react-instantsearch/src/widgets/SearchBox/connect.js
+++ b/packages/react-instantsearch/src/widgets/SearchBox/connect.js
@@ -41,17 +41,4 @@ export default createConnector({
   getSearchParameters(searchParameters, props, state) {
     return searchParameters.setQuery(getQuery(props, state));
   },
-
-  getMetadata(props, state) {
-    const query = getQuery(props, state);
-    return {
-      id: props.id,
-      filters: !query ? [] : [{
-        key: props.id,
-        label: query,
-        hide: true,
-        clear: nextState => ({...nextState, [props.id]: ''}),
-      }],
-    };
-  },
 });

--- a/packages/react-instantsearch/src/widgets/SearchBox/connect.test.js
+++ b/packages/react-instantsearch/src/widgets/SearchBox/connect.test.js
@@ -9,7 +9,6 @@ const {
   getProps,
   refine,
   getSearchParameters: getSP,
-  getMetadata,
 } = connect;
 
 let props;
@@ -35,30 +34,5 @@ describe('SearchBox.connect', () => {
   it('refines the query parameter', () => {
     params = getSP(new SearchParameters(), {id: 'q'}, {q: 'bar'});
     expect(params.query).toBe('bar');
-  });
-
-  it('registers its filter in metadata', () => {
-    let metadata = getMetadata({id: 'q'}, {});
-    expect(metadata).toEqual({
-      id: 'q',
-      filters: [],
-    });
-
-    metadata = getMetadata({id: 'q'}, {q: 'wat'});
-    expect(metadata).toEqual({
-      id: 'q',
-      filters: [
-        {
-          key: 'q',
-          label: 'wat',
-          hide: true,
-          // Ignore clear, we test it later
-          clear: metadata.filters[0].clear,
-        },
-      ],
-    });
-
-    const state = metadata.filters[0].clear({q: 'wat'});
-    expect(state).toEqual({q: ''});
   });
 });

--- a/packages/react-instantsearch/src/widgets/Toggle/connect.js
+++ b/packages/react-instantsearch/src/widgets/Toggle/connect.js
@@ -103,7 +103,6 @@ export default createConnector({
     const filters = [];
     if (checked) {
       filters.push({
-        key: id,
         label: props.label,
         clear: nextState => ({
           ...nextState,

--- a/packages/react-instantsearch/src/widgets/Toggle/connect.test.js
+++ b/packages/react-instantsearch/src/widgets/Toggle/connect.test.js
@@ -70,7 +70,6 @@ describe('Toggle.connect', () => {
       id: 't',
       filters: [
         {
-          key: 't',
           label: 'yep',
           // Ignore clear, we test it later
           clear: metadata.filters[0].clear,


### PR DESCRIPTION
Before:
1. we computed a `key` property that was pretty similar to the `label`
one but different.
2. we injected a `filters: [{label, key}]` with the connector
3. we used hide: true in the searchBox metadata to not display it in
our default component

After:
1. Cannot see the reasoning for this, it works well without it, maybe
in edge cases where different ids are manipulating the same
attributeName. But then, I can't imagine any situation where it would
make sense to display: Category: Movies, Type: Movies since it's the
same attributeName
2. Now injecting `items: [{label}]`, on my way to provide a consistent
connector API (#1423, #1405)
3. hide: true was only used to hide and avoid refining the query but
still give the possibility to users to display and clear the query in
their CurrentFilters connected custom components. Let's wait for that
to happen.