### PR TITLE
feat(react-native): make react-instantsearch compatible for native dev

### DIFF
--- a/docgen/src/guides/advanced-topics.md
+++ b/docgen/src/guides/advanced-topics.md
@@ -51,7 +51,7 @@ To do that, you can use the appropriate connector and manually add your values.
 
 Here's an example to force category values for a Menu.
 
-```javascript
+```jsx
 const ConnectedMenu = connectMenu(props => {
     const items = [];
     
@@ -90,7 +90,7 @@ This function while provided to every widgets and connectors is only useful if y
 
 Here's an example showing you how to use [react-router](https://github.com/ReactTraining/react-router) with react-instantsearch. 
 
-```javascript
+```jsx
 import React, {Component} from 'react';
 import {
     InstantSearch
@@ -152,4 +152,128 @@ class App extends Component {
 
 export default withRouter(App);
 ```
+
+## React Native
+
+`react-instantsearch` is made to be compatible with [react native](https://facebook.github.io/react-native/). 
+To build your mobile application using both `react-instantsearch` and `react native` you will need to use the 
+proper [`InstantSearch root component`](/component/InstantSearch.html) 
+and take advantage of our [connectors API](/connector.html).
+
+Instead of using the `dom namespace` when importing the `InstantSearch root component` you will have to use the `native
+namespace`. 
+
+Here's an example showing you how to build a `SearchBox` and an infinite scroll view: 
+
+```jsx
+import React, {Component} from 'react';
+import {
+    AppRegistry,
+    StyleSheet,
+    Text,
+    View,
+    ListView,
+    TextInput,
+    Image,
+} from 'react-native';
+import {InstantSearch} from 'react-instantsearch/native';
+import {connectSearchBox, connectInfiniteHits} from 'react-instantsearch/connectors';
+
+
+export default AwesomeProject = React.createClass({
+    render: function () {
+        return (
+            <View style={styles.maincontainer}>
+                <InstantSearch
+                    className="container-fluid"
+                    appId="appId"
+                    apiKey="apiKey"
+                    indexName="indexName"
+                >
+                    <View style={styles.maincontainer}>
+                        <CustomSearchBox/>
+                        <CustomHits/>
+                    </View>
+                </InstantSearch>
+            </View>
+        );
+    },
+});
+
+class SearchBox extends Component {
+    constructor(props) {
+        super(props);
+    }
+
+    render() {
+        return (
+            <TextInput
+                style={{height: 40, borderColor: 'gray', borderWidth: 1}}
+                onChangeText={(text) => this.props.refine(text)}
+                value={this.props.query}
+            />
+        );
+    }
+}
+
+const CustomSearchBox = connectSearchBox(SearchBox);
+
+const CustomHits = connectInfiniteHits(React.createClass({
+    onEndReached: function () {
+        if (this.props.hasMore) {
+            this.props.refine();
+        }
+    },
+
+    render: function () {
+        const ds = new ListView.DataSource({rowHasChanged: (r1, r2) => r1 !== r2});
+        const hits = this.props.hits.length > 0 ?
+            <View style={styles.maincontainer}>
+                <ListView
+                    style={styles.list}
+                    dataSource={ds.cloneWithRows(this.props.hits)}
+                    renderRow={this._renderRow}
+                    onEndReached={this.onEndReached}/>
+            </View> : null;
+        return hits;
+    },
+
+    _renderRow: function (hit) {
+        return (
+            <View style={styles.item}>
+                <Image
+                    style={{height: 100, width: 100}}
+                    source={{uri: hit.image}}
+                />
+                <Text>
+                    {hit.name}
+                </Text>
+            </View> );
+    },
+}));
+
+
+const styles = StyleSheet.create({
+    maincontainer: {
+        backgroundColor: 'white',
+        flex: 1,
+        paddingTop: 20,
+        paddingBottom: 10,
+        flexDirection: 'column',
+    },
+    list: {
+        flex: 1,
+        flexDirection: 'column',
+    },
+    item: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        backgroundColor: 'white'
+    }
+});
+
+AppRegistry.registerComponent('AwesomeProject', () => AwesomeProject);
+```
+
+
 

--- a/packages/react-instantsearch/dom.js
+++ b/packages/react-instantsearch/dom.js
@@ -1,4 +1,8 @@
-export {default as InstantSearch} from './src/core/InstantSearch.js';
+import createInstantSearch from './src/core/createInstantSearch';
+import algoliasearch from 'algoliasearch';
+
+const InstantSearch = createInstantSearch(algoliasearch);
+export {InstantSearch};
 export {default as CurrentRefinements} from './src/widgets/CurrentRefinements.js';
 export {default as HierarchicalMenu} from './src/widgets/HierarchicalMenu.js';
 export {default as Hits} from './src/widgets/Hits.js';

--- a/packages/react-instantsearch/index.js
+++ b/packages/react-instantsearch/index.js
@@ -1,1 +1,2 @@
 export {default as createConnector} from './src/core/createConnector';
+

--- a/packages/react-instantsearch/native.js
+++ b/packages/react-instantsearch/native.js
@@ -1,0 +1,5 @@
+import algoliasearch from 'algoliasearch/reactnative';
+import createInstantSearch from './src/core/createInstantSearch';
+
+const InstantSearch = createInstantSearch(algoliasearch);
+export {InstantSearch};

--- a/packages/react-instantsearch/scripts/build.sh
+++ b/packages/react-instantsearch/scripts/build.sh
@@ -9,4 +9,5 @@ cp README.md dist/
 babel -q index.js -o dist/index.js
 babel -q dom.js -o dist/dom.js
 babel -q connectors.js -o dist/connectors.js
+babel -q native.js -o dist/native.js
 babel -q --ignore test.js,__mocks__ --out-dir dist/src src

--- a/packages/react-instantsearch/src/core/InstantSearch.js
+++ b/packages/react-instantsearch/src/core/InstantSearch.js
@@ -64,12 +64,9 @@ class InstantSearch extends Component {
     const initialState = this.isControlled ? props.state : {};
 
     this.aisManager = createInstantSearchManager({
-      appId: props.appId,
-      apiKey: props.apiKey,
       indexName: props.indexName,
       searchParameters: props.searchParameters,
       algoliaClient: props.algoliaClient,
-
       initialState,
     });
   }
@@ -136,11 +133,9 @@ class InstantSearch extends Component {
 
 InstantSearch.propTypes = {
   // @TODO: These props are currently constant.
-  appId: PropTypes.string,
-  apiKey: PropTypes.string,
   indexName: PropTypes.string.isRequired,
 
-  algoliaClient: PropTypes.object,
+  algoliaClient: PropTypes.object.isRequired,
 
   searchParameters: PropTypes.object,
 

--- a/packages/react-instantsearch/src/core/InstantSearch.test.js
+++ b/packages/react-instantsearch/src/core/InstantSearch.test.js
@@ -15,7 +15,8 @@ const DEFAULT_PROPS = {
   appId: 'foo',
   apiKey: 'bar',
   indexName: 'foobar',
-  urlSync: false,
+  algoliaClient: {},
+  searchParameters: {},
 };
 
 describe('InstantSearch', () => {
@@ -126,10 +127,10 @@ describe('InstantSearch', () => {
       </InstantSearch>
     );
     expect(createInstantSearchManager.mock.calls[0][0]).toEqual({
-      appId: DEFAULT_PROPS.appId,
-      apiKey: DEFAULT_PROPS.apiKey,
       indexName: DEFAULT_PROPS.indexName,
       initialState: {},
+      searchParameters: {},
+      algoliaClient: {},
     });
   });
 

--- a/packages/react-instantsearch/src/core/createInstantSearch.js
+++ b/packages/react-instantsearch/src/core/createInstantSearch.js
@@ -1,0 +1,22 @@
+import React, {Component, PropTypes} from 'react';
+import InstantSearch from './InstantSearch';
+
+export default function createInstantSearch(defaultAlgoliaClient) {
+  return class CreateInstantSearch extends Component {
+    static propTypes = {
+      algoliaClient: PropTypes.object,
+      appId: PropTypes.string,
+      apiKey: PropTypes.string,
+    };
+
+    render() {
+      const client = this.props.algoliaClient || defaultAlgoliaClient(this.props.appId, this.props.apiKey);
+      return (
+        <InstantSearch
+          {...this.props}
+          algoliaClient={client}
+        />
+      );
+    }
+  };
+}

--- a/packages/react-instantsearch/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch/src/core/createInstantSearchManager.js
@@ -1,4 +1,3 @@
-import algoliasearch from 'algoliasearch';
 import algoliasearchHelper, {SearchParameters} from 'algoliasearch-helper';
 
 import createWidgetsManager from './createWidgetsManager';
@@ -7,23 +6,18 @@ import createStore from './createStore';
 /**
  * Creates a new instance of the InstantSearchManager which controls the widgets and
  * trigger the search when the widgets are updated.
- * @param {string} appId - the application ID
- * @param {string} apiKey - the api key
  * @param {string} indexName - the main index name
  * @param {object} initialState - initial widget state
  * @param {object} SearchParameters - optional additional parameters to send to the algolia API
  * @return {InstantSearchManager} a new instance of InstantSearchManager
  */
 export default function createInstantSearchManager({
-  appId,
-  apiKey,
   indexName,
   initialState,
   algoliaClient,
   searchParameters = {},
 }) {
-  const client = algoliaClient || algoliasearch(appId, apiKey);
-  const helper = algoliasearchHelper(client);
+  const helper = algoliasearchHelper(algoliaClient);
 
   const widgetsManager = createWidgetsManager(onWidgetsUpdate);
 
@@ -103,8 +97,8 @@ export default function createInstantSearchManager({
     return widgetsManager.getWidgets()
       .filter(widget => Boolean(widget.transitionState))
       .reduce((res, widget) =>
-        widget.transitionState(state, res)
-      , nextState);
+          widget.transitionState(state, res)
+        , nextState);
   }
 
   function onExternalStateUpdate(nextState) {
@@ -122,8 +116,8 @@ export default function createInstantSearchManager({
 
   function getWidgetsIds() {
     return store.getState().metadata.reduce((res, meta) =>
-      typeof meta.id !== 'undefined' ? res.concat(meta.id) : res
-    , []);
+        typeof meta.id !== 'undefined' ? res.concat(meta.id) : res
+      , []);
   }
 
   return {

--- a/packages/react-instantsearch/src/core/createInstantSearchManager.test.js
+++ b/packages/react-instantsearch/src/core/createInstantSearchManager.test.js
@@ -3,8 +3,6 @@
 
 import createInstantSearchManager from './createInstantSearchManager';
 
-import algoliasearch from 'algoliasearch';
-jest.mock('algoliasearch', () => jest.fn());
 import algoliasearchHelper from 'algoliasearch-helper';
 jest.mock('algoliasearch-helper', () => {
   const output = jest.fn();
@@ -31,18 +29,18 @@ describe('createInstantSearchManager', () => {
   let onInternalStateUpdate;
   let initialState;
   let ism;
+  let algoliaClient;
 
   function init(otherISMParameters = {}) {
     createHrefForState = jest.fn(a => a);
     onInternalStateUpdate = jest.fn();
+    algoliaClient = jest.fn();
     initialState = {
       hello: 'yes',
     };
     ism = createInstantSearchManager({
-      appId: 'appId',
-      apiKey: 'apiKey',
       indexName: 'indexName',
-
+      algoliaClient,
       initialState,
       createHrefForState,
       onInternalStateUpdate,
@@ -51,29 +49,14 @@ describe('createInstantSearchManager', () => {
   }
 
   beforeEach(() => {
-    algoliasearch.mockClear();
     algoliasearchHelper.mockClear();
     createStore.mockClear();
     createWidgetsManager.mockClear();
   });
 
-  it('initializes the algoliasearch client with correct options', () => {
+  it('initializes the algoliasearch helper client with correct options', () => {
     init();
-    expect(algoliasearch.mock.calls[0]).toEqual(['appId', 'apiKey']);
-  });
-
-  it('overrides the default algoliasearch client with algoliaClient', () => {
-    const algoliaClient = {};
-    init({algoliaClient});
-    expect(algoliasearch.mock.calls.length).toEqual(0);
     expect(algoliasearchHelper.mock.calls[0][0]).toBe(algoliaClient);
-  });
-
-  it('initializes the algoliasearch helper with correct options', () => {
-    const client = {};
-    algoliasearch.mockImplementationOnce(() => client);
-    init();
-    expect(algoliasearchHelper.mock.calls[0][0]).toBe(client);
   });
 
   describe('store', () => {

--- a/packages/react-instantsearch/src/core/createWidgetsManager.js
+++ b/packages/react-instantsearch/src/core/createWidgetsManager.js
@@ -10,7 +10,7 @@ export default function createWidgetsManager(onWidgetsUpdate) {
       return;
     }
     scheduled = true;
-    process.nextTick(() => {
+    setImmediate(() => {
       scheduled = false;
       onWidgetsUpdate();
     });

--- a/packages/react-instantsearch/src/core/createWidgetsManager.test.js
+++ b/packages/react-instantsearch/src/core/createWidgetsManager.test.js
@@ -23,10 +23,10 @@ describe('createWidgetsManager', () => {
       jest.useFakeTimers();
       const onUpdate = jest.fn();
       const wm = createWidgetsManager(onUpdate);
-      jest.runAllTicks();
+      jest.runAllImmediates();
       wm.registerWidget({});
       expect(onUpdate.mock.calls.length).toBe(0);
-      jest.runAllTicks();
+      jest.runAllImmediates();
       expect(onUpdate.mock.calls.length).toBe(1);
       jest.useRealTimers();
     });
@@ -37,10 +37,10 @@ describe('createWidgetsManager', () => {
       jest.useFakeTimers();
       const onUpdate = jest.fn();
       const wm = createWidgetsManager(onUpdate);
-      jest.runAllTicks();
+      jest.runAllImmediates();
       wm.update();
       expect(onUpdate.mock.calls.length).toBe(0);
-      jest.runAllTicks();
+      jest.runAllImmediates();
       expect(onUpdate.mock.calls.length).toBe(1);
       jest.useRealTimers();
     });


### PR DESCRIPTION
Contains:

- new native namespace
- guide for react-native with the source code of an example showing searchbox+infinitHits (the api of the connector is really simple to use, thanks @bobylito !)

![react-native-example](https://cloud.githubusercontent.com/assets/6885378/20389948/98e423d0-accc-11e6-875d-459c6b627395.gif)
