### PR TITLE
fix(id): remove id props

### DIFF
--- a/docgen/src/examples/e-commerce-infinite/App.js
+++ b/docgen/src/examples/e-commerce-infinite/App.js
@@ -60,7 +60,6 @@ const Facets = () =>
         title="Show results for"
         items={[
           <HierarchicalMenu
-            id="categories"
             key="categories"
             attributes={[
               'category',
@@ -94,7 +93,6 @@ const Facets = () =>
             key="Price"
             item={ <CustomPriceRanges
               attributeName="price"
-              id="price_ranges"
               items={[
                 {end: 10},
                 {start: 10, end: 20},
@@ -106,7 +104,7 @@ const Facets = () =>
               ]}
             />}
           />,
-          <RangeInput key="price_input" attributeName="price" id="price_input"/>,
+          <RangeInput key="price_input" attributeName="price" />,
         ]}
       />
       <div className="thank-you">Data courtesy of <a href="http://www.ikea.com/">ikea.com</a></div>

--- a/docgen/src/examples/e-commerce/App.js
+++ b/docgen/src/examples/e-commerce/App.js
@@ -62,7 +62,6 @@ const Facets = () =>
         title="Show results for"
         items={[
           <HierarchicalMenu
-            id="categories"
             key="categories"
             attributes={[
               'category',
@@ -96,7 +95,6 @@ const Facets = () =>
             key="Price"
             item={ <CustomPriceRanges
               attributeName="price"
-              id="price_ranges"
               items={[
                 {end: 10},
                 {start: 10, end: 20},
@@ -108,7 +106,7 @@ const Facets = () =>
               ]}
             />}
           />,
-          <RangeInput key="price_input" attributeName="price" id="price_input"/>,
+          <RangeInput key="price_input" attributeName="price"/>,
         ]}
       />
       <div className="thank-you">Data courtesy of <a href="http://www.ikea.com/">ikea.com</a></div>

--- a/docgen/src/examples/material-ui/App.js
+++ b/docgen/src/examples/material-ui/App.js
@@ -98,7 +98,7 @@ const Content = React.createClass({
           </div>
           <div className="Sidebar__facets">
             <ConnectedNestedList
-              id="categories"
+              id="Categories"
               attributes={[
                 'category',
                 'sub_category',

--- a/packages/react-instantsearch/src/connectors/connectHierarchicalMenu.test.js
+++ b/packages/react-instantsearch/src/connectors/connectHierarchicalMenu.test.js
@@ -23,15 +23,15 @@ describe('connectHierarchicalMenu', () => {
     };
 
     results.getFacetValues.mockImplementationOnce(() => ({}));
-    props = getProps({id: 'ok'}, {ok: 'wat'}, {results});
+    props = getProps({attributes: ['ok']}, {ok: 'wat'}, {results});
     expect(props).toEqual({items: [], currentRefinement: 'wat'});
 
     results.getFacetValues.mockImplementationOnce(() => ({}));
-    props = getProps({id: 'ok', defaultRefinement: 'wat'}, {}, {results});
+    props = getProps({attributes: ['ok'], defaultRefinement: 'wat'}, {}, {results});
     expect(props).toEqual({items: [], currentRefinement: 'wat'});
 
     results.getFacetValues.mockImplementationOnce(() => ({}));
-    props = getProps({id: 'ok'}, {}, {results});
+    props = getProps({attributes: ['ok']}, {}, {results});
     expect(props).toEqual({items: [], currentRefinement: null});
 
     results.getFacetValues.mockClear();
@@ -61,7 +61,7 @@ describe('connectHierarchicalMenu', () => {
         },
       ],
     }));
-    props = getProps({id: 'ok'}, {}, {results});
+    props = getProps({attributes: ['ok']}, {}, {results});
     expect(props.items).toEqual([
       {
         label: 'wat',
@@ -87,7 +87,7 @@ describe('connectHierarchicalMenu', () => {
       },
     ]);
 
-    props = getProps({id: 'ok', limitMin: 1}, {}, {results});
+    props = getProps({attributes: ['ok'], limitMin: 1}, {}, {results});
     expect(props.items).toEqual([
       {
         label: 'wat',
@@ -104,7 +104,7 @@ describe('connectHierarchicalMenu', () => {
     ]);
 
     props = getProps(
-      {id: 'ok', showMore: true, limitMin: 0, limitMax: 1},
+      {attributes: ['ok'], showMore: true, limitMin: 0, limitMax: 1},
       {},
       {results}
     );
@@ -125,12 +125,12 @@ describe('connectHierarchicalMenu', () => {
   });
 
   it('doesn\'t render when no results are available', () => {
-    props = getProps({id: 'ok'}, {}, {});
+    props = getProps({attributes: ['ok']}, {}, {});
     expect(props).toBe(null);
   });
 
   it('calling refine updates the widget\'s state', () => {
-    const nextState = refine({id: 'ok'}, {otherKey: 'val'}, 'yep');
+    const nextState = refine({attributes: ['ok']}, {otherKey: 'val'}, 'yep');
     expect(nextState).toEqual({
       otherKey: 'val',
       ok: 'yep',
@@ -141,22 +141,26 @@ describe('connectHierarchicalMenu', () => {
     const initSP = new SearchParameters({maxValuesPerFacet: 100});
 
     params = getSP(initSP, {
+      attributes: ['attribute'],
       limitMin: 101,
     }, {});
     expect(params.maxValuesPerFacet).toBe(101);
 
     params = getSP(initSP, {
+      attributes: ['attribute'],
       showMore: true,
       limitMax: 101,
     }, {});
     expect(params.maxValuesPerFacet).toBe(101);
 
     params = getSP(initSP, {
+      attributes: ['attribute'],
       limitMin: 99,
     }, {});
     expect(params.maxValuesPerFacet).toBe(100);
 
     params = getSP(initSP, {
+      attributes: ['attribute'],
       showMore: true,
       limitMax: 99,
     }, {});
@@ -167,34 +171,33 @@ describe('connectHierarchicalMenu', () => {
     const initSP = new SearchParameters();
 
     params = getSP(initSP, {
-      id: 'NAME',
       attributes: ['ATTRIBUTE'],
       separator: 'SEPARATOR',
       rootPath: 'ROOT_PATH',
       showParentLevel: true,
       limitMin: 1,
-    }, {NAME: 'ok'});
+    }, {ATTRIBUTE: 'ok'});
     expect(params).toEqual(
       initSP
       .addHierarchicalFacet({
-        name: 'NAME',
+        name: 'ATTRIBUTE',
         attributes: ['ATTRIBUTE'],
         separator: 'SEPARATOR',
         rootPath: 'ROOT_PATH',
         showParentLevel: true,
       })
-      .toggleHierarchicalFacetRefinement('NAME', 'ok')
+      .toggleHierarchicalFacetRefinement('ATTRIBUTE', 'ok')
       .setQueryParameter('maxValuesPerFacet', 1)
     );
   });
 
   it('registers its id in metadata', () => {
-    const metadata = getMetadata({id: 'ok'}, {});
+    const metadata = getMetadata({attributes: ['ok']}, {});
     expect(metadata).toEqual({items: [], id: 'ok'});
   });
 
   it('registers its filter in metadata', () => {
-    const metadata = getMetadata({id: 'ok'}, {ok: 'wat'});
+    const metadata = getMetadata({attributes: ['ok']}, {ok: 'wat'});
     expect(metadata).toEqual({
       id: 'ok',
       items: [{

--- a/packages/react-instantsearch/src/connectors/connectHitsPerPage.js
+++ b/packages/react-instantsearch/src/connectors/connectHitsPerPage.js
@@ -1,13 +1,16 @@
-import {PropTypes} from 'react';
-
 import createConnector from '../core/createConnector';
 
+function getId() {
+  return 'hPP';
+}
+
 function getCurrentRefinement(props, state) {
-  if (typeof state[props.id] !== 'undefined') {
-    if (typeof state[props.id] === 'string') {
-      return parseInt(state[props.id], 10);
+  const id = getId();
+  if (typeof state[id] !== 'undefined') {
+    if (typeof state[id] === 'string') {
+      return parseInt(state[id], 10);
     }
-    return state[props.id];
+    return state[id];
   }
   return props.defaultRefinement;
 }
@@ -18,7 +21,6 @@ function getCurrentRefinement(props, state) {
  * @name connectHitsPerPage
  * @kind connector
  * @category connector
- * @propType {string} [id="hPP"] - The id of the widget.
  * @propType {number} defaultRefinement - The number of items selected by default
  * @propType {{value, label}[]|number[]} items - List of hits per page options. Passing a list of numbers [n] is a shorthand for [{value: n, label: n}].
  * @providedPropType {function} refine - a function to remove a single filter
@@ -28,15 +30,6 @@ function getCurrentRefinement(props, state) {
 export default createConnector({
   displayName: 'AlgoliaHitsPerPage',
 
-  propTypes: {
-    id: PropTypes.string,
-    defaultRefinement: PropTypes.number.isRequired,
-  },
-
-  defaultProps: {
-    id: 'hPP',
-  },
-
   getProps(props, state) {
     return {
       currentRefinement: getCurrentRefinement(props, state),
@@ -44,9 +37,10 @@ export default createConnector({
   },
 
   refine(props, state, nextHitsPerPage) {
+    const id = getId();
     return {
       ...state,
-      [props.id]: nextHitsPerPage,
+      [id]: nextHitsPerPage,
     };
   },
 
@@ -54,7 +48,7 @@ export default createConnector({
     return searchParameters.setHitsPerPage(getCurrentRefinement(props, state));
   },
 
-  getMetadata(props) {
-    return {id: props.id};
+  getMetadata() {
+    return {id: getId()};
   },
 });

--- a/packages/react-instantsearch/src/connectors/connectHitsPerPage.test.js
+++ b/packages/react-instantsearch/src/connectors/connectHitsPerPage.test.js
@@ -17,18 +17,15 @@ let params;
 
 describe('connectHitsPerPage', () => {
   it('provides the correct props to the component', () => {
-    props = getProps({id: 'hPP'}, {hPP: 10});
+    props = getProps({}, {hPP: '10'});
     expect(props).toEqual({currentRefinement: 10});
 
-    props = getProps({id: 'hPP'}, {hPP: '10'});
-    expect(props).toEqual({currentRefinement: 10});
-
-    props = getProps({id: 'hPP', defaultRefinement: 20}, {});
+    props = getProps({defaultRefinement: 20}, {});
     expect(props).toEqual({currentRefinement: 20});
   });
 
   it('calling refine updates the widget\'s state', () => {
-    const nextState = refine({id: 'hPP'}, {otherKey: 'val'}, 30);
+    const nextState = refine({}, {otherKey: 'val'}, 30);
     expect(nextState).toEqual({
       otherKey: 'val',
       hPP: 30,
@@ -38,18 +35,18 @@ describe('connectHitsPerPage', () => {
   it('refines the hitsPerPage parameter', () => {
     const sp = new SearchParameters();
 
-    params = getSP(sp, {id: 'hPP'}, {hPP: 10});
+    params = getSP(sp, {}, {hPP: 10});
     expect(params).toEqual(sp.setQueryParameter('hitsPerPage', 10));
 
-    params = getSP(sp, {id: 'hPP'}, {hPP: '10'});
+    params = getSP(sp, {}, {hPP: '10'});
     expect(params).toEqual(sp.setQueryParameter('hitsPerPage', 10));
 
-    params = getSP(sp, {id: 'hPP', defaultRefinement: 20}, {});
+    params = getSP(sp, {defaultRefinement: 20}, {});
     expect(params).toEqual(sp.setQueryParameter('hitsPerPage', 20));
   });
 
   it('registers its id in metadata', () => {
-    const metadata = getMetadata({id: 'hPP'});
+    const metadata = getMetadata({});
     expect(metadata).toEqual({id: 'hPP'});
   });
 });

--- a/packages/react-instantsearch/src/connectors/connectInfiniteHits.js
+++ b/packages/react-instantsearch/src/connectors/connectInfiniteHits.js
@@ -5,6 +5,10 @@ import {PropTypes} from 'react';
 
 import createConnector from '../core/createConnector';
 
+function getId() {
+  return 'p';
+}
+
 /**
  * InfiniteHits connector provides the logic to create connected
  * components that will render an continuous list of results retrieved from
@@ -22,10 +26,6 @@ export default createConnector({
 
   propTypes: {
     hitsPerPage: PropTypes.number,
-  },
-
-  defaultProps: {
-    id: 'infinityPagesOfThe1000hits',
   },
 
   getProps(componentProps, allWidgetsState, resultsStruct) {
@@ -64,8 +64,9 @@ export default createConnector({
   },
 
   getSearchParameters(searchParameters, props, widgetsState) {
-    const currentPage = widgetsState[props.id] ?
-      widgetsState[props.id].page :
+    const id = getId();
+    const currentPage = widgetsState[id] ?
+      widgetsState[id] :
       0;
     const isHitsPerPageDefined = typeof searchParameters.hitsPerPage !== 'undefined';
 
@@ -76,24 +77,22 @@ export default createConnector({
   },
 
   refine(props, widgetsState) {
-    const nextPage = widgetsState[props.id] ?
-      widgetsState[props.id].page + 1 :
+    const id = getId();
+    const nextPage = widgetsState[id] ?
+      widgetsState[id] + 1 :
       1;
     return {
       ...widgetsState,
-      [props.id]: {
-        page: nextPage,
-      },
+      [id]: nextPage,
     };
   },
 
   transitionState(props, prevState, nextState) {
-    if (prevState[props.id] === nextState[props.id]) {
+    const id = getId();
+    if (prevState[id] === nextState[id]) {
       return {
         ...nextState,
-        [props.id]: {
-          page: 0,
-        },
+        [id]: 0,
       };
     }
     return nextState;

--- a/packages/react-instantsearch/src/connectors/connectInfiniteHits.test.js
+++ b/packages/react-instantsearch/src/connectors/connectInfiniteHits.test.js
@@ -90,14 +90,14 @@ describe.only('connectInfiniteHits', () => {
   });
 
   it('adds 1 to page when calling refine', () => {
-    const props = {id: 'pager'};
+    const props = {};
 
     const state0 = {};
 
     const state1 = connect.refine(props, state0);
-    expect(state1).toEqual({pager: {page: 1}});
+    expect(state1).toEqual({p: 1});
 
     const state2 = connect.refine(props, state1);
-    expect(state2).toEqual({pager: {page: 2}});
+    expect(state2).toEqual({p: 2});
   });
 });

--- a/packages/react-instantsearch/src/connectors/connectMenu.js
+++ b/packages/react-instantsearch/src/connectors/connectMenu.js
@@ -3,7 +3,7 @@ import {PropTypes} from 'react';
 import createConnector from '../core/createConnector';
 
 function getId(props) {
-  return props.id || props.attributeName;
+  return props.attributeName;
 }
 
 function getCurrentRefinement(props, state) {
@@ -28,7 +28,6 @@ const sortBy = ['count:desc', 'name:asc'];
  * @name connectMenu
  * @kind connector
  * @category connector
- * @propType {string} id - the id of the widget. Defaults to `attributeName`.
  * @propType {string} attributeName - the name of the attribute in the record
  * @propType {boolean} [showMore=false] - true if the component should display a button that will expand the number of items
  * @propType {number} [limitMin=10] - the minimum number of diplayed items
@@ -43,7 +42,6 @@ export default createConnector({
   displayName: 'AlgoliaMenu',
 
   propTypes: {
-    id: PropTypes.string,
     attributeName: PropTypes.string.isRequired,
     showMore: PropTypes.bool,
     limitMin: PropTypes.number,

--- a/packages/react-instantsearch/src/connectors/connectMenu.test.js
+++ b/packages/react-instantsearch/src/connectors/connectMenu.test.js
@@ -23,16 +23,16 @@ describe('connectMenu', () => {
       getFacetByName: () => true,
     };
 
-    props = getProps({id: 'ok'}, {ok: 'wat'}, {results});
+    props = getProps({attributeName: 'ok'}, {ok: 'wat'}, {results});
     expect(props).toEqual({items: [], currentRefinement: 'wat'});
 
     props = getProps({attributeName: 'ok'}, {ok: 'wat'}, {results});
     expect(props).toEqual({items: [], currentRefinement: 'wat'});
 
-    props = getProps({id: 'ok', defaultRefinement: 'wat'}, {}, {results});
+    props = getProps({attributeName: 'ok', defaultRefinement: 'wat'}, {}, {results});
     expect(props).toEqual({items: [], currentRefinement: 'wat'});
 
-    props = getProps({id: 'ok'}, {}, {results});
+    props = getProps({attributeName: 'ok'}, {}, {results});
     expect(props).toEqual({items: [], currentRefinement: null});
 
     results.getFacetValues.mockClear();
@@ -48,7 +48,7 @@ describe('connectMenu', () => {
         count: 10,
       },
     ]);
-    props = getProps({id: 'ok'}, {}, {results});
+    props = getProps({attributeName: 'ok'}, {}, {results});
     expect(props.items).toEqual([
       {
         value: 'wat',
@@ -64,7 +64,7 @@ describe('connectMenu', () => {
       },
     ]);
 
-    props = getProps({id: 'ok', limitMin: 1}, {}, {results});
+    props = getProps({attributeName: 'ok', limitMin: 1}, {}, {results});
     expect(props.items).toEqual([
       {
         value: 'wat',
@@ -75,7 +75,7 @@ describe('connectMenu', () => {
     ]);
 
     props = getProps(
-      {id: 'ok', showMore: true, limitMin: 0, limitMax: 1},
+      {attributeName: 'ok', showMore: true, limitMin: 0, limitMax: 1},
       {},
       {results}
     );
@@ -90,12 +90,12 @@ describe('connectMenu', () => {
   });
 
   it('doesn\'t render when no results are available', () => {
-    props = getProps({id: 'ok'}, {}, {});
+    props = getProps({attributeName: 'ok'}, {}, {});
     expect(props).toBe(null);
   });
 
   it('calling refine updates the widget\'s state', () => {
-    const nextState = refine({id: 'ok'}, {otherKey: 'val'}, 'yep');
+    const nextState = refine({attributeName: 'ok'}, {otherKey: 'val'}, 'yep');
     expect(nextState).toEqual({
       otherKey: 'val',
       ok: 'yep',
@@ -144,14 +144,14 @@ describe('connectMenu', () => {
   });
 
   it('registers its id in metadata', () => {
-    const metadata = getMetadata({id: 'ok'}, {});
+    const metadata = getMetadata({attributeName: 'ok'}, {});
     expect(metadata).toEqual({id: 'ok', items: []});
   });
 
   it('registers its filter in metadata', () => {
-    const metadata = getMetadata({id: 'ok', attributeName: 'wot'}, {ok: 'wat'});
+    const metadata = getMetadata({attributeName: 'wot'}, {wot: 'wat'});
     expect(metadata).toEqual({
-      id: 'ok',
+      id: 'wot',
       items: [{
         label: 'wot: wat',
         attributeName: 'wot',
@@ -161,7 +161,7 @@ describe('connectMenu', () => {
       }],
     });
 
-    const state = metadata.items[0].value({ok: 'wat'});
-    expect(state).toEqual({ok: ''});
+    const state = metadata.items[0].value({wot: 'wat'});
+    expect(state).toEqual({wot: ''});
   });
 });

--- a/packages/react-instantsearch/src/connectors/connectMultiRange.js
+++ b/packages/react-instantsearch/src/connectors/connectMultiRange.js
@@ -22,7 +22,7 @@ function parseItem(value) {
 }
 
 function getId(props) {
-  return props.id || props.attributeName;
+  return props.attributeName;
 }
 
 function getCurrentRefinement(props, state) {
@@ -43,7 +43,6 @@ function getCurrentRefinement(props, state) {
  * @name connectMultiRange
  * @kind connector
  * @category connector
- * @propType {string} id - widget id, defaults to the attribute name
  * @propType {string} attributeName - the name of the attribute in the records
  * @propType {{label: string, start: number, end: number}[]} items - List of options. With a text label, and upper and lower bounds.
  * @propType {string} defaultRefinement - the value of the item selected by default, follow the shape of a `string` with a pattern of `'{start}:{end}'`.

--- a/packages/react-instantsearch/src/connectors/connectMultiRange.test.js
+++ b/packages/react-instantsearch/src/connectors/connectMultiRange.test.js
@@ -75,18 +75,18 @@ describe('connectMultiRange', () => {
       currentRefinement: '',
     });
 
-    props = getProps({id: 'ok', items: []}, {ok: 'wat'});
+    props = getProps({attributeName: 'ok', items: []}, {ok: 'wat'});
     expect(props).toEqual({items: [], currentRefinement: 'wat'});
 
     props = getProps({attributeName: 'ok', items: []}, {ok: 'wat'});
     expect(props).toEqual({items: [], currentRefinement: 'wat'});
 
-    props = getProps({id: 'ok', items: [], defaultRefinement: 'wat'}, {});
+    props = getProps({attributeName: 'ok', items: [], defaultRefinement: 'wat'}, {});
     expect(props).toEqual({items: [], currentRefinement: 'wat'});
   });
 
   it('calling refine updates the widget\'s state', () => {
-    const nextState = refine({id: 'ok'}, {otherKey: 'val'}, 'yep');
+    const nextState = refine({attributeName: 'ok'}, {otherKey: 'val'}, 'yep');
     expect(nextState).toEqual({
       otherKey: 'val',
       ok: 'yep',
@@ -117,7 +117,7 @@ describe('connectMultiRange', () => {
   });
 
   it('registers its id in metadata', () => {
-    const metadata = getMetadata({id: 'ok'}, {});
+    const metadata = getMetadata({attributeName: 'ok'}, {});
     expect(metadata).toEqual({id: 'ok', items: []});
   });
 

--- a/packages/react-instantsearch/src/connectors/connectPagination.js
+++ b/packages/react-instantsearch/src/connectors/connectPagination.js
@@ -1,10 +1,14 @@
-import {PropTypes} from 'react';
 import {omit} from 'lodash';
 
 import createConnector from '../core/createConnector';
 
+function getId() {
+  return 'p';
+}
+
 function getCurrentRefinement(props, state) {
-  let page = state[props.id];
+  const id = getId();
+  let page = state[id];
   if (typeof page === 'undefined') {
     page = 1;
   } else if (typeof page === 'string') {
@@ -34,14 +38,6 @@ function getCurrentRefinement(props, state) {
 export default createConnector({
   displayName: 'AlgoliaPagination',
 
-  propTypes: {
-    id: PropTypes.string,
-  },
-
-  defaultProps: {
-    id: 'p',
-  },
-
   getProps(props, state, search) {
     if (!search.results) {
       return null;
@@ -53,9 +49,10 @@ export default createConnector({
   },
 
   refine(props, state, nextPage) {
+    const id = getId();
     return {
       ...state,
-      [props.id]: nextPage,
+      [id]: nextPage,
     };
   },
 
@@ -64,20 +61,22 @@ export default createConnector({
   },
 
   transitionState(props, prevState, nextState) {
-    if (nextState[props.id] && nextState[props.id].isSamePage) {
+    const id = getId();
+    if (nextState[id] && nextState[id].isSamePage) {
       return {
         ...nextState,
-        [props.id]: prevState[props.id],
+        [id]: prevState[id],
       };
-    } else if (prevState[props.id] === nextState[props.id]) {
-      return omit(nextState, props.id);
+    } else if (prevState[id] === nextState[id]) {
+      return omit(nextState, id);
     }
     return nextState;
   },
 
-  getMetadata(props) {
+  getMetadata() {
+    const id = getId();
     return {
-      id: props.id,
+      id,
     };
   },
 });

--- a/packages/react-instantsearch/src/connectors/connectPagination.test.js
+++ b/packages/react-instantsearch/src/connectors/connectPagination.test.js
@@ -19,54 +19,54 @@ let state;
 
 describe('connectPagination', () => {
   it('provides the correct props to the component', () => {
-    props = getProps({id: 'ok'}, {}, {results: {nbPages: 666}});
+    props = getProps({}, {}, {results: {nbPages: 666}});
     expect(props).toEqual({currentRefinement: 1, nbPages: 666});
 
-    props = getProps({id: 'ok'}, {ok: 5}, {results: {nbPages: 666}});
+    props = getProps({}, {p: 5}, {results: {nbPages: 666}});
     expect(props).toEqual({currentRefinement: 5, nbPages: 666});
 
-    props = getProps({id: 'ok'}, {ok: '5'}, {results: {nbPages: 666}});
+    props = getProps({}, {p: '5'}, {results: {nbPages: 666}});
     expect(props).toEqual({currentRefinement: 5, nbPages: 666});
   });
 
   it('doesn\'t render when no results are available', () => {
-    props = getProps({id: 'ok'}, {}, {});
+    props = getProps({}, {}, {});
     expect(props).toBe(null);
   });
 
   it('calling refine updates the widget\'s state', () => {
-    const nextState = refine({id: 'ok'}, {otherKey: 'val'}, 'yep');
+    const nextState = refine({}, {otherKey: 'val'}, 'yep');
     expect(nextState).toEqual({
       otherKey: 'val',
-      ok: 'yep',
+      p: 'yep',
     });
   });
 
   it('refines the page parameter', () => {
     const initSP = new SearchParameters();
-    params = getSP(initSP, {id: 'ok'}, {ok: 667});
+    params = getSP(initSP, {}, {p: 667});
     expect(params.page).toBe(666);
   });
 
   it('Transition state when the value is identical and does not contain isSamePage flag', () => {
-    state = transitionState({id: 'ok'}, {ok: 1}, {ok: 1});
+    state = transitionState({}, {p: 1}, {p: 1});
     expect(state).toEqual({});
-    state = transitionState({id: 'ok'}, {ok: 1}, {ok: 2});
+    state = transitionState({}, {p: 1}, {p: 2});
     expect(state).toEqual({
-      ok: 2,
+      p: 2,
     });
     const newSameValue = {
       valueOf: () => 1,
       isSamePage: true,
     };
-    state = transitionState({id: 'ok'}, {ok: 1}, {ok: newSameValue});
+    state = transitionState({}, {p: 1}, {p: newSameValue});
     expect(state).toEqual({
-      ok: 1,
+      p: 1,
     });
   });
 
   it('registers its id in metadata', () => {
-    const metadata = getMetadata({id: 'ok'}, {});
-    expect(metadata).toEqual({id: 'ok'});
+    const metadata = getMetadata({}, {});
+    expect(metadata).toEqual({id: 'p'});
   });
 });

--- a/packages/react-instantsearch/src/connectors/connectRange.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.js
@@ -9,7 +9,6 @@ import createConnector from '../core/createConnector';
  * @name connectRange
  * @kind connector
  * @category connector
- * @propType {string} id - URL state serialization key. Defaults to the value of `attributeName`.
  * @propType {string} attributeName - Name of the attribute for faceting
  * @propType {{min: number, max: number}} defaultRefinement - Default state of the widget containing the start and the end of the range.
  * @propType {number} min - Minimum value. When this isn't set, the minimum value will be automatically computed by Algolia using the data in the index.
@@ -20,7 +19,7 @@ import createConnector from '../core/createConnector';
  */
 
 function getId(props) {
-  return props.id || props.attributeName;
+  return props.attributeName;
 }
 
 function getCurrentRefinement(props, state) {

--- a/packages/react-instantsearch/src/connectors/connectRange.test.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.test.js
@@ -83,7 +83,7 @@ describe('connectRange', () => {
   });
 
   it('calling refine updates the widget\'s state', () => {
-    const nextState = refine({id: 'ok'}, {otherKey: 'val'}, 'yep');
+    const nextState = refine({attributeName: 'ok'}, {otherKey: 'val'}, 'yep');
     expect(nextState).toEqual({
       otherKey: 'val',
       ok: 'yep',

--- a/packages/react-instantsearch/src/connectors/connectRefinementList.js
+++ b/packages/react-instantsearch/src/connectors/connectRefinementList.js
@@ -3,7 +3,7 @@ import {PropTypes} from 'react';
 import createConnector from '../core/createConnector';
 
 function getId(props) {
-  return props.id || props.attributeName;
+  return props.attributeName;
 }
 
 function getCurrentRefinement(props, state) {
@@ -43,7 +43,6 @@ const sortBy = ['isRefined', 'count:desc', 'name:asc'];
  * @name connectRefinementList
  * @kind connector
  * @category connector
- * @propType {string} id - the id of the widget
  * @propType {string} [operator=or] - How to apply the refinements. Possible values: 'or' or 'and'.
  * @propType {string} attributeName - the name of the attribute in the record
  * @propType {boolean} [showMore=false] - true if the component should display a button that will expand the number of items

--- a/packages/react-instantsearch/src/connectors/connectRefinementList.test.js
+++ b/packages/react-instantsearch/src/connectors/connectRefinementList.test.js
@@ -23,17 +23,14 @@ describe('connectRefinementList', () => {
       getFacetByName: () => true,
     };
 
-    props = getProps({id: 'ok'}, {ok: ['wat']}, {results});
-    expect(props).toEqual({items: [], currentRefinement: ['wat']});
+    props = getProps({attributeName: 'ok'}, {}, {results});
+    expect(props).toEqual({items: [], currentRefinement: []});
 
     props = getProps({attributeName: 'ok'}, {ok: ['wat']}, {results});
     expect(props).toEqual({items: [], currentRefinement: ['wat']});
 
-    props = getProps({id: 'ok', defaultRefinement: ['wat']}, {}, {results});
+    props = getProps({attributeName: 'ok', defaultRefinement: ['wat']}, {}, {results});
     expect(props).toEqual({items: [], currentRefinement: ['wat']});
-
-    props = getProps({id: 'ok'}, {}, {results});
-    expect(props).toEqual({items: [], currentRefinement: []});
 
     results.getFacetValues.mockClear();
     results.getFacetValues.mockImplementation(() => [
@@ -48,7 +45,7 @@ describe('connectRefinementList', () => {
         count: 10,
       },
     ]);
-    props = getProps({id: 'ok'}, {}, {results});
+    props = getProps({attributeName: 'ok'}, {}, {results});
     expect(props.items).toEqual([
       {
         value: ['wat'],
@@ -64,7 +61,7 @@ describe('connectRefinementList', () => {
       },
     ]);
 
-    props = getProps({id: 'ok', limitMin: 1}, {}, {results});
+    props = getProps({attributeName: 'ok', limitMin: 1}, {}, {results});
     expect(props.items).toEqual([
       {
         value: ['wat'],
@@ -75,7 +72,7 @@ describe('connectRefinementList', () => {
     ]);
 
     props = getProps(
-      {id: 'ok', showMore: true, limitMin: 0, limitMax: 1},
+      {attributeName: 'ok', showMore: true, limitMin: 0, limitMax: 1},
       {},
       {results}
     );
@@ -90,12 +87,12 @@ describe('connectRefinementList', () => {
   });
 
   it('doesn\'t render when no results are available', () => {
-    props = getProps({id: 'ok'}, {}, {});
+    props = getProps({attributeName: 'ok'}, {}, {});
     expect(props).toBe(null);
   });
 
   it('calling refine updates the widget\'s state', () => {
-    const nextState = refine({id: 'ok'}, {otherKey: 'val'}, ['yep']);
+    const nextState = refine({attributeName: 'ok'}, {otherKey: 'val'}, ['yep']);
     expect(nextState).toEqual({
       otherKey: 'val',
       ok: ['yep'],
@@ -157,17 +154,17 @@ describe('connectRefinementList', () => {
   });
 
   it('registers its id in metadata', () => {
-    const metadata = getMetadata({id: 'ok'}, {});
+    const metadata = getMetadata({attributeName: 'ok'}, {});
     expect(metadata).toEqual({id: 'ok', items: []});
   });
 
   it('registers its filter in metadata', () => {
     const metadata = getMetadata(
-      {id: 'ok', attributeName: 'wot'},
-      {ok: ['wat', 'wut']}
+      {attributeName: 'wot'},
+      {wot: ['wat', 'wut']}
     );
     expect(metadata).toEqual({
-      id: 'ok',
+      id: 'wot',
       items: [
         {
           label: 'wot: ',
@@ -189,9 +186,9 @@ describe('connectRefinementList', () => {
       ],
     });
 
-    let state = metadata.items[0].items[0].value({ok: ['wat', 'wut']});
-    expect(state).toEqual({ok: ['wut']});
+    let state = metadata.items[0].items[0].value({wot: ['wat', 'wut']});
+    expect(state).toEqual({wot: ['wut']});
     state = metadata.items[0].items[1].value(state);
-    expect(state).toEqual({ok: ''});
+    expect(state).toEqual({wot: ''});
   });
 });

--- a/packages/react-instantsearch/src/connectors/connectSearchBox.js
+++ b/packages/react-instantsearch/src/connectors/connectSearchBox.js
@@ -1,10 +1,13 @@
-import {PropTypes} from 'react';
-
 import createConnector from '../core/createConnector';
 
+function getId() {
+  return 'q';
+}
+
 function getCurrentRefinement(props, state) {
-  if (typeof state[props.id] !== 'undefined') {
-    return state[props.id];
+  const id = getId();
+  if (typeof state[id] !== 'undefined') {
+    return state[id];
   }
   return '';
 }
@@ -26,14 +29,6 @@ function getCurrentRefinement(props, state) {
 export default createConnector({
   displayName: 'AlgoliaSearchBox',
 
-  propTypes: {
-    id: PropTypes.string,
-  },
-
-  defaultProps: {
-    id: 'q',
-  },
-
   getProps(props, state) {
     return {
       query: getCurrentRefinement(props, state),
@@ -41,9 +36,10 @@ export default createConnector({
   },
 
   refine(props, state, nextQuery) {
+    const id = getId();
     return {
       ...state,
-      [props.id]: nextQuery,
+      [id]: nextQuery,
     };
   },
 

--- a/packages/react-instantsearch/src/connectors/connectSearchBox.test.js
+++ b/packages/react-instantsearch/src/connectors/connectSearchBox.test.js
@@ -16,23 +16,23 @@ let params;
 
 describe('connectSearchBox', () => {
   it('provides the correct props to the component', () => {
-    props = getProps({id: 'q'}, {});
+    props = getProps({}, {});
     expect(props).toEqual({query: ''});
 
-    props = getProps({id: 'q'}, {q: 'yep'});
+    props = getProps({}, {q: 'yep'});
     expect(props).toEqual({query: 'yep'});
   });
 
   it('calling refine updates the widget\'s state', () => {
-    const nextState = refine({id: 'ok'}, {otherKey: 'val'}, 'yep');
+    const nextState = refine({}, {otherKey: 'val'}, 'yep');
     expect(nextState).toEqual({
       otherKey: 'val',
-      ok: 'yep',
+      q: 'yep',
     });
   });
 
   it('refines the query parameter', () => {
-    params = getSP(new SearchParameters(), {id: 'q'}, {q: 'bar'});
+    params = getSP(new SearchParameters(), {}, {q: 'bar'});
     expect(params.query).toBe('bar');
   });
 });

--- a/packages/react-instantsearch/src/connectors/connectSortBy.js
+++ b/packages/react-instantsearch/src/connectors/connectSortBy.js
@@ -2,8 +2,12 @@ import {PropTypes} from 'react';
 
 import createConnector from '../core/createConnector';
 
+function getId() {
+  return 'sortBy';
+}
+
 function getCurrentRefinement(props, state) {
-  const {id} = props;
+  const id = getId();
   if (state[id]) {
     return state[id];
   }
@@ -19,7 +23,6 @@ function getCurrentRefinement(props, state) {
  * @name connectSortBy
  * @kind connector
  * @category connector
- * @propType {string} [id="sort_by"] - URL state serialization key.
  * @propType {string} defaultRefinement - The default selected index.
  * @propType {{value, label}[]} items - The list of indexes to search in.
  * @providedPropType {function} refine - a function to remove a single filter
@@ -31,12 +34,7 @@ export default createConnector({
   displayName: 'AlgoliaSortBy',
 
   propTypes: {
-    id: PropTypes.string,
     defaultRefinement: PropTypes.string,
-  },
-
-  defaultProps: {
-    id: 'sort_by',
   },
 
   getProps(props, state) {
@@ -45,9 +43,10 @@ export default createConnector({
   },
 
   refine(props, state, nextRefinement) {
+    const id = getId();
     return {
       ...state,
-      [props.id]: nextRefinement,
+      [id]: nextRefinement,
     };
   },
 
@@ -56,7 +55,7 @@ export default createConnector({
     return searchParameters.setIndex(selectedIndex);
   },
 
-  getMetadata(props) {
-    return {id: props.id};
+  getMetadata() {
+    return {id: getId()};
   },
 });

--- a/packages/react-instantsearch/src/connectors/connectSortBy.test.js
+++ b/packages/react-instantsearch/src/connectors/connectSortBy.test.js
@@ -17,31 +17,31 @@ let params;
 
 describe('connectSortBy', () => {
   it('provides the correct props to the component', () => {
-    props = getProps({id: 'i'}, {});
+    props = getProps({}, {});
     expect(props).toEqual({currentRefinement: null});
 
-    props = getProps({id: 'i'}, {i: 'yep'});
+    props = getProps({}, {sortBy: 'yep'});
     expect(props).toEqual({currentRefinement: 'yep'});
 
-    props = getProps({id: 'i', defaultRefinement: 'yep'}, {});
+    props = getProps({defaultRefinement: 'yep'}, {});
     expect(props).toEqual({currentRefinement: 'yep'});
   });
 
   it('calling refine updates the widget\'s state', () => {
-    const nextState = refine({id: 'ok'}, {otherKey: 'val'}, 'yep');
+    const nextState = refine({}, {otherKey: 'val'}, 'yep');
     expect(nextState).toEqual({
       otherKey: 'val',
-      ok: 'yep',
+      sortBy: 'yep',
     });
   });
 
   it('refines the index parameter', () => {
-    params = getSP(new SearchParameters(), {id: 'i'}, {i: 'yep'});
+    params = getSP(new SearchParameters(), {}, {sortBy: 'yep'});
     expect(params.index).toBe('yep');
   });
 
   it('registers its id in metadata', () => {
-    const metadata = getMetadata({id: 'i'});
-    expect(metadata).toEqual({id: 'i'});
+    const metadata = getMetadata({});
+    expect(metadata).toEqual({id: 'sortBy'});
   });
 });

--- a/packages/react-instantsearch/src/connectors/connectToggle.js
+++ b/packages/react-instantsearch/src/connectors/connectToggle.js
@@ -3,7 +3,7 @@ import {PropTypes} from 'react';
 import createConnector from '../core/createConnector';
 
 function getId(props) {
-  return props.id || props.attributeName;
+  return props.attributeName;
 }
 
 function getCurrentRefinement(props, state) {
@@ -23,7 +23,6 @@ function getCurrentRefinement(props, state) {
  * @name connectToggle
  * @kind connector
  * @category connector
- * @propType {string} id - URL state serialization key. The state of this widget takes the form of a `string` that can be either `'on'` or `'off'`. Required when `attributeName` isn't present.
  * @propType {string} attributeName - Name of the attribute on which to apply the `value` refinement. Required when `value` is present.
  * @propType {string} label - Label for this toggle.
  * @propType {string} function - Custom filter. Takes in a `SearchParameters` and returns a new `SearchParameters` with the filter applied.
@@ -36,7 +35,6 @@ export default createConnector({
   displayName: 'AlgoliaToggle',
 
   propTypes: {
-    id: PropTypes.string,
     label: PropTypes.string,
     filter: PropTypes.func,
     attributeName: PropTypes.string,

--- a/packages/react-instantsearch/src/connectors/connectToggle.test.js
+++ b/packages/react-instantsearch/src/connectors/connectToggle.test.js
@@ -17,55 +17,54 @@ let params;
 
 describe('connectToggle', () => {
   it('provides the correct props to the component', () => {
-    props = getProps({id: 't'}, {});
+    props = getProps({attributeName: 't'}, {});
     expect(props).toEqual({checked: false});
 
-    props = getProps({id: 't'}, {t: 'on'});
+    props = getProps({attributeName: 't'}, {t: 'on'});
     expect(props).toEqual({checked: true});
 
-    props = getProps({id: 't', defaultRefinement: true}, {});
+    props = getProps({defaultRefinement: true, attributeName: 't'}, {});
     expect(props).toEqual({checked: true});
   });
 
   it('calling refine updates the widget\'s state', () => {
-    let state = refine({id: 'ok'}, {otherKey: 'val'}, true);
+    let state = refine({attributeName: 't'}, {otherKey: 'val'}, true);
     expect(state).toEqual({
       otherKey: 'val',
-      ok: 'on',
+      t: 'on',
     });
 
-    state = refine({id: 'ok'}, {otherKey: 'val'}, false);
+    state = refine({attributeName: 't'}, {otherKey: 'val'}, false);
     expect(state).toEqual({
       otherKey: 'val',
-      ok: 'off',
+      t: 'off',
     });
   });
 
   it('refines the corresponding facet', () => {
     params = getSP(new SearchParameters(), {
-      id: 't',
       attributeName: 'facet',
       value: 'val',
-    }, {t: 'on'});
+    }, {facet: 'on'});
     expect(params.getConjunctiveRefinements('facet')).toEqual(['val']);
   });
 
   it('applies the provided filter', () => {
     params = getSP(new SearchParameters(), {
-      id: 't',
+      attributeName: 'facet',
       filter: sp => sp.setQuery('yep'),
-    }, {t: 'on'});
+    }, {facet: 'on'});
     expect(params.query).toEqual('yep');
   });
 
   it('registers its filter in metadata', () => {
-    let metadata = getMetadata({id: 't'}, {});
+    let metadata = getMetadata({attributeName: 't'}, {});
     expect(metadata).toEqual({
       items: [],
       id: 't',
     });
 
-    metadata = getMetadata({attributeName: 't', id: 't', label: 'yep'}, {t: 'on'});
+    metadata = getMetadata({attributeName: 't', label: 'yep'}, {t: 'on'});
     expect(metadata).toEqual({
       items: [
         {

--- a/packages/react-instantsearch/src/widgets/HierarchicalMenu.js
+++ b/packages/react-instantsearch/src/widgets/HierarchicalMenu.js
@@ -8,7 +8,6 @@ import HierarchicalMenuComponent from '../components/HierarchicalMenu.js';
  * @name HierarchicalMenu
  * @kind component
  * @category widget
- * @propType {string} id - URL state serialization key. The state of this widget takes the shape of a `string`, which corresponds to the full path of the current selected refinement.
  * @propType {string} attributes - List of attributes to use to generate the hierarchy of the menu. See the example for the convention to follow.
  * @propType {boolean} [showMore=false] - Flag to activate the show more button, for toggling the number of items between limitMin and limitMax.
  * @propType {number} [limitMin=10] -  The maximum number of items displayed.

--- a/packages/react-instantsearch/src/widgets/HitsPerPage.js
+++ b/packages/react-instantsearch/src/widgets/HitsPerPage.js
@@ -11,7 +11,6 @@ import HitsPerPageSelectComponent from '../components/HitsPerPage.js';
  * @name HitsPerPage
  * @kind component
  * @category widget
- * @propType {string} [id="hPP"] - The id of the widget.
  * @propType {number} defaultRefinement - The number of items selected by default
  * @propType {{value, label}[]|number[]} items - List of hits per page options. Passing a list of numbers [n] is a shorthand for [{value: n, label: n}].
  * @themeKey ais-HitsPerPage__root - the root of the component.

--- a/packages/react-instantsearch/src/widgets/Menu.js
+++ b/packages/react-instantsearch/src/widgets/Menu.js
@@ -6,7 +6,6 @@ import MenuComponent from '../components/Menu.js';
  * @name Menu
  * @kind component
  * @category widget
- * @propType {string} id - the id of the widget
  * @propType {string} attributeName - the name of the attribute in the record
  * @propType {boolean} [showMore=false] - true if the component should display a button that will expand the number of items
  * @propType {number} [limitMin=10] - the minimum number of diplayed items

--- a/packages/react-instantsearch/src/widgets/MultiRange.js
+++ b/packages/react-instantsearch/src/widgets/MultiRange.js
@@ -6,7 +6,6 @@ import MultiRangeComponent from '../components/MultiRange.js';
  * @name MultiRange
  * @kind component
  * @category widget
- * @propType {string} id - widget id, defaults to the attribute name
  * @propType {string} attributeName - the name of the attribute in the records
  * @propType {{label: string, start: number, end: number}[]} items - List of options. With a text label, and upper and lower bounds.
  * @propType {string} defaultRefinement - the value of the item selected by default, follow the format "min:max".

--- a/packages/react-instantsearch/src/widgets/Pagination.js
+++ b/packages/react-instantsearch/src/widgets/Pagination.js
@@ -6,7 +6,6 @@ import PaginationComponent from '../components/Pagination.js';
  * @name Pagination
  * @kind component
  * @category widget
- * @propType {string} id - widget id, URL state serialization key. The state of this widget takes the shape of a `number`.
  * @propType {boolean} [showFirst=true] - Display the first page link.
  * @propType {boolean} [showLast=false] - Display the last page link.
  * @propType {boolean} [showPrevious=true] - Display the previous page link.

--- a/packages/react-instantsearch/src/widgets/RangeInput.js
+++ b/packages/react-instantsearch/src/widgets/RangeInput.js
@@ -6,7 +6,6 @@ import RangeInputComponent from '../components/RangeInput.js';
  * @name RangeInput
  * @kind component
  * @category widget
- * @propType {string} id - widget id, defaults to the attribute name
  * @propType {string} attributeName - the name of the attribute in the record
  * @propType {{min: number, max: number}} defaultRefinement - Default state of the widget containing the start and the end of the range.
  * @propType {number} min - Minimum value. When this isn't set, the minimum value will be automatically computed by Algolia using the data in the index.

--- a/packages/react-instantsearch/src/widgets/RangeRatings.js
+++ b/packages/react-instantsearch/src/widgets/RangeRatings.js
@@ -6,7 +6,6 @@ import RangeRatingsComponent from '../components/RangeRatings.js';
  * @name RangeRatings
  * @kind component
  * @category widget
- * @propType {string} id - widget id, defaults to the attribute name
  * @propType {string} attributeName - the name of the attribute in the record
  * @propType {number} min - Minimum value for the rating. When this isn't set, the minimum value will be automatically computed by Algolia using the data in the index.
  * @propType {number} max - Maximum value for the rating. When this isn't set, the maximum value will be automatically computed by Algolia using the data in the index.

--- a/packages/react-instantsearch/src/widgets/RefinementList.js
+++ b/packages/react-instantsearch/src/widgets/RefinementList.js
@@ -6,7 +6,6 @@ import RefinementListComponent from '../components/RefinementList.js';
  * @name RefinementList
  * @kind component
  * @category widget
- * @propType {string} id - the id of the widget
  * @propType {string} attributeName - the name of the attribute in the record
  * @propType {string} [operator=or] - How to apply the refinements. Possible values: 'or' or 'and'.
  * @propType {boolean} [showMore=false] - true if the component should display a button that will expand the number of items

--- a/packages/react-instantsearch/src/widgets/SearchBox.js
+++ b/packages/react-instantsearch/src/widgets/SearchBox.js
@@ -6,7 +6,6 @@ import SearchBoxComponent from '../components/SearchBox.js';
  * @name SearchBox
  * @kind component
  * @category widget
- * @propType {string} [id="q"] - URL state serialization key. The state of this widget takes the form of a `string`.
  * @propType {string[]} [focusShortcuts=['s','/']] - List of keyboard shortcuts that focus the search box. Accepts key names and key codes.
  * @propType {boolean} [autoFocus=false] - Should the search box be focused on render?
  * @propType {boolean} [searchAsYouType=true] - Should we search on every change to the query? If you disable this option, new searches will only be triggered by clicking the search button or by pressing the enter key while the search box is focused.

--- a/packages/react-instantsearch/src/widgets/SortBy.js
+++ b/packages/react-instantsearch/src/widgets/SortBy.js
@@ -6,7 +6,6 @@ import SortByComponent from '../components/SortBy.js';
  * @name SortBy
  * @kind component
  * @category widget
- * @propType {string} [id="sort_by"] - URL state serialization key. The state of this widget takes the form of a `string` (the current selected index).
  * @propType {string} defaultRefinement - The default selected index.
  * @propType {{value, label}[]} items - The list of indexes to search in.
  * @themeKey ais-SortBy__root - the root of the component

--- a/packages/react-instantsearch/src/widgets/Toggle.js
+++ b/packages/react-instantsearch/src/widgets/Toggle.js
@@ -6,7 +6,6 @@ import ToggleComponent from '../components/Toggle.js';
  * @name Toggle
  * @kind component
  * @category widget
- * @propType {string} id - URL state serialization key. The state of this widget takes the form of a `string` that can be either `'on'` or `'off'`. Required when `attributeName` isn't present.
  * @propType {string} attributeName - Name of the attribute on which to apply the `value` refinement. Required when `value` is present.
  * @propType {string} label - Label for this toggle.
  * @propType {string} function - Custom filter. Takes in a `SearchParameters` and returns a new `SearchParameters` with the filter applied.

--- a/stories/HierarchicalMenu.stories.js
+++ b/stories/HierarchicalMenu.stories.js
@@ -11,7 +11,6 @@ stories.addDecorator(withKnobs);
 stories.add('default', () =>
   <WrapWithHits hasPlayground={true} linkedStoryGroup="HierarchicalMenu" >
     <HierarchicalMenu
-      id="categories"
       attributes={[
         'category',
         'sub_category',
@@ -22,7 +21,6 @@ stories.add('default', () =>
 ).add('with default selected item', () =>
   <WrapWithHits >
     <HierarchicalMenu
-      id="categories"
       attributes={[
         'category',
         'sub_category',
@@ -34,7 +32,6 @@ stories.add('default', () =>
 ).add('with show more', () =>
   <WrapWithHits >
     <HierarchicalMenu
-      id="categories"
       attributes={[
         'category',
         'sub_category',
@@ -48,7 +45,6 @@ stories.add('default', () =>
 ).add('with sort by', () =>
   <WrapWithHits >
     <HierarchicalMenu
-      id="categories"
       attributes={[
         'category',
         'sub_category',
@@ -60,7 +56,6 @@ stories.add('default', () =>
 ).add('playground', () =>
   <WrapWithHits >
     <HierarchicalMenu
-      id="categories"
       attributes={[
         'category',
         'sub_category',


### PR DESCRIPTION
 > The id props was used to let a user choose a custom key for the internal map that holds the values of filters of each widgets. This was used in the URL sync system that we no longer have. Let's remove it!

fix #1556