### PR TITLE
feat(connectors): consistent connectors API second pass

### DIFF
--- a/docgen/src/examples/e-commerce/App.js
+++ b/docgen/src/examples/e-commerce/App.js
@@ -139,34 +139,28 @@ const CustomCheckbox = ({query, refine}) =>
     </div>
   ;
 
-const ColorItem = ({item, selectedItems, createURL, refine}) => {
-  const selected = selectedItems.indexOf(item.value) !== -1;
-  const active = selected ? 'checked' : '';
-  const value = selected ?
-    selectedItems.filter(v => v !== item.value) :
-    selectedItems.concat([item.value]);
+const ColorItem = ({item, createURL, refine}) => {
+  const active = item.isRefined ? 'checked' : '';
   return (
     <a
-      key={item.value}
       className={`${active} facet-color`}
-      href={createURL(value)}
+      href={createURL(item.value)}
       onClick={e => {
         e.preventDefault();
-        refine(value);
+        refine(item.value);
       }}
-      data-facet-value={item.value}
+      data-facet-value={item.label}
     >
     </a>
   );
 };
 
-const CustomColorRefinementList = ({items, currentRefinement, refine, createURL}) =>
+const CustomColorRefinementList = ({items, refine, createURL}) =>
     <div>
       {items.map(item =>
         <ColorItem
-          key={item.value}
+          key={item.label}
           item={item}
-          selectedItems={currentRefinement}
           refine={refine}
           createURL={createURL}
         />

--- a/docgen/src/examples/material-ui/App.js
+++ b/docgen/src/examples/material-ui/App.js
@@ -142,33 +142,25 @@ const MaterialUiSearchBox = ({query, refine, marginLeft}) => {
     </div>);
 };
 
-const CheckBoxItem = ({item, selectedItems, refine}) => {
-  const selected = selectedItems.indexOf(item.value) !== -1;
-  const value = selected ?
-    selectedItems.filter(v => v !== item.value) :
-    selectedItems.concat([item.value]);
-  return (
-    <ListItem key={item.value}
-              primaryText={item.value}
+const CheckBoxItem = ({item, refine}) =>
+    <ListItem
+              primaryText={item.label}
               leftCheckbox={
-                <Checkbox checked={selected}
+                <Checkbox checked={item.isRefined}
                           onCheck={e => {
                             e.preventDefault();
-                            refine(value);
+                            refine(item.value);
                           }}
                 />}
-    />)
-    ;
-};
+    />;
 
-const MaterialUiCheckBoxRefinementList = ({items, attributeName, currentRefinement, refine, createURL}) =>
+const MaterialUiCheckBoxRefinementList = ({items, attributeName, refine, createURL}) =>
     <List>
       <Subheader style={{fontSize: 18}}>{attributeName.toUpperCase()}</Subheader>
       {items.map(item =>
         <CheckBoxItem
-          key={item.value}
+          key={item.label}
           item={item}
-          selectedItems={currentRefinement}
           refine={refine}
           createURL={createURL}
         />
@@ -176,7 +168,7 @@ const MaterialUiCheckBoxRefinementList = ({items, attributeName, currentRefineme
     </List>
   ;
 
-const MaterialUiNestedList = function ({id, items, refine, currentRefinement}) {
+const MaterialUiNestedList = function ({id, items, refine}) {
   return <List>
     <Subheader style={{fontSize: 18}}>{id.toUpperCase()}</Subheader>
     {items.map((item, idx) => {
@@ -188,7 +180,7 @@ const MaterialUiNestedList = function ({id, items, refine, currentRefinement}) {
             e.preventDefault();
             refine(child.value);
           }}
-          style={currentRefinement && currentRefinement.includes(child.value) ? {fontWeight: 700} : {}}
+          style={child.isRefined ? {fontWeight: 700} : {}}
         />
       ) : [];
       return <ListItem
@@ -200,7 +192,7 @@ const MaterialUiNestedList = function ({id, items, refine, currentRefinement}) {
           e.preventDefault();
           refine(item.value);
         }}
-        style={currentRefinement && currentRefinement.includes(item.value) ? {fontWeight: 700} : {}}
+        style={item.isRefined ? {fontWeight: 700} : {}}
       />;
     }
     )}

--- a/docgen/src/examples/media/App.js
+++ b/docgen/src/examples/media/App.js
@@ -17,6 +17,7 @@ export default function App() {
     appId="latency"
     apiKey="6be0576ff61c053d5f9a3225e2a90f76"
     indexName="movies"
+    urlSync
   >
     <div>
       <Header/>
@@ -124,26 +125,18 @@ const Results = () =>
     <div id="pagination" className="text-center"><Pagination /></div>
   </article>;
 
-const RefinementListLinks = connectRefinementList(({items, refine, currentRefinement}) => {
-  const itemComponents = items.map(item => {
-    const isSelected = currentRefinement.indexOf(item.value) !== -1;
-    const value = isSelected ?
-      currentRefinement.filter(v => v !== item.value) :
-      currentRefinement.concat([item.value]);
-    const selectedClassName = isSelected ? ' active' : '';
-    const itemClassName = `${selectedClassName}`;
-    return (
-      <div className={itemClassName} key={item.value}>
-        <a className="item" onClick={e => {
-          e.preventDefault();
-          refine(value);
-        }}>
-          <span> {item.value}</span>
-          <span className="badge pull-right">{item.count}</span>
-        </a>
-      </div>
-    );
-  });
+const RefinementListLinks = connectRefinementList(({items, refine, createURL}) => {
+  const itemComponents = items.map(item =>
+    <div className={item.isRefined ? ' active' : ''} key={item.label}>
+      <a className="item" href={createURL(item.value)} onClick={e => {
+        e.preventDefault();
+        refine(item.value);
+      }}>
+        <span> {item.label}</span>
+        <span className="badge pull-right">{item.count}</span>
+      </a>
+    </div>
+  );
 
   return (
     <div className="nav nav-list">
@@ -151,4 +144,3 @@ const RefinementListLinks = connectRefinementList(({items, refine, currentRefine
     </div>
   );
 });
-

--- a/docgen/src/examples/tourism/App.js
+++ b/docgen/src/examples/tourism/App.js
@@ -172,10 +172,9 @@ const CapacitySelector = connectMultiRange(({items, currentRefinement, refine}) 
   const allOption = <OptionCapacity label="" value="" isSelected={Boolean(currentRefinement)} key="all"/>;
 
   const options = items.map(item => {
-    const isSelected = item.value === currentRefinement;
     const val = parseFloat(item.value.split(':')[0]);
     const label = `${val} person${val > 1 ? 's' : ''}`;
-    return <OptionCapacity label={label} value={item.value} isSelected={isSelected} key={item.value}/>;
+    return <OptionCapacity label={label} value={item.value} isSelected={item.isRefined} key={item.value}/>;
   });
 
   options.unshift(allOption);
@@ -200,27 +199,23 @@ function DatesAndGuest() {
   );
 }
 
-const RoomType = connectRefinementList(({items, refine, currentRefinement}) => {
+const RoomType = connectRefinementList(({items, refine}) => {
   const itemComponents = items.map(item => {
-    const isSelected = currentRefinement.indexOf(item.value) !== -1;
-    const value = isSelected ?
-      currentRefinement.filter(v => v !== item.value) :
-      currentRefinement.concat([item.value]);
-    const selectedClassName = isSelected ? ' ais-refinement-list--item__active' : '';
+    const selectedClassName = item.isRefined ? ' ais-refinement-list--item__active' : '';
     const itemClassName = `ais-refinement-list--item col-sm-3 ${selectedClassName}`;
     return (
-      <div className={itemClassName} key={item.value}>
+      <div className={itemClassName} key={item.label}>
         <div>
           <label className="ais-refinement-list--label" onClick={e => {
             e.preventDefault();
-            refine(value);
+            refine(item.value);
           }}>
             <input
               type="checkbox"
               className="ais-refinement-list--checkbox"
-              defaultChecked={isSelected ? 'checked' : ''}
+              defaultChecked={item.isRefined ? 'checked' : ''}
               />
-            {item.value}
+            {item.label}
             <span className="ais-refinement-list--count">{item.count}</span>
           </label>
         </div>
@@ -292,7 +287,7 @@ function Results() {
   );
 }
 
-const ConnectedRange = connectRange(({min, max, value, refine}) => {
+const ConnectedRange = connectRange(({min, max, currentRefinement, refine}) => {
   const updateValue = sliderState => {
     if (sliderState.values[0] !== min || sliderState.values[1] !== max) {
       refine({min: sliderState.values[0], max: sliderState.values[1]});
@@ -304,12 +299,12 @@ const ConnectedRange = connectRange(({min, max, value, refine}) => {
       <Rheostat
         min={min}
         max={max}
-        values={[value.min, value.max]}
+        values={[currentRefinement.min, currentRefinement.max]}
         onChange={updateValue}
       />
       <div className="rheostat-values">
-        <span>{value.min}</span>
-        <span>{value.max}</span>
+        <span>{currentRefinement.min}</span>
+        <span>{currentRefinement.max}</span>
       </div>
     </div>
   );

--- a/packages/react-instantsearch/src/components/HierarchicalMenu.enzyme.test.js
+++ b/packages/react-instantsearch/src/components/HierarchicalMenu.enzyme.test.js
@@ -20,8 +20,6 @@ describe('HierarchicalMenu', () => {
           {value: 'black', count: 20, label: 'black'},
           {value: 'blue', count: 30, label: 'blue'},
         ]}
-        currentRefinement=""
-        selectedItems=""
       />
     );
 
@@ -52,8 +50,6 @@ describe('HierarchicalMenu', () => {
         limitMin={2}
         limitMax={4}
         showMore={true}
-        currentRefinement=""
-        selectedItems=""
       />
     );
 
@@ -81,8 +77,6 @@ describe('HierarchicalMenu', () => {
         limitMin={2}
         limitMax={4}
         showMore={true}
-        currentRefinement=""
-        selectedItems=""
       />
     );
 

--- a/packages/react-instantsearch/src/components/HierarchicalMenu.js
+++ b/packages/react-instantsearch/src/components/HierarchicalMenu.js
@@ -10,8 +10,8 @@ import Link from './Link';
 import theme from './HierarchicalMenu.css';
 
 const itemsPropType = PropTypes.arrayOf(PropTypes.shape({
-  label: PropTypes.node,
-  value: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  value: PropTypes.string,
   count: PropTypes.number.isRequired,
   children: (...args) => itemsPropType(...args),
 }));
@@ -23,29 +23,19 @@ class HierarchicalMenu extends Component {
     refine: PropTypes.func.isRequired,
     createURL: PropTypes.func.isRequired,
     items: itemsPropType,
-    currentRefinement: PropTypes.string,
     showMore: PropTypes.bool,
     limitMin: PropTypes.number,
     limitMax: PropTypes.number,
   };
 
-  renderItem = (item, selected, parent, selectedParent) => {
+  renderItem = item => {
     const {createURL, refine, translate, applyTheme} = this.props;
-    let refineValue;
-    if (selected || selectedParent) {
-      if (parent !== null) {
-        refineValue = parent.value;
-      } else {
-        refineValue = null;
-      }
-    } else {
-      refineValue = item.value;
-    }
+
     return (
       <Link
         {...applyTheme('itemLink', 'itemLink')}
-        onClick={refine.bind(null, refineValue)}
-        href={createURL(refineValue)}
+        onClick={() => refine(item.value)}
+        href={createURL(item.value)}
       >
         <span {...applyTheme('itemLabel', 'itemLabel')}>
           {item.label}
@@ -62,9 +52,6 @@ class HierarchicalMenu extends Component {
     return (
       <List
         renderItem={this.renderItem}
-        selectedItems={
-          this.props.currentRefinement === null ? [] : [this.props.currentRefinement]
-        }
         {...pick(this.props, [
           'applyTheme',
           'translate',

--- a/packages/react-instantsearch/src/components/HierarchicalMenu.test.js
+++ b/packages/react-instantsearch/src/components/HierarchicalMenu.test.js
@@ -17,8 +17,6 @@ describe('HierarchicalMenu', () => {
           {value: 'black', count: 20, label: 'black'},
           {value: 'blue', count: 30, label: 'blue'},
         ]}
-        currentRefinement=""
-        selectedItems=""
         limitMin={2}
         limitMax={4}
         showMore={true}
@@ -38,8 +36,6 @@ describe('HierarchicalMenu', () => {
           {value: 'black', count: 20, label: 'black'},
           {value: 'blue', count: 30, label: 'blue'},
         ]}
-        currentRefinement=""
-        selectedItems=""
         translations={{
           showMore: ' display more',
         }}

--- a/packages/react-instantsearch/src/components/List.js
+++ b/packages/react-instantsearch/src/components/List.js
@@ -1,16 +1,10 @@
 import React, {PropTypes, Component} from 'react';
 
 const itemsPropType = PropTypes.arrayOf(PropTypes.shape({
-  value: PropTypes.string.isRequired,
+  value: PropTypes.any,
+  label: PropTypes.string.isRequired,
   children: (...args) => itemsPropType(...args),
 }));
-
-function hasSelectedChild(item, selectedItems) {
-  return item.children && item.children.some(child =>
-    selectedItems.indexOf(child.value) !== -1 ||
-    hasSelectedChild(child, selectedItems)
-  );
-}
 
 class List extends Component {
   static propTypes = {
@@ -18,7 +12,6 @@ class List extends Component {
     // Only required with showMore.
     translate: PropTypes.func,
     items: itemsPropType,
-    selectedItems: PropTypes.arrayOf(PropTypes.string).isRequired,
     renderItem: PropTypes.func.isRequired,
     showMore: PropTypes.bool,
     limitMin: PropTypes.number,
@@ -47,31 +40,25 @@ class List extends Component {
     return extended ? limitMax : limitMin;
   };
 
-  renderItem = (item, parent = null) => {
-    const {selectedItems, applyTheme} = this.props;
-    const selected = selectedItems.indexOf(item.value) !== -1;
-    const limit = this.getLimit();
-
+  renderItem = item => {
     const children = item.children &&
-      <div {...applyTheme('itemChildren', 'itemChildren')}>
-        {item.children.slice(0, limit).map(child =>
+      <div {...this.props.applyTheme('itemChildren', 'itemChildren')}>
+        {item.children.slice(0, this.getLimit()).map(child =>
           this.renderItem(child, item)
         )}
       </div>;
 
-    const selectedParent = hasSelectedChild(item, selectedItems);
-
     return (
       <div
-        {...applyTheme(
-          item.value,
+        {...this.props.applyTheme(
+          item.key || item.label,
           'item',
-          selected && 'itemSelected',
+          item.isRefined && 'itemSelected',
           children && 'item_parent',
-          selectedParent && 'itemSelectedParent'
+          children && item.isRefined && 'itemSelectedParent'
         )}
       >
-        {this.props.renderItem(item, selected, parent, selectedParent)}
+        {this.props.renderItem(item)}
         {children}
       </div>
     );

--- a/packages/react-instantsearch/src/components/Menu.enzyme.test.js
+++ b/packages/react-instantsearch/src/components/Menu.enzyme.test.js
@@ -15,12 +15,10 @@ describe('Menu', () => {
         refine={refine}
         createURL={() => '#'}
         items={[
-          {value: 'white', count: 10},
-          {value: 'black', count: 20},
-          {value: 'blue', count: 30},
+          {label: 'white', value: 'white', count: 10, isRefined: false},
+          {label: 'black', value: 'black', count: 20, isRefined: false},
+          {label: 'blue', value: 'blue', count: 30, isRefined: false},
         ]}
-        currentRefinement=""
-        selectedItems=""
       />
     );
 
@@ -45,14 +43,12 @@ describe('Menu', () => {
         refine={refine}
         createURL={() => '#'}
         items={[
-          {value: 'white', count: 10},
-          {value: 'black', count: 20},
-          {value: 'blue', count: 30},
-          {value: 'green', count: 30},
-          {value: 'red', count: 30},
+          {label: 'white', value: 'white', count: 10, isRefined: false},
+          {label: 'black', value: 'black', count: 20, isRefined: false},
+          {label: 'blue', value: 'blue', count: 30, isRefined: false},
+          {label: 'green', value: 'green', count: 30, isRefined: false},
+          {label: 'red', value: 'red', count: 30, isRefined: false},
         ]}
-        currentRefinement=""
-        selectedItems=""
         limitMin={2}
         limitMax={4}
         showMore={true}
@@ -77,11 +73,9 @@ describe('Menu', () => {
         refine={refine}
         createURL={() => '#'}
         items={[
-          {value: 'white', count: 10},
-          {value: 'black', count: 20},
+          {label: 'white', value: 'white', count: 10, isRefined: false},
+          {label: 'black', value: 'black', count: 20, isRefined: false},
         ]}
-        currentRefinement=""
-        selectedItems=""
         limitMin={2}
         limitMax={4}
         showMore={true}

--- a/packages/react-instantsearch/src/components/Menu.js
+++ b/packages/react-instantsearch/src/components/Menu.js
@@ -16,29 +16,29 @@ class Menu extends Component {
     refine: PropTypes.func.isRequired,
     createURL: PropTypes.func.isRequired,
     items: PropTypes.arrayOf(PropTypes.shape({
+      label: PropTypes.string.isRequired,
       value: PropTypes.string.isRequired,
       count: PropTypes.number.isRequired,
+      isRefined: PropTypes.bool.isRequired,
     })),
-    currentRefinement: PropTypes.string,
     showMore: PropTypes.bool,
     limitMin: PropTypes.number,
     limitMax: PropTypes.number,
   };
 
-  renderItem = (item, selected) => {
+  renderItem = item => {
     const {refine, createURL, applyTheme, translate} = this.props;
-    const value = selected ? null : item.value;
     return (
       <Link
-        {...applyTheme('itemLink', 'itemLink', selected && 'itemLinkSelected')}
-        onClick={refine.bind(null, value)}
-        href={createURL(value)}
+        {...applyTheme('itemLink', 'itemLink', item.isRefined && 'itemLinkSelected')}
+        onClick={() => refine(item.value)}
+        href={createURL(item.value)}
       >
-        <span {...applyTheme('itemLabel', 'itemLabel', selected && 'itemLabelSelected')}>
-          {item.value}
+        <span {...applyTheme('itemLabel', 'itemLabel', item.isRefined && 'itemLabelSelected')}>
+          {item.label}
         </span>
         {' '}
-        <span {...applyTheme('itemCount', 'itemCount', selected && 'itemCountSelected')}>
+        <span {...applyTheme('itemCount', 'itemCount', item.isRefined && 'itemCountSelected')}>
           {translate('count', item.count)}
         </span>
       </Link>
@@ -49,7 +49,6 @@ class Menu extends Component {
     return (
       <List
         renderItem={this.renderItem}
-        selectedItems={[this.props.currentRefinement]}
         {...pick(this.props, [
           'applyTheme',
           'translate',

--- a/packages/react-instantsearch/src/components/Menu.test.js
+++ b/packages/react-instantsearch/src/components/Menu.test.js
@@ -12,14 +12,12 @@ describe('HierarchicalMenu', () => {
         refine={() => null}
         createURL={() => '#'}
         items={[
-          {value: 'white', count: 10},
-          {value: 'black', count: 20},
-          {value: 'blue', count: 30},
-          {value: 'green', count: 30},
-          {value: 'red', count: 30},
+          {label: 'white', value: 'white', count: 10, isRefined: false},
+          {label: 'black', value: 'black', count: 20, isRefined: false},
+          {label: 'blue', value: 'blue', count: 30, isRefined: false},
+          {label: 'green', value: 'green', count: 30, isRefined: false},
+          {label: 'red', value: 'red', count: 30, isRefined: false},
         ]}
-        currentRefinement=""
-        selectedItems=""
         limitMin={2}
         limitMax={4}
         showMore={true}
@@ -34,14 +32,12 @@ describe('HierarchicalMenu', () => {
         refine={() => null}
         createURL={() => '#'}
         items={[
-          {value: 'white', count: 10},
-          {value: 'black', count: 20},
-          {value: 'blue', count: 30},
-          {value: 'green', count: 30},
-          {value: 'red', count: 30},
+          {label: 'white', value: 'white', count: 10, isRefined: false},
+          {label: 'black', value: 'black', count: 20, isRefined: false},
+          {label: 'blue', value: 'blue', count: 30, isRefined: false},
+          {label: 'green', value: 'green', count: 30, isRefined: false},
+          {label: 'red', value: 'red', count: 30, isRefined: false},
         ]}
-        currentRefinement=""
-        selectedItems=""
         limitMin={2}
         limitMax={4}
         showMore={true}

--- a/packages/react-instantsearch/src/components/MultiRange.enzyme.test.js
+++ b/packages/react-instantsearch/src/components/MultiRange.enzyme.test.js
@@ -19,7 +19,6 @@ describe('RangeInput', () => {
           {label: 'label', value: '20:30'},
           {label: 'label', value: '30:'},
         ]}
-        currentRefinement=""
       />
     );
 

--- a/packages/react-instantsearch/src/components/MultiRange.js
+++ b/packages/react-instantsearch/src/components/MultiRange.js
@@ -13,22 +13,21 @@ class MultiRange extends Component {
       label: PropTypes.node.isRequired,
       value: PropTypes.string.isRequired,
     })).isRequired,
-    currentRefinement: PropTypes.string.isRequired,
     refine: PropTypes.func.isRequired,
   };
 
-  renderItem = (item, selected) => {
+  renderItem = item => {
     const {applyTheme, refine} = this.props;
 
     return (
       <label>
         <input
-          {...applyTheme('itemRadio', 'itemRadio', selected && 'itemRadioSelected')}
+          {...applyTheme('itemRadio', 'itemRadio', item.isRefined && 'itemRadioSelected')}
           type="radio"
-          checked={selected}
+          checked={item.isRefined}
           onChange={refine.bind(null, item.value)}
         />
-        <span {...applyTheme('itemLabel', 'itemLabel', selected && 'itemLabelSelected')}>
+        <span {...applyTheme('itemLabel', 'itemLabel', item.isRefined && 'itemLabelSelected')}>
           {item.label}
         </span>
       </label>
@@ -36,15 +35,14 @@ class MultiRange extends Component {
   };
 
   render() {
-    const {items, currentRefinement, applyTheme} = this.props;
+    const {items, applyTheme} = this.props;
 
     return (
       <List
         renderItem={this.renderItem}
         showMore={false}
         applyTheme={applyTheme}
-        items={items}
-        selectedItems={[currentRefinement]}
+        items={items.map(item => ({...item, key: item.value}))}
       />
     );
   }

--- a/packages/react-instantsearch/src/components/MultiRange.test.js
+++ b/packages/react-instantsearch/src/components/MultiRange.test.js
@@ -5,19 +5,18 @@ import renderer from 'react/lib/ReactTestRenderer';
 
 import MultiRange from './MultiRange';
 
-describe('RangeInput', () => {
+describe('MultiRange', () => {
   it('supports passing items values', () => {
     const tree = renderer.create(
       <MultiRange
         createURL={() => '#'}
         refine={() => null}
         items={[
-          {label: 'label', value: '10:'},
-          {label: 'label', value: '10:20'},
-          {label: 'label', value: '20:30'},
-          {label: 'label', value: '30:'},
+          {label: 'label1', value: '10:', isRefined: false},
+          {label: 'label2', value: '10:20', isRefined: false},
+          {label: 'label3', value: '20:30', isRefined: false},
+          {label: 'label4', value: '30:', isRefined: false},
         ]}
-        currentRefinement=""
       />
     ).toJSON();
     expect(tree).toMatchSnapshot();
@@ -29,12 +28,11 @@ describe('RangeInput', () => {
         createURL={() => '#'}
         refine={() => null}
         items={[
-          {label: 'label', value: '10:'},
-          {label: 'label', value: '10:20'},
-          {label: 'label', value: '20:30'},
-          {label: 'label', value: '30:'},
+          {label: 'label1', value: '10:', isRefined: false},
+          {label: 'label2', value: '10:20', isRefined: true},
+          {label: 'label3', value: '20:30', isRefined: false},
+          {label: 'label4', value: '30:', isRefined: false},
         ]}
-        currentRefinement="10:20"
       />
     ).toJSON();
     expect(tree).toMatchSnapshot();

--- a/packages/react-instantsearch/src/components/RangeInput.enzyme.test.js
+++ b/packages/react-instantsearch/src/components/RangeInput.enzyme.test.js
@@ -16,7 +16,7 @@ describe('RangeInput', () => {
         refine={refine}
         min={0}
         max={100}
-        value={{min: 0, max: 100}}
+        currentRefinement={{min: 0, max: 100}}
       />
     );
 
@@ -51,7 +51,7 @@ describe('RangeInput', () => {
         refine={refine}
         min={0}
         max={100}
-        value={{min: 0, max: 100}}
+        currentRefinement={{min: 0, max: 100}}
       />
     );
 

--- a/packages/react-instantsearch/src/components/RangeInput.js
+++ b/packages/react-instantsearch/src/components/RangeInput.js
@@ -13,7 +13,7 @@ class RangeInput extends Component {
     refine: PropTypes.func.isRequired,
     min: PropTypes.number.isRequired,
     max: PropTypes.number.isRequired,
-    value: PropTypes.shape({
+    currentRefinement: PropTypes.shape({
       min: PropTypes.number,
       max: PropTypes.number,
     }).isRequired,
@@ -21,11 +21,11 @@ class RangeInput extends Component {
 
   constructor(props) {
     super(props);
-    this.state = {from: props.value.min, to: props.value.max};
+    this.state = {from: props.currentRefinement.min, to: props.currentRefinement.max};
   }
 
   componentWillReceiveProps(nextProps) {
-    this.setState({from: nextProps.value.min, to: nextProps.value.max});
+    this.setState({from: nextProps.currentRefinement.min, to: nextProps.currentRefinement.max});
   }
 
   onSubmit = e => {

--- a/packages/react-instantsearch/src/components/RangeInput.test.js
+++ b/packages/react-instantsearch/src/components/RangeInput.test.js
@@ -13,7 +13,7 @@ describe('RangeInput', () => {
         refine={() => null}
         min={0}
         max={100}
-        value={{min: 0, max: 100}}
+        currentRefinement={{min: 0, max: 100}}
       />
     ).toJSON();
     expect(tree).toMatchSnapshot();
@@ -30,7 +30,7 @@ describe('RangeInput', () => {
         }}
         min={0}
         max={100}
-        value={{min: 0, max: 100}}
+        currentRefinement={{min: 0, max: 100}}
       />
     ).toJSON();
     expect(tree).toMatchSnapshot();

--- a/packages/react-instantsearch/src/components/RangeRatings.enzyme.test.js
+++ b/packages/react-instantsearch/src/components/RangeRatings.enzyme.test.js
@@ -15,7 +15,7 @@ describe('RangeRatings', () => {
       refine={refine}
       min={1}
       max={5}
-      value={{min: 1, max: 5}}
+      currentRefinement={{min: 1, max: 5}}
       count={[{value: '1', count: 1},
         {value: '2', count: 2},
         {value: '3', count: 3},

--- a/packages/react-instantsearch/src/components/RangeRatings.js
+++ b/packages/react-instantsearch/src/components/RangeRatings.js
@@ -13,7 +13,7 @@ class RangeRatings extends Component {
     createURL: PropTypes.func.isRequired,
     min: PropTypes.number.isRequired,
     max: PropTypes.number.isRequired,
-    value: PropTypes.shape({
+    currentRefinement: PropTypes.shape({
       min: PropTypes.number,
       max: PropTypes.number,
     }).isRequired,
@@ -26,7 +26,7 @@ class RangeRatings extends Component {
   onClick(min, max, e) {
     e.preventDefault();
     e.stopPropagation();
-    if (min === this.props.value.min && max === this.props.value.max) {
+    if (min === this.props.currentRefinement.min && max === this.props.currentRefinement.max) {
       this.props.refine('');
     } else {
       this.props.refine({min, max});
@@ -34,8 +34,8 @@ class RangeRatings extends Component {
   }
 
   buildItem({max, lowerBound, count, applyTheme, translate, createURL}) {
-    const selected = lowerBound === this.props.value.min &&
-      max === this.props.value.max;
+    const selected = lowerBound === this.props.currentRefinement.min &&
+      max === this.props.currentRefinement.max;
     const disabled = !count;
 
     const icons = [];

--- a/packages/react-instantsearch/src/components/RangeRatings.test.js
+++ b/packages/react-instantsearch/src/components/RangeRatings.test.js
@@ -13,7 +13,7 @@ describe('RangeRatings', () => {
         refine={() => null}
         min={1}
         max={5}
-        value={{min: 1, max: 5}}
+        currentRefinement={{min: 1, max: 5}}
         count={[{value: '1', count: 1},
           {value: '2', count: 2},
           {value: '3', count: 3},
@@ -34,7 +34,7 @@ describe('RangeRatings', () => {
         }}
         min={1}
         max={5}
-        value={{min: 1, max: 5}}
+        currentRefinement={{min: 1, max: 5}}
         count={[{value: '1', count: 1},
           {value: '2', count: 2},
           {value: '3', count: 3},

--- a/packages/react-instantsearch/src/components/RefinementList.enzyme.test.js
+++ b/packages/react-instantsearch/src/components/RefinementList.enzyme.test.js
@@ -15,12 +15,10 @@ describe('RefinementList', () => {
         refine={refine}
         createURL={() => '#'}
         items={[
-          {value: 'white', count: 10},
-          {value: 'black', count: 20},
-          {value: 'blue', count: 30},
+          {label: 'white', value: ['white'], count: 10, isRefined: false},
+          {label: 'black', value: ['black'], count: 20, isRefined: false},
+          {label: 'blue', value: ['blue'], count: 30, isRefined: false},
         ]}
-        currentRefinement={[]}
-        selectedItems={[]}
       />
     );
 
@@ -45,17 +43,15 @@ describe('RefinementList', () => {
         refine={refine}
         createURL={() => '#'}
         items={[
-          {value: 'white', count: 10},
-          {value: 'black', count: 20},
-          {value: 'blue', count: 30},
-          {value: 'red', count: 30},
-          {value: 'green', count: 30},
+          {label: 'white', value: ['white'], count: 10, isRefined: false},
+          {label: 'black', value: ['black'], count: 20, isRefined: false},
+          {label: 'blue', value: ['blue'], count: 30, isRefined: false},
+          {label: 'red', value: ['red'], count: 30, isRefined: false},
+          {label: 'green', value: ['green'], count: 30, isRefined: false},
         ]}
         limitMin={2}
         limitMax={4}
         showMore={true}
-        currentRefinement={[]}
-        selectedItems={[]}
       />
     );
 
@@ -77,14 +73,12 @@ describe('RefinementList', () => {
         refine={refine}
         createURL={() => '#'}
         items={[
-          {value: 'white', count: 10},
-          {value: 'black', count: 20},
+          {label: 'white', value: ['white'], count: 10, isRefined: false},
+          {label: 'black', value: ['black'], count: 20, isRefined: false},
         ]}
         limitMin={2}
         limitMax={4}
         showMore={true}
-        currentRefinement={[]}
-        selectedItems={[]}
       />
     );
 

--- a/packages/react-instantsearch/src/components/RefinementList.js
+++ b/packages/react-instantsearch/src/components/RefinementList.js
@@ -15,43 +15,32 @@ class RefinementList extends Component {
     refine: PropTypes.func.isRequired,
     createURL: PropTypes.func.isRequired,
     items: PropTypes.arrayOf(PropTypes.shape({
-      value: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+      value: PropTypes.arrayOf(PropTypes.string).isRequired,
       count: PropTypes.number.isRequired,
+      isRefined: PropTypes.bool.isRequired,
     })),
-    currentRefinement: PropTypes.arrayOf(PropTypes.string),
     showMore: PropTypes.bool,
     limitMin: PropTypes.number,
     limitMax: PropTypes.number,
   };
 
-  onItemChange = (item, e) => {
-    const {currentRefinement} = this.props;
-    const nextSelectedItems = currentRefinement.slice();
-    const idx = nextSelectedItems.indexOf(item.value);
-    if (e.target.checked && idx === -1) {
-      nextSelectedItems.push(item.value);
-    } else if (!e.target.checked && idx !== -1) {
-      nextSelectedItems.splice(idx, 1);
-    }
-    this.props.refine(nextSelectedItems);
-  }
-
-  renderItem = (item, selected) => {
+  renderItem = item => {
     const {translate, applyTheme} = this.props;
 
     return (
       <label>
         <input
-          {...applyTheme('itemCheckbox', 'itemCheckbox', selected && 'itemCheckboxSelected')}
+          {...applyTheme('itemCheckbox', 'itemCheckbox', item.isRefined && 'itemCheckboxSelected')}
           type="checkbox"
-          checked={selected}
-          onChange={this.onItemChange.bind(null, item)}
+          checked={item.isRefined}
+          onChange={() => this.props.refine(item.value)}
         />
-        <span {...applyTheme('itemLabel', 'itemLabel', selected && 'itemLabelSelected')}>
-          {item.value}
+        <span {...applyTheme('itemLabel', 'itemLabel', item.isRefined && 'itemLabelSelected')}>
+          {item.label}
         </span>
         {' '}
-        <span {...applyTheme('itemCount', 'itemCount', selected && 'itemCountSelected')}>
+        <span {...applyTheme('itemCount', 'itemCount', item.isRefined && 'itemCountSelected')}>
           {translate('count', item.count)}
         </span>
       </label>
@@ -62,7 +51,6 @@ class RefinementList extends Component {
     return (
       <List
         renderItem={this.renderItem}
-        selectedItems={this.props.currentRefinement}
         {...pick(this.props, [
           'applyTheme',
           'translate',

--- a/packages/react-instantsearch/src/components/RefinementList.test.js
+++ b/packages/react-instantsearch/src/components/RefinementList.test.js
@@ -12,12 +12,10 @@ describe('RefinementList', () => {
         refine={() => null}
         createURL={() => '#'}
         items={[
-          {value: 'white', count: 10},
-          {value: 'black', count: 20},
-          {value: 'blue', count: 30},
+          {label: 'white', value: ['white'], count: 10, isRefined: true},
+          {label: 'black', value: ['black'], count: 20, isRefined: false},
+          {label: 'blue', value: ['blue'], count: 30, isRefined: false},
         ]}
-        currentRefinement={['white']}
-        selectedItems={['white']}
         limitMin={2}
         limitMax={4}
         showMore={true}
@@ -32,12 +30,10 @@ describe('RefinementList', () => {
         refine={() => null}
         createURL={() => '#'}
         items={[
-          {value: 'white', count: 10},
-          {value: 'black', count: 20},
-          {value: 'blue', count: 30},
+          {label: 'white', value: ['white'], count: 10, isRefined: false},
+          {label: 'black', value: ['black'], count: 20, isRefined: false},
+          {label: 'blue', value: ['blue'], count: 30, isRefined: false},
         ]}
-        currentRefinement={[]}
-        selectedItems={[]}
         translations={{
           showMore: ' display more',
         }}

--- a/packages/react-instantsearch/src/components/Toggle.js
+++ b/packages/react-instantsearch/src/components/Toggle.js
@@ -6,7 +6,7 @@ import theme from './Toggle.css';
 class Toggle extends Component {
   static propTypes = {
     applyTheme: PropTypes.func.isRequired,
-    checked: PropTypes.bool.isRequired,
+    currentRefinement: PropTypes.bool.isRequired,
     refine: PropTypes.func.isRequired,
     label: PropTypes.string.isRequired,
   };
@@ -16,14 +16,14 @@ class Toggle extends Component {
   };
 
   render() {
-    const {applyTheme, checked, label} = this.props;
+    const {applyTheme, currentRefinement, label} = this.props;
 
     return (
       <label {...applyTheme('root')}>
         <input
           {...applyTheme('checkbox')}
           type="checkbox"
-          checked={checked}
+          checked={currentRefinement}
           onChange={this.onChange}
         />
         <span {...applyTheme('label')}>

--- a/packages/react-instantsearch/src/components/__snapshots__/MultiRange.test.js.snap
+++ b/packages/react-instantsearch/src/components/__snapshots__/MultiRange.test.js.snap
@@ -1,4 +1,4 @@
-exports[`RangeInput supports having a selected item 1`] = `
+exports[`MultiRange supports having a selected item 1`] = `
 <div
   className="root">
   <div
@@ -13,7 +13,7 @@ exports[`RangeInput supports having a selected item 1`] = `
           type="radio" />
         <span
           className="itemLabel">
-          label
+          label1
         </span>
       </label>
     </div>
@@ -27,7 +27,7 @@ exports[`RangeInput supports having a selected item 1`] = `
           type="radio" />
         <span
           className="itemLabel itemLabelSelected">
-          label
+          label2
         </span>
       </label>
     </div>
@@ -41,7 +41,7 @@ exports[`RangeInput supports having a selected item 1`] = `
           type="radio" />
         <span
           className="itemLabel">
-          label
+          label3
         </span>
       </label>
     </div>
@@ -55,7 +55,7 @@ exports[`RangeInput supports having a selected item 1`] = `
           type="radio" />
         <span
           className="itemLabel">
-          label
+          label4
         </span>
       </label>
     </div>
@@ -63,7 +63,7 @@ exports[`RangeInput supports having a selected item 1`] = `
 </div>
 `;
 
-exports[`RangeInput supports passing items values 1`] = `
+exports[`MultiRange supports passing items values 1`] = `
 <div
   className="root">
   <div
@@ -78,7 +78,7 @@ exports[`RangeInput supports passing items values 1`] = `
           type="radio" />
         <span
           className="itemLabel">
-          label
+          label1
         </span>
       </label>
     </div>
@@ -92,7 +92,7 @@ exports[`RangeInput supports passing items values 1`] = `
           type="radio" />
         <span
           className="itemLabel">
-          label
+          label2
         </span>
       </label>
     </div>
@@ -106,7 +106,7 @@ exports[`RangeInput supports passing items values 1`] = `
           type="radio" />
         <span
           className="itemLabel">
-          label
+          label3
         </span>
       </label>
     </div>
@@ -120,7 +120,7 @@ exports[`RangeInput supports passing items values 1`] = `
           type="radio" />
         <span
           className="itemLabel">
-          label
+          label4
         </span>
       </label>
     </div>

--- a/packages/react-instantsearch/src/connectors/connectHitsPerPage.js
+++ b/packages/react-instantsearch/src/connectors/connectHitsPerPage.js
@@ -2,7 +2,7 @@ import {PropTypes} from 'react';
 
 import createConnector from '../core/createConnector';
 
-function getHitsPerPage(props, state) {
+function getCurrentRefinement(props, state) {
   if (typeof state[props.id] !== 'undefined') {
     if (typeof state[props.id] === 'string') {
       return parseInt(state[props.id], 10);
@@ -34,7 +34,7 @@ export default createConnector({
 
   getProps(props, state) {
     return {
-      currentRefinement: getHitsPerPage(props, state),
+      currentRefinement: getCurrentRefinement(props, state),
     };
   },
 
@@ -46,7 +46,7 @@ export default createConnector({
   },
 
   getSearchParameters(searchParameters, props, state) {
-    return searchParameters.setHitsPerPage(getHitsPerPage(props, state));
+    return searchParameters.setHitsPerPage(getCurrentRefinement(props, state));
   },
 
   getMetadata(props) {

--- a/packages/react-instantsearch/src/connectors/connectMenu.js
+++ b/packages/react-instantsearch/src/connectors/connectMenu.js
@@ -6,7 +6,7 @@ function getId(props) {
   return props.id || props.attributeName;
 }
 
-function getSelectedItem(props, state) {
+function getCurrentRefinement(props, state) {
   const id = getId(props);
   if (typeof state[id] !== 'undefined') {
     if (state[id] === '') {
@@ -92,17 +92,22 @@ export default createConnector({
       .slice(0, limit)
       .map(v => ({
         value: v.name,
+        label: v.name,
         count: v.count,
+        isRefined: v.isRefined,
       }));
 
-    return {items, currentRefinement: getSelectedItem(props, state)};
+    return {
+      items,
+      currentRefinement: getCurrentRefinement(props, state),
+    };
   },
 
-  refine(props, state, nextSelectedItem) {
+  refine(props, state, nextRefinement) {
     const id = getId(props);
     return {
       ...state,
-      [id]: nextSelectedItem || '',
+      [id]: nextRefinement || '',
     };
   },
 
@@ -119,11 +124,11 @@ export default createConnector({
 
     searchParameters = searchParameters.addDisjunctiveFacet(attributeName);
 
-    const selectedItem = getSelectedItem(props, state);
-    if (selectedItem !== null) {
+    const currentRefinement = getCurrentRefinement(props, state);
+    if (currentRefinement !== null) {
       searchParameters = searchParameters.addDisjunctiveFacetRefinement(
         attributeName,
-        selectedItem
+        currentRefinement
       );
     }
 
@@ -132,11 +137,11 @@ export default createConnector({
 
   getMetadata(props, state) {
     const id = getId(props);
-    const selectedItem = getSelectedItem(props, state);
+    const currentRefinement = getCurrentRefinement(props, state);
     return {
       id,
-      filters: selectedItem === null ? [] : [{
-        label: `${props.attributeName}: ${selectedItem}`,
+      filters: currentRefinement === null ? [] : [{
+        label: `${props.attributeName}: ${currentRefinement}`,
         clear: nextState => ({
           ...nextState,
           [id]: '',

--- a/packages/react-instantsearch/src/connectors/connectMenu.test.js
+++ b/packages/react-instantsearch/src/connectors/connectMenu.test.js
@@ -44,10 +44,12 @@ describe('connectMenu', () => {
     results.getFacetValues.mockImplementation(() => [
       {
         name: 'wat',
+        isRefined: true,
         count: 20,
       },
       {
         name: 'oy',
+        isRefined: false,
         count: 10,
       },
     ]);
@@ -55,10 +57,14 @@ describe('connectMenu', () => {
     expect(props.items).toEqual([
       {
         value: 'wat',
+        label: 'wat',
+        isRefined: true,
         count: 20,
       },
       {
         value: 'oy',
+        label: 'oy',
+        isRefined: false,
         count: 10,
       },
     ]);
@@ -67,6 +73,8 @@ describe('connectMenu', () => {
     expect(props.items).toEqual([
       {
         value: 'wat',
+        label: 'wat',
+        isRefined: true,
         count: 20,
       },
     ]);
@@ -79,6 +87,8 @@ describe('connectMenu', () => {
     expect(props.items).toEqual([
       {
         value: 'wat',
+        label: 'wat',
+        isRefined: true,
         count: 20,
       },
     ]);

--- a/packages/react-instantsearch/src/connectors/connectMultiRange.js
+++ b/packages/react-instantsearch/src/connectors/connectMultiRange.js
@@ -25,7 +25,7 @@ function getId(props) {
   return props.id || props.attributeName;
 }
 
-function getSelectedItem(props, state) {
+function getCurrentRefinement(props, state) {
   const id = getId(props);
   if (typeof state[id] !== 'undefined') {
     return state[id];
@@ -82,27 +82,31 @@ export default createConnector({
 
   getProps(props, state) {
     const {items} = props;
-    const currentRefinement = getSelectedItem(props, state);
+    const currentRefinement = getCurrentRefinement(props, state);
 
     return {
-      items: items.map(item => ({
-        label: item.label,
-        value: stringifyItem(item),
-      })),
+      items: items.map(item => {
+        const value = stringifyItem(item);
+        return {
+          label: item.label,
+          value,
+          isRefined: value === currentRefinement,
+        };
+      }),
       currentRefinement,
     };
   },
 
-  refine(props, state, nextSelectedItem) {
+  refine(props, state, nextRefinement) {
     return {
       ...state,
-      [getId(props, state)]: nextSelectedItem,
+      [getId(props, state)]: nextRefinement,
     };
   },
 
   getSearchParameters(searchParameters, props, state) {
     const {attributeName} = props;
-    const {start, end} = parseItem(getSelectedItem(props, state));
+    const {start, end} = parseItem(getCurrentRefinement(props, state));
 
     if (start) {
       searchParameters = searchParameters.addNumericRefinement(
@@ -123,7 +127,7 @@ export default createConnector({
 
   getMetadata(props, state) {
     const id = getId(props);
-    const value = getSelectedItem(props, state);
+    const value = getCurrentRefinement(props, state);
     const filters = [];
     if (value !== '') {
       const {label} = find(props.items, item => stringifyItem(item) === value);

--- a/packages/react-instantsearch/src/connectors/connectMultiRange.test.js
+++ b/packages/react-instantsearch/src/connectors/connectMultiRange.test.js
@@ -24,7 +24,7 @@ describe('connectMultiRange', () => {
     }, {});
     expect(props).toEqual({
       items: [
-        {label: 'All', value: ''},
+        {label: 'All', value: '', isRefined: true},
       ],
       currentRefinement: '',
     });
@@ -37,8 +37,8 @@ describe('connectMultiRange', () => {
     }, {});
     expect(props).toEqual({
       items: [
-        {label: 'All', value: ''},
-        {label: 'Ok', value: '100:'},
+        {label: 'All', value: '', isRefined: true},
+        {label: 'Ok', value: '100:', isRefined: false},
       ],
       currentRefinement: '',
     });
@@ -51,8 +51,8 @@ describe('connectMultiRange', () => {
     }, {});
     expect(props).toEqual({
       items: [
-        {label: 'All', value: ''},
-        {label: 'Not ok', value: ':200'},
+        {label: 'All', value: '', isRefined: true},
+        {label: 'Not ok', value: ':200', isRefined: false},
       ],
       currentRefinement: '',
     });
@@ -67,10 +67,10 @@ describe('connectMultiRange', () => {
     }, {});
     expect(props).toEqual({
       items: [
-        {label: 'All', value: ''},
-        {label: 'Ok', value: '100:'},
-        {label: 'Not ok', value: ':200'},
-        {label: 'Maybe ok?', value: '100:200'},
+        {label: 'All', value: '', isRefined: true},
+        {label: 'Ok', value: '100:', isRefined: false},
+        {label: 'Not ok', value: ':200', isRefined: false},
+        {label: 'Maybe ok?', value: '100:200', isRefined: false},
       ],
       currentRefinement: '',
     });

--- a/packages/react-instantsearch/src/connectors/connectPagination.js
+++ b/packages/react-instantsearch/src/connectors/connectPagination.js
@@ -3,7 +3,7 @@ import {omit} from 'lodash';
 
 import createConnector from '../core/createConnector';
 
-function getPage(props, state) {
+function getCurrentRefinement(props, state) {
   let page = state[props.id];
   if (typeof page === 'undefined') {
     page = 1;
@@ -34,7 +34,7 @@ export default createConnector({
     }
     return {
       nbPages: search.results.nbPages,
-      page: getPage(props, state),
+      page: getCurrentRefinement(props, state),
     };
   },
 
@@ -46,7 +46,7 @@ export default createConnector({
   },
 
   getSearchParameters(searchParameters, props, state) {
-    return searchParameters.setPage(getPage(props, state) - 1);
+    return searchParameters.setPage(getCurrentRefinement(props, state) - 1);
   },
 
   transitionState(props, prevState, nextState) {

--- a/packages/react-instantsearch/src/connectors/connectRange.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.js
@@ -6,7 +6,7 @@ function getId(props) {
   return props.id || props.attributeName;
 }
 
-function getValue(props, state) {
+function getCurrentRefinement(props, state) {
   const id = getId(props);
   if (typeof state[id] !== 'undefined') {
     let {min, max} = state[id];
@@ -86,29 +86,29 @@ export default createConnector({
     const {
       min: valueMin = min,
       max: valueMax = max,
-    } = getValue(props, state);
+    } = getCurrentRefinement(props, state);
 
     return {
       min,
       max,
-      value: {min: valueMin, max: valueMax},
+      currentRefinement: {min: valueMin, max: valueMax},
       count,
     };
   },
 
-  refine(props, state, nextValue) {
+  refine(props, state, nextRefinement) {
     return {
       ...state,
-      [getId(props)]: nextValue,
+      [getId(props)]: nextRefinement,
     };
   },
 
   getSearchParameters(params, props, state) {
     const {attributeName} = props;
-    const value = getValue(props, state);
+    const currentRefinement = getCurrentRefinement(props, state);
     params = params.addDisjunctiveFacet(attributeName);
 
-    const {min, max} = value;
+    const {min, max} = currentRefinement;
     if (typeof min !== 'undefined') {
       params = params.addNumericRefinement(attributeName, '>=', min);
     }
@@ -121,18 +121,18 @@ export default createConnector({
 
   getMetadata(props, state) {
     const id = getId(props);
-    const value = getValue(props, state);
+    const currentRefinement = getCurrentRefinement(props, state);
     let filter;
-    const hasMin = typeof value.min !== 'undefined';
-    const hasMax = typeof value.max !== 'undefined';
+    const hasMin = typeof currentRefinement.min !== 'undefined';
+    const hasMax = typeof currentRefinement.max !== 'undefined';
     if (hasMin || hasMax) {
       let filterLabel = '';
       if (hasMin) {
-        filterLabel += `${value.min} <= `;
+        filterLabel += `${currentRefinement.min} <= `;
       }
       filterLabel += props.attributeName;
       if (hasMax) {
-        filterLabel += ` <= ${value.max}`;
+        filterLabel += ` <= ${currentRefinement.max}`;
       }
       filter = {
         label: filterLabel,

--- a/packages/react-instantsearch/src/connectors/connectRange.test.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.test.js
@@ -21,7 +21,7 @@ describe('connectRange', () => {
     expect(props).toEqual({
       min: 5,
       max: 10,
-      value: {min: 5, max: 10},
+      currentRefinement: {min: 5, max: 10},
       count: [],
     });
 
@@ -33,7 +33,7 @@ describe('connectRange', () => {
     expect(props).toEqual({
       min: 5,
       max: 10,
-      value: {min: 5, max: 10},
+      currentRefinement: {min: 5, max: 10},
       count: [{value: '5', count: 10}, {value: '2', count: 20}],
     });
 
@@ -50,7 +50,7 @@ describe('connectRange', () => {
     expect(props).toEqual({
       min: 5,
       max: 10,
-      value: {min: 6, max: 9},
+      currentRefinement: {min: 6, max: 9},
       count: [],
     });
 
@@ -64,7 +64,7 @@ describe('connectRange', () => {
     expect(props).toEqual({
       min: 5,
       max: 10,
-      value: {min: 6, max: 9},
+      currentRefinement: {min: 6, max: 9},
       count: [],
     });
 
@@ -77,7 +77,7 @@ describe('connectRange', () => {
     expect(props).toEqual({
       min: 5,
       max: 10,
-      value: {min: 6, max: 9},
+      currentRefinement: {min: 6, max: 9},
       count: [],
     });
   });

--- a/packages/react-instantsearch/src/connectors/connectRefinementList.test.js
+++ b/packages/react-instantsearch/src/connectors/connectRefinementList.test.js
@@ -44,21 +44,27 @@ describe('connectRefinementList', () => {
     results.getFacetValues.mockImplementation(() => [
       {
         name: 'wat',
+        isRefined: true,
         count: 20,
       },
       {
         name: 'oy',
+        isRefined: false,
         count: 10,
       },
     ]);
     props = getProps({id: 'ok'}, {}, {results});
     expect(props.items).toEqual([
       {
-        value: 'wat',
+        value: ['wat'],
+        label: 'wat',
+        isRefined: true,
         count: 20,
       },
       {
-        value: 'oy',
+        value: ['oy'],
+        label: 'oy',
+        isRefined: false,
         count: 10,
       },
     ]);
@@ -66,7 +72,9 @@ describe('connectRefinementList', () => {
     props = getProps({id: 'ok', limitMin: 1}, {}, {results});
     expect(props.items).toEqual([
       {
-        value: 'wat',
+        value: ['wat'],
+        label: 'wat',
+        isRefined: true,
         count: 20,
       },
     ]);
@@ -78,7 +86,9 @@ describe('connectRefinementList', () => {
     );
     expect(props.items).toEqual([
       {
-        value: 'wat',
+        value: ['wat'],
+        label: 'wat',
+        isRefined: true,
         count: 20,
       },
     ]);
@@ -90,10 +100,10 @@ describe('connectRefinementList', () => {
   });
 
   it('calling refine updates the widget\'s state', () => {
-    const nextState = refine({id: 'ok'}, {otherKey: 'val'}, 'yep');
+    const nextState = refine({id: 'ok'}, {otherKey: 'val'}, ['yep']);
     expect(nextState).toEqual({
       otherKey: 'val',
-      ok: 'yep',
+      ok: ['yep'],
     });
   });
 

--- a/packages/react-instantsearch/src/connectors/connectSearchBox.js
+++ b/packages/react-instantsearch/src/connectors/connectSearchBox.js
@@ -2,7 +2,7 @@ import {PropTypes} from 'react';
 
 import createConnector from '../core/createConnector';
 
-function getQuery(props, state) {
+function getCurrentRefinement(props, state) {
   if (typeof state[props.id] !== 'undefined') {
     return state[props.id];
   }
@@ -27,7 +27,7 @@ export default createConnector({
 
   getProps(props, state) {
     return {
-      query: getQuery(props, state),
+      query: getCurrentRefinement(props, state),
     };
   },
 
@@ -39,6 +39,6 @@ export default createConnector({
   },
 
   getSearchParameters(searchParameters, props, state) {
-    return searchParameters.setQuery(getQuery(props, state));
+    return searchParameters.setQuery(getCurrentRefinement(props, state));
   },
 });

--- a/packages/react-instantsearch/src/connectors/connectSortBy.js
+++ b/packages/react-instantsearch/src/connectors/connectSortBy.js
@@ -2,7 +2,7 @@ import {PropTypes} from 'react';
 
 import createConnector from '../core/createConnector';
 
-function getSelectedIndex(props, state) {
+function getCurrentRefinement(props, state) {
   const {id} = props;
   if (state[id]) {
     return state[id];
@@ -37,19 +37,19 @@ export default createConnector({
   },
 
   getProps(props, state) {
-    const currentRefinement = getSelectedIndex(props, state);
+    const currentRefinement = getCurrentRefinement(props, state);
     return {currentRefinement};
   },
 
-  refine(props, state, nextSelectedIndex) {
+  refine(props, state, nextRefinement) {
     return {
       ...state,
-      [props.id]: nextSelectedIndex,
+      [props.id]: nextRefinement,
     };
   },
 
   getSearchParameters(searchParameters, props, state) {
-    const selectedIndex = getSelectedIndex(props, state);
+    const selectedIndex = getCurrentRefinement(props, state);
     return searchParameters.setIndex(selectedIndex);
   },
 

--- a/packages/react-instantsearch/src/connectors/connectToggle.js
+++ b/packages/react-instantsearch/src/connectors/connectToggle.js
@@ -6,13 +6,13 @@ function getId(props) {
   return props.id || props.attributeName;
 }
 
-function getChecked(props, state) {
+function getCurrentRefinement(props, state) {
   const id = getId(props);
   if (state[id]) {
     return state[id] === 'on';
   }
-  if (props.defaultChecked) {
-    return props.defaultChecked;
+  if (props.defaultRefinement) {
+    return props.defaultRefinement;
   }
   return false;
 }
@@ -61,11 +61,11 @@ export default createConnector({
     /**
      * Default state of the widget. Should the toggle be checked by default?
      */
-    defaultChecked: PropTypes.bool,
+    defaultRefinement: PropTypes.bool,
   },
 
   getProps(props, state) {
-    const checked = getChecked(props, state);
+    const checked = getCurrentRefinement(props, state);
     return {checked};
   },
 
@@ -78,7 +78,7 @@ export default createConnector({
 
   getSearchParameters(searchParameters, props, state) {
     const {attributeName, value, filter} = props;
-    const checked = getChecked(props, state);
+    const checked = getCurrentRefinement(props, state);
 
     if (checked) {
       if (attributeName) {
@@ -99,7 +99,7 @@ export default createConnector({
 
   getMetadata(props, state) {
     const id = getId(props);
-    const checked = getChecked(props, state);
+    const checked = getCurrentRefinement(props, state);
     const filters = [];
     if (checked) {
       filters.push({

--- a/packages/react-instantsearch/src/connectors/connectToggle.test.js
+++ b/packages/react-instantsearch/src/connectors/connectToggle.test.js
@@ -23,7 +23,7 @@ describe('connectToggle', () => {
     props = getProps({id: 't'}, {t: 'on'});
     expect(props).toEqual({checked: true});
 
-    props = getProps({id: 't', defaultChecked: true}, {});
+    props = getProps({id: 't', defaultRefinement: true}, {});
     expect(props).toEqual({checked: true});
   });
 

--- a/packages/react-instantsearch/src/core/createHistoryStateManager.js
+++ b/packages/react-instantsearch/src/core/createHistoryStateManager.js
@@ -37,9 +37,13 @@ function applyStateToLocation(location, state, knownKeys) {
       query,
     };
   }
+
   return {
     ...location,
-    search: query ? `?${qs.stringify(query, {sort: alphabeticalSort})}` : '',
+    search:
+      query && Object.keys(query).length > 0 ?
+        `?${qs.stringify(query, {sort: alphabeticalSort, arrayFormat: 'repeat'})}`
+        : '',
   };
 }
 

--- a/stories/3rdPartiesIntegration.stories.js
+++ b/stories/3rdPartiesIntegration.stories.js
@@ -12,7 +12,7 @@ stories.add('Airbnb Rheostat', () =>
   </WrapWithHits>
 );
 
-const ConnectedRange = connectRange(({min, max, value, refine}) => {
+const ConnectedRange = connectRange(({min, max, currentRefinement, refine}) => {
   const updateValue = sliderState => {
     if (sliderState.values[0] !== min || sliderState.values[1] !== max) {
       refine({min: sliderState.values[0], max: sliderState.values[1]});
@@ -24,7 +24,7 @@ const ConnectedRange = connectRange(({min, max, value, refine}) => {
       <Rheostat
         min={min}
         max={max}
-        values={[value.min, value.max]}
+        values={[currentRefinement.min, currentRefinement.max]}
         onChange={updateValue}
       />
     </div>


### PR DESCRIPTION
BREAKING CHANGE:
- when using connectors, `value` is now the precomputed value to
refine, to display the corresponding name, use `label`
- when using connectors, `selectedItems` is no more available. Every
`item` now has a `isRefined` property

Basically this should make using connectors a lot easier since the API
is again more consistent between connectors.