### PR TITLE
docs(sort function): more info on expected function param

### DIFF
--- a/docs/_includes/widget-jsdoc/hierarchicalMenu.md
+++ b/docs/_includes/widget-jsdoc/hierarchicalMenu.md
@@ -33,7 +33,7 @@
 <span class='attr-optional'>`options.sortBy`<span class="show-description">…</span></span>
   <span class="attr-infos">Default:<code class="attr-default">[&#x27;name:asc&#x27;]</code>(<code>Array.&lt;string&gt;</code> &#124; <code>function</code>)</span>
 </p>
-<p class="attr-description">How to sort refinements. Possible values: `count|isRefined|name:asc|name:desc`</p>
+<p class="attr-description">How to sort refinements. Possible values: `count|isRefined|name:asc|name:desc`.     You can also use a sort function that behaves like the standard Javascript [compareFunction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#Syntax).</p>
 <p class="attr-name">
 <span class='attr-optional'>`options.templates`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>Object</code>)</span>

--- a/docs/_includes/widget-jsdoc/menu.md
+++ b/docs/_includes/widget-jsdoc/menu.md
@@ -13,7 +13,7 @@
 <span class='attr-optional'>`options.sortBy`<span class="show-description">…</span></span>
   <span class="attr-infos">Default:<code class="attr-default">[&#x27;count:desc&#x27;, &#x27;name:asc&#x27;]</code>(<code>Array.&lt;string&gt;</code> &#124; <code>function</code>)</span>
 </p>
-<p class="attr-description">How to sort refinements. Possible values: `count|isRefined|name:asc|name:desc`</p>
+<p class="attr-description">How to sort refinements. Possible values: `count|isRefined|name:asc|name:desc`.     You can also use a sort function that behaves like the standard Javascript [compareFunction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#Syntax).</p>
 <p class="attr-name">
 <span class='attr-optional'>`options.limit`<span class="show-description">…</span></span>
   <span class="attr-infos">Default:<code class="attr-default">10</code>(<code>string</code>)</span>

--- a/docs/_includes/widget-jsdoc/refinementList.md
+++ b/docs/_includes/widget-jsdoc/refinementList.md
@@ -18,7 +18,7 @@
 <span class='attr-optional'>`options.sortBy`<span class="show-description">…</span></span>
   <span class="attr-infos">Default:<code class="attr-default">[&#x27;count:desc&#x27;, &#x27;name:asc&#x27;]</code>(<code>Array.&lt;string&gt;</code> &#124; <code>function</code>)</span>
 </p>
-<p class="attr-description">How to sort refinements. Possible values: `count:asc|count:desc|name:asc|name:desc|isRefined`</p>
+<p class="attr-description">How to sort refinements. Possible values: `count:asc|count:desc|name:asc|name:desc|isRefined`.     You can also use a sort function that behaves like the standard Javascript [compareFunction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#Syntax).</p>
 <p class="attr-name">
 <span class='attr-optional'>`options.limit`<span class="show-description">…</span></span>
   <span class="attr-infos">Default:<code class="attr-default">10</code>(<code>string</code>)</span>

--- a/src/widgets/hierarchical-menu/hierarchical-menu.js
+++ b/src/widgets/hierarchical-menu/hierarchical-menu.js
@@ -22,7 +22,8 @@ const bem = bemHelper('ais-hierarchical-menu');
  * @param  {string} [options.rootPath] Prefix path to use if the first level is not the root level.
  * @param  {string} [options.showParentLevel=false] Show the parent level of the current refined value
  * @param  {number} [options.limit=10] How much facet values to get
- * @param  {string[]|Function} [options.sortBy=['name:asc']] How to sort refinements. Possible values: `count|isRefined|name:asc|name:desc`
+ * @param  {string[]|Function} [options.sortBy=['name:asc']] How to sort refinements. Possible values: `count|isRefined|name:asc|name:desc`.  
+ *   You can also use a sort function that behaves like the standard Javascript [compareFunction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#Syntax).
  * @param  {Object} [options.templates] Templates to use for the widget
  * @param  {string|Function} [options.templates.header=''] Header template (root level only)
  * @param  {string|Function} [options.templates.item] Item template, provided with `name`, `count`, `isRefined`, `url` data properties

--- a/src/widgets/menu/menu.js
+++ b/src/widgets/menu/menu.js
@@ -20,7 +20,8 @@ const bem = bemHelper('ais-menu');
  * @function menu
  * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
  * @param  {string} options.attributeName Name of the attribute for faceting
- * @param  {string[]|Function} [options.sortBy=['count:desc', 'name:asc']] How to sort refinements. Possible values: `count|isRefined|name:asc|name:desc`
+ * @param  {string[]|Function} [options.sortBy=['count:desc', 'name:asc']] How to sort refinements. Possible values: `count|isRefined|name:asc|name:desc`.  
+ *   You can also use a sort function that behaves like the standard Javascript [compareFunction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#Syntax).
  * @param  {string} [options.limit=10] How many facets values to retrieve
  * @param  {object|boolean} [options.showMore=false] Limit the number of results and display a showMore button
  * @param  {object} [options.showMore.templates] Templates to use for showMore

--- a/src/widgets/refinement-list/refinement-list.js
+++ b/src/widgets/refinement-list/refinement-list.js
@@ -21,7 +21,8 @@ const bem = bemHelper('ais-refinement-list');
  * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
  * @param  {string} options.attributeName Name of the attribute for faceting
  * @param  {string} [options.operator='or'] How to apply refinements. Possible values: `or`, `and`
- * @param  {string[]|Function} [options.sortBy=['count:desc', 'name:asc']] How to sort refinements. Possible values: `count:asc|count:desc|name:asc|name:desc|isRefined`
+ * @param  {string[]|Function} [options.sortBy=['count:desc', 'name:asc']] How to sort refinements. Possible values: `count:asc|count:desc|name:asc|name:desc|isRefined`.  
+ *   You can also use a sort function that behaves like the standard Javascript [compareFunction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#Syntax).
  * @param  {string} [options.limit=10] How much facet values to get. When the show more feature is activated this is the minimum number of facets requested (the show more button is not in active state).
  * @param  {object|boolean} [options.showMore=false] Limit the number of results and display a showMore button
  * @param  {object} [options.showMore.templates] Templates to use for showMore


### PR DESCRIPTION
This is a small update of our docs to indicate that the function option for `sortBy` in the menu, hierarchicalMenu and refinementList widgets is the same as the `compareFunction` param for the standard Javascript `Array.prototype.sort`.