### PR TITLE
docs(examples): add url sync

### DIFF
--- a/docgen/src/examples/e-commerce/App.js
+++ b/docgen/src/examples/e-commerce/App.js
@@ -19,25 +19,26 @@ import {
   connectHits,
   connectMultiRange,
 } from 'react-instantsearch/connectors';
+import {withUrlSync} from '../urlSync';
 
-export default function App() {
-  return (
-    <InstantSearch
-      className="container-fluid"
-      appId="latency"
-      apiKey="6be0576ff61c053d5f9a3225e2a90f76"
-      indexName="ikea"
-    >
-      <div>
-        <Header />
-        <div className="content-wrapper">
-          <Facets />
-          <CustomResults />
-        </div>
+const App = props =>
+  <InstantSearch
+    className="container-fluid"
+    appId="latency"
+    apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+    indexName="ikea"
+    state={props.state}
+    createURL={props.createURL.bind(this)}
+    onStateChange={props.onStateChange.bind(this)}
+  >
+    <div>
+      <Header />
+      <div className="content-wrapper">
+        <Facets />
+        <CustomResults />
       </div>
-    </InstantSearch>
-  );
-}
+    </div>
+  </InstantSearch>;
 
 const Header = () =>
   <header className="content-wrapper">
@@ -295,3 +296,5 @@ const PriceRange = ({label, value, onClick}) =>
 const ConnectedSearchBox = connectSearchBox(CustomCheckbox);
 const ConnectedColorRefinementList = connectRefinementList(CustomColorRefinementList);
 const ConnectedHits = connectHits(CustomHits);
+
+export default withUrlSync(App);

