### PR TITLE
docs: add react-router small demo app

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,6 @@
 # eslint by default only ignores root node_modules/
 packages/*/node_modules
-packages/examples
+packages/react-instantsearch/examples/*/node_modules/
 coverage/
 # generated documentation website
 docs/

--- a/docgen/src/guides/advanced-topics.md
+++ b/docgen/src/guides/advanced-topics.md
@@ -88,77 +88,11 @@ To be able to do that, you will need to provide three props to the [InstantSearc
 * createURL(state): this function is needed for every widgets that will render a link. It expects a string in return.
 This function while provided to every widgets and connectors is only useful if you are in a browser context. 
 
-Here's an example showing you how to use [react-router](https://github.com/ReactTraining/react-router) with react-instantsearch. 
-
-```jsx
-import React, {Component} from 'react';
-import {
-    InstantSearch
-} from 'react-instantsearch/dom';
-import {withRouter} from 'react-router';
-import qs from 'qs';
-
-class App extends Component {
-   constructor (props) {
-       super(props);
-       // we initialize the state by parsing the url
-       this.state = {state: {...qs.parse(this.props.router.location.query)}}; 
-    }
-    
-    /*
-    Update the state when the back/forward button is used
-     */
-    componentWillReceiveProps(){
-        this.setState({state: qs.parse(this.props.router.location.query)});
-    }
-    
-    /*
-    Push the new state to the react-router history. The threshold is there 
-    to specify how long we should wait between state changes before pushing 
-    a new location instead of replacing the old one. This is a very basic 
-    implementation you might want to perform advanced behaviors like removing 
-    empty values from the url or being able to keep others query params. 
-    */
-    onStateChange = (nextState) => {
-        const THRESHOLD = 700;
-        const newPush = Date.now();
-        /*
-        the current state is saved to be given as the 
-        state props of InstantSearch root component
-        */
-        this.setState({lastPush: newPush, state: nextState});
-        if (this.state.lastPush && newPush - this.state.lastPush  <= THRESHOLD) {
-            this.props.router.replace(nextState ? `?${qs.stringify(nextState)}` : '');
-        } else {
-            this.props.router.push(nextState ? `?${qs.stringify(nextState)}` : '');
-        }
-    };
-    
-    /*
-    This is the function that will be provided to every widgets and connectors. 
-    It allows you to be able to create a link. 
-    */
-    createURL = (state) => {
-        return `?${qs.stringify(state)}`; 
-    };
-
-    render() {
-        return (
-            <InstantSearch
-                appId="appId"
-                apiKey="apiKey"
-                indexName="indexName"
-                state={this.state.state}
-                onStateChange={this.onStateChange.bind(this)}
-                createURL={this.createURL.bind(this)}
-            >
-            </InstantSearch>
-        );
-    }
-}
-
-export default withRouter(App);
-```
+It exists many ways to manipulate the browser history. Here are some you could use:
+* Using [the browser history api](https://developer.mozilla.org/en-US/docs/Web/API/History_API)
+* Using a JavaScript history library
+* Using [react-router](https://github.com/ReactTraining/react-router). 
+See our [small demo app to have a full integration example](https://github.com/algolia/instantsearch.js/tree/v2/packages/react-instantsearch/examples/react-router). 
 
 ## React Native
 

--- a/packages/react-instantsearch/examples/react-router/README.md
+++ b/packages/react-instantsearch/examples/react-router/README.md
@@ -1,0 +1,9 @@
+This example shows how to synchronize your instantsearch url
+if you are using react-router.
+
+To start the example: 
+
+* npm install
+* npm start
+
+Read more about react-instantsearch [in our documentation](https://community.algolia.com/instantsearch.js/react/).

--- a/packages/react-instantsearch/examples/react-router/package.json
+++ b/packages/react-instantsearch/examples/react-router/package.json
@@ -1,0 +1,19 @@
+{
+  "private": true,
+  "devDependencies": {
+    "react-scripts": "0.7.0"
+  },
+  "dependencies": {
+    "lodash": "^4.16.6",
+    "qs": "^6.3.0",
+    "react": "^15.3.2",
+    "react-dom": "^15.3.2",
+    "react-instantsearch": "^2.0.0-beta.17",
+    "react-router": "^3.0.0"
+  },
+  "scripts": {
+    "start": "react-scripts start"
+  },
+  "main": "index.js",
+  "license": "MIT"
+}

--- a/packages/react-instantsearch/examples/react-router/public/index.html
+++ b/packages/react-instantsearch/examples/react-router/public/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>react-router feat react-instantsearch</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/packages/react-instantsearch/examples/react-router/src/App.js
+++ b/packages/react-instantsearch/examples/react-router/src/App.js
@@ -1,0 +1,99 @@
+import React, {Component} from 'react';
+import {
+  InstantSearch, HierarchicalMenu,
+  Hits, Menu, Pagination, PoweredBy, RangeRatings,
+  RefinementList, SearchBox, ClearAll,
+} from 'react-instantsearch/dom';
+/* eslint-disable import/no-unresolved */
+import {withRouter} from 'react-router';
+/* eslint-enable import/no-unresolved */
+import qs from 'qs';
+
+class App extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {state: {...qs.parse(this.props.router.location.query)}};
+  }
+
+  componentWillReceiveProps() {
+    this.setState({state: qs.parse(this.props.router.location.query)});
+  }
+
+  onStateChange = nextState => {
+    const THRESHOLD = 700;
+    const newPush = Date.now();
+    this.setState({lastPush: newPush, state: nextState});
+    if (this.state.lastPush && newPush - this.state.lastPush <= THRESHOLD) {
+      this.props.router.replace(nextState ? `?${qs.stringify(nextState)}` : '');
+    } else {
+      this.props.router.push(nextState ? `?${qs.stringify(nextState)}` : '');
+    }
+  };
+
+  createURL = state => `?${qs.stringify(state)}`;
+
+  render() {
+    return (
+      <InstantSearch
+        appId="latency"
+        apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+        indexName="ikea"
+        state={this.state.state}
+        onStateChange={this.onStateChange.bind(this)}
+        createURL={this.createURL.bind(this)}
+      >
+        <div>
+          <div>
+            <div style={{
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: 'center',
+              alignItems: 'center',
+              marginBottom: 10,
+            }}>
+              <SearchBox/>
+              <PoweredBy />
+            </div>
+            <div style={{display: 'flex'}}>
+              <div style={{padding: '0px 20px'}}>
+                <p>Hierarchical Menu</p>
+                <HierarchicalMenu
+                  id="categories"
+                  attributes={[
+                    'category',
+                    'sub_category',
+                    'sub_sub_category',
+                  ]}
+                />
+                <p>Menu</p>
+                <Menu attributeName="type"/>
+                <p>Refinement List</p>
+                <RefinementList attributeName="colors"/>
+                <p>Range Ratings</p>
+                <RangeRatings attributeName="rating" max={6}/>
+
+              </div>
+              <div style={{display: 'flex', flexDirection: 'column', flex: 1}}>
+                <div style={{display: 'flex', justifyContent: 'space-around'}}>
+                  <ClearAll/>
+                </div>
+                <div>
+                  <Hits />
+                </div>
+                <div style={{alignSelf: 'center'}}>
+                  <Pagination showLast={true}/>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </InstantSearch>
+    );
+  }
+}
+
+App.propTypes = {
+  router: React.PropTypes.object.isRequired,
+};
+
+export default withRouter(App);

--- a/packages/react-instantsearch/examples/react-router/src/index.js
+++ b/packages/react-instantsearch/examples/react-router/src/index.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from './App';
+/* eslint-disable import/no-unresolved */
+import {Router, Route, browserHistory} from 'react-router';
+/* eslint-enable import/no-unresolved */
+
+ReactDOM.render(
+  <Router history={browserHistory}>
+    <Route path="/" component={App}/>
+  </Router>,
+  document.getElementById('root')
+);


### PR DESCRIPTION
I decided to remove the code sample from the guide and just add the link pointing to the demo app. 
Let me know if you think we need both.

Also, can someone just perform a yarn install in the demo directory and tell me if the react-instantsearch directory under node_modules is correct? (without any /dist, /.storybook...etc)?