### PR TITLE
fix(connectors): remove itemComponent from hits connectors

### DIFF
--- a/packages/react-instantsearch/src/connectors/connectHits.js
+++ b/packages/react-instantsearch/src/connectors/connectHits.js
@@ -14,9 +14,6 @@ import createConnector from '../core/createConnector';
  * @category connector
  * @propType {number} hitsPerPage - How many hits should be displayed for every page.
  *   Ignored when a `HitsPerPage` component is also present.
- * @propType {Component} itemComponent - Component used for rendering each hit from
- *   the results. If it is not provided the rendering defaults to displaying the
- *   hit in its JSON form. The component will be called with a `hit` prop.
  * @providedPropType {array.<object>} hits - the records that matched the search state
  */
 export default createConnector({
@@ -24,10 +21,6 @@ export default createConnector({
 
   propTypes: {
     hitsPerPage: PropTypes.number,
-    itemComponent: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.func,
-    ]),
   },
 
   getProps(props, state, search) {

--- a/packages/react-instantsearch/src/connectors/connectInfiniteHits.js
+++ b/packages/react-instantsearch/src/connectors/connectInfiniteHits.js
@@ -14,9 +14,6 @@ import createConnector from '../core/createConnector';
  * @category connector
  * @propType {number} hitsPerPage - How many hits should be displayed for every page.
  *   Ignored when a `HitsPerPage` component is also present.
- * @propType {Component} itemComponent - Component used for rendering each hit from
- *   the results. If it is not provided the rendering defaults to displaying the
- *   hit in its JSON form. The component will be called with a `hit` prop.
  * @providedPropType {array.<object>} hits - the records that matched the search state
  * @providedPropType {boolean} hasMore - indicates if there are more pages to load
  */
@@ -25,10 +22,6 @@ export default createConnector({
 
   propTypes: {
     hitsPerPage: PropTypes.number,
-    itemComponent: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.func,
-    ]),
   },
 
   defaultProps: {


### PR DESCRIPTION
**Summary**

Removes the itemComponent that doesn't make sense on the connector (only on the widget).

fix #1554