### PR TITLE
docs(guide): reorganising the guide section

### DIFF
--- a/docgen/layouts/HOC/connector.pug
+++ b/docgen/layouts/HOC/connector.pug
@@ -52,8 +52,3 @@ block content
             td(colspan=3)=type.description
   else
     p This connector does not provided props to its wrapped Component.
-  h2#example Example
-    a.anchor(href='#example')
-  if examples
-    each example in examples
-      p!=h.highlight(example, {lang: 'jsx'})

--- a/docgen/layouts/component/widget.pug
+++ b/docgen/layouts/component/widget.pug
@@ -71,6 +71,6 @@ block content
   h2#live See it live
     a.anchor(href='#live')
   if (process.env.NODE_ENV === 'development')
-    p <iframe frameborder="0" height=800px width=800px src="http://localhost:6006/iframe.html?dataId=0&selectedKind=#{name}&selectedStory=default&full=0&down=1&left=0&panelRight=1&downPanel=kadirahq%2Fstorybook-addon-knobs"></iframe>
+    p <iframe frameborder="0" height=800px width=650px src="http://localhost:6006/iframe.html?dataId=0&selectedKind=#{name}&selectedStory=default&full=0&down=1&left=0&panelRight=1&downPanel=kadirahq%2Fstorybook-addon-knobs"></iframe>
   else
-    p <iframe frameborder="0" height=800px width=800px src="https://community.algolia.com/instantsearch.js/react/storybook/iframe.html?dataId=0&selectedKind=#{name}&selectedStory=default&full=0&down=1&left=0&panelRight=1&downPanel=kadirahq%2Fstorybook-addon-knobs"></iframe>
+    p <iframe frameborder="0" height=800px width=650px src="https://community.algolia.com/instantsearch.js/react/storybook/iframe.html?dataId=0&selectedKind=#{name}&selectedStory=default&full=0&down=1&left=0&panelRight=1&downPanel=kadirahq%2Fstorybook-addon-knobs"></iframe>

