### PR TITLE
doc(highlight): fix hl for html and css

### DIFF
--- a/docgen/src/guides/styling.md
+++ b/docgen/src/guides/styling.md
@@ -15,18 +15,18 @@ By default we provide BEM class names to every element of a widget. That way it'
 
 Let's see an example with the `RangeInput` widget:
 
-```html
+```text/html
 <form data-reactroot="" class="ais-RangeInput__root">
 	<label class="ais-RangeInput__labelMin">
 		<input type="number" 
 		       class="ais-RangeInput__inputMin" 
-		       value="0.39">
+		       value="0.39" />
 	</label>
 	<span class="ais-RangeInput__separator">to</span>
 	<label class="ais-RangeInput__labelMax">
 		<input type="number" 
 		       class="ais-RangeInput__inputMax" 
-		       value="799">
+		       value="799" />
 	</label>
 	<button class="ais-RangeInput__submit" type="submit">go</button>
 </form>

--- a/docgen/syntaxHighlighting.js
+++ b/docgen/syntaxHighlighting.js
@@ -1,5 +1,7 @@
 import {runMode} from 'codemirror/addon/runmode/runmode.node';
 import 'codemirror/mode/jsx/jsx';
+import 'codemirror/mode/htmlmixed/htmlmixed';
+import 'codemirror/mode/css/css';
 
 import escape from 'escape-html';
 


### PR DESCRIPTION
Fix the syntax highlighting on the styling page:

![screenshot 2016-11-15 16 11 26](https://cloud.githubusercontent.com/assets/393765/20310958/2cd6e968-ab4e-11e6-93a9-54f97e3de0a0.png)
