### PR TITLE
feat(sortBy): implement default sortBy, remove option

### DIFF
--- a/docgen/src/examples/media/App.js
+++ b/docgen/src/examples/media/App.js
@@ -62,11 +62,9 @@ const Facets = () => <aside>
     <li><a href="./"><i className="fa fa-home"></i> Home</a></li>
     <li className="separator"></li>
   </ul>
-  <Panel title="Genres" id="genres"
-  >
+  <Panel title="Genres" id="genres">
     <RefinementListLinks
       attributeName="genre"
-      sortBy={['isRefined']}
     />
   </Panel>
   <Panel title="Rating" id="ratings">

--- a/docgen/src/examples/tourism/App.js
+++ b/docgen/src/examples/tourism/App.js
@@ -68,7 +68,6 @@ function Filters() {
             <RoomType
               attributeName="room_type"
               operator="or"
-              sortBy={['name:asc']}
               limitMin={3}/>
             <Price />
           </div>
@@ -209,7 +208,8 @@ function DatesAndGuest() {
 }
 
 const RoomType = connectRefinementList(({items, refine}) => {
-  const itemComponents = items.map(item => {
+  const sortedItems = items.sort((i1, i2) => i1.label.localeCompare(i2.label));
+  const itemComponents = sortedItems.map(item => {
     const selectedClassName = item.isRefined ? ' ais-refinement-list--item__active' : '';
     const itemClassName = `ais-refinement-list--item col-sm-3 ${selectedClassName}`;
     return (

--- a/packages/react-instantsearch/src/connectors/connectHierarchicalMenu.js
+++ b/packages/react-instantsearch/src/connectors/connectHierarchicalMenu.js
@@ -62,6 +62,8 @@ function transformValue(value, limit, props, state) {
   }));
 }
 
+const sortBy = ['name:asc'];
+
 /**
  * connectHierarchicalMenu connector provides the logic to build a widget that will
  * give the user the ability to explore a tree-like structure.
@@ -76,7 +78,6 @@ function transformValue(value, limit, props, state) {
  * @propType {boolean} [showMore=false] - Flag to activate the show more button, for toggling the number of items between limitMin and limitMax.
  * @propType {number} [limitMin=10] -  The maximum number of items displayed.
  * @propType {number} [limitMax=20] -  The maximum number of items displayed when the user triggers the show more. Not considered if `showMore` is false.
- * @propType {string[]} [sortBy=['name:asc']] - Specifies the way the values are sorted for display. See [the helper documentation](https://community.algolia.com/algoliasearch-helper-js/reference.html#specifying-a-different-sort-order-for-values) for the full list of options.
  * @propType {string} [separator='>'] -  Specifies the level separator used in the data.
  * @propType {string[]} [rootPath=null] - The already selected and hidden path.
  * @propType {boolean} [showParentLevel=true] - Flag to set if the parent level should be displayed.
@@ -94,7 +95,6 @@ export default createConnector({
     separator: PropTypes.string,
     rootPath: PropTypes.string,
     showParentLevel: PropTypes.bool,
-    sortBy: PropTypes.arrayOf(PropTypes.string),
 
     /**
      * Default state of this widget.
@@ -127,14 +127,13 @@ export default createConnector({
     showMore: false,
     limitMin: 10,
     limitMax: 20,
-    sortBy: ['name:asc'],
     separator: ' > ',
     rootPath: null,
     showParentLevel: true,
   },
 
   getProps(props, state, search) {
-    const {id, sortBy, showMore, limitMin, limitMax} = props;
+    const {id, showMore, limitMin, limitMax} = props;
     const {results} = search;
 
     const isFacetPresent =

--- a/packages/react-instantsearch/src/connectors/connectHierarchicalMenu.test.js
+++ b/packages/react-instantsearch/src/connectors/connectHierarchicalMenu.test.js
@@ -35,12 +35,6 @@ describe('connectHierarchicalMenu', () => {
     expect(props).toEqual({items: [], currentRefinement: null});
 
     results.getFacetValues.mockClear();
-    results.getFacetValues.mockImplementationOnce(() => ({}));
-    const sortBy = ['my:custom:sort'];
-    getProps({id: 'ok', sortBy}, {}, {results});
-    expect(results.getFacetValues.mock.calls[0]).toEqual(['ok', {sortBy}]);
-
-    results.getFacetValues.mockClear();
     results.getFacetValues.mockImplementation(() => ({
       data: [
         {

--- a/packages/react-instantsearch/src/connectors/connectMenu.js
+++ b/packages/react-instantsearch/src/connectors/connectMenu.js
@@ -20,6 +20,8 @@ function getCurrentRefinement(props, state) {
   return null;
 }
 
+const sortBy = ['count:desc', 'name:asc'];
+
 /**
  * connectMenu connector provides the logic to build a widget that will
  * give the user tha ability to choose a single value for a specific facet.
@@ -31,7 +33,6 @@ function getCurrentRefinement(props, state) {
  * @propType {boolean} [showMore=false] - true if the component should display a button that will expand the number of items
  * @propType {number} [limitMin=10] - the minimum number of diplayed items
  * @propType {number} [limitMax=20] - the maximun number of displayed items. Only used when showMore is set to `true`
- * @propType {string[]} [sortBy=['count:desc','name:asc']] - defines how the items are sorted. See [the helper documentation](https://community.algolia.com/algoliasearch-helper-js/reference.html#specifying-a-different-sort-order-for-values) for the full list of options
  * @propType {string} defaultRefinement - the value of the item selected by default
  * @providedPropType {function} refine - a function to remove a single filter
  * @providedPropType {function} createURL - a function to generate a URL for the corresponding state
@@ -47,7 +48,6 @@ export default createConnector({
     showMore: PropTypes.bool,
     limitMin: PropTypes.number,
     limitMax: PropTypes.number,
-    sortBy: PropTypes.arrayOf(PropTypes.string),
     defaultRefinement: PropTypes.string,
   },
 
@@ -55,12 +55,11 @@ export default createConnector({
     showMore: false,
     limitMin: 10,
     limitMax: 20,
-    sortBy: ['count:desc', 'name:asc'],
   },
 
   getProps(props, state, search) {
     const {results} = search;
-    const {attributeName, sortBy, showMore, limitMin, limitMax} = props;
+    const {attributeName, showMore, limitMin, limitMax} = props;
     const limit = showMore ? limitMax : limitMin;
 
     const isFacetPresent =

--- a/packages/react-instantsearch/src/connectors/connectMenu.test.js
+++ b/packages/react-instantsearch/src/connectors/connectMenu.test.js
@@ -36,11 +36,6 @@ describe('connectMenu', () => {
     expect(props).toEqual({items: [], currentRefinement: null});
 
     results.getFacetValues.mockClear();
-    const sortBy = ['my:custom:sort'];
-    getProps({attributeName: 'ok', sortBy}, {}, {results});
-    expect(results.getFacetValues.mock.calls[0]).toEqual(['ok', {sortBy}]);
-
-    results.getFacetValues.mockClear();
     results.getFacetValues.mockImplementation(() => [
       {
         name: 'wat',

--- a/packages/react-instantsearch/src/connectors/connectRefinementList.js
+++ b/packages/react-instantsearch/src/connectors/connectRefinementList.js
@@ -35,6 +35,8 @@ function getValue(name, props, state) {
   return nextRefinement;
 }
 
+const sortBy = ['isRefined', 'count:desc', 'name:asc'];
+
 /**
  * connectRefinementList connector provides the logic to build a widget that will
  * give the user tha ability to choose multiple values for a specific facet.
@@ -47,7 +49,6 @@ function getValue(name, props, state) {
  * @propType {boolean} [showMore=false] - true if the component should display a button that will expand the number of items
  * @propType {number} [limitMin=10] - the minimum number of diplayed items
  * @propType {number} [limitMax=20] - the maximun number of displayed items. Only used when showMore is set to `true`
- * @propType {string[]} [sortBy=['count:desc','name:asc']] - defines how the items are sorted. See [the helper documentation](https://community.algolia.com/algoliasearch-helper-js/reference.html#specifying-a-different-sort-order-for-values) for the full list of options
  * @propType {string[]} defaultRefinement - the values of the items selected by default. The state of this widget takes the form of a list of `string`s, which correspond to the values of all selected refinements. However, when there are no refinements selected, the value of the state is an empty string.
  * @providedPropType {function} refine - a function to remove a single filter
  * @providedPropType {function} createURL - a function to generate a URL for the corresponding state
@@ -64,7 +65,6 @@ export default createConnector({
     showMore: PropTypes.bool,
     limitMin: PropTypes.number,
     limitMax: PropTypes.number,
-    sortBy: PropTypes.arrayOf(PropTypes.string),
     defaultRefinement: PropTypes.arrayOf(PropTypes.string),
   },
 
@@ -73,12 +73,11 @@ export default createConnector({
     showMore: false,
     limitMin: 10,
     limitMax: 20,
-    sortBy: ['count:desc', 'name:asc'],
   },
 
   getProps(props, state, search) {
     const {results} = search;
-    const {attributeName, sortBy, showMore, limitMin, limitMax} = props;
+    const {attributeName, showMore, limitMin, limitMax} = props;
     const limit = showMore ? limitMax : limitMin;
 
     const isFacetPresent =

--- a/packages/react-instantsearch/src/connectors/connectRefinementList.test.js
+++ b/packages/react-instantsearch/src/connectors/connectRefinementList.test.js
@@ -36,11 +36,6 @@ describe('connectRefinementList', () => {
     expect(props).toEqual({items: [], currentRefinement: []});
 
     results.getFacetValues.mockClear();
-    const sortBy = ['my:custom:sort'];
-    getProps({attributeName: 'ok', sortBy}, {}, {results});
-    expect(results.getFacetValues.mock.calls[0]).toEqual(['ok', {sortBy}]);
-
-    results.getFacetValues.mockClear();
     results.getFacetValues.mockImplementation(() => [
       {
         name: 'wat',

--- a/packages/react-instantsearch/src/widgets/HierarchicalMenu.js
+++ b/packages/react-instantsearch/src/widgets/HierarchicalMenu.js
@@ -13,7 +13,6 @@ import HierarchicalMenuComponent from '../components/HierarchicalMenu.js';
  * @propType {boolean} [showMore=false] - Flag to activate the show more button, for toggling the number of items between limitMin and limitMax.
  * @propType {number} [limitMin=10] -  The maximum number of items displayed.
  * @propType {number} [limitMax=20] -  The maximum number of items displayed when the user triggers the show more. Not considered if `showMore` is false.
- * @propType {string[]} [sortBy=['name:asc']] - Specifies the way the values are sorted for diplay.
  * @propType {string} [separator='>'] -  Specifies the level separator used in the data.
  * @propType {string[]} [rootPath=null] - The already selected and hidden path.
  * @propType {boolean} [showParentLevel=true] - Flag to set if the parent level should be displayed.

--- a/packages/react-instantsearch/src/widgets/Menu.js
+++ b/packages/react-instantsearch/src/widgets/Menu.js
@@ -11,7 +11,6 @@ import MenuComponent from '../components/Menu.js';
  * @propType {boolean} [showMore=false] - true if the component should display a button that will expand the number of items
  * @propType {number} [limitMin=10] - the minimum number of diplayed items
  * @propType {number} [limitMax=20] - the maximun number of displayed items. Only used when showMore is set to `true`
- * @propType {string[]} [sortBy=['count:desc','name:asc']] - defines how the items are sorted. See [the helper documentation](https://community.algolia.com/algoliasearch-helper-js/reference.html#specifying-a-different-sort-order-for-values) for the full list of options
  * @propType {string} defaultRefinement - the value of the item selected by default
  * @themeKey ais-Menu__root - the root of the component
  * @themeKey ais-Menu__items - the container of all items in the menu

--- a/packages/react-instantsearch/src/widgets/RefinementList.js
+++ b/packages/react-instantsearch/src/widgets/RefinementList.js
@@ -12,7 +12,6 @@ import RefinementListComponent from '../components/RefinementList.js';
  * @propType {boolean} [showMore=false] - true if the component should display a button that will expand the number of items
  * @propType {number} [limitMin=10] - the minimum number of diplayed items
  * @propType {number} [limitMax=20] - the maximun number of displayed items. Only used when showMore is set to `true`
- * @propType {string[]} [sortBy=['count:desc','name:asc']] - defines how the items are sorted. See [the helper documentation](https://community.algolia.com/algoliasearch-helper-js/reference.html#specifying-a-different-sort-order-for-values) for the full list of options
  * @propType {string[]} defaultRefinement - the values of the items selected by default
  * @themeKey ais-RefinementList__root - the root of the component
  * @themeKey ais-RefinementList__items - the container of all items in the list


### PR DESCRIPTION
**Summary**

We have chosen to make the widget API simple and let the customisation of behavior for components that will be wrapped in connectors. This sortBy option is now removed.