--- a/docgen/src/examples/e-commerce/style.css
+++ b/docgen/src/examples/e-commerce/style.css
@@ -344,7 +344,7 @@ aside .facet-color[data-facet-value="White stained oak effect"] {
 
 .results-wrapper {
   position: absolute;
-  top: 0;
+  top: 60px;
   right: 0;
   padding: 70px 10px 10px 240px;
 }
@@ -386,7 +386,7 @@ aside .facet-color[data-facet-value="White stained oak effect"] {
   display: inline-block;
 }
 
-.ClearAll {
+.ais-ClearAll__root {
   display: block;
   margin-bottom: 16px;
   font-size: 13px;

--- a/docgen/src/examples/material-ui/App.js
+++ b/docgen/src/examples/material-ui/App.js
@@ -33,23 +33,24 @@ import {
 } from 'material-ui';
 import {BottomNavigation, BottomNavigationItem} from 'material-ui/BottomNavigation';
 import SortIcon from 'material-ui/svg-icons/content/sort';
+import {withUrlSync} from '../urlSync';
 
 injectTapEventPlugin();
 
-export default function App() {
-  return (
-    <MuiThemeProvider>
-      <MaterialUiExample />
-    </MuiThemeProvider>
-  );
-}
+const App = props =>
+  <MuiThemeProvider>
+    <MaterialUiExample {...props} />
+  </MuiThemeProvider>;
 
-const MaterialUiExample = () =>
+const MaterialUiExample = props =>
   <InstantSearch
     appId="latency"
     apiKey="6be0576ff61c053d5f9a3225e2a90f76"
-    indexName="ikea">
-
+    indexName="ikea"
+    state={props.state}
+    createURL={props.createURL.bind(this)}
+    onStateChange={props.onStateChange.bind(this)}
+  >
     <Content/>
   </InstantSearch>;
 
@@ -145,16 +146,16 @@ const MaterialUiSearchBox = ({query, refine, marginLeft}) => {
 };
 
 const CheckBoxItem = ({item, refine}) =>
-    <ListItem
-              primaryText={item.label}
-              leftCheckbox={
-                <Checkbox checked={item.isRefined}
-                          onCheck={e => {
-                            e.preventDefault();
-                            refine(item.value);
-                          }}
-                />}
-    />;
+  <ListItem
+    primaryText={item.label}
+    leftCheckbox={
+      <Checkbox checked={item.isRefined}
+                onCheck={e => {
+                  e.preventDefault();
+                  refine(item.value);
+                }}
+      />}
+  />;
 
 const MaterialUiCheckBoxRefinementList = ({items, attributeName, refine, createURL}) =>
     <List>
@@ -175,27 +176,27 @@ const MaterialUiNestedList = function ({id, items, refine}) {
     <Subheader style={{fontSize: 18}}>{id.toUpperCase()}</Subheader>
     {items.map((item, idx) => {
       const nestedElements = item.children ? item.children.map((child, childIdx) =>
-        <ListItem
-          primaryText={child.label}
-          key={childIdx}
+          <ListItem
+            primaryText={child.label}
+            key={childIdx}
+            onClick={e => {
+              e.preventDefault();
+              refine(child.value);
+            }}
+            style={child.isRefined ? {fontWeight: 700} : {}}
+          />
+        ) : [];
+      return <ListItem
+          primaryText={item.label}
+          key={idx}
+          primaryTogglesNestedList={true}
+          nestedItems={nestedElements}
           onClick={e => {
             e.preventDefault();
-            refine(child.value);
+            refine(item.value);
           }}
-          style={child.isRefined ? {fontWeight: 700} : {}}
-        />
-      ) : [];
-      return <ListItem
-        primaryText={item.label}
-        key={idx}
-        primaryTogglesNestedList={true}
-        nestedItems={nestedElements}
-        onClick={e => {
-          e.preventDefault();
-          refine(item.value);
-        }}
-        style={item.isRefined ? {fontWeight: 700} : {}}
-      />;
+          style={item.isRefined ? {fontWeight: 700} : {}}
+        />;
     }
     )}
   </List>;
@@ -278,10 +279,10 @@ function CustomHits({hits, marginLeft}) {
   );
 }
 
-function MaterialUiClearAllFilters({filters, refine}) {
+function MaterialUiClearAllFilters({items, refine}) {
   return (
     <FlatButton
-      onTouchTap={() => refine(filters)}
+      onTouchTap={() => refine(items)}
       label="Clear All"
       style={{height: 48, width: 300, backgroundColor: 'white'}}
     />
@@ -367,3 +368,5 @@ const ConnectedHits = connectHits(CustomHits);
 const ConnectedCurrentRefinements = connectCurrentRefinements(MaterialUiClearAllFilters);
 
 const ConnectedPagination = connectPagination(MaterialUiBottomNavigation);
+
+export default withUrlSync(App);

--- a/docgen/src/examples/media/App.js
+++ b/docgen/src/examples/media/App.js
@@ -11,12 +11,16 @@ import {
 } from 'react-instantsearch/dom';
 
 import {connectSearchBox, connectRefinementList} from 'react-instantsearch/connectors';
+import {withUrlSync} from '../urlSync';
 
-export default function App() {
-  return <InstantSearch
+const App = props =>
+  <InstantSearch
     appId="latency"
     apiKey="6be0576ff61c053d5f9a3225e2a90f76"
     indexName="movies"
+    state={props.state}
+    createURL={props.createURL.bind(this)}
+    onStateChange={props.onStateChange.bind(this)}
   >
     <div>
       <Header/>
@@ -26,7 +30,6 @@ export default function App() {
       </section>
     </div>
   </InstantSearch>;
-}
 
 const Header = () =>
   <header className="row">
@@ -143,3 +146,5 @@ const RefinementListLinks = connectRefinementList(({items, refine, createURL}) =
     </div>
   );
 });
+
+export default withUrlSync(App);

--- a/docgen/src/examples/tourism/App.js
+++ b/docgen/src/examples/tourism/App.js
@@ -1,3 +1,4 @@
+/* eslint react/prop-types: 0 */
 import {
   InstantSearch,
   SearchBox,
@@ -15,22 +16,23 @@ import GoogleMap from 'google-map-react';
 import {fitBounds} from 'google-map-react/utils';
 
 import Rheostat from 'rheostat';
+import {withUrlSync} from '../urlSync';
 
-export default function TourismInstantsearchSample() {
-  return (
-    <InstantSearch
-      appId="latency"
-      apiKey="6be0576ff61c053d5f9a3225e2a90f76"
-      indexName="airbnb"
-    >
-      <div>
-        <Header />
-        <Filters />
-        <Results />
-      </div>
-    </InstantSearch>
-  );
-}
+const App = props =>
+  <InstantSearch
+    appId="latency"
+    apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+    indexName="airbnb"
+    state={props.state}
+    createURL={props.createURL.bind(this)}
+    onStateChange={props.onStateChange.bind(this)}
+  >
+    <div>
+      <Header />
+      <Filters />
+      <Results />
+    </div>
+  </InstantSearch>;
 
 function Header() {
   const containerStyle = {
@@ -42,7 +44,9 @@ function Header() {
     <div className="container-fluid" style={containerStyle}>
       <header className="navbar navbar-static-top aisdemo-navbar">
         <a href="./" className="is-logo">
-          <img src="https://res.cloudinary.com/hilnmyskv/image/upload/w_100,h_100,dpr_2.0//v1461180087/logo-instantsearchjs-avatar.png" width={40} />
+          <img
+            src="https://res.cloudinary.com/hilnmyskv/image/upload/w_100,h_100,dpr_2.0//v1461180087/logo-instantsearchjs-avatar.png"
+            width={40}/>
         </a>
         <a href="./" className="logo">A</a>
         <i className="fa fa-search"></i>
@@ -65,7 +69,7 @@ function Filters() {
               attributeName="room_type"
               operator="or"
               sortBy={['name:asc']}
-              limitMin={3} />
+              limitMin={3}/>
             <Price />
           </div>
 
@@ -88,8 +92,12 @@ function CustomMarker() {
     <svg width="60" height="102" viewBox="0 0 102 60" className="marker">
       <g fill="none" fillRule="evenodd">
         <g transform="translate(-60, 0)" stroke="#8962B2" id="pin" viewBox="0 0 100 100">
-          <path d="M157.39 34.315c0 18.546-33.825 83.958-33.825 83.958S89.74 52.86 89.74 34.315C89.74 15.768 104.885.73 123.565.73c18.68 0 33.825 15.038 33.825 33.585z" strokeWidth="5.53" fill="#E6D2FC"></path>
-          <path d="M123.565 49.13c-8.008 0-14.496-6.498-14.496-14.52 0-8.017 6.487-14.52 14.495-14.52s14.496 6.503 14.496 14.52c0 8.022-6.487 14.52-14.495 14.52z" strokeWidth="2.765" fill="#FFF"></path>
+          <path
+            d="M157.39 34.315c0 18.546-33.825 83.958-33.825 83.958S89.74 52.86 89.74 34.315C89.74 15.768 104.885.73 123.565.73c18.68 0 33.825 15.038 33.825 33.585z"
+            strokeWidth="5.53" fill="#E6D2FC"></path>
+          <path
+            d="M123.565 49.13c-8.008 0-14.496-6.498-14.496-14.52 0-8.017 6.487-14.52 14.495-14.52s14.496 6.503 14.496 14.52c0 8.022-6.487 14.52-14.495 14.52z"
+            strokeWidth="2.765" fill="#FFF"></path>
         </g>
       </g>
     </svg>);
@@ -193,8 +201,8 @@ function DatesAndGuest() {
   return (
     <div className="row aisdemo-filter">
       <div className="col-sm-2 aisdemo-filter-title">Dates</div>
-      <div className="col-sm-3"><input className="date form-control" value="10/30/3015" disabled /></div>
-      <div className="col-sm-3"><input className="date form-control" value="10/30/3015" disabled /></div>
+      <div className="col-sm-3"><input className="date form-control" value="10/30/3015" disabled/></div>
+      <div className="col-sm-3"><input className="date form-control" value="10/30/3015" disabled/></div>
       <div className="col-sm-3"></div>
     </div>
   );
@@ -215,7 +223,7 @@ const RoomType = connectRefinementList(({items, refine}) => {
               type="checkbox"
               className="ais-refinement-list--checkbox"
               defaultChecked={item.isRefined ? 'checked' : ''}
-              />
+            />
             {item.label}
             <span className="ais-refinement-list--count">{item.count}</span>
           </label>
@@ -246,7 +254,7 @@ function Price() {
 }
 
 const MyHits = connectHits(({hits}) => {
-  const hs = hits.map(hit => <HitComponent key={hit.objectID} hit={hit} />);
+  const hs = hits.map(hit => <HitComponent key={hit.objectID} hit={hit}/>);
   return <div id="hits">{hs}</div>;
 });
 
@@ -256,12 +264,12 @@ function HitComponent({hit}) {
   return (
     <div className="hit col-sm-3">
       <div className="pictures-wrapper">
-        <img className="picture" src={hit.picture_url} />
-        <img className="profile" src={hit.user.user.thumbnail_url} />
+        <img className="picture" src={hit.picture_url}/>
+        <img className="profile" src={hit.user.user.thumbnail_url}/>
       </div>
       <div className="infos">
-      <h4 className="media-heading" dangerouslySetInnerHTML={{__html: title}}></h4>
-      <p dangerouslySetInnerHTML={{__html: description}}></p>
+        <h4 className="media-heading" dangerouslySetInnerHTML={{__html: title}}></h4>
+        <p dangerouslySetInnerHTML={{__html: description}}></p>
       </div>
     </div>
   );
@@ -310,3 +318,5 @@ const ConnectedRange = connectRange(({min, max, currentRefinement, refine}) => {
     </div>
   );
 });
+
+export default withUrlSync(App);

--- a/docgen/src/examples/urlSync.js
+++ b/docgen/src/examples/urlSync.js
@@ -1,0 +1,30 @@
+import React, {Component} from 'react';
+import qs from 'qs';
+
+export const withUrlSync = App => class extends Component {
+  constructor() {
+    super();
+    this.state = {searchState: qs.parse(window.location.search.slice(1))};
+  }
+
+  onStateChange = nextState => {
+    const THRESHOLD = 700;
+    const newPush = Date.now();
+    this.setState({lastPush: newPush, searchState: nextState});
+    const search = nextState ? `?${qs.stringify({...qs.parse(window.location.search.slice(1)), ...nextState})}` : '';
+    if (this.state.lastPush && newPush - this.state.lastPush <= THRESHOLD) {
+      window.history.replaceState(null, null, search);
+    } else {
+      window.history.pushState(null, null, search);
+    }
+  };
+
+  createURL = state => `?${qs.stringify(state)}`;
+
+  render() {
+    return <App {...this.props}
+                state={this.state.searchState}
+                onStateChange={this.onStateChange}
+                createURL={this.createURL}/>;
+  }
+};

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "postcss": "^5.2.5",
     "postcss-scss": "^0.3.1",
     "pug": "^2.0.0-beta6",
+    "qs": "^6.3.0",
     "react": "^15.3.2",
     "react-addons-test-utils": "^15.3.2",
     "react-dev-utils": "^0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2490,7 +2490,7 @@ decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
-deep-equal@^1.0.0, deep-equal@^1.0.1:
+deep-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
 
@@ -3747,15 +3747,6 @@ he@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.0.tgz#29319d49beec13a9b1f3c4f9b2a6dde4859bb2a7"
 
-history@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/history/-/history-2.1.2.tgz#4aa2de897a0e4867e4539843be6ecdb2986bfdec"
-  dependencies:
-    deep-equal "^1.0.0"
-    invariant "^2.0.0"
-    query-string "^3.0.0"
-    warning "^2.0.0"
-
 hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
@@ -3958,7 +3949,7 @@ interpret@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.1.tgz#d579fb7f693b858004947af39fa0db49f795602c"
 
-invariant@^2.0.0, invariant@^2.2.0, invariant@2.x.x:
+invariant@^2.2.0, invariant@2.x.x:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.1.tgz#b097010547668c7e337028ebe816ebe36c8a8d54"
   dependencies:
@@ -6540,7 +6531,7 @@ qs@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-1.2.2.tgz#19b57ff24dc2a99ce1f8bdf6afcda59f8ef61f88"
 
-qs@^6.1.0, qs@^6.2.0, qs@^6.2.1, "qs@>= 0.4.0", qs@~6.3.0:
+qs@^6.1.0, qs@^6.2.0, qs@^6.2.1, qs@^6.3.0, "qs@>= 0.4.0", qs@~6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.0.tgz#f403b264f23bc01228c74131b407f18d5ea5d442"
 
@@ -6559,12 +6550,6 @@ qs@6.2.0:
 qs@6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.2.1.tgz#ce03c5ff0935bc1d9d69a9f14cbd18e568d67625"
-
-query-string@^3.0.0:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-3.0.3.tgz#ae2e14b4d05071d4e9b9eb4873c35b0dcd42e638"
-  dependencies:
-    strict-uri-encode "^1.0.0"
 
 query-string@^4.1.0:
   version "4.2.3"
@@ -6697,7 +6682,7 @@ react-inspector@^1.1.0:
     is-dom "^1.0.5"
 
 "react-instantsearch@file:./packages/react-instantsearch/":
-  version "2.0.0-beta.16"
+  version "2.0.0-beta.17"
   dependencies:
     algoliasearch "^3.18.1"
     algoliasearch-helper "^2.14.0"
@@ -8163,12 +8148,6 @@ ware@^1.2.0, ware@^1.3.0:
   resolved "https://registry.yarnpkg.com/ware/-/ware-1.3.0.tgz#d1b14f39d2e2cb4ab8c4098f756fe4b164e473d4"
   dependencies:
     wrap-fn "^0.1.0"
-
-warning@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/warning/-/warning-2.1.0.tgz#21220d9c63afc77a8c92111e011af705ce0c6901"
-  dependencies:
-    loose-envify "^1.0.0"
 
 warning@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
uses browser history and a 700 ms threshold. 

the url sync on our examples does not cover:
* removing empty refinements
* ordering query params by alphabetical order

I can add them if you think it worth it. 
