### PR TITLE
feat(unmount): clean state if a widget is unmounted except if it is persistent

### DIFF
--- a/docgen/src/examples/urlSync.js
+++ b/docgen/src/examples/urlSync.js
@@ -11,13 +11,13 @@ export const withUrlSync = App => class extends Component {
   onStateChange = nextState => {
     const THRESHOLD = 700;
     const newPush = Date.now();
-    this.setState({lastPush: newPush, searchState: nextState});
-    const search = nextState ? `?${qs.stringify({...qs.parse(window.location.search.slice(1)), ...nextState})}` : '';
+    const search = nextState ? `?${qs.stringify(nextState)}` : '';
     if (this.state.lastPush && newPush - this.state.lastPush <= THRESHOLD) {
       window.history.replaceState(null, null, search);
     } else {
       window.history.pushState(null, null, search);
     }
+    this.setState({lastPush: newPush, searchState: nextState});
   };
 
   createURL = state => `?${qs.stringify(state)}`;

--- a/docgen/src/guides/create-own-widget.md
+++ b/docgen/src/guides/create-own-widget.md
@@ -174,3 +174,25 @@ const CoolWidget = createConnector({
   },
 })(Widget);
 ```
+
+### cleanUp(props, state)
+
+This method is called when a widget is about to unmount in order to clean the state.
+
+It takes in the current props of the higher-order component and the state of all widgets and expect a new state in return.
+
+`props` are the props that were provided to the higher-order component.
+
+`state` holds the state of all widgets, with the shape `{[widgetId]: widgetState}`. Stateful widgets describe the format of their state in their respective documentation entry.
+
+```javascript
+import {omit} from 'lodash';
+
+const CoolWidget = createConnector({
+  // displayName, getProps, refine, getSearchParameters, getMetadata
+
+  cleanUp(props, state) {
+    return omit('queryAndPage', state)
+  },
+})(Widget);
+```

--- a/packages/react-instantsearch/src/connectors/connectHierarchicalMenu.js
+++ b/packages/react-instantsearch/src/connectors/connectHierarchicalMenu.js
@@ -1,4 +1,5 @@
 import {PropTypes} from 'react';
+import {omit} from 'lodash';
 
 import createConnector from '../core/createConnector';
 import {SearchParameters} from 'algoliasearch-helper';
@@ -147,6 +148,10 @@ export default createConnector({
       ...state,
       [id]: nextRefinement || '',
     };
+  },
+
+  cleanUp(props, state) {
+    return omit(state, getId(props));
   },
 
   getSearchParameters(searchParameters, props, state) {

--- a/packages/react-instantsearch/src/connectors/connectHierarchicalMenu.test.js
+++ b/packages/react-instantsearch/src/connectors/connectHierarchicalMenu.test.js
@@ -10,6 +10,7 @@ const {
   refine,
   getSearchParameters: getSP,
   getMetadata,
+  cleanUp,
 } = connect;
 
 let props;
@@ -179,15 +180,15 @@ describe('connectHierarchicalMenu', () => {
     }, {ATTRIBUTE: 'ok'});
     expect(params).toEqual(
       initSP
-      .addHierarchicalFacet({
-        name: 'ATTRIBUTE',
-        attributes: ['ATTRIBUTE'],
-        separator: 'SEPARATOR',
-        rootPath: 'ROOT_PATH',
-        showParentLevel: true,
-      })
-      .toggleHierarchicalFacetRefinement('ATTRIBUTE', 'ok')
-      .setQueryParameter('maxValuesPerFacet', 1)
+        .addHierarchicalFacet({
+          name: 'ATTRIBUTE',
+          attributes: ['ATTRIBUTE'],
+          separator: 'SEPARATOR',
+          rootPath: 'ROOT_PATH',
+          showParentLevel: true,
+        })
+        .toggleHierarchicalFacetRefinement('ATTRIBUTE', 'ok')
+        .setQueryParameter('maxValuesPerFacet', 1)
     );
   });
 
@@ -211,5 +212,10 @@ describe('connectHierarchicalMenu', () => {
 
     const state = metadata.items[0].value({ok: 'wat'});
     expect(state).toEqual({ok: ''});
+  });
+
+  it('should return the right state when clean up', () => {
+    const state = cleanUp({attributes: ['name']}, {name: {state: 'state'}, another: {state: 'state'}});
+    expect(state).toEqual({another: {state: 'state'}});
   });
 });

--- a/packages/react-instantsearch/src/connectors/connectHitsPerPage.js
+++ b/packages/react-instantsearch/src/connectors/connectHitsPerPage.js
@@ -1,4 +1,5 @@
 import createConnector from '../core/createConnector';
+import {omit} from 'lodash';
 
 function getId() {
   return 'hPP';
@@ -42,6 +43,10 @@ export default createConnector({
       ...state,
       [id]: nextHitsPerPage,
     };
+  },
+
+  cleanUp(props, state) {
+    return omit(state, getId());
   },
 
   getSearchParameters(searchParameters, props, state) {

--- a/packages/react-instantsearch/src/connectors/connectHitsPerPage.test.js
+++ b/packages/react-instantsearch/src/connectors/connectHitsPerPage.test.js
@@ -10,6 +10,7 @@ const {
   refine,
   getSearchParameters: getSP,
   getMetadata,
+  cleanUp,
 } = connect;
 
 let props;
@@ -48,5 +49,10 @@ describe('connectHitsPerPage', () => {
   it('registers its id in metadata', () => {
     const metadata = getMetadata({});
     expect(metadata).toEqual({id: 'hPP'});
+  });
+
+  it('should return the right state when clean up', () => {
+    const state = cleanUp({}, {hPP: {state: 'state'}, another: {state: 'state'}});
+    expect(state).toEqual({another: {state: 'state'}});
   });
 });

--- a/packages/react-instantsearch/src/connectors/connectMenu.js
+++ b/packages/react-instantsearch/src/connectors/connectMenu.js
@@ -1,4 +1,5 @@
 import {PropTypes} from 'react';
+import {omit} from 'lodash';
 
 import createConnector from '../core/createConnector';
 
@@ -90,6 +91,10 @@ export default createConnector({
       ...state,
       [id]: nextRefinement || '',
     };
+  },
+
+  cleanUp(props, state) {
+    return omit(state, getId(props));
   },
 
   getSearchParameters(searchParameters, props, state) {

--- a/packages/react-instantsearch/src/connectors/connectMenu.test.js
+++ b/packages/react-instantsearch/src/connectors/connectMenu.test.js
@@ -11,6 +11,7 @@ const {
   refine,
   getSearchParameters: getSP,
   getMetadata,
+  cleanUp,
 } = connect;
 
 let props;
@@ -163,5 +164,10 @@ describe('connectMenu', () => {
 
     const state = metadata.items[0].value({wot: 'wat'});
     expect(state).toEqual({wot: ''});
+  });
+
+  it('should return the right state when clean up', () => {
+    const state = cleanUp({attributeName: 'name'}, {name: {state: 'state'}, another: {state: 'state'}});
+    expect(state).toEqual({another: {state: 'state'}});
   });
 });

--- a/packages/react-instantsearch/src/connectors/connectMultiRange.js
+++ b/packages/react-instantsearch/src/connectors/connectMultiRange.js
@@ -1,5 +1,5 @@
 import {PropTypes} from 'react';
-import {find} from 'lodash';
+import {find, omit} from 'lodash';
 
 import createConnector from '../core/createConnector';
 
@@ -86,6 +86,10 @@ export default createConnector({
       ...state,
       [getId(props, state)]: nextRefinement,
     };
+  },
+
+  cleanUp(props, state) {
+    return omit(state, getId(props));
   },
 
   getSearchParameters(searchParameters, props, state) {

--- a/packages/react-instantsearch/src/connectors/connectMultiRange.test.js
+++ b/packages/react-instantsearch/src/connectors/connectMultiRange.test.js
@@ -10,6 +10,7 @@ const {
   refine,
   getSearchParameters: getSP,
   getMetadata,
+  cleanUp,
 } = connect;
 
 let props;
@@ -146,5 +147,10 @@ describe('connectMultiRange', () => {
 
     const state = metadata.items[0].value({wot: '100:200'});
     expect(state).toEqual({wot: ''});
+  });
+
+  it('should return the right state when clean up', () => {
+    const state = cleanUp({attributeName: 'name'}, {name: {state: 'state'}, another: {state: 'state'}});
+    expect(state).toEqual({another: {state: 'state'}});
   });
 });

--- a/packages/react-instantsearch/src/connectors/connectPagination.js
+++ b/packages/react-instantsearch/src/connectors/connectPagination.js
@@ -56,6 +56,10 @@ export default createConnector({
     };
   },
 
+  cleanUp(props, state) {
+    return omit(state, getId());
+  },
+
   getSearchParameters(searchParameters, props, state) {
     return searchParameters.setPage(getCurrentRefinement(props, state) - 1);
   },

--- a/packages/react-instantsearch/src/connectors/connectPagination.test.js
+++ b/packages/react-instantsearch/src/connectors/connectPagination.test.js
@@ -11,6 +11,7 @@ const {
   getSearchParameters: getSP,
   transitionState,
   getMetadata,
+  cleanUp,
 } = connect;
 
 let props;
@@ -68,5 +69,10 @@ describe('connectPagination', () => {
   it('registers its id in metadata', () => {
     const metadata = getMetadata({}, {});
     expect(metadata).toEqual({id: 'p'});
+  });
+
+  it('should return the right state when clean up', () => {
+    const newState = cleanUp({}, {p: {state: 'state'}, another: {state: 'state'}});
+    expect(newState).toEqual({another: {state: 'state'}});
   });
 });

--- a/packages/react-instantsearch/src/connectors/connectRange.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.js
@@ -1,4 +1,5 @@
 import {PropTypes} from 'react';
+import {omit} from 'lodash';
 
 import createConnector from '../core/createConnector';
 
@@ -65,7 +66,9 @@ export default createConnector({
         return null;
       }
 
-      const stats = search.results.getFacetStats(attributeName);
+      const stats = search.results.getFacetByName(attributeName) ?
+        search.results.getFacetStats(attributeName) : null;
+
       if (!stats) {
         return null;
       }
@@ -103,6 +106,10 @@ export default createConnector({
       ...state,
       [getId(props)]: nextRefinement,
     };
+  },
+
+  cleanUp(props, state) {
+    return omit(state, getId(props));
   },
 
   getSearchParameters(params, props, state) {

--- a/packages/react-instantsearch/src/connectors/connectRange.test.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.test.js
@@ -10,6 +10,7 @@ const {
   refine,
   getSearchParameters: getSP,
   getMetadata,
+  cleanUp,
 } = connect;
 
 let props;
@@ -28,6 +29,7 @@ describe('connectRange', () => {
     const results = {
       getFacetStats: () => ({min: 5, max: 10}),
       getFacetValues: () => [{name: '5', count: 10}, {name: '2', count: 20}],
+      getFacetByName: () => true,
     };
     props = getProps({attributeName: 'ok'}, {}, {results});
     expect(props).toEqual({
@@ -148,5 +150,10 @@ describe('connectRange', () => {
         value: metadata.items[0].value,
       }],
     });
+  });
+
+  it('should return the right state when clean up', () => {
+    const state = cleanUp({attributeName: 'name'}, {name: {state: 'state'}, another: {state: 'state'}});
+    expect(state).toEqual({another: {state: 'state'}});
   });
 });

--- a/packages/react-instantsearch/src/connectors/connectRefinementList.js
+++ b/packages/react-instantsearch/src/connectors/connectRefinementList.js
@@ -1,4 +1,5 @@
 import {PropTypes} from 'react';
+import {omit} from 'lodash';
 
 import createConnector from '../core/createConnector';
 
@@ -117,6 +118,10 @@ export default createConnector({
       // {foo: []} => ""
       [id]: nextRefinement.length > 0 ? nextRefinement : '',
     };
+  },
+
+  cleanUp(props, state) {
+    return omit(state, getId(props));
   },
 
   getSearchParameters(searchParameters, props, state) {

--- a/packages/react-instantsearch/src/connectors/connectRefinementList.test.js
+++ b/packages/react-instantsearch/src/connectors/connectRefinementList.test.js
@@ -11,6 +11,7 @@ const {
   refine,
   getSearchParameters: getSP,
   getMetadata,
+  cleanUp,
 } = connect;
 
 let props;
@@ -190,5 +191,10 @@ describe('connectRefinementList', () => {
     expect(state).toEqual({wot: ['wut']});
     state = metadata.items[0].items[1].value(state);
     expect(state).toEqual({wot: ''});
+  });
+
+  it('should return the right state when clean up', () => {
+    const state = cleanUp({attributeName: 'name'}, {name: {state: 'state'}, another: {state: 'state'}});
+    expect(state).toEqual({another: {state: 'state'}});
   });
 });

--- a/packages/react-instantsearch/src/connectors/connectSearchBox.js
+++ b/packages/react-instantsearch/src/connectors/connectSearchBox.js
@@ -1,4 +1,5 @@
 import createConnector from '../core/createConnector';
+import {omit} from 'lodash';
 
 function getId() {
   return 'q';
@@ -41,6 +42,10 @@ export default createConnector({
       ...state,
       [id]: nextQuery,
     };
+  },
+
+  cleanUp(props, state) {
+    return omit(state, getId());
   },
 
   getSearchParameters(searchParameters, props, state) {

--- a/packages/react-instantsearch/src/connectors/connectSearchBox.test.js
+++ b/packages/react-instantsearch/src/connectors/connectSearchBox.test.js
@@ -9,6 +9,7 @@ const {
   getProps,
   refine,
   getSearchParameters: getSP,
+  cleanUp,
 } = connect;
 
 let props;
@@ -34,5 +35,10 @@ describe('connectSearchBox', () => {
   it('refines the query parameter', () => {
     params = getSP(new SearchParameters(), {}, {q: 'bar'});
     expect(params.query).toBe('bar');
+  });
+
+  it('should return the right state when clean up', () => {
+    const state = cleanUp({}, {q: {state: 'state'}, another: {state: 'state'}});
+    expect(state).toEqual({another: {state: 'state'}});
   });
 });

--- a/packages/react-instantsearch/src/connectors/connectSortBy.js
+++ b/packages/react-instantsearch/src/connectors/connectSortBy.js
@@ -1,4 +1,5 @@
 import {PropTypes} from 'react';
+import {omit} from 'lodash';
 
 import createConnector from '../core/createConnector';
 
@@ -48,6 +49,10 @@ export default createConnector({
       ...state,
       [id]: nextRefinement,
     };
+  },
+
+  cleanUp(props, state) {
+    return omit(state, getId());
   },
 
   getSearchParameters(searchParameters, props, state) {

--- a/packages/react-instantsearch/src/connectors/connectSortBy.test.js
+++ b/packages/react-instantsearch/src/connectors/connectSortBy.test.js
@@ -10,6 +10,7 @@ const {
   refine,
   getSearchParameters: getSP,
   getMetadata,
+  cleanUp,
 } = connect;
 
 let props;
@@ -43,5 +44,10 @@ describe('connectSortBy', () => {
   it('registers its id in metadata', () => {
     const metadata = getMetadata({});
     expect(metadata).toEqual({id: 'sortBy'});
+  });
+
+  it('should return the right state when clean up', () => {
+    const state = cleanUp({}, {sortBy: {state: 'state'}, another: {state: 'state'}});
+    expect(state).toEqual({another: {state: 'state'}});
   });
 });

--- a/packages/react-instantsearch/src/connectors/connectToggle.js
+++ b/packages/react-instantsearch/src/connectors/connectToggle.js
@@ -1,5 +1,5 @@
 import {PropTypes} from 'react';
-
+import {omit} from 'lodash';
 import createConnector from '../core/createConnector';
 
 function getId(props) {
@@ -52,6 +52,10 @@ export default createConnector({
       ...state,
       [getId(props, state)]: nextChecked ? 'on' : 'off',
     };
+  },
+
+  cleanUp(props, state) {
+    return omit(state, getId(props));
   },
 
   getSearchParameters(searchParameters, props, state) {

--- a/packages/react-instantsearch/src/connectors/connectToggle.test.js
+++ b/packages/react-instantsearch/src/connectors/connectToggle.test.js
@@ -10,6 +10,7 @@ const {
   refine,
   getSearchParameters: getSP,
   getMetadata,
+  cleanUp,
 } = connect;
 
 let props;
@@ -80,5 +81,10 @@ describe('connectToggle', () => {
 
     const state = metadata.items[0].value({t: 'on'});
     expect(state).toEqual({t: 'off'});
+  });
+
+  it('should return the right state when clean up', () => {
+    const state = cleanUp({attributeName: 'name'}, {name: {state: 'state'}, another: {state: 'state'}});
+    expect(state).toEqual({another: {state: 'state'}});
   });
 });

--- a/packages/react-instantsearch/src/core/createConnector.test.js
+++ b/packages/react-instantsearch/src/core/createConnector.test.js
@@ -17,6 +17,7 @@ function createState() {
 }
 
 describe('createConnector', () => {
+  const getId = () => 'id';
   describe('state', () => {
     it('computes passed props from props and state', () => {
       const getProps = jest.fn(props => ({gotProps: props}));
@@ -24,6 +25,7 @@ describe('createConnector', () => {
       const Connected = createConnector({
         displayName: 'CoolConnector',
         getProps,
+        getId,
       })(Dummy);
       const state = createState();
       const props = {
@@ -53,6 +55,7 @@ describe('createConnector', () => {
       const Connected = createConnector({
         displayName: 'CoolConnector',
         getProps,
+        getId,
       })(Dummy);
       const state = createState();
       let props = {hello: 'there'};
@@ -83,6 +86,7 @@ describe('createConnector', () => {
       const Connected = createConnector({
         displayName: 'CoolConnector',
         getProps,
+        getId,
       })(Dummy);
       let state = {
         ...createState(),
@@ -127,6 +131,7 @@ describe('createConnector', () => {
       const Connected = createConnector({
         displayName: 'CoolConnector',
         getProps: () => null,
+        getId,
       })(() => null);
       const unsubscribe = jest.fn();
       const wrapper = mount(<Connected />, {context: {
@@ -149,6 +154,7 @@ describe('createConnector', () => {
       const Connected = createConnector({
         displayName: 'CoolConnector',
         getProps,
+        getId,
       })(Dummy);
       const props = {
         hello: 'there',
@@ -184,6 +190,7 @@ describe('createConnector', () => {
       const Connected = createConnector({
         displayName: 'CoolConnector',
         getProps: () => null,
+        getId,
       })(() => null);
       const registerWidget = jest.fn();
       mount(<Connected />, {context: {
@@ -207,6 +214,7 @@ describe('createConnector', () => {
         displayName: 'CoolConnector',
         getProps: () => null,
         getMetadata,
+        getId,
       })(() => null);
       const registerWidget = jest.fn();
       const props = {hello: 'there'};
@@ -237,6 +245,7 @@ describe('createConnector', () => {
         displayName: 'CoolConnector',
         getProps: () => null,
         getSearchParameters,
+        getId,
       })(() => null);
       const registerWidget = jest.fn();
       const props = {hello: 'there'};
@@ -269,6 +278,7 @@ describe('createConnector', () => {
         displayName: 'CoolConnector',
         getProps: () => null,
         getMetadata: () => null,
+        getId,
       })(() => null);
       const update = jest.fn();
       const props = {hello: 'there'};
@@ -294,22 +304,35 @@ describe('createConnector', () => {
         displayName: 'CoolConnector',
         getProps: () => null,
         getMetadata: () => null,
+        cleanUp: () => ({another: {state: 'state'}}),
       })(() => null);
       const unregister = jest.fn();
+      const setState = jest.fn();
+      const onInternalStateUpdate = jest.fn();
       const wrapper = mount(<Connected />, {context: {
         ais: {
           store: {
-            getState: () => ({}),
+            getState: () => ({widgets: {another: {state: 'state'}}}),
+            setState,
             subscribe: () => () => null,
           },
           widgetsManager: {
             registerWidget: () => unregister,
           },
+          onInternalStateUpdate,
         },
       }});
       expect(unregister.mock.calls.length).toBe(0);
+      expect(setState.mock.calls.length).toBe(0);
+      expect(onInternalStateUpdate.mock.calls.length).toBe(0);
+
       wrapper.unmount();
+
       expect(unregister.mock.calls.length).toBe(1);
+      expect(setState.mock.calls.length).toBe(1);
+      expect(onInternalStateUpdate.mock.calls.length).toBe(1);
+      expect(setState.mock.calls[0][0]).toEqual({widgets: {another: {state: 'state'}}});
+      expect(onInternalStateUpdate.mock.calls[0][0]).toEqual({another: {state: 'state'}});
     });
   });
 
@@ -323,6 +346,7 @@ describe('createConnector', () => {
         displayName: 'CoolConnector',
         getProps: () => ({}),
         refine,
+        getId,
       })(Dummy);
       const onInternalStateUpdate = jest.fn();
       const props = {hello: 'there'};
@@ -357,6 +381,7 @@ describe('createConnector', () => {
         displayName: 'CoolConnector',
         getProps: () => ({}),
         refine,
+        getId,
       })(Dummy);
       const createHrefForState = jest.fn();
       const props = {hello: 'there'};


### PR DESCRIPTION
Clean the state when a widget is unmounted except if the widget is marked has persistent (via a props). 

Needs review about the way to achieve the clean:
-> I did it forcing the user to define an id inside the connector (instead of having it outside). 
It avoids the repetition of the clean up code and in a way clarify the need of an id (when there's a refinement). But it also complexify the user api and some widgets code (you need to pass the id a lot of time). Also it hides from the user how the widget cleanup is done. 

An alternative from Vincent would be to let the user do the cleanup using the same interface as the refine method (you got the whole state, and return the whole state). The cleanup function would be called when the widget unmount. 

What do you think?
