### PR TITLE
docs(slider): update out-of-date example and improve it

### DIFF
--- a/packages/react-instantsearch/src/widgets/RangeSlider.js
+++ b/packages/react-instantsearch/src/widgets/RangeSlider.js
@@ -17,28 +17,57 @@ import React from 'react';
  * import {connectRange} from 'react-instantsearch/connectors';
  * import Rheostat from 'rheostat';
  *
- * const ConnectedRange = connectRange(({min, max, value, refine}) => {
-  const updateValue = sliderState => {
-    if (sliderState.values[0] !== min || sliderState.values[1] !== max) {
-      refine({min: sliderState.values[0], max: sliderState.values[1]});
-    }
-  };
+ * const Range = React.createClass({
+  propTypes: {
+    min: React.PropTypes.number.isRequired,
+    max: React.PropTypes.number.isRequired,
+    currentRefinement: React.PropTypes.object.isRequired,
+    refine: React.PropTypes.func.isRequired,
+  },
 
-  return (
-    <div>
-      <Rheostat
-        min={min}
-        max={max}
-        values={[value.min, value.max]}
-        onChange={updateValue}
-      />
+  getInitialState() {
+    return {currentValues: {min: this.props.min, max: this.props.max}};
+  },
+
+  onValuesUpdated(sliderState) {
+    this.setState({currentValues: {min: sliderState.values[0], max: sliderState.values[1]}});
+  },
+
+  onChange(sliderState) {
+    if (sliderState.values[0] !== this.props.min || sliderState.values[1] !== this.props.max) {
+      this.props.refine({min: sliderState.values[0], max: sliderState.values[1]});
+    }
+  },
+
+  render() {
+    const {min, max, currentRefinement} = this.props;
+    const {currentValues} = this.state;
+    return (
       <div>
-        <span>{value.min}</span>
-        <span>{value.max}</span>
+        <Rheostat
+          min={min}
+          max={max}
+          values={[currentRefinement.min, currentRefinement.max]}
+          onChange={this.onChange}
+          onValuesUpdated={this.onValuesUpdated}
+        />
+        <div style={{display: 'flex', justifyContent: 'space-between'}}>
+          <div>{currentValues.min}</div>
+          <div>{currentValues.max}</div>
+        </div>
       </div>
-    </div>
-  );
+    );
+  },
 });
+
+ Range.propTypes = {
+  min: React.PropTypes.number.isRequired,
+  max: React.PropTypes.number.isRequired,
+  currentRefinement: React.PropTypes.object.isRequired,
+  refine: React.PropTypes.func.isRequired,
+};
+
+ const ConnectedRange = connectRange(Range);
 
  */
 export default connectRange(() =>

--- a/stories/3rdPartiesIntegration.stories.js
+++ b/stories/3rdPartiesIntegration.stories.js
@@ -12,23 +12,56 @@ stories.add('Airbnb Rheostat', () =>
   </WrapWithHits>
 );
 
-const ConnectedRange = connectRange(({min, max, currentRefinement, refine}) => {
-  const updateValue = sliderState => {
-    if (sliderState.values[0] !== min || sliderState.values[1] !== max) {
-      refine({min: sliderState.values[0], max: sliderState.values[1]});
-    }
-  };
+const Range = React.createClass({
+  propTypes: {
+    min: React.PropTypes.number.isRequired,
+    max: React.PropTypes.number.isRequired,
+    currentRefinement: React.PropTypes.object.isRequired,
+    refine: React.PropTypes.func.isRequired,
+  },
 
-  return (
-    <div>
-      <Rheostat
-        min={min}
-        max={max}
-        values={[currentRefinement.min, currentRefinement.max]}
-        onChange={updateValue}
-      />
-    </div>
-  );
+  getInitialState() {
+    return {currentValues: {min: this.props.min, max: this.props.max}};
+  },
+
+  onValuesUpdated(sliderState) {
+    this.setState({currentValues: {min: sliderState.values[0], max: sliderState.values[1]}});
+  },
+
+  onChange(sliderState) {
+    if (sliderState.values[0] !== this.props.min || sliderState.values[1] !== this.props.max) {
+      this.props.refine({min: sliderState.values[0], max: sliderState.values[1]});
+    }
+  },
+
+  render() {
+    const {min, max, currentRefinement} = this.props;
+    const {currentValues} = this.state;
+    return (
+      <div>
+        <Rheostat
+          min={min}
+          max={max}
+          values={[currentRefinement.min, currentRefinement.max]}
+          onChange={this.onChange}
+          onValuesUpdated={this.onValuesUpdated}
+        />
+        <div style={{display: 'flex', justifyContent: 'space-between'}}>
+          <div>{currentValues.min}</div>
+          <div>{currentValues.max}</div>
+        </div>
+      </div>
+    );
+  },
 });
+
+Range.propTypes = {
+  min: React.PropTypes.number.isRequired,
+  max: React.PropTypes.number.isRequired,
+  currentRefinement: React.PropTypes.object.isRequired,
+  refine: React.PropTypes.func.isRequired,
+};
+
+const ConnectedRange = connectRange(Range);
 
 export default ConnectedRange;


### PR DESCRIPTION
Our jsdoc example (copy and paste from the story range slider source code) was oudated. 

Also I improved it by displaying labels showing in real time the selected values in order to avoid confusion between the slider instantsearch state and the one only used for those label values. 

see #1617 