### PR TITLE
docs(website): improve the readability of required (or important) opt…

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -14,6 +14,7 @@ group :development, :test do
   gem 'thin'
   gem 'guard-livereload'
   gem 'guard-bundler', require: false
+  gem 'rb-readline'
 end
 
 group :jekyll_plugins do

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -128,6 +128,7 @@ GEM
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
+    rb-readline (0.5.3)
     redcarpet (3.3.4)
     safe_yaml (1.0.4)
     sass (3.4.22)
@@ -172,6 +173,7 @@ DEPENDENCIES
   jekyll-assets
   jekyll-contentblocks
   nokogiri
+  rb-readline
   sass
   thin
   uglifier

--- a/docs/_assets/javascripts/doc.js
+++ b/docs/_assets/javascripts/doc.js
@@ -185,7 +185,7 @@
     $('.attr-name').on('click', function() {
       var $descriptionParagraph = $(this).next('.attr-description')
       var isVisible = $descriptionParagraph.is(':visible');
-      $('.attr-description').hide();
+      $('.attr-description:not(.important)').hide();
       if(!isVisible) $descriptionParagraph.show();
     });
   }

--- a/docs/_assets/stylesheets/_documentation.scss
+++ b/docs/_assets/stylesheets/_documentation.scss
@@ -352,6 +352,11 @@ code {
       &:hover .show-description {
         color: #FFF;
       }
+      .attr-required, .attr-optional.important {
+        .show-description {
+          display: none;
+        }
+      }
     }
     .attr-optional code {
       color: #46AEDA;
@@ -368,6 +373,10 @@ code {
       margin: -5px 0 0;
       display: none;
       clear: both;
+
+      &.important {
+        display: block;
+      }
     }
     h5 {
       text-decoration: underline;

--- a/docs/_includes/widget-jsdoc/clearAll.md
+++ b/docs/_includes/widget-jsdoc/clearAll.md
@@ -3,7 +3,7 @@
 <span class='attr-required'>`options.container`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code> &#124; <code>DOMElement</code>)</span>
 </p>
-<p class="attr-description">CSS Selector or DOMElement to insert the widget</p>
+<p class="attr-description important">CSS Selector or DOMElement to insert the widget</p>
 <p class="attr-name">
 <span class='attr-optional'>`options.excludeAttributes`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>Array.&lt;string&gt;</code>)</span>

--- a/docs/_includes/widget-jsdoc/currentRefinedValues.md
+++ b/docs/_includes/widget-jsdoc/currentRefinedValues.md
@@ -3,7 +3,7 @@
 <span class='attr-required'>`options.container`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code> &#124; <code>DOMElement</code>)</span>
 </p>
-<p class="attr-description">CSS Selector or DOMElement to insert the widget</p>
+<p class="attr-description important">CSS Selector or DOMElement to insert the widget</p>
 <p class="attr-name">
 <span class='attr-optional'>`option.attributes`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>Array</code>)</span>

--- a/docs/_includes/widget-jsdoc/hierarchicalMenu.md
+++ b/docs/_includes/widget-jsdoc/hierarchicalMenu.md
@@ -3,17 +3,22 @@
 <span class='attr-required'>`options.container`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code> &#124; <code>DOMElement</code>)</span>
 </p>
-<p class="attr-description">CSS Selector or DOMElement to insert the widget</p>
+<p class="attr-description important">CSS Selector or DOMElement to insert the widget</p>
 <p class="attr-name">
 <span class='attr-required'>`options.attributes`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>Array.&lt;string&gt;</code>)</span>
 </p>
-<p class="attr-description">Array of attributes to use to generate the hierarchy of the menu. See the example for the convention to follow.</p>
+<p class="attr-description important">Array of attributes to use to generate the hierarchy of the menu. See the example for the convention to follow.</p>
 <p class="attr-name">
-<span class='attr-optional'>`options.separator`<span class="show-description">…</span></span>
-  <span class="attr-infos">Default:<code class="attr-default">&#x27; &gt; &#x27;</code>(<code>string</code>)</span>
+<span class='attr-optional important'>`options.limit`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">10</code>(<code>number</code>)</span>
 </p>