--- a/docgen/plugins/navigation.js
+++ b/docgen/plugins/navigation.js
@@ -28,9 +28,7 @@ export default function() {
       // Then navigation is sorted by title.
       data.navigation = categories[category].sort((a, b) => {
         if (a.title && b.title &&
-            (a.navWeight === b.navWeight ||
-            a.navWeight === undefined ||
-            b.navWeight === undefined)) {
+            a.navWeight === b.navWeight) {
           return a.title.localeCompare(b.title);
         } else {
           return b.navWeight - a.navWeight;

--- a/docgen/src/component.md
+++ b/docgen/src/component.md
@@ -1,8 +1,9 @@
 ---
-title: Components Introduction
+title: Components
 layout: main-entry.pug
 category: component
 tocVisibility: true
+navWeight: 1000
 ---
 
 ## Components Introduction
@@ -15,5 +16,13 @@ are components that have the ability to interact with the context.
 
 The widgets are plain components that are connected to the instantsearch context.
 To make this connection, they are wrapped using our collection of Higher Order
-Components that we call connectors.
+Components that we call connectors. They are available under 
+the namespace `dom`.
+
+Here's an example for the SearchBox:
+
+```js
+import {SearchBox} from 'react-instantsearch/dom'
+```
+
 

--- a/docgen/src/connector.md
+++ b/docgen/src/connector.md
@@ -1,8 +1,9 @@
 ---
-title: Connectors Introduction
+title: Connectors
 layout: main-entry.pug
 category: HOC
 tocVisibility: true
+navWeight: 1000
 ---
 
 ## Connectors Introduction
@@ -14,4 +15,12 @@ As higher order components, they have an outer component API that we call
 **exposed props** and they will provide some other props to the wrapped
 components which are called the **provided props**.
 
-Connectors are exposed so that you can create your own widgets very easily.
+Connectors are exposed so that you can create your own widgets very easily. They  
+are available under the namespace `connectors` and follow the 
+convention `connectWidgetName`. 
+
+Here's an example for the SearchBox:
+
+```js
+import {connectSearchBox} from 'react-instantsearch/connectors'
+```

--- a/docgen/src/examples.md
+++ b/docgen/src/examples.md
@@ -3,6 +3,7 @@ title: Examples Introduction
 layout: main-entry.pug
 category: examples
 tocVisibility: true
+navWeight: 1000
 ---
 
 ## Examples Introduction

--- a/docgen/src/examples/e-commerce/index.html
+++ b/docgen/src/examples/e-commerce/index.html
@@ -4,6 +4,7 @@ layout: example.pug
 name: e-commerce
 category: examples
 source: https://github.com/algolia/instantsearch.js/tree/v2/docgen/src/examples/e-commerce
+navWeight: 1
 stylesheets:
   - https://cdn.jsdelivr.net/bootstrap/3.3.5/css/bootstrap.min.css
   - https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css

--- a/docgen/src/examples/material-ui/index.html
+++ b/docgen/src/examples/material-ui/index.html
@@ -4,6 +4,7 @@ layout: example.pug
 name: material-ui
 category: examples
 source: https://github.com/algolia/instantsearch.js/tree/v2/docgen/src/examples/material-ui
+navWeight: 1
 stylesheets:
   - https://fonts.googleapis.com/icon?family=Material+Icons
 ---

--- a/docgen/src/examples/media/index.html
+++ b/docgen/src/examples/media/index.html
@@ -4,6 +4,7 @@ layout: example.pug
 name: media
 category: examples
 source: https://github.com/algolia/instantsearch.js/tree/v2/docgen/src/examples/media
+navWeight: 1
 stylesheets:
   - https://cdn.jsdelivr.net/bootstrap/3.3.5/css/bootstrap.min.css
   - https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css

--- a/docgen/src/examples/tourism/index.html
+++ b/docgen/src/examples/tourism/index.html
@@ -4,6 +4,7 @@ layout: example.pug
 name: tourism
 category: examples
 source: https://github.com/algolia/instantsearch.js/tree/v2/docgen/src/examples/tourism
+navWeight: 1
 stylesheets:
   - https://cdn.jsdelivr.net/bootstrap/3.3.5/css/bootstrap.min.css
   - https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css

--- a/docgen/src/gettingstarted.md
+++ b/docgen/src/gettingstarted.md
@@ -49,7 +49,7 @@ npm install --save react-instantsearch
 
 ## Add the InstantSearch wrapper
 
-The [instantsearch](InstantSearch.html) wrapper is the component that will connect to Algolia
+The [instantsearch](/component/InstantSearch.html) wrapper is the component that will connect to Algolia
 and that will synchronise all the widgets together. It maintains the state
 of the search, do the queries and provide the results to the widgets so
 that they can update themselves if needed.
@@ -86,7 +86,7 @@ In this section we've seen:
  - configure your credentials with react-instantsearch
 
  > To get more *under the hood* information about the `InstantSearch` wrapper
- > component, we have [full documentation](InstantSearch.html) in the widget
+ > component, we have [full documentation](/component/InstantSearch.html) in the widget
  > section.
 
 ## Display the results
@@ -94,7 +94,7 @@ In this section we've seen:
 The core of a search experience is to display results. By default, react-instantsearch
 will do a query at the start of the page.
 
-The next widget we want to use is the [Hits](Hits.html) widget. This widget will
+The next widget we want to use is the [Hits](component/Hits.html) widget. This widget will
 display all the results returned by Algolia, and it will update when there
 are new results.
 
@@ -172,7 +172,7 @@ Now that we've added the results, we can start querying our index and filtering 
 to extract the meaningful records. With Algolia, the main way to filter the records
 into hits, is the text search.
 
-To implement this, react-instantsearch provides the [Searchbox](SearchBox.html) component. Let's add it
+To implement this, react-instantsearch provides the [Searchbox](component/SearchBox.html) component. Let's add it
 in the Search component that we created before:
 
 ```javascript
@@ -228,7 +228,7 @@ may also want to provide filters based on the structure of the records.
 Algolia provides a set of parameters for filtering by facets, numbers or geo
 location. Instantsearch packages those into a set of components and connector.
 
-Since the dataset used here is an e-commerce one, let's add a [RefinementList](RefinementList.html)
+Since the dataset used here is an e-commerce one, let's add a [RefinementList](component/RefinementList.html)
 to filter the products by categories:
 
 ```javascript
@@ -264,8 +264,8 @@ We now miss two elements in our search interface:
  - the ability to browse beyond the first page of results
  - the ability to reset the search state
 
-Those two features are implemented respectively with the [Pagination](Pagination.html), the [ClearAll](ClearAll.html)
-and [CurrentRefinements](CurrentRefinements.html) components. Both have nice defaults which means that
+Those two features are implemented respectively with the [Pagination](component/Pagination.html), the [ClearAll](component/ClearAll.html)
+and [CurrentRefinements](component/CurrentRefinements.html) components. Both have nice defaults which means that
 we can use them directly without further configuration.
 
 ```javascript
@@ -303,7 +303,7 @@ components can be customised further using connectors, like
 in the paragraph about displaying the results.
 
 Here are some suggested guides and references that you might be interested in:
- - [How to style your search](Styling.html)
+ - [How to style your search](/guides/styling.html)
  - [Advanced examples using react-instantsearch](examples.html)
- - [The API for widgets and components](InstantSearch.html)
+ - [The API for widgets and components](component.html)
  - [All the other guides](guides.html)

--- a/docgen/src/guides.md
+++ b/docgen/src/guides.md
@@ -1,11 +1,48 @@
 ---
-title: Guides Introduction
+title: What's react-instantsearch? 
 layout: main-entry.pug
 category: guide
 tocVisibility: true
-navWeight: 0
+navWeight: 7
 ---
-## Introduction
+
+React-instantsearch is the ultimate toolbox for creating instant search experience using React and Algolia. 
+It's built around three pillars: 
+
+* InstantSearch component
+* Widgets
+* Connectors
+
+## Instant Search
+
+React-instantsearch provides a root component. The root-component will provide a context to 
+its children to let them interact with Algolia. 
+
+* [Check out the InstantSearch API documentation.](component/InstantSearch.html) 
+
+## Widgets
+
+React-instantsearch provides a set of widgets that are styled and ready to use.
+
+The widgets are plain components that are connected to the instantsearch context. 
+To make this connection, they are wrapped using our collection of Higher Order Components that we call connectors.
+
+* [Check out the widgets API documentation.](/component.html) 
+
+## Connectors
+
+While react-instantsearch already provides widgets out of the box, there are cases where you need to implement 
+a custom feature that isn't covered by the default widget set.
+ 
+Connectors are higher order components. They encapsulate the logic for a specific kind of widget 
+and they provide a way to interact with the instantsearch context.
+
+Connectors are exposed so that you can create your own widgets very easily.
+
+* [Check out our connectors guide to learn how to use them.](/guides/connectors.html) 
+* [Check out the connectors API documentation.](/connector.html) 
+
+## Going further
 In order to complete your knowledge of react-instantsearch, we wrote a series
 of guides. Each guide covers a specific subject from a practical point of view.
 

--- a/docgen/src/guides/3rd-party-librairies.md
+++ b/docgen/src/guides/3rd-party-librairies.md
@@ -1,16 +1,16 @@
 ---
-title: Integration with other React UI Libraries
+title: 3rd party UI Libraries
 layout: guide.pug
 category: guide
+navWeight: 3
 ---
 
 Even if react-instantsearch provides widgets out of the box you are free to use it with
 any other React UI library (such as Material-UI, React Toolbox, React-Bootstrap and so
 on...). It also applies if you already have components of your own.
 
-To integrate react-instantsearch with another component you can use the **default connector provided by each widget**.
-Once connected, react-instantsearch widgets will behave as High-Order Components.
-More on that on the [making your own widgets](Customization.html#making-your-own-widgets) documentation.
+To integrate react-instantsearch within another component you can use the **connector provided for each kind of widget**.
+Check out the [connectors guide](connectors.html) to learn how to use them.
 
 Let's take an example building a SearchBox using Material UI:
 
@@ -40,8 +40,8 @@ Then, you will be able to use your `ConnectedSearchBox` inside the `InstantSearc
  </InstantSearch>
 ```
 
-Basically this strategy will work with any UI libraries. However, if you hit any limitation with the default connectors
-you can also [create your own connectors](Customization.html#creating-your-own-connectors).
+Basically this strategy will work with any UI libraries. However, if you hit any limitation with the connectors we provide
+you can also [create your own connectors](create-own-widget.html).
 
 ## Check out our Examples !
 
@@ -49,8 +49,6 @@ In this section you can find several examples based on popular React UI librarie
 
 ### Material-UI
 
-<script src="webpack.assets[`assets/img/examples/ecommerce.png>"></script>
+[![material-ui-demo](/assets/img/material-ui.gif)](/examples/material-ui)
 
-[![material-ui-demo](assets/img/material-ui.gif)](MaterialUI.html)
-
-[View it live](MaterialUI.html), [read the code](http://github.com/algolia/instantsearch.js/tree/v2/docgen/src/examples/material-ui)
+[View it live](/examples/material-ui), [read the code](http://github.com/algolia/instantsearch.js/tree/v2/docgen/src/examples/material-ui)

--- a/docgen/src/guides/advanced-topics.md
+++ b/docgen/src/guides/advanced-topics.md
@@ -1,0 +1,70 @@
+---
+title: Advanced Topics
+layout: guide.pug
+category: guide
+navWeight: 0
+---
+
+## How to preselect values
+
+Let's say you want to have some facet values already selected but without displaying them to the user. What you could do
+is to to use a connector that will render nothing, like a virtual widget. 
+
+Here's an example using the Menu connector to display by default the results from the "Dining" category.
+
+```
+const ConnectedMenu = connectMenu(() => {
+    return null;
+  });
+
+<ConnectedMenu attributeName="category" defaultRefinement="Dining"/>
+```
+
+## How to use manual values with Menu and List
+
+By default Algolia provides automatically the facet values that are being displayed in a Menu or in a List. But sometimes
+for one reason or another you might want to be able to provide manually those facet values.
+
+To do that, you can use the appropriate connector and manually add your values.
+
+Here's an example to force category values for a Menu.
+
+```
+const ConnectedMenu = connectMenu(props => {
+    const items = [];`
+    
+    items.push(
+      {label: 'Outdoor', value: 'Outdoor'},
+      {label: 'Dining', value: 'Dining'},
+      {label: 'Bathroom', value: 'Bathroom'},
+    );
+    
+    return <div>{items.map(i =>
+        <div key={i.value}>
+          <a href={props.createURL(i.value)}
+             onClick={() => props.refine(i.value)}>
+            {i.label}</a>
+        </div>
+      )}</div>;
+```
+
+## How to synchronize the url with the search
+
+The InstantSearch component features a complete URL synchronization solution. Whenever a widget's state changes, the URL will be updated to reflect the new state of the search UI. This has two main benefits:
+
+* the user can use the browser's back and forward buttons to navigate back and forth between the different states of the search.
+* the user can bookmark, copy and share a custom search URL.`
+
+To activate this feature, you need to pass the `urlSync` props when instantiating the InstantSearch component.
+
+Here's an example
+
+```
+<InstantSearch
+    appId="appId"
+    apiKey="apiKey"
+    indexName="indexName"
+    urlSync
+  >
+</InstantSearch>
+```

--- a/docgen/src/guides/conditional-display.md
+++ b/docgen/src/guides/conditional-display.md
@@ -2,18 +2,19 @@
 title: Conditional Display
 layout: guide.pug
 category: guide
+navWeight: 1
 ---
 
-Using our connector and [`createConnector`](Customization.html#creating-your-own-connectors) approach, you can 
+Using our connector and [`createConnector`](create-own-widget.html) approach, you can 
 conditionally displayed content based on the search state. 
 
 Below are some typical use cases when using conditional display makes sense but don't hesitate to read the 
-[making your own widget documentation](Customization.html#creating-your-own-connectors), it will give you more details 
+[create your own widget documentation](create-own-widget.html), it will give you more details 
 about the api. 
 
 ## Displaying content when the query is empty
 
-You can do that by using the [`createConnector`](Customization.html#creating-your-own-connectors) function and
+You can do that by using the [`createConnector`](create-own-widget.html) function and
 then access the `state` of all widgets. By doing so you're able to get the query and decide what to do according to its state.
 
 Here's an example:
@@ -34,7 +35,7 @@ const Content = createConnector({
 
 ## Displaying content when there's no results 
  
-By using the [`createConnector`](Customization.html#creating-your-own-connectors) function you may also access the `search` object 
+By using the [`createConnector`](create-own-widget.html) function you may also access the `search` object 
 that holds the search results, search errors and search loading state. By doing so you're able to get the number of hits 
 returned and decide what to do according to this number. 
 
@@ -57,7 +58,7 @@ const content = createConnector({
 
 ## Displaying content when there's an error
  
-By using the [`createConnector`](Customization.html#creating-your-own-connectors) function you may also access the `search` object 
+By using the [`createConnector`](create-own-widget.html) function you may also access the `search` object 
 that holds the search results, search errors and search loading state. By doing so you're able to know when an error occurred and 
 decide what to do with it. 
 

--- a/docgen/src/guides/connectors.md
+++ b/docgen/src/guides/connectors.md
@@ -1,0 +1,69 @@
+---
+title: Using connectors
+layout: guide.pug
+category: guide
+navWeight: 4
+---
+
+While react-instantsearch already provides widgets out of the box, 
+there are cases where you need to implement a custom feature that isn't covered by the default widget set.
+
+Connectors are higher order components. They encapsulate the logic for
+a specific kind of widget and they provide a way to interact with
+the instantsearch context.
+
+As higher order components, they have an outer component API that we call
+**exposed props** and they will provide some other props to the wrapped
+components which are called the **provided props**.
+
+Connectors are exposed so that you can create your own widgets very easily.
+
+## How to use connectors
+
+All default widgets have a corresponding higher-order component that acts as a connector, providing the required props to the widget.
+
+For instance, if you want to create your own search box, you will need to use the `connectSearchBox` connector:
+
+```js
+import {connectSearchBox} from 'react-instantsearch/connectors';
+
+const MySearchBox = props =>
+  <input
+    type="text"
+    value={props.query}
+    onChange={e => props.refine(e.target.value)}
+  />;
+
+// `ConnectedSearchBox` renders a `MySearchBox` component that is connected to
+// the InstantSearch state, providing it with `query` and `refine` props for
+// reading and manipulating the current query of the search.
+// Note that this `ConnectedSearchBox` component will only work when rendered
+// as a child or a descendant of the `InstantSearch` component.
+const ConnectedSearchBox = connectSearchBox(MySearchBox);
+```
+
+### Stateful widgets
+
+While some widgets hold no state, like the `Hits` widget which simply renders the available hits, others do. For instance, the `SearchBox` widget's state is the current query.
+
+When a widget is stateful, its state will get serialized and persisted to the URL. The corresponding URL parameter key can be customized via the widget's `id` prop.
+
+Stateful widgets are also provided with `refine` and `createURL` methods. The `refine(nextState)` method allows the widget to edit its state, while the `createURL(nextState)` method allows the widget to generate a URL for the corresponding state.
+
+```js
+// Here's a variation on the usage of `connectSearchBox`: a component that just
+// renders a link to set the current query to "cute cats".
+// By adding an `onClick` handler on top of the `href`, and cancelling the
+// default behavior of the link, we avoid making a full-page reload when the
+// user clicks on the link, while ensuring that opening the link in a new tab
+// still works.
+const LookUpCuteCats = connectSearchBox(props =>
+  <a
+    href={props.createURL('cute cats')}
+    onClick={e => {
+      e.preventDefault();
+      props.refine('cute cats');
+    }}
+  />
+);
+```

--- a/docgen/src/guides/create-own-widget.md
+++ b/docgen/src/guides/create-own-widget.md
@@ -1,64 +1,13 @@
 ---
-title: Making your own widgets
+title: Creating widgets
 layout: guide.pug
 category: guide
+navWeight: 2
 ---
 
-While react-instantsearch already provides widgets out of the box, there are cases where you need to implement a custom feature that isn't covered by the default widget set.
-
-## Default widgets connectors
-
-All default widgets have a corresponding higher-order component that acts as a connector, providing the required props to the widget.
-
-For instance, if you want to create your own search box, you will need to use the `connectSearchBox` connector:
-
-```js
-import {connectSearchBox} from 'react-instantsearch/connectors';
-
-const MySearchBox = props =>
-  <input
-    type="text"
-    value={props.query}
-    onChange={e => props.refine(e.target.value)}
-  />;
-
-// `ConnectedSearchBox` renders a `MySearchBox` component that is connected to
-// the InstantSearch state, providing it with `query` and `refine` props for
-// reading and manipulating the current query of the search.
-// Note that this `ConnectedSearchBox` component will only work when rendered
-// as a child or a descendant of the `InstantSearch` component.
-const ConnectedSearchBox = connectSearchBox(MySearchBox);
-```
-
-### Stateful widgets
-
-While some widgets hold no state, like the `Hits` widget which simply renders the available hits, others do. For instance, the `SearchBox` widget's state is the current query.
-
-When a widget is stateful, its state will get serialized and persisted to the URL. The corresponding URL parameter key can be customized via the widget's `id` prop.
-
-Stateful widgets are also provided with `refine` and `createURL` methods. The `refine(nextState)` method allows the widget to edit its state, while the `createURL(nextState)` method allows the widget to generate a URL for the corresponding state.
-
-```js
-// Here's a variation on the usage of `connectSearchBox`: a component that just
-// renders a link to set the current query to "cute cats".
-// By adding an `onClick` handler on top of the `href`, and cancelling the
-// default behavior of the link, we avoid making a full-page reload when the
-// user clicks on the link, while ensuring that opening the link in a new tab
-// still works.
-const LookUpCuteCats = connectSearchBox(props =>
-  <a
-    href={props.createURL('cute cats')}
-    onClick={e => {
-      e.preventDefault();
-      props.refine('cute cats');
-    }}
-  />
-);
-```
-
-## Creating your own connectors
-
 If you wish to implement features that are not covered by the default widgets connectors, you will need to create your own connector via the `createConnector` method. This methods takes in a descriptor of your connector with the following properties and methods:
+
+## Creating your own connector
 
 ### displayName, propTypes, defaultProps
 

--- a/docgen/src/guides/internationalization.md
+++ b/docgen/src/guides/internationalization.md
@@ -2,6 +2,7 @@
 title: Internationalization
 layout: guide.pug
 category: guide
+navWeight: 5
 ---
 
 All widgets rendering text that is not otherwise configurable via props accept a `translations` prop. This prop is a mapping of keys to translation values. Translation values can be either a `String` or a `Function`, as some take parameters. The different translation keys supported by components and their optional parameters are described on their respective documentation page.

--- a/docgen/src/guides/styling.md
+++ b/docgen/src/guides/styling.md
@@ -2,6 +2,7 @@
 title: Styling
 layout: guide.pug
 category: guide
+navWeight: 6
 ---
 
 Default widgets in react-instantsearch comes with some styling already applied and loaded. When styling components, you can decide to either extend or completely replace our default styles, using CSS class names.

--- a/docgen/src/stylesheets/components/_documentation.scss
+++ b/docgen/src/stylesheets/components/_documentation.scss
@@ -397,4 +397,4 @@ tr.api-entry-description {
   }
 }
 
-@import "docs/method"
+@import "docs/method";


### PR DESCRIPTION
Contains the reorganization of our guide section following #1315 proposition.

Also includes:
1. Usage of navWeight to make intro page first in their TOC
2. Remove Examples section from connectors API
3. Resizing of the storybook iframe
4. Correcting dead links

I'll let you watch the doc but they are currently some duplications between the Guides Intro Page and the API Intro Page, as well as the intro for the Using Connectors guide. Your feedback on that is more than welcome :)