### PR TITLE
fix(currentRefinedValues): unescape disjunctive facet refinement names

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -17,6 +17,8 @@ export {
   clearRefinementsFromState,
   clearRefinementsAndSearch,
   prefixKeys,
+  escapeRefinement,
+  unescapeRefinement,
 };
 
 /**
@@ -171,7 +173,17 @@ function getRefinements(results, state) {
 
   forEach(state.disjunctiveFacetsRefinements, (refinements, attributeName) => {
     forEach(refinements, name => {
-      res.push(getRefinement(state, 'disjunctive', attributeName, name, results.disjunctiveFacets));
+      res.push(
+        getRefinement(
+          state,
+          'disjunctive',
+          attributeName,
+          // we unescapeRefinement any disjunctive refined value since they can be escaped
+          // when negative numeric values search `escapeRefinement` usage in code
+          unescapeRefinement(name),
+          results.disjunctiveFacets
+        )
+      );
     });
   });
 
@@ -232,4 +244,16 @@ function prefixKeys(prefix, obj) {
   }
 
   return undefined;
+}
+
+function escapeRefinement(value) {
+  if (typeof value === 'number' && value < 0) {
+    value = String(value).replace(/^-/, '\\-');
+  }
+
+  return value;
+}
+
+function unescapeRefinement(value) {
+  return String(value).replace(/^\\-/, '-');
 }

--- a/src/widgets/toggle/implementations/currentToggle.js
+++ b/src/widgets/toggle/implementations/currentToggle.js
@@ -4,6 +4,8 @@ import ReactDOM from 'react-dom';
 import defaultTemplates from '../defaultTemplates.js';
 import {
   prepareTemplateProps,
+  escapeRefinement,
+  unescapeRefinement,
 } from '../../../lib/utils.js';
 
 // cannot use a function declaration because of
@@ -122,17 +124,5 @@ const currentToggle = ({
     },
   };
 };
-
-function escapeRefinement(value) {
-  if (typeof value === 'number' && value < 0) {
-    value = String(value).replace('-', '\\-');
-  }
-
-  return value;
-}
-
-function unescapeRefinement(value) {
-  return String(value).replace(/^\\-/, '-');
-}
 
 export default currentToggle;


### PR DESCRIPTION
following #1551, we also now need to unescape in currentRefinedValues
widget because the refinement name is public API.

fixes #1569