-<p class="attr-description">Separator used in the attributes to separate level values.</p>
+<p class="attr-description important">How much facet values to get</p>
+<p class="attr-name">
+<span class='attr-optional important'>`options.separator`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">&quot;&gt;&quot;</code>(<code>string</code>)</span>
+</p>
+<p class="attr-description important">Separator used in the attributes to separate level values.</p>
 <p class="attr-name">
 <span class='attr-optional'>`options.rootPath`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code>)</span>
@@ -24,11 +29,6 @@
   <span class="attr-infos">Default:<code class="attr-default">false</code>(<code>string</code>)</span>
 </p>
 <p class="attr-description">Show the parent level of the current refined value</p>
-<p class="attr-name">
-<span class='attr-optional'>`options.limit`<span class="show-description">…</span></span>
-  <span class="attr-infos">Default:<code class="attr-default">10</code>(<code>number</code>)</span>
-</p>
-<p class="attr-description">How much facet values to get</p>
 <p class="attr-name">
 <span class='attr-optional'>`options.sortBy`<span class="show-description">…</span></span>
   <span class="attr-infos">Default:<code class="attr-default">[&#x27;name:asc&#x27;]</code>(<code>Array.&lt;string&gt;</code> &#124; <code>function</code>)</span>

--- a/docs/_includes/widget-jsdoc/hits.md
+++ b/docs/_includes/widget-jsdoc/hits.md
@@ -3,7 +3,12 @@
 <span class='attr-required'>`options.container`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code> &#124; <code>DOMElement</code>)</span>
 </p>
-<p class="attr-description">CSS Selector or DOMElement to insert the widget</p>
+<p class="attr-description important">CSS Selector or DOMElement to insert the widget</p>
+<p class="attr-name">
+<span class='attr-optional important'>`options.hitsPerPage`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">20</code>(<code>number</code>)</span>
+</p>
+<p class="attr-description important">The number of hits to display per page</p>
 <p class="attr-name">
 <span class='attr-optional'>`options.templates`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>Object</code>)</span>
@@ -44,11 +49,6 @@
   <span class="attr-infos">(<code>function</code>)</span>
 </p>
 <p class="attr-description">Method used to change the object passed to the `allItems` template</p>
-<p class="attr-name">
-<span class='attr-optional'>`hitsPerPage`<span class="show-description">…</span></span>
-  <span class="attr-infos">Default:<code class="attr-default">20</code>(<code>number</code>)</span>
-</p>
-<p class="attr-description">The number of hits to display per page</p>
 <p class="attr-name">
 <span class='attr-optional'>`options.cssClasses`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>Object</code>)</span>

--- a/docs/_includes/widget-jsdoc/hitsPerPageSelector.md
+++ b/docs/_includes/widget-jsdoc/hitsPerPageSelector.md
@@ -3,22 +3,22 @@
 <span class='attr-required'>`options.container`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code> &#124; <code>DOMElement</code>)</span>
 </p>
-<p class="attr-description">CSS Selector or DOMElement to insert the widget</p>
+<p class="attr-description important">CSS Selector or DOMElement to insert the widget</p>
 <p class="attr-name">
 <span class='attr-required'>`options.options`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>Array</code>)</span>
 </p>
-<p class="attr-description">Array of objects defining the different values and labels</p>
+<p class="attr-description important">Array of objects defining the different values and labels</p>
 <p class="attr-name">
 <span class='attr-required'>`options.options[0].value`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>number</code>)</span>
 </p>
-<p class="attr-description">number of hits to display per page</p>
+<p class="attr-description important">number of hits to display per page</p>
 <p class="attr-name">
 <span class='attr-required'>`options.options[0].label`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code>)</span>
 </p>
-<p class="attr-description">Label to display in the option</p>
+<p class="attr-description important">Label to display in the option</p>
 <p class="attr-name">
 <span class='attr-optional'>`options.autoHideContainer`<span class="show-description">…</span></span>
   <span class="attr-infos">Default:<code class="attr-default">false</code>(<code>boolean</code>)</span>

--- a/docs/_includes/widget-jsdoc/instantsearch.md
+++ b/docs/_includes/widget-jsdoc/instantsearch.md
@@ -3,17 +3,17 @@
 <span class='attr-required'>`options.appId`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code>)</span>
 </p>
