### PR TITLE
fix(Pagination): when page === 1, first should not be selected

### DIFF
--- a/packages/react-instantsearch/src/components/LinkList.js
+++ b/packages/react-instantsearch/src/components/LinkList.js
@@ -46,7 +46,7 @@ export default class LinkList extends Component {
               has(item, 'key') ? item.key : item.value,
               'item',
               // eslint-disable-next-line
-              item.value == selectedItem && 'itemSelected',
+              item.value == selectedItem && !item.disabled && 'itemSelected',
               item.disabled && 'itemDisabled',
               item.modifier
             )}

--- a/packages/react-instantsearch/src/components/Pagination.test.js
+++ b/packages/react-instantsearch/src/components/Pagination.test.js
@@ -89,6 +89,26 @@ describe('Pagination', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('indicates when first button is relevant', () => {
+    tree = renderer.create(
+      <Pagination
+        {...DEFAULT_PROPS}
+        showFirst
+        currentRefinement={1}
+      />
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+
+    tree = renderer.create(
+      <Pagination
+        {...DEFAULT_PROPS}
+        showLast
+        currentRefinement={DEFAULT_PROPS.nbPages}
+      />
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it('allows toggling display of the last page button on and off', () => {
     tree = renderer.create(
       <Pagination

--- a/packages/react-instantsearch/src/components/__snapshots__/Pagination.test.js.snap
+++ b/packages/react-instantsearch/src/components/__snapshots__/Pagination.test.js.snap
@@ -1396,6 +1396,216 @@ exports[`Pagination displays the correct padding of links 4`] = `
 </ul>
 `;
 
+exports[`Pagination indicates when first button is relevant 1`] = `
+<ul
+  className="root">
+  <li
+    className="item itemDisabled itemFirst">
+    <span
+      className="itemLink">
+      «
+    </span>
+  </li>
+  <li
+    className="item itemDisabled itemPrevious">
+    <span
+      className="itemLink">
+      ‹
+    </span>
+  </li>
+  <li
+    className="item itemSelected itemPage">
+    <a
+      aria-label="Page 1"
+      className="itemLink"
+      href="#"
+      onClick={[Function]}>
+      1
+    </a>
+  </li>
+  <li
+    className="item itemPage">
+    <a
+      aria-label="Page 2"
+      className="itemLink"
+      href="#"
+      onClick={[Function]}>
+      2
+    </a>
+  </li>
+  <li
+    className="item itemPage">
+    <a
+      aria-label="Page 3"
+      className="itemLink"
+      href="#"
+      onClick={[Function]}>
+      3
+    </a>
+  </li>
+  <li
+    className="item itemPage">
+    <a
+      aria-label="Page 4"
+      className="itemLink"
+      href="#"
+      onClick={[Function]}>
+      4
+    </a>
+  </li>
+  <li
+    className="item itemPage">
+    <a
+      aria-label="Page 5"
+      className="itemLink"
+      href="#"
+      onClick={[Function]}>
+      5
+    </a>
+  </li>
+  <li
+    className="item itemPage">
+    <a
+      aria-label="Page 6"
+      className="itemLink"
+      href="#"
+      onClick={[Function]}>
+      6
+    </a>
+  </li>
+  <li
+    className="item itemPage">
+    <a
+      aria-label="Page 7"
+      className="itemLink"
+      href="#"
+      onClick={[Function]}>
+      7
+    </a>
+  </li>
+  <li
+    className="item itemNext">
+    <a
+      aria-label="Next page"
+      className="itemLink"
+      href="#"
+      onClick={[Function]}>
+      ›
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`Pagination indicates when first button is relevant 2`] = `
+<ul
+  className="root">
+  <li
+    className="item itemFirst">
+    <a
+      aria-label="First page"
+      className="itemLink"
+      href="#"
+      onClick={[Function]}>
+      «
+    </a>
+  </li>
+  <li
+    className="item itemPrevious">
+    <a
+      aria-label="Previous page"
+      className="itemLink"
+      href="#"
+      onClick={[Function]}>
+      ‹
+    </a>
+  </li>
+  <li
+    className="item itemPage">
+    <a
+      aria-label="Page 14"
+      className="itemLink"
+      href="#"
+      onClick={[Function]}>
+      14
+    </a>
+  </li>
+  <li
+    className="item itemPage">
+    <a
+      aria-label="Page 15"
+      className="itemLink"
+      href="#"
+      onClick={[Function]}>
+      15
+    </a>
+  </li>
+  <li
+    className="item itemPage">
+    <a
+      aria-label="Page 16"
+      className="itemLink"
+      href="#"
+      onClick={[Function]}>
+      16
+    </a>
+  </li>
+  <li
+    className="item itemPage">
+    <a
+      aria-label="Page 17"
+      className="itemLink"
+      href="#"
+      onClick={[Function]}>
+      17
+    </a>
+  </li>
+  <li
+    className="item itemPage">
+    <a
+      aria-label="Page 18"
+      className="itemLink"
+      href="#"
+      onClick={[Function]}>
+      18
+    </a>
+  </li>
+  <li
+    className="item itemPage">
+    <a
+      aria-label="Page 19"
+      className="itemLink"
+      href="#"
+      onClick={[Function]}>
+      19
+    </a>
+  </li>
+  <li
+    className="item itemSelected itemPage">
+    <a
+      aria-label="Page 20"
+      className="itemLink"
+      href="#"
+      onClick={[Function]}>
+      20
+    </a>
+  </li>
+  <li
+    className="item itemDisabled itemNext">
+    <span
+      className="itemLink">
+      ›
+    </span>
+  </li>
+  <li
+    className="item itemDisabled itemLast">
+    <span
+      className="itemLink">
+      »
+    </span>
+  </li>
+</ul>
+`;
+
 exports[`Pagination lets you customize its theme 1`] = `
 <ul
   className="ROOT">


### PR DESCRIPTION
Before this commit, when on first page, the "First" link was selected
AND disabled.

Ultimately it's overkill to have LinkList.js since Pagination is the
only one using it, should we remove this layer of abstraction?