### PR TITLE
chore(release): separate release from docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,15 @@ npm run dev # watch mode, no lint
 npm run lint # only changed files in dev, all files in CI
 npm run lint:fix
 ```
+
+# Release
+
+```sh
+npm run release
+```
+
+# Update docs
+
+```sh
+npm run docs:update
+```

--- a/docgen/src/gettingstarted.md
+++ b/docgen/src/gettingstarted.md
@@ -9,10 +9,6 @@ category: gettingstarted
 React-instantsearch is the ultimate toolbox for creating instant search
 experience using [React](https://facebook.github.io/react/) and Algolia.
 
-**react-instantsearch is currently in Alpha stage, which means that API will
-break and you are VERY welcome to make any constructive feedback about your
-experience with our newest library on [github](https://github.com/algolia/instantsearch.js/issues/new?labels[]=packages/react-instantsearch) or [gitter](https://gitter.im/algolia/instantsearch.js). Thanks for trying it!**
-
 In this tutorial, you'll learn how to:
 
  - add react-instantsearch in your [React](https://facebook.github.io/react/) project

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "start": "NODE_ENV=development babel-node docgen/start.js & npm run storybook & wait",
     "build": "NODE_ENV=production ./scripts/build.sh",
     "docs:build": "DOCS_DIST=docs/react babel-node docgen/build.js && npm run build-storybook",
-    "docs:publish": "babel-node scripts/gh-pages.js",
+    "docs:update": "./scripts/docs:update.sh",
     "release": "NODE_ENV=production ./scripts/release.sh",
     "lint": "if [ \"$CI\" = \"true\" ]; then eslint .; else eslint . --cache; fi",
     "lint:fix": "eslint . --fix",

--- a/scripts/docs:update.sh
+++ b/scripts/docs:update.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e # exit when error
+
+NODE_ENV=production DOCS_MOUNT_POINT=/instantsearch.js/react/ DOCS_DIST=docs/react/ npm run docs:build &&
+babel-node scripts/gh-pages.js

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -46,12 +46,13 @@ yarn
 
 newVersion=$(npm version --no-git-tag-version prerelease)
 
-# now build react-instantsearch
 (
 cd packages/react-instantsearch
 npm version --no-git-tag-version prerelease
+yarn
 )
 
+yarn
 npm run build
 
 # update changelog, not yet because of prototyping
@@ -66,7 +67,7 @@ npm run doctoc
 # git add and tag
 # commitMessage="v$newVersion\n\n$changelog"
 commitMessage="$newVersion"
-git add package.json CHANGELOG.md README.md CONTRIBUTING.md packages/
+git add package.json CHANGELOG.md README.md CONTRIBUTING.md packages/ yarn.lock
 printf "%s" $commitMessage | git commit --file -
 # not git tagging for now, still prototyping
 # git tag "v$newVersion"
@@ -85,9 +86,6 @@ npm publish
 cd ..
 rm -rf dist/
 )
-
-DOCS_MOUNT_POINT=/instantsearch.js/react/ NODE_ENV=production DOCS_DIST=docs/react/ npm run docs:build
-npm run docs:publish
 
 printf "Release:
 Package was published to npm.

--- a/yarn.lock
+++ b/yarn.lock
@@ -6697,7 +6697,7 @@ react-inspector@^1.1.0:
     is-dom "^1.0.5"
 
 "react-instantsearch@file:./packages/react-instantsearch/":
-  version "2.0.0-beta.15"
+  version "2.0.0-beta.16"
   dependencies:
     algoliasearch "^3.18.1"
     algoliasearch-helper "^2.14.0"


### PR DESCRIPTION
There's now two separate commands:
- npm run release
- npm run docs:update

So that we can update the website without having to do a new release
of the libraries.