-<p class="attr-description">The Algolia application ID</p>
+<p class="attr-description important">The Algolia application ID</p>
 <p class="attr-name">
 <span class='attr-required'>`options.apiKey`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code>)</span>
 </p>
-<p class="attr-description">The Algolia search-only API key</p>
+<p class="attr-description important">The Algolia search-only API key</p>
 <p class="attr-name">
 <span class='attr-required'>`options.indexName`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code>)</span>
 </p>
-<p class="attr-description">The name of the main index</p>
+<p class="attr-description important">The name of the main index</p>
 <p class="attr-name">
 <span class='attr-optional'>`options.numberLocale`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code>)</span>

--- a/docs/_includes/widget-jsdoc/menu.md
+++ b/docs/_includes/widget-jsdoc/menu.md
@@ -3,22 +3,22 @@
 <span class='attr-required'>`options.container`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code> &#124; <code>DOMElement</code>)</span>
 </p>
-<p class="attr-description">CSS Selector or DOMElement to insert the widget</p>
+<p class="attr-description important">CSS Selector or DOMElement to insert the widget</p>
 <p class="attr-name">
 <span class='attr-required'>`options.attributeName`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code>)</span>
 </p>
-<p class="attr-description">Name of the attribute for faceting</p>
+<p class="attr-description important">Name of the attribute for faceting</p>
 <p class="attr-name">
-<span class='attr-optional'>`options.sortBy`<span class="show-description">…</span></span>
+<span class='attr-optional important'>`options.sortBy`<span class="show-description">…</span></span>
   <span class="attr-infos">Default:<code class="attr-default">[&#x27;count:desc&#x27;, &#x27;name:asc&#x27;]</code>(<code>Array.&lt;string&gt;</code> &#124; <code>function</code>)</span>
 </p>
-<p class="attr-description">How to sort refinements. Possible values: `count|isRefined|name:asc|name:desc`.   You can also use a sort function that behaves like the standard Javascript [compareFunction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#Syntax).</p>
+<p class="attr-description important">How to sort refinements. Possible values: `count|isRefined|name:asc|name:desc`.   You can also use a sort function that behaves like the standard Javascript [compareFunction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#Syntax).</p>
 <p class="attr-name">
-<span class='attr-optional'>`options.limit`<span class="show-description">…</span></span>
+<span class='attr-optional important'>`options.limit`<span class="show-description">…</span></span>
   <span class="attr-infos">Default:<code class="attr-default">10</code>(<code>string</code>)</span>
 </p>
-<p class="attr-description">How many facets values to retrieve</p>
+<p class="attr-description important">How many facets values to retrieve</p>
 <p class="attr-name">
 <span class='attr-optional'>`options.showMore`<span class="show-description">…</span></span>
   <span class="attr-infos">Default:<code class="attr-default">false</code>(<code>object</code> &#124; <code>boolean</code>)</span>

--- a/docs/_includes/widget-jsdoc/numericRefinementList.md
+++ b/docs/_includes/widget-jsdoc/numericRefinementList.md
@@ -3,22 +3,22 @@
 <span class='attr-required'>`options.container`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code> &#124; <code>DOMElement</code>)</span>
 </p>
-<p class="attr-description">CSS Selector or DOMElement to insert the widget</p>
+<p class="attr-description important">CSS Selector or DOMElement to insert the widget</p>
 <p class="attr-name">
 <span class='attr-required'>`options.attributeName`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code>)</span>
 </p>
-<p class="attr-description">Name of the attribute for filtering</p>
+<p class="attr-description important">Name of the attribute for filtering</p>
 <p class="attr-name">
 <span class='attr-required'>`options.options`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>Array.&lt;Object&gt;</code>)</span>
 </p>
-<p class="attr-description">List of all the options</p>
+<p class="attr-description important">List of all the options</p>
 <p class="attr-name">
 <span class='attr-required'>`options.options[].name`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code>)</span>
 </p>
-<p class="attr-description">Name of the option</p>
+<p class="attr-description important">Name of the option</p>
 <p class="attr-name">
 <span class='attr-optional'>`options.options[].start`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>number</code>)</span>

--- a/docs/_includes/widget-jsdoc/numericSelector.md
+++ b/docs/_includes/widget-jsdoc/numericSelector.md
@@ -3,30 +3,30 @@
 <span class='attr-required'>`options.container`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code> &#124; <code>DOMElement</code>)</span>
 </p>
-<p class="attr-description">CSS Selector or DOMElement to insert the widget</p>
+<p class="attr-description important">CSS Selector or DOMElement to insert the widget</p>
 <p class="attr-name">
 <span class='attr-required'>`options.attributeName`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code>)</span>
 </p>
-<p class="attr-description">Name of the numeric attribute to use</p>
+<p class="attr-description important">Name of the numeric attribute to use</p>
 <p class="attr-name">
 <span class='attr-required'>`options.options`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>Array</code>)</span>
 </p>
-<p class="attr-description">Array of objects defining the different values and labels</p>
+<p class="attr-description important">Array of objects defining the different values and labels</p>
 <p class="attr-name">
 <span class='attr-required'>`options.options[i].value`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>number</code>)</span>
 </p>
-<p class="attr-description">The numerical value to refine with</p>
+<p class="attr-description important">The numerical value to refine with</p>
 <p class="attr-name">
 <span class='attr-required'>`options.options[i].label`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code>)</span>
 </p>
-<p class="attr-description">Label to display in the option</p>
+<p class="attr-description important">Label to display in the option</p>
 <p class="attr-name">
 <span class='attr-optional'>`options.operator`<span class="show-description">…</span></span>
-  <span class="attr-infos">(<code>string</code>)</span>
+  <span class="attr-infos">Default:<code class="attr-default">&#x27;=&#x27;</code>(<code>string</code>)</span>
 </p>
 <p class="attr-description">The operator to use to refine</p>
 <p class="attr-name">

--- a/docs/_includes/widget-jsdoc/pagination.md
+++ b/docs/_includes/widget-jsdoc/pagination.md
@@ -3,7 +3,7 @@
 <span class='attr-required'>`options.container`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code> &#124; <code>DOMElement</code>)</span>
 </p>
-<p class="attr-description">CSS Selector or DOMElement to insert the widget</p>
+<p class="attr-description important">CSS Selector or DOMElement to insert the widget</p>
 <p class="attr-name">
 <span class='attr-optional'>`options.labels`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>Object</code>)</span>

--- a/docs/_includes/widget-jsdoc/priceRanges.md
+++ b/docs/_includes/widget-jsdoc/priceRanges.md
@@ -3,12 +3,12 @@
 <span class='attr-required'>`options.container`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code> &#124; <code>DOMElement</code>)</span>
 </p>
-<p class="attr-description">Valid CSS Selector as a string or DOMElement</p>
+<p class="attr-description important">Valid CSS Selector as a string or DOMElement</p>
 <p class="attr-name">
 <span class='attr-required'>`options.attributeName`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code>)</span>
 </p>
-<p class="attr-description">Name of the attribute for faceting</p>
+<p class="attr-description important">Name of the attribute for faceting</p>
 <p class="attr-name">
 <span class='attr-optional'>`options.templates`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>Object</code>)</span>

--- a/docs/_includes/widget-jsdoc/rangeSlider.md
+++ b/docs/_includes/widget-jsdoc/rangeSlider.md
@@ -3,12 +3,12 @@
 <span class='attr-required'>`options.container`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code> &#124; <code>DOMElement</code>)</span>
 </p>
-<p class="attr-description">CSS Selector or DOMElement to insert the widget</p>
+<p class="attr-description important">CSS Selector or DOMElement to insert the widget</p>
 <p class="attr-name">
 <span class='attr-required'>`options.attributeName`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code>)</span>
 </p>
-<p class="attr-description">Name of the attribute for faceting</p>
+<p class="attr-description important">Name of the attribute for faceting</p>
 <p class="attr-name">
 <span class='attr-optional'>`options.tooltips`<span class="show-description">…</span></span>
   <span class="attr-infos">Default:<code class="attr-default">true</code>(<code>boolean</code> &#124; <code>Object</code>)</span>

--- a/docs/_includes/widget-jsdoc/refinementList.md
+++ b/docs/_includes/widget-jsdoc/refinementList.md
@@ -3,27 +3,27 @@
 <span class='attr-required'>`options.container`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code> &#124; <code>DOMElement</code>)</span>
 </p>
-<p class="attr-description">CSS Selector or DOMElement to insert the widget</p>
+<p class="attr-description important">CSS Selector or DOMElement to insert the widget</p>
 <p class="attr-name">
 <span class='attr-required'>`options.attributeName`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code>)</span>
 </p>
-<p class="attr-description">Name of the attribute for faceting</p>
+<p class="attr-description important">Name of the attribute for faceting</p>
 <p class="attr-name">
-<span class='attr-optional'>`options.operator`<span class="show-description">…</span></span>
+<span class='attr-required'>`options.operator`<span class="show-description">…</span></span>
   <span class="attr-infos">Default:<code class="attr-default">&#x27;or&#x27;</code>(<code>string</code>)</span>
 </p>
-<p class="attr-description">How to apply refinements. Possible values: `or`, `and`</p>
+<p class="attr-description important">How to apply refinements. Possible values: `or`, `and`</p>
 <p class="attr-name">
-<span class='attr-optional'>`options.sortBy`<span class="show-description">…</span></span>
+<span class='attr-optional important'>`options.sortBy`<span class="show-description">…</span></span>
   <span class="attr-infos">Default:<code class="attr-default">[&#x27;count:desc&#x27;, &#x27;name:asc&#x27;]</code>(<code>Array.&lt;string&gt;</code> &#124; <code>function</code>)</span>
 </p>
-<p class="attr-description">How to sort refinements. Possible values: `count:asc|count:desc|name:asc|name:desc|isRefined`.   You can also use a sort function that behaves like the standard Javascript [compareFunction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#Syntax).</p>
+<p class="attr-description important">How to sort refinements. Possible values: `count:asc|count:desc|name:asc|name:desc|isRefined`.   You can also use a sort function that behaves like the standard Javascript [compareFunction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#Syntax).</p>
 <p class="attr-name">
-<span class='attr-optional'>`options.limit`<span class="show-description">…</span></span>
+<span class='attr-optional important'>`options.limit`<span class="show-description">…</span></span>
   <span class="attr-infos">Default:<code class="attr-default">10</code>(<code>string</code>)</span>
 </p>
-<p class="attr-description">How much facet values to get. When the show more feature is activated this is the minimum number of facets requested (the show more button is not in active state).</p>
+<p class="attr-description important">How much facet values to get. When the show more feature is activated this is the minimum number of facets requested (the show more button is not in active state).</p>
 <p class="attr-name">
 <span class='attr-optional'>`options.showMore`<span class="show-description">…</span></span>
   <span class="attr-infos">Default:<code class="attr-default">false</code>(<code>object</code> &#124; <code>boolean</code>)</span>

--- a/docs/_includes/widget-jsdoc/searchBox.md
+++ b/docs/_includes/widget-jsdoc/searchBox.md
@@ -3,12 +3,12 @@
 <span class='attr-required'>`options.container`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code> &#124; <code>DOMElement</code>)</span>
 </p>
-<p class="attr-description">CSS Selector or DOMElement to insert the widget</p>
+<p class="attr-description important">CSS Selector or DOMElement to insert the widget</p>
 <p class="attr-name">
-<span class='attr-optional'>`options.placeholder`<span class="show-description">…</span></span>
+<span class='attr-optional important'>`options.placeholder`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code>)</span>
 </p>
-<p class="attr-description">Input's placeholder</p>
+<p class="attr-description important">Input's placeholder</p>
 <p class="attr-name">
 <span class='attr-optional'>`options.poweredBy`<span class="show-description">…</span></span>
   <span class="attr-infos">Default:<code class="attr-default">false</code>(<code>boolean</code> &#124; <code>Object</code>)</span>

--- a/docs/_includes/widget-jsdoc/sortBySelector.md
+++ b/docs/_includes/widget-jsdoc/sortBySelector.md
@@ -3,22 +3,22 @@
 <span class='attr-required'>`options.container`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code> &#124; <code>DOMElement</code>)</span>
 </p>
-<p class="attr-description">CSS Selector or DOMElement to insert the widget</p>
+<p class="attr-description important">CSS Selector or DOMElement to insert the widget</p>
 <p class="attr-name">
 <span class='attr-required'>`options.indices`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>Array</code>)</span>
 </p>
-<p class="attr-description">Array of objects defining the different indices to choose from.</p>
+<p class="attr-description important">Array of objects defining the different indices to choose from.</p>
 <p class="attr-name">
 <span class='attr-required'>`options.indices[0].name`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code>)</span>
 </p>
-<p class="attr-description">Name of the index to target</p>
+<p class="attr-description important">Name of the index to target</p>
 <p class="attr-name">
 <span class='attr-required'>`options.indices[0].label`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code>)</span>
 </p>
-<p class="attr-description">Label displayed in the dropdown</p>
+<p class="attr-description important">Label displayed in the dropdown</p>
 <p class="attr-name">
 <span class='attr-optional'>`options.autoHideContainer`<span class="show-description">…</span></span>
   <span class="attr-infos">Default:<code class="attr-default">false</code>(<code>boolean</code>)</span>

--- a/docs/_includes/widget-jsdoc/starRating.md
+++ b/docs/_includes/widget-jsdoc/starRating.md
@@ -3,12 +3,12 @@
 <span class='attr-required'>`options.container`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code> &#124; <code>DOMElement</code>)</span>
 </p>
-<p class="attr-description">CSS Selector or DOMElement to insert the widget</p>
+<p class="attr-description important">CSS Selector or DOMElement to insert the widget</p>
 <p class="attr-name">
 <span class='attr-required'>`options.attributeName`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code>)</span>
 </p>
-<p class="attr-description">Name of the attribute for filtering</p>
+<p class="attr-description important">Name of the attribute for filtering</p>
 <p class="attr-name">
 <span class='attr-optional'>`options.max`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>number</code>)</span>

--- a/docs/_includes/widget-jsdoc/stats.md
+++ b/docs/_includes/widget-jsdoc/stats.md
@@ -3,7 +3,7 @@
 <span class='attr-required'>`options.container`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code> &#124; <code>DOMElement</code>)</span>
 </p>
-<p class="attr-description">CSS Selector or DOMElement to insert the widget</p>
+<p class="attr-description important">CSS Selector or DOMElement to insert the widget</p>
 <p class="attr-name">
 <span class='attr-optional'>`options.templates`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>Object</code>)</span>

--- a/docs/_includes/widget-jsdoc/toggle.md
+++ b/docs/_includes/widget-jsdoc/toggle.md
@@ -3,17 +3,17 @@
 <span class='attr-required'>`options.container`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code> &#124; <code>DOMElement</code>)</span>
 </p>
-<p class="attr-description">CSS Selector or DOMElement to insert the widget</p>
+<p class="attr-description important">CSS Selector or DOMElement to insert the widget</p>
 <p class="attr-name">
 <span class='attr-required'>`options.attributeName`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code>)</span>
 </p>
-<p class="attr-description">Name of the attribute for faceting (eg. "free_shipping")</p>
+<p class="attr-description important">Name of the attribute for faceting (eg. "free_shipping")</p>
 <p class="attr-name">
 <span class='attr-required'>`options.label`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>string</code>)</span>
 </p>
-<p class="attr-description">Human-readable name of the filter (eg. "Free Shipping")</p>
+<p class="attr-description important">Human-readable name of the filter (eg. "Free Shipping")</p>
 <p class="attr-name">
 <span class='attr-optional'>`options.values`<span class="show-description">…</span></span>
   <span class="attr-infos">(<code>Object</code>)</span>

--- a/scripts/docs/gen-widget-doc.js
+++ b/scripts/docs/gen-widget-doc.js
@@ -28,6 +28,16 @@ function dataReady(data) {
   other functions like the instantsearch() one */
   let fns = data.filter(token => token.kind === 'function');
 
+  // consider optional but important ([*]) params as important
+  data.forEach(d => {
+    (d.params || []).forEach(param => {
+      if (param.optional && param.description.indexOf('[*]') > -1) {
+        param.description = param.description.replace(/\s*\[\*\]$/g, '');
+        param.important = true;
+      }
+    });
+  });
+
   /* render an output file for each class */
   renderMarkdown(data, fns);
 }

--- a/scripts/docs/widgetTemplate.hbs
+++ b/scripts/docs/widgetTemplate.hbs
@@ -2,10 +2,10 @@
 <h4 class="no-toc">Parameters</h4>
 {{#tableRow params "name" "type" "defaultvalue" "description" ~}}
 <p class="attr-name">
-{{#if optional}}<span class='attr-optional'>{{else}}<span class='attr-required'>{{/if}}`{{name}}`<span class="show-description">…</span></span>
+{{#if optional}}<span class='attr-optional{{#if important}} important{{/if}}'>{{else}}<span class='attr-required'>{{/if}}`{{name}}`<span class="show-description">…</span></span>
   <span class="attr-infos">{{#unless (equal defaultvalue undefined)}}Default:<code class="attr-default">{{defaultvalue}}</code>{{/unless}}({{>linked-type-list types=type.names delimiter=" &#124; " }})</span>
 </p>
-<p class="attr-description">{{{stripNewlines (inlineLinks description)}}}</p>
+<p class="attr-description{{#if important}} important{{/if}}{{#unless optional}} important{{/unless}}">{{{stripNewlines (inlineLinks description)}}}</p>
 {{/tableRow}}
 {{/function}}
 

--- a/src/widgets/hierarchical-menu/hierarchical-menu.js
+++ b/src/widgets/hierarchical-menu/hierarchical-menu.js
@@ -18,10 +18,10 @@ const bem = bemHelper('ais-hierarchical-menu');
  * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
  * @param  {string[]} options.attributes Array of attributes to use to generate the hierarchy of the menu.
  * See the example for the convention to follow.
- * @param  {string} [options.separator=' > '] Separator used in the attributes to separate level values.
+ * @param  {number} [options.limit=10] How much facet values to get [*]
+ * @param  {string} [options.separator=">"] Separator used in the attributes to separate level values. [*]
  * @param  {string} [options.rootPath] Prefix path to use if the first level is not the root level.
  * @param  {string} [options.showParentLevel=false] Show the parent level of the current refined value
- * @param  {number} [options.limit=10] How much facet values to get
  * @param  {string[]|Function} [options.sortBy=['name:asc']] How to sort refinements. Possible values: `count|isRefined|name:asc|name:desc`.
  *   You can also use a sort function that behaves like the standard Javascript [compareFunction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#Syntax).
  * @param  {Object} [options.templates] Templates to use for the widget

--- a/src/widgets/hits/hits.js
+++ b/src/widgets/hits/hits.js
@@ -15,6 +15,7 @@ const bem = bemHelper('ais-hits');
  * Display the list of results (hits) from the current search
  * @function hits
  * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
+ * @param  {number} [options.hitsPerPage=20] The number of hits to display per page [*]
  * @param  {Object} [options.templates] Templates to use for the widget
  * @param  {string|Function} [options.templates.empty=''] Template to use when there are no results.
  * @param  {string|Function} [options.templates.item=''] Template to use for each result. This template will receive an object containing a single record.
@@ -23,7 +24,6 @@ const bem = bemHelper('ais-hits');
  * @param  {Function} [options.transformData.empty] Method used to change the object passed to the `empty` template
  * @param  {Function} [options.transformData.item] Method used to change the object passed to the `item` template
  * @param  {Function} [options.transformData.allItems] Method used to change the object passed to the `allItems` template
- * @param  {number} [hitsPerPage=20] The number of hits to display per page
  * @param  {Object} [options.cssClasses] CSS classes to add
  * @param  {string|string[]} [options.cssClasses.root] CSS class to add to the wrapping element
  * @param  {string|string[]} [options.cssClasses.empty] CSS class to add to the wrapping element when no results

--- a/src/widgets/menu/menu.js
+++ b/src/widgets/menu/menu.js
@@ -21,8 +21,8 @@ const bem = bemHelper('ais-menu');
  * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
  * @param  {string} options.attributeName Name of the attribute for faceting
  * @param  {string[]|Function} [options.sortBy=['count:desc', 'name:asc']] How to sort refinements. Possible values: `count|isRefined|name:asc|name:desc`.
- *   You can also use a sort function that behaves like the standard Javascript [compareFunction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#Syntax).
- * @param  {string} [options.limit=10] How many facets values to retrieve
+ *   You can also use a sort function that behaves like the standard Javascript [compareFunction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#Syntax). [*]
+ * @param  {string} [options.limit=10] How many facets values to retrieve [*]
  * @param  {object|boolean} [options.showMore=false] Limit the number of results and display a showMore button
  * @param  {object} [options.showMore.templates] Templates to use for showMore
  * @param  {object} [options.showMore.templates.active] Template used when showMore was clicked

--- a/src/widgets/numeric-selector/numeric-selector.js
+++ b/src/widgets/numeric-selector/numeric-selector.js
@@ -18,7 +18,7 @@ const bem = bemHelper('ais-numeric-selector');
  * @param  {Array} options.options Array of objects defining the different values and labels
  * @param  {number} options.options[i].value The numerical value to refine with
  * @param  {string} options.options[i].label Label to display in the option
- * @param  {string} [options.operator] The operator to use to refine
+ * @param  {string} [options.operator='='] The operator to use to refine
  * @param  {boolean} [options.autoHideContainer=false] Hide the container when no results match
  * @param  {Object} [options.cssClasses] CSS classes to be added
  * @param  {string|string[]} [options.cssClasses.root] CSS classes added to the parent `<select>`

--- a/src/widgets/refinement-list/refinement-list.js
+++ b/src/widgets/refinement-list/refinement-list.js
@@ -20,10 +20,10 @@ const bem = bemHelper('ais-refinement-list');
  * @function refinementList
  * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
  * @param  {string} options.attributeName Name of the attribute for faceting
- * @param  {string} [options.operator='or'] How to apply refinements. Possible values: `or`, `and`
+ * @param  {string} [options.operator='or'] How to apply refinements. Possible values: `or`, `and` [*]
  * @param  {string[]|Function} [options.sortBy=['count:desc', 'name:asc']] How to sort refinements. Possible values: `count:asc|count:desc|name:asc|name:desc|isRefined`.
- *   You can also use a sort function that behaves like the standard Javascript [compareFunction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#Syntax).
- * @param  {string} [options.limit=10] How much facet values to get. When the show more feature is activated this is the minimum number of facets requested (the show more button is not in active state).
+ *   You can also use a sort function that behaves like the standard Javascript [compareFunction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#Syntax). [*]
+ * @param  {string} [options.limit=10] How much facet values to get. When the show more feature is activated this is the minimum number of facets requested (the show more button is not in active state). [*]
  * @param  {object|boolean} [options.showMore=false] Limit the number of results and display a showMore button
  * @param  {object} [options.showMore.templates] Templates to use for showMore
  * @param  {object} [options.showMore.templates.active] Template used when showMore was clicked

--- a/src/widgets/search-box/search-box.js
+++ b/src/widgets/search-box/search-box.js
@@ -17,7 +17,7 @@ const KEY_SUPPRESS = 8;
  * Instantiate a searchbox
  * @function searchBox
  * @param  {string|DOMElement} options.container CSS Selector or DOMElement to insert the widget
- * @param  {string} [options.placeholder] Input's placeholder
+ * @param  {string} [options.placeholder] Input's placeholder [*]
  * @param  {boolean|Object} [options.poweredBy=false] Define if a "powered by Algolia" link should be added near the input
  * @param  {function|string} [options.poweredBy.template] Template used for displaying the link. Can accept a function or a Hogan string.
  * @param  {number} [options.poweredBy.cssClasses] CSS classes to add


### PR DESCRIPTION
Often times, I feel a bit lost while reading the documentation because
all the options' descriptions re collapsed, resulting in me considering
all the options with the same importance.

I feel like this is definitely something we want for templates &
cssClasses but some other options (even optional ones) are used a lot
and should be emphasized.

Before:

![screen shot 2016-11-23 at 10 16 45](https://cloud.githubusercontent.com/assets/29529/20556154/fa8d9416-b165-11e6-93d3-09a843778ae5.png)

After:

![screen shot 2016-11-23 at 10 17 07](https://cloud.githubusercontent.com/assets/29529/20556161/047ba74c-b166-11e6-8e25-42ae1ca657d1.png)

I'm still wondering if the `* Required` mention is required at the end; because I want some option to be "important" without putting them "required" (like `hitsPerPage` which has a default value of 20).

I therefore updated a few JSDocs snippets to remove the `[`...`]` optional notations.

Let me know what you guys think 👍 