### PR TITLE
[WIP][POC] feat(ga-widget): new GA widget which allows users to plug instant sea…

### DIFF
--- a/dev/app.js
+++ b/dev/app.js
@@ -29,6 +29,10 @@ search.addWidget(
 );
 
 search.addWidget(
+  instantsearch.widgets.ga()
+);
+
+search.addWidget(
   instantsearch.widgets.stats({
     container: '#stats',
   })

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -24,6 +24,7 @@ import sortBySelector from '../widgets/sort-by-selector/sort-by-selector.js';
 import starRating from '../widgets/star-rating/star-rating.js';
 import stats from '../widgets/stats/stats.js';
 import toggle from '../widgets/toggle/toggle.js';
+import ga from '../widgets/ga/ga.js';
 import version from './version.js';
 
 const instantsearch = toFactory(InstantSearch);
@@ -45,6 +46,7 @@ instantsearch.widgets = {
   starRating,
   stats,
   toggle,
+  ga,
 };
 instantsearch.version = version;
 instantsearch.createQueryString = algoliasearchHelper.url.getQueryStringFromState;

--- a/src/widgets/ga/ga.js
+++ b/src/widgets/ga/ga.js
@@ -1,0 +1,115 @@
+/**
+ * Pushes analytics data to GoogleAnalytics
+ * @function ga
+ * @param  {int} [options.delay=3000] Number of milliseconds between last search key stroke and push data to GA
+ * @param  {boolean} [options.triggerOnUIInteraction=true] Trigger push to GA after click on page or redirecting the page
+ * @return {Object}
+ */
+function ga({
+  delay = 3000,
+  triggerOnUIInteraction = true,
+} = {}) {
+
+  let lastSentGa = '';
+  let sendAnalytics = function(state, results) {
+    let params = [];
+
+    params.push(serializeRefinements(Object.assign({}, state.disjunctiveFacetsRefinements, state.facetsRefinements)));
+    params.push(serializeNumericRefinements(state.numericRefinements));
+
+    params = params.filter(function(n) {
+      return n != '';
+    }).join('&');
+
+    let paramsToSend = 'Query: ' + state.query + ', ' + params;
+
+    if(lastSentGa !== paramsToSend) {
+      if(typeof window.ga === 'undefined') {
+        throw new Error('Google Analytics are not present in the website');
+      }
+
+      // console.log({'event': 'search', 'Search Query': state.query, 'Facet Parameters': params, 'Number of Hits': results.nbHits});
+      window.ga('set', 'page', '/search/query/?query = ' + state.query + '&params= ' + params + '&numberOfHits=' + results.nbHits);
+      window.ga('send', 'pageView');
+
+      lastSentGa = paramsToSend;
+    }
+  };
+
+  let serializeRefinements = function(obj) {
+    let str = [];
+    for(let p in obj) {
+      if (obj.hasOwnProperty(p)) {
+        let values = obj[p].join('+');
+        str.push(encodeURIComponent(p) + '=' + encodeURIComponent(p) + '_' + encodeURIComponent(values));
+      }
+    }
+
+    return str.join('&');
+  };
+
+  let serializeNumericRefinements = function(numericRefinements) {
+    let numericStr = [];
+
+    for(let attr in numericRefinements) {
+      if(numericRefinements.hasOwnProperty(attr)) {
+        let filter = numericRefinements[attr];
+
+        if(filter.hasOwnProperty('>=') && filter.hasOwnProperty('<=')) {
+          if(filter['>='][0] == filter['<='][0]) {
+            numericStr.push(attr + '=' + attr + '_' + filter['>=']);
+          }
+          else {
+            numericStr.push(attr + '=' + attr + '_' + filter['>='] + 'to' + filter['<=']);
+          }
+        }
+        else if(filter.hasOwnProperty('>=')) {
+          numericStr.push(attr + '=' + attr + '_from' + filter['>=']);
+        }
+        else if(filter.hasOwnProperty('<=')) {
+          numericStr.push(attr + '=' + attr + '_to' + filter['<=']);
+        }
+        else if(filter.hasOwnProperty('=')) {
+          let equals = [];
+          for(let equal in filter['=']) {
+            if(filter['='].hasOwnProperty(equal)) {
+              equals.push(filter['='][equal]);
+            }
+          }
+
+          numericStr.push(attr + '=' + attr + '_' + equals.join('-'));
+        }
+      }
+    }
+
+    return numericStr.join('&');
+  };
+
+  let gaTimeout;
+
+  return {
+    init() {
+      if(triggerOnUIInteraction === true) {
+        // Add these listeners:
+        // Not sure how to do it now
+
+        // window.onClick = function(e) {
+        //   sendAnalytics(state, results);
+        // });
+        //
+        // window.onbeforeunload = function() {
+        //   sendAnalytics(state, results);
+        // };
+      }
+    },
+    render({results, state}) {
+      if(gaTimeout) {
+        clearTimeout(gaTimeout);
+      }
+
+      gaTimeout = setTimeout(() => sendAnalytics(state, results), delay);
+    },
+  };
+}
+
+export default ga;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

Hey guys, we are working with @Shipow on easy way how to plug instant search pages to GA as currently there is no easy way and a lot of people are struggling with it.

So I create a simple widget for IS which easily allows people to plug IS to their Google Analytics and analyze their search data there in relations with conversion and other stuff...
<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

New widget with easy API: 
```js
search.addWidget(
  instantsearch.widgets.ga()
);
```

Two optional configuration are present: 
- `delay` - time between last search key stroke and push to GA
- `triggerOnUIInteraction` - if the push to GA should happen after any click or reload of website even before `delay` is out 


This is a **POC** and my first widget, so I'm definitely not rock solid about it. It's missing tests and few checks right now. I'm pushing this PR to get your feedback on it about if it's the right way to go, how to structure the code in better way and how to inject the `click` and `beforeunload` events correctly.

Thank you guys for any help. Cheers.