### PR TITLE
feat(api): add namespace when storing widgets state

### DIFF
--- a/docgen/src/examples/e-commerce-infinite/App.js
+++ b/docgen/src/examples/e-commerce-infinite/App.js
@@ -206,7 +206,7 @@ const CustomResults = createConnector({
 
   getProps(props, state, search) {
     const noResults = search.results ? search.results.nbHits === 0 : false;
-    return {query: state.q, noResults};
+    return {query: state.query, noResults};
   },
 })(({noResults, query}) => {
   if (noResults) {

--- a/docgen/src/examples/e-commerce/App.js
+++ b/docgen/src/examples/e-commerce/App.js
@@ -204,7 +204,7 @@ const CustomResults = createConnector({
 
   getProps(props, state, search) {
     const noResults = search.results ? search.results.nbHits === 0 : false;
-    return {query: state.q, noResults};
+    return {query: state.query, noResults};
   },
 })(({noResults, query}) => {
   if (noResults) {

--- a/docgen/src/guides.md
+++ b/docgen/src/guides.md
@@ -3,7 +3,7 @@ title: What's react-instantsearch?
 layout: main-entry.pug
 category: guide
 tocVisibility: true
-navWeight: 7
+navWeight: 1000
 ---
 
 React-instantsearch is the ultimate toolbox for creating instant search experience using React and Algolia. 

--- a/docgen/src/guides/3rd-party-librairies.md
+++ b/docgen/src/guides/3rd-party-librairies.md
@@ -2,7 +2,7 @@
 title: 3rd party UI Libraries
 layout: guide.pug
 category: guide
-navWeight: 3
+navWeight: 500
 ---
 
 Even if react-instantsearch provides widgets out of the box you are free to use it with

--- a/docgen/src/guides/advanced-topics.md
+++ b/docgen/src/guides/advanced-topics.md
@@ -2,7 +2,7 @@
 title: Advanced Topics
 layout: guide.pug
 category: guide
-navWeight: -1
+navWeight: 100
 ---
 
 ## How to preselect values using Virtual Widgets

--- a/docgen/src/guides/conditional-display.md
+++ b/docgen/src/guides/conditional-display.md
@@ -2,7 +2,7 @@
 title: Conditional Display
 layout: guide.pug
 category: guide
-navWeight: 1
+navWeight: 300
 ---
 
 Using our connector and [`createConnector`](create-own-widget.html) approach, you can 
@@ -15,7 +15,7 @@ about the api.
 ## Displaying content when the query is empty
 
 You can do that by using the [`createConnector`](create-own-widget.html) function and
-then access the `state` of all widgets. By doing so you're able to get the query and decide what to do according to its state.
+then access the [`state`](/guides/instantsearch-state.html) of all widgets. By doing so you're able to get the query and decide what to do according to its state.
 
 Here's an example:
 
@@ -23,7 +23,7 @@ Here's an example:
 const Content = createConnector({
     displayName: 'ConditionalQuery',
     getProps(props, state) {
-      return {query: state.q};
+      return {query: state.query};
     },
  })(({query}) => {
     const content = query
@@ -46,7 +46,7 @@ const content = createConnector({
     displayName: 'ConditionalResults',
     getProps(props, state, search) {
       const noResults = search.results ? search.results.nbHits === 0 : false;
-      return {query: state.q, noResults};
+      return {query: state.query, noResults};
     },
  })(({noResults, query}) => {
     const content = noResults

--- a/docgen/src/guides/connectors.md
+++ b/docgen/src/guides/connectors.md
@@ -2,7 +2,7 @@
 title: Using connectors
 layout: guide.pug
 category: guide
-navWeight: 4
+navWeight: 700
 ---
 
 While react-instantsearch already provides widgets out of the box, 

--- a/docgen/src/guides/create-own-widget.md
+++ b/docgen/src/guides/create-own-widget.md
@@ -2,7 +2,7 @@
 title: Creating widgets
 layout: guide.pug
 category: guide
-navWeight: 2
+navWeight: 400
 ---
 
 If you wish to implement features that are not covered by the default widgets connectors, you will need to create your own connector via the `createConnector` method. This methods takes in a descriptor of your connector with the following properties and methods:
@@ -19,7 +19,7 @@ This method should return the props to forward to the composed component.
 
 `props` are the props that were provided to the higher-order component.
 
-`state` holds the state of all widgets, with the shape `{[widgetId]: widgetState}`. Stateful widgets describe the format of their state in their respective documentation entry.
+`state` holds the state of all widgets. You can find the shape of all widgets state in [the corresponding guide](/guides/instantsearch-state.html). 
 
 `search` holds the search results, search errors and search loading state, with the shape `{results: ?SearchResults, error: ?Error, loading: bool}`. The `SearchResults` type is described in the [Helper's documentation](https://community.algolia.com/algoliasearch-helper-js/reference.html#searchresults).
 
@@ -29,7 +29,7 @@ This method should return the props to forward to the composed component.
 
 This method defines exactly how the `refine` prop of connected widgets affects the InstantSearch state.
 
-It takes in the current props of the higher-order component, the state of all widgets, as well as all arguments passed to the `refine` and `createURL` props of stateful widgets, and returns a new state.
+It takes in the current props of the higher-order component, the [state](/guides/instantsearch-state.html) of all widgets, as well as all arguments passed to the `refine` and `createURL` props of stateful widgets, and returns a new state.
 
 ```javascript
 const CoolWidget = createConnector({

--- a/docgen/src/guides/instantsearch-state.md
+++ b/docgen/src/guides/instantsearch-state.md
@@ -1,0 +1,112 @@
+---
+title: InstantSearch state
+layout: guide.pug
+category: guide
+navWeight: 600
+---
+
+The `InstantSearch` state contains all widgets states. 
+If a widget uses an attribute, we store it under its widget category to prevent collision. 
+
+Here's the `InstantSearch` state shape for all the connectors or widgets that we provide:
+
+### Range state
+
+```javascript
+{
+  range: {
+    attributeName: {
+      min: 'min_value',
+      max: 'max_value'
+    }
+  }
+}
+```
+### RefinementList state
+
+```javascript
+{
+  refinementList: {
+      attributeName: ['value']
+    }
+}
+```
+
+### HierarchicalMenu state
+
+```javascript
+{
+  hierarchicalMenu: {
+      attributeName: 'value'
+    }
+}
+```
+
+### HitsPerPage state
+
+```javascript
+{
+  hitsPerPage: 10
+}
+```
+
+### Menu state
+
+```javascript
+{
+  menu: {
+      attributeName: 'value'
+    }
+}
+```
+
+### MultiRange state
+
+```javascript
+{
+  multiRange: {
+    attributeName: 'min_value:max_value'
+    }
+}
+```
+### Toggle state
+
+```javascript
+{
+  toggle: {
+    attributeName: 'true || false'
+    }
+}
+```
+
+### SortBy state
+
+```javascript
+{
+  sortBy: 'index_name'
+}
+```
+
+### SearchBox state
+
+```javascript
+{
+  query: 'query_value'
+}
+```
+
+### Pagination state
+
+```javascript
+{
+  page: 2
+}
+```
+
+### InfiniteHits state
+
+```javascript
+{
+  page: 2
+}
+```

--- a/docgen/src/guides/internationalization.md
+++ b/docgen/src/guides/internationalization.md
@@ -2,7 +2,7 @@
 title: Internationalization
 layout: guide.pug
 category: guide
-navWeight: 5
+navWeight: 800
 ---
 
 All widgets rendering text that is not otherwise configurable via props accept a `translations` prop. This prop is a mapping of keys to translation values. Translation values can be either a `String` or a `Function`, as some take parameters. The different translation keys supported by components and their optional parameters are described on their respective documentation page.

--- a/docgen/src/guides/styling.md
+++ b/docgen/src/guides/styling.md
@@ -2,7 +2,7 @@
 title: Styling
 layout: guide.pug
 category: guide
-navWeight: 6
+navWeight: 900
 ---
 
 Default widgets in react-instantsearch comes with some styling already applied and loaded. When styling components, you can decide to either extend or completely replace our default styles, using CSS class names.

--- a/docgen/src/guides/using-multiple-instantsearch.md
+++ b/docgen/src/guides/using-multiple-instantsearch.md
@@ -2,7 +2,7 @@
 title: Multiple InstantSearch
 layout: guide.pug
 category: guide
-navWeight: 0
+navWeight: 200
 ---
 
 You can use multiple `<InstantSearch/>` instances for cases like:
@@ -14,7 +14,7 @@ You can use multiple `<InstantSearch/>` instances for cases like:
 Two props on the [InstantSearch root component](/component/InstantSearch.html) can be used to inject state or be notified of state changes:
 
 * onStateChange(nextState): a function being called every time the `InstantSearch` state is updated. 
-* state: an object that is the current state of InstantSearch
+* [state](/guides/instantsearch-state.html): an object that is the current state of InstantSearch
 
 The idea is to have a main component that will receive every new state of the first instance and then pass it back to each `InstantSearch` instances.  
 

--- a/packages/react-instantsearch/src/connectors/connectHierarchicalMenu.test.js
+++ b/packages/react-instantsearch/src/connectors/connectHierarchicalMenu.test.js
@@ -24,7 +24,7 @@ describe('connectHierarchicalMenu', () => {
     };
 
     results.getFacetValues.mockImplementationOnce(() => ({}));
-    props = getProps({attributes: ['ok']}, {ok: 'wat'}, {results});
+    props = getProps({attributes: ['ok']}, {hierarchicalMenu: {ok: 'wat'}}, {results});
     expect(props).toEqual({items: [], currentRefinement: 'wat'});
 
     results.getFacetValues.mockImplementationOnce(() => ({}));
@@ -134,7 +134,7 @@ describe('connectHierarchicalMenu', () => {
     const nextState = refine({attributes: ['ok']}, {otherKey: 'val'}, 'yep');
     expect(nextState).toEqual({
       otherKey: 'val',
-      ok: 'yep',
+      hierarchicalMenu: {ok: 'yep'},
     });
   });
 
@@ -177,7 +177,7 @@ describe('connectHierarchicalMenu', () => {
       rootPath: 'ROOT_PATH',
       showParentLevel: true,
       limitMin: 1,
-    }, {ATTRIBUTE: 'ok'});
+    }, {hierarchicalMenu: {ATTRIBUTE: 'ok'}});
     expect(params).toEqual(
       initSP
         .addHierarchicalFacet({
@@ -198,7 +198,7 @@ describe('connectHierarchicalMenu', () => {
   });
 
   it('registers its filter in metadata', () => {
-    const metadata = getMetadata({attributes: ['ok']}, {ok: 'wat'});
+    const metadata = getMetadata({attributes: ['ok']}, {hierarchicalMenu: {ok: 'wat'}});
     expect(metadata).toEqual({
       id: 'ok',
       items: [{
@@ -210,12 +210,18 @@ describe('connectHierarchicalMenu', () => {
       }],
     });
 
-    const state = metadata.items[0].value({ok: 'wat'});
-    expect(state).toEqual({ok: ''});
+    const state = metadata.items[0].value({hierarchicalMenu: {ok: 'wat'}});
+    expect(state).toEqual({hierarchicalMenu: {ok: ''}});
   });
 
   it('should return the right state when clean up', () => {
-    const state = cleanUp({attributes: ['name']}, {name: {state: 'state'}, another: {state: 'state'}});
+    let state = cleanUp({attributes: ['name']}, {
+      hierarchicalMenu: {name: 'state', name2: 'state'},
+      another: {state: 'state'},
+    });
+    expect(state).toEqual({hierarchicalMenu: {name2: 'state'}, another: {state: 'state'}});
+
+    state = cleanUp({attributes: ['name2']}, state);
     expect(state).toEqual({another: {state: 'state'}});
   });
 });

--- a/packages/react-instantsearch/src/connectors/connectHitsPerPage.js
+++ b/packages/react-instantsearch/src/connectors/connectHitsPerPage.js
@@ -2,7 +2,7 @@ import createConnector from '../core/createConnector';
 import {omit} from 'lodash';
 
 function getId() {
-  return 'hPP';
+  return 'hitsPerPage';
 }
 
 function getCurrentRefinement(props, state) {

--- a/packages/react-instantsearch/src/connectors/connectHitsPerPage.test.js
+++ b/packages/react-instantsearch/src/connectors/connectHitsPerPage.test.js
@@ -18,7 +18,7 @@ let params;
 
 describe('connectHitsPerPage', () => {
   it('provides the correct props to the component', () => {
-    props = getProps({}, {hPP: '10'});
+    props = getProps({}, {hitsPerPage: '10'});
     expect(props).toEqual({currentRefinement: 10});
 
     props = getProps({defaultRefinement: 20}, {});
@@ -29,17 +29,17 @@ describe('connectHitsPerPage', () => {
     const nextState = refine({}, {otherKey: 'val'}, 30);
     expect(nextState).toEqual({
       otherKey: 'val',
-      hPP: 30,
+      hitsPerPage: 30,
     });
   });
 
   it('refines the hitsPerPage parameter', () => {
     const sp = new SearchParameters();
 
-    params = getSP(sp, {}, {hPP: 10});
+    params = getSP(sp, {}, {hitsPerPage: 10});
     expect(params).toEqual(sp.setQueryParameter('hitsPerPage', 10));
 
-    params = getSP(sp, {}, {hPP: '10'});
+    params = getSP(sp, {}, {hitsPerPage: '10'});
     expect(params).toEqual(sp.setQueryParameter('hitsPerPage', 10));
 
     params = getSP(sp, {defaultRefinement: 20}, {});
@@ -48,11 +48,11 @@ describe('connectHitsPerPage', () => {
 
   it('registers its id in metadata', () => {
     const metadata = getMetadata({});
-    expect(metadata).toEqual({id: 'hPP'});
+    expect(metadata).toEqual({id: 'hitsPerPage'});
   });
 
   it('should return the right state when clean up', () => {
-    const state = cleanUp({}, {hPP: {state: 'state'}, another: {state: 'state'}});
+    const state = cleanUp({}, {hitsPerPage: {state: 'state'}, another: {state: 'state'}});
     expect(state).toEqual({another: {state: 'state'}});
   });
 });

--- a/packages/react-instantsearch/src/connectors/connectInfiniteHits.js
+++ b/packages/react-instantsearch/src/connectors/connectInfiniteHits.js
@@ -3,7 +3,7 @@ import {PropTypes} from 'react';
 import createConnector from '../core/createConnector';
 
 function getId() {
-  return 'p';
+  return 'page';
 }
 
 /**

--- a/packages/react-instantsearch/src/connectors/connectInfiniteHits.test.js
+++ b/packages/react-instantsearch/src/connectors/connectInfiniteHits.test.js
@@ -95,18 +95,18 @@ describe.only('connectInfiniteHits', () => {
     const state0 = {};
 
     const state1 = connect.refine(props, state0);
-    expect(state1).toEqual({p: 1});
+    expect(state1).toEqual({page: 1});
 
     const state2 = connect.refine(props, state1);
-    expect(state2).toEqual({p: 2});
+    expect(state2).toEqual({page: 2});
   });
 
   it('automatically converts String state to Number', () => {
     const props = {};
 
-    const state0 = {p: '0'};
+    const state0 = {page: '0'};
 
     const state1 = connect.refine(props, state0);
-    expect(state1).toEqual({p: 1});
+    expect(state1).toEqual({page: 1});
   });
 });

--- a/packages/react-instantsearch/src/connectors/connectMenu.js
+++ b/packages/react-instantsearch/src/connectors/connectMenu.js
@@ -1,5 +1,5 @@
 import {PropTypes} from 'react';
-import {omit} from 'lodash';
+import {omit, isEmpty} from 'lodash';
 
 import createConnector from '../core/createConnector';
 
@@ -7,13 +7,15 @@ function getId(props) {
   return props.attributeName;
 }
 
+const namespace = 'menu';
+
 function getCurrentRefinement(props, state) {
   const id = getId(props);
-  if (typeof state[id] !== 'undefined') {
-    if (state[id] === '') {
+  if (state[namespace] && typeof state[namespace][id] !== 'undefined') {
+    if (state[namespace][id] === '') {
       return null;
     }
-    return state[id];
+    return state[namespace][id];
   }
   if (props.defaultRefinement) {
     return props.defaultRefinement;
@@ -89,12 +91,16 @@ export default createConnector({
     const id = getId(props);
     return {
       ...state,
-      [id]: nextRefinement || '',
+      [namespace]: {[id]: nextRefinement ? nextRefinement : ''},
     };
   },
 
   cleanUp(props, state) {
-    return omit(state, getId(props));
+    const cleanState = omit(state, `${namespace}.${getId(props)}`);
+    if (isEmpty(cleanState[namespace])) {
+      return omit(cleanState, namespace);
+    }
+    return cleanState;
   },
 
   getSearchParameters(searchParameters, props, state) {
@@ -131,7 +137,7 @@ export default createConnector({
         attributeName: props.attributeName,
         value: nextState => ({
           ...nextState,
-          [id]: '',
+          [namespace]: {[id]: ''},
         }),
         currentRefinement,
       }],

--- a/packages/react-instantsearch/src/connectors/connectMenu.test.js
+++ b/packages/react-instantsearch/src/connectors/connectMenu.test.js
@@ -24,10 +24,10 @@ describe('connectMenu', () => {
       getFacetByName: () => true,
     };
 
-    props = getProps({attributeName: 'ok'}, {ok: 'wat'}, {results});
+    props = getProps({attributeName: 'ok'}, {menu: {ok: 'wat'}}, {results});
     expect(props).toEqual({items: [], currentRefinement: 'wat'});
 
-    props = getProps({attributeName: 'ok'}, {ok: 'wat'}, {results});
+    props = getProps({attributeName: 'ok'}, {menu: {ok: 'wat'}}, {results});
     expect(props).toEqual({items: [], currentRefinement: 'wat'});
 
     props = getProps({attributeName: 'ok', defaultRefinement: 'wat'}, {}, {results});
@@ -99,7 +99,7 @@ describe('connectMenu', () => {
     const nextState = refine({attributeName: 'ok'}, {otherKey: 'val'}, 'yep');
     expect(nextState).toEqual({
       otherKey: 'val',
-      ok: 'yep',
+      menu: {ok: 'yep'},
     });
   });
 
@@ -135,12 +135,12 @@ describe('connectMenu', () => {
     params = getSP(initSP, {
       attributeName: 'ok',
       limitMin: 1,
-    }, {ok: 'wat'});
+    }, {menu: {ok: 'wat'}});
     expect(params).toEqual(
       initSP
-      .addDisjunctiveFacet('ok')
-      .addDisjunctiveFacetRefinement('ok', 'wat')
-      .setQueryParameter('maxValuesPerFacet', 1)
+        .addDisjunctiveFacet('ok')
+        .addDisjunctiveFacetRefinement('ok', 'wat')
+        .setQueryParameter('maxValuesPerFacet', 1)
     );
   });
 
@@ -150,7 +150,7 @@ describe('connectMenu', () => {
   });
 
   it('registers its filter in metadata', () => {
-    const metadata = getMetadata({attributeName: 'wot'}, {wot: 'wat'});
+    const metadata = getMetadata({attributeName: 'wot'}, {menu: {wot: 'wat'}});
     expect(metadata).toEqual({
       id: 'wot',
       items: [{
@@ -162,12 +162,18 @@ describe('connectMenu', () => {
       }],
     });
 
-    const state = metadata.items[0].value({wot: 'wat'});
-    expect(state).toEqual({wot: ''});
+    const state = metadata.items[0].value({menu: {wot: 'wat'}});
+    expect(state).toEqual({menu: {wot: ''}});
   });
 
   it('should return the right state when clean up', () => {
-    const state = cleanUp({attributeName: 'name'}, {name: {state: 'state'}, another: {state: 'state'}});
+    let state = cleanUp({attributeName: 'name'}, {
+      menu: {name: 'state', name2: 'state'},
+      another: {state: 'state'},
+    });
+    expect(state).toEqual({menu: {name2: 'state'}, another: {state: 'state'}});
+
+    state = cleanUp({attributeName: 'name2'}, state);
     expect(state).toEqual({another: {state: 'state'}});
   });
 });

--- a/packages/react-instantsearch/src/connectors/connectMultiRange.test.js
+++ b/packages/react-instantsearch/src/connectors/connectMultiRange.test.js
@@ -76,10 +76,10 @@ describe('connectMultiRange', () => {
       currentRefinement: '',
     });
 
-    props = getProps({attributeName: 'ok', items: []}, {ok: 'wat'});
+    props = getProps({attributeName: 'ok', items: []}, {multiRange: {ok: 'wat'}});
     expect(props).toEqual({items: [], currentRefinement: 'wat'});
 
-    props = getProps({attributeName: 'ok', items: []}, {ok: 'wat'});
+    props = getProps({attributeName: 'ok', items: []}, {multiRange: {ok: 'wat'}});
     expect(props).toEqual({items: [], currentRefinement: 'wat'});
 
     props = getProps({attributeName: 'ok', items: [], defaultRefinement: 'wat'}, {});
@@ -90,7 +90,7 @@ describe('connectMultiRange', () => {
     const nextState = refine({attributeName: 'ok'}, {otherKey: 'val'}, 'yep');
     expect(nextState).toEqual({
       otherKey: 'val',
-      ok: 'yep',
+      multiRange: {ok: 'yep'},
     });
   });
 
@@ -100,17 +100,17 @@ describe('connectMultiRange', () => {
     params = getSP(initSP, {attributeName: 'facet'}, {facet: ''});
     expect(params.getNumericRefinements('facet')).toEqual({});
 
-    params = getSP(initSP, {attributeName: 'facet'}, {facet: '100:'});
+    params = getSP(initSP, {attributeName: 'facet'}, {multiRange: {facet: '100:'}});
     expect(params.getNumericRefinements('facet')).toEqual({
       '>=': [100],
     });
 
-    params = getSP(initSP, {attributeName: 'facet'}, {facet: ':200'});
+    params = getSP(initSP, {attributeName: 'facet'}, {multiRange: {facet: ':200'}});
     expect(params.getNumericRefinements('facet')).toEqual({
       '<=': [200],
     });
 
-    params = getSP(initSP, {attributeName: 'facet'}, {facet: '100:200'});
+    params = getSP(initSP, {attributeName: 'facet'}, {multiRange: {facet: '100:200'}});
     expect(params.getNumericRefinements('facet')).toEqual({
       '>=': [100],
       '<=': [200],
@@ -132,7 +132,7 @@ describe('connectMultiRange', () => {
           end: 200,
         }],
       },
-      {wot: '100:200'}
+      {multiRange: {wot: '100:200'}}
     );
     expect(metadata).toEqual({
       id: 'wot',
@@ -145,12 +145,18 @@ describe('connectMultiRange', () => {
       }],
     });
 
-    const state = metadata.items[0].value({wot: '100:200'});
-    expect(state).toEqual({wot: ''});
+    const state = metadata.items[0].value({multiRange: {wot: '100:200'}});
+    expect(state).toEqual({multiRange: {wot: ''}});
   });
 
   it('should return the right state when clean up', () => {
-    const state = cleanUp({attributeName: 'name'}, {name: {state: 'state'}, another: {state: 'state'}});
+    let state = cleanUp({attributeName: 'name'}, {
+      multiRange: {name: 'state', name2: 'state'},
+      another: {state: 'state'},
+    });
+    expect(state).toEqual({multiRange: {name2: 'state'}, another: {state: 'state'}});
+
+    state = cleanUp({attributeName: 'name2'}, state);
     expect(state).toEqual({another: {state: 'state'}});
   });
 });

--- a/packages/react-instantsearch/src/connectors/connectPagination.js
+++ b/packages/react-instantsearch/src/connectors/connectPagination.js
@@ -3,7 +3,7 @@ import {omit} from 'lodash';
 import createConnector from '../core/createConnector';
 
 function getId() {
-  return 'p';
+  return 'page';
 }
 
 function getCurrentRefinement(props, state) {

--- a/packages/react-instantsearch/src/connectors/connectPagination.test.js
+++ b/packages/react-instantsearch/src/connectors/connectPagination.test.js
@@ -23,10 +23,10 @@ describe('connectPagination', () => {
     props = getProps({}, {}, {results: {nbPages: 666}});
     expect(props).toEqual({currentRefinement: 1, nbPages: 666});
 
-    props = getProps({}, {p: 5}, {results: {nbPages: 666}});
+    props = getProps({}, {page: 5}, {results: {nbPages: 666}});
     expect(props).toEqual({currentRefinement: 5, nbPages: 666});
 
-    props = getProps({}, {p: '5'}, {results: {nbPages: 666}});
+    props = getProps({}, {page: '5'}, {results: {nbPages: 666}});
     expect(props).toEqual({currentRefinement: 5, nbPages: 666});
   });
 
@@ -39,40 +39,40 @@ describe('connectPagination', () => {
     const nextState = refine({}, {otherKey: 'val'}, 'yep');
     expect(nextState).toEqual({
       otherKey: 'val',
-      p: 'yep',
+      page: 'yep',
     });
   });
 
   it('refines the page parameter', () => {
     const initSP = new SearchParameters();
-    params = getSP(initSP, {}, {p: 667});
+    params = getSP(initSP, {}, {page: 667});
     expect(params.page).toBe(666);
   });
 
   it('Transition state when the value is identical and does not contain isSamePage flag', () => {
-    state = transitionState({}, {p: 1}, {p: 1});
+    state = transitionState({}, {page: 1}, {page: 1});
     expect(state).toEqual({});
-    state = transitionState({}, {p: 1}, {p: 2});
+    state = transitionState({}, {page: 1}, {page: 2});
     expect(state).toEqual({
-      p: 2,
+      page: 2,
     });
     const newSameValue = {
       valueOf: () => 1,
       isSamePage: true,
     };
-    state = transitionState({}, {p: 1}, {p: newSameValue});
+    state = transitionState({}, {page: 1}, {page: newSameValue});
     expect(state).toEqual({
-      p: 1,
+      page: 1,
     });
   });
 
   it('registers its id in metadata', () => {
     const metadata = getMetadata({}, {});
-    expect(metadata).toEqual({id: 'p'});
+    expect(metadata).toEqual({id: 'page'});
   });
 
   it('should return the right state when clean up', () => {
-    const newState = cleanUp({}, {p: {state: 'state'}, another: {state: 'state'}});
+    const newState = cleanUp({}, {page: {state: 'state'}, another: {state: 'state'}});
     expect(newState).toEqual({another: {state: 'state'}});
   });
 });

--- a/packages/react-instantsearch/src/connectors/connectRange.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.js
@@ -1,5 +1,5 @@
 import {PropTypes} from 'react';
-import {omit} from 'lodash';
+import {omit, isEmpty} from 'lodash';
 
 import createConnector from '../core/createConnector';
 
@@ -23,10 +23,12 @@ function getId(props) {
   return props.attributeName;
 }
 
+const namespace = 'range';
+
 function getCurrentRefinement(props, state) {
   const id = getId(props);
-  if (typeof state[id] !== 'undefined') {
-    let {min, max} = state[id];
+  if (state[namespace] && typeof state[namespace][id] !== 'undefined') {
+    let {min, max} = state[namespace][id];
     if (typeof min === 'string') {
       min = parseInt(min, 10);
     }
@@ -104,12 +106,16 @@ export default createConnector({
   refine(props, state, nextRefinement) {
     return {
       ...state,
-      [getId(props)]: nextRefinement,
+      [namespace]: {[getId(props)]: nextRefinement},
     };
   },
 
   cleanUp(props, state) {
-    return omit(state, getId(props));
+    const cleanState = omit(state, `${namespace}.${getId(props)}`);
+    if (isEmpty(cleanState[namespace])) {
+      return omit(cleanState, namespace);
+    }
+    return cleanState;
   },
 
   getSearchParameters(params, props, state) {
@@ -149,7 +155,7 @@ export default createConnector({
         attributeName: props.attributeName,
         value: nextState => ({
           ...nextState,
-          [id]: {},
+          [namespace]: {[id]: {}},
         }),
       };
     }

--- a/packages/react-instantsearch/src/connectors/connectRange.test.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.test.js
@@ -47,7 +47,7 @@ describe('connectRange', () => {
       min: 5,
       max: 10,
     }, {
-      ok: {min: 6, max: 9},
+      range: {ok: {min: 6, max: 9}},
     }, {});
     expect(props).toEqual({
       min: 5,
@@ -61,7 +61,7 @@ describe('connectRange', () => {
       min: 5,
       max: 10,
     }, {
-      ok: {min: '6', max: '9'},
+      range: {ok: {min: '6', max: '9'}},
     }, {});
     expect(props).toEqual({
       min: 5,
@@ -88,7 +88,7 @@ describe('connectRange', () => {
     const nextState = refine({attributeName: 'ok'}, {otherKey: 'val'}, 'yep');
     expect(nextState).toEqual({
       otherKey: 'val',
-      ok: 'yep',
+      range: {ok: 'yep'},
     });
   });
 
@@ -96,7 +96,7 @@ describe('connectRange', () => {
     params = getSP(
       new SearchParameters(),
       {attributeName: 'facet'},
-      {facet: {min: 10, max: 30}}
+      {range: {facet: {min: 10, max: 30}}}
     );
     expect(params.getNumericRefinements('facet')).toEqual({
       '>=': [10],
@@ -107,7 +107,7 @@ describe('connectRange', () => {
   it('registers its filter in metadata', () => {
     let metadata = getMetadata(
       {attributeName: 'wot'},
-      {wot: {min: 5}}
+      {range: {wot: {min: 5}}}
     );
     expect(metadata).toEqual({
       id: 'wot',
@@ -120,12 +120,12 @@ describe('connectRange', () => {
       }],
     });
 
-    const state = metadata.items[0].value({wot: {min: 5}});
-    expect(state).toEqual({wot: {}});
+    const state = metadata.items[0].value({range: {wot: {min: 5}}});
+    expect(state).toEqual({range: {wot: {}}});
 
     metadata = getMetadata(
       {attributeName: 'wot'},
-      {wot: {max: 10}}
+      {range: {wot: {max: 10}}}
     );
     expect(metadata).toEqual({
       id: 'wot',
@@ -139,7 +139,7 @@ describe('connectRange', () => {
 
     metadata = getMetadata(
       {attributeName: 'wot'},
-      {wot: {min: 5, max: 10}}
+      {range: {wot: {min: 5, max: 10}}}
     );
     expect(metadata).toEqual({
       id: 'wot',
@@ -153,7 +153,13 @@ describe('connectRange', () => {
   });
 
   it('should return the right state when clean up', () => {
-    const state = cleanUp({attributeName: 'name'}, {name: {state: 'state'}, another: {state: 'state'}});
+    let state = cleanUp({attributeName: 'name'}, {
+      range: {name: 'state', name2: 'state'},
+      another: {state: 'state'},
+    });
+    expect(state).toEqual({range: {name2: 'state'}, another: {state: 'state'}});
+
+    state = cleanUp({attributeName: 'name2'}, state);
     expect(state).toEqual({another: {state: 'state'}});
   });
 });

--- a/packages/react-instantsearch/src/connectors/connectRefinementList.test.js
+++ b/packages/react-instantsearch/src/connectors/connectRefinementList.test.js
@@ -27,7 +27,7 @@ describe('connectRefinementList', () => {
     props = getProps({attributeName: 'ok'}, {}, {results});
     expect(props).toEqual({items: [], currentRefinement: []});
 
-    props = getProps({attributeName: 'ok'}, {ok: ['wat']}, {results});
+    props = getProps({attributeName: 'ok'}, {refinementList: {ok: ['wat']}}, {results});
     expect(props).toEqual({items: [], currentRefinement: ['wat']});
 
     props = getProps({attributeName: 'ok', defaultRefinement: ['wat']}, {}, {results});
@@ -96,7 +96,7 @@ describe('connectRefinementList', () => {
     const nextState = refine({attributeName: 'ok'}, {otherKey: 'val'}, ['yep']);
     expect(nextState).toEqual({
       otherKey: 'val',
-      ok: ['yep'],
+      refinementList: {ok: ['yep']},
     });
   });
 
@@ -133,24 +133,24 @@ describe('connectRefinementList', () => {
       attributeName: 'ok',
       operator: 'or',
       limitMin: 1,
-    }, {ok: ['wat']});
+    }, {refinementList: {ok: ['wat']}});
     expect(params).toEqual(
       initSP
-      .addDisjunctiveFacet('ok')
-      .addDisjunctiveFacetRefinement('ok', 'wat')
-      .setQueryParameter('maxValuesPerFacet', 1)
+        .addDisjunctiveFacet('ok')
+        .addDisjunctiveFacetRefinement('ok', 'wat')
+        .setQueryParameter('maxValuesPerFacet', 1)
     );
 
     params = getSP(initSP, {
       attributeName: 'ok',
       operator: 'and',
       limitMin: 1,
-    }, {ok: ['wat']});
+    }, {refinementList: {ok: ['wat']}});
     expect(params).toEqual(
       initSP
-      .addFacet('ok')
-      .addFacetRefinement('ok', 'wat')
-      .setQueryParameter('maxValuesPerFacet', 1)
+        .addFacet('ok')
+        .addFacetRefinement('ok', 'wat')
+        .setQueryParameter('maxValuesPerFacet', 1)
     );
   });
 
@@ -162,7 +162,7 @@ describe('connectRefinementList', () => {
   it('registers its filter in metadata', () => {
     const metadata = getMetadata(
       {attributeName: 'wot'},
-      {wot: ['wat', 'wut']}
+      {refinementList: {wot: ['wat', 'wut']}}
     );
     expect(metadata).toEqual({
       id: 'wot',
@@ -187,14 +187,20 @@ describe('connectRefinementList', () => {
       ],
     });
 
-    let state = metadata.items[0].items[0].value({wot: ['wat', 'wut']});
-    expect(state).toEqual({wot: ['wut']});
+    let state = metadata.items[0].items[0].value({refinementList: {wot: ['wat', 'wut']}});
+    expect(state).toEqual({refinementList: {wot: ['wut']}});
     state = metadata.items[0].items[1].value(state);
-    expect(state).toEqual({wot: ''});
+    expect(state).toEqual({refinementList: {wot: ''}});
   });
 
   it('should return the right state when clean up', () => {
-    const state = cleanUp({attributeName: 'name'}, {name: {state: 'state'}, another: {state: 'state'}});
+    let state = cleanUp({attributeName: 'name'}, {
+      refinementList: {name: 'state', name2: 'state'},
+      another: {state: 'state'},
+    });
+    expect(state).toEqual({refinementList: {name2: 'state'}, another: {state: 'state'}});
+
+    state = cleanUp({attributeName: 'name2'}, state);
     expect(state).toEqual({another: {state: 'state'}});
   });
 });

--- a/packages/react-instantsearch/src/connectors/connectScrollTo.js
+++ b/packages/react-instantsearch/src/connectors/connectScrollTo.js
@@ -8,7 +8,7 @@ import createConnector from '../core/createConnector';
  * @name connectScrollTo
  * @kind connector
  * @category connector
- * @propType {string} [scrollOn="p"] - Widget state key on which to listen for changes, default to the pagination widget.
+ * @propType {string} [scrollOn="page"] - Widget state key on which to listen for changes, default to the pagination widget.
  * @providedPropType {any} value - the current refinement applied to the widget listened by scrollTo
  */
 export default createConnector({
@@ -19,7 +19,7 @@ export default createConnector({
   },
 
   defaultProps: {
-    scrollOn: 'p',
+    scrollOn: 'page',
   },
 
   getProps(props, state) {

--- a/packages/react-instantsearch/src/connectors/connectSearchBox.js
+++ b/packages/react-instantsearch/src/connectors/connectSearchBox.js
@@ -2,7 +2,7 @@ import createConnector from '../core/createConnector';
 import {omit} from 'lodash';
 
 function getId() {
-  return 'q';
+  return 'query';
 }
 
 function getCurrentRefinement(props, state) {

--- a/packages/react-instantsearch/src/connectors/connectSearchBox.test.js
+++ b/packages/react-instantsearch/src/connectors/connectSearchBox.test.js
@@ -20,7 +20,7 @@ describe('connectSearchBox', () => {
     props = getProps({}, {});
     expect(props).toEqual({query: ''});
 
-    props = getProps({}, {q: 'yep'});
+    props = getProps({}, {query: 'yep'});
     expect(props).toEqual({query: 'yep'});
   });
 
@@ -28,17 +28,17 @@ describe('connectSearchBox', () => {
     const nextState = refine({}, {otherKey: 'val'}, 'yep');
     expect(nextState).toEqual({
       otherKey: 'val',
-      q: 'yep',
+      query: 'yep',
     });
   });
 
   it('refines the query parameter', () => {
-    params = getSP(new SearchParameters(), {}, {q: 'bar'});
+    params = getSP(new SearchParameters(), {}, {query: 'bar'});
     expect(params.query).toBe('bar');
   });
 
   it('should return the right state when clean up', () => {
-    const state = cleanUp({}, {q: {state: 'state'}, another: {state: 'state'}});
+    const state = cleanUp({}, {query: {state: 'state'}, another: {state: 'state'}});
     expect(state).toEqual({another: {state: 'state'}});
   });
 });

--- a/packages/react-instantsearch/src/connectors/connectToggle.js
+++ b/packages/react-instantsearch/src/connectors/connectToggle.js
@@ -1,15 +1,17 @@
 import {PropTypes} from 'react';
-import {omit} from 'lodash';
+import {omit, isEmpty} from 'lodash';
 import createConnector from '../core/createConnector';
 
 function getId(props) {
   return props.attributeName;
 }
 
+const namespace = 'toggle';
+
 function getCurrentRefinement(props, state) {
   const id = getId(props);
-  if (state[id]) {
-    return state[id] === 'on';
+  if (state[namespace] && state[namespace][id]) {
+    return state[namespace][id];
   }
   if (props.defaultRefinement) {
     return props.defaultRefinement;
@@ -50,12 +52,16 @@ export default createConnector({
   refine(props, state, nextChecked) {
     return {
       ...state,
-      [getId(props, state)]: nextChecked ? 'on' : 'off',
+      [namespace]: {[getId(props, state)]: nextChecked},
     };
   },
 
   cleanUp(props, state) {
-    return omit(state, getId(props));
+    const cleanState = omit(state, `${namespace}.${getId(props)}`);
+    if (isEmpty(cleanState[namespace])) {
+      return omit(cleanState, namespace);
+    }
+    return cleanState;
   },
 
   getSearchParameters(searchParameters, props, state) {
@@ -90,7 +96,7 @@ export default createConnector({
         attributeName: props.attributeName,
         value: nextState => ({
           ...nextState,
-          [id]: 'off',
+          [namespace]: {[id]: false},
         }),
       });
     }

--- a/packages/react-instantsearch/src/connectors/connectToggle.test.js
+++ b/packages/react-instantsearch/src/connectors/connectToggle.test.js
@@ -21,7 +21,7 @@ describe('connectToggle', () => {
     props = getProps({attributeName: 't'}, {});
     expect(props).toEqual({checked: false});
 
-    props = getProps({attributeName: 't'}, {t: 'on'});
+    props = getProps({attributeName: 't'}, {toggle: {t: true}});
     expect(props).toEqual({checked: true});
 
     props = getProps({defaultRefinement: true, attributeName: 't'}, {});
@@ -32,13 +32,13 @@ describe('connectToggle', () => {
     let state = refine({attributeName: 't'}, {otherKey: 'val'}, true);
     expect(state).toEqual({
       otherKey: 'val',
-      t: 'on',
+      toggle: {t: true},
     });
 
     state = refine({attributeName: 't'}, {otherKey: 'val'}, false);
     expect(state).toEqual({
       otherKey: 'val',
-      t: 'off',
+      toggle: {t: false},
     });
   });
 
@@ -46,7 +46,7 @@ describe('connectToggle', () => {
     params = getSP(new SearchParameters(), {
       attributeName: 'facet',
       value: 'val',
-    }, {facet: 'on'});
+    }, {toggle: {facet: true}});
     expect(params.getConjunctiveRefinements('facet')).toEqual(['val']);
   });
 
@@ -54,7 +54,7 @@ describe('connectToggle', () => {
     params = getSP(new SearchParameters(), {
       attributeName: 'facet',
       filter: sp => sp.setQuery('yep'),
-    }, {facet: 'on'});
+    }, {toggle: {facet: true}});
     expect(params.query).toEqual('yep');
   });
 
@@ -65,7 +65,7 @@ describe('connectToggle', () => {
       id: 't',
     });
 
-    metadata = getMetadata({attributeName: 't', label: 'yep'}, {t: 'on'});
+    metadata = getMetadata({attributeName: 't', label: 'yep'}, {toggle: {t: true}});
     expect(metadata).toEqual({
       items: [
         {
@@ -79,12 +79,18 @@ describe('connectToggle', () => {
       id: 't',
     });
 
-    const state = metadata.items[0].value({t: 'on'});
-    expect(state).toEqual({t: 'off'});
+    const state = metadata.items[0].value({toggle: {t: true}});
+    expect(state).toEqual({toggle: {t: false}});
   });
 
   it('should return the right state when clean up', () => {
-    const state = cleanUp({attributeName: 'name'}, {name: {state: 'state'}, another: {state: 'state'}});
+    let state = cleanUp({attributeName: 'name'}, {
+      toggle: {name: 'state', name2: 'state'},
+      another: {state: 'state'},
+    });
+    expect(state).toEqual({toggle: {name2: 'state'}, another: {state: 'state'}});
+
+    state = cleanUp({attributeName: 'name2'}, state);
     expect(state).toEqual({another: {state: 'state'}});
   });
 });

--- a/stories/Conditional.stories.js
+++ b/stories/Conditional.stories.js
@@ -10,7 +10,7 @@ stories.add('NoResults/HasResults', () => {
     displayName: 'ConditionalResults',
     getProps(props, state, search) {
       const noResults = search.results ? search.results.nbHits === 0 : false;
-      return {query: state.q, noResults};
+      return {query: state.query, noResults};
     },
   })(({noResults, query}) => {
     const content = noResults
@@ -25,7 +25,7 @@ stories.add('NoResults/HasResults', () => {
   const Content = createConnector({
     displayName: 'ConditionalQuery',
     getProps(props, state) {
-      return {query: state.q};
+      return {query: state.query};
     },
   })(({query}) => {
     const content = query


### PR DESCRIPTION
Does not contain the doc yet, only the namespacing.

```json
{
  "range": {
    "price": {
      "min": "200",
      "max": "500"
    }
  },
  "refinementList": {
    "colors": [
      "White",
      "High gloss gray",
      "Black-brown",
      "High gloss white",
      "Walnut effect"
    ]
  },
  "hierarchicalMenu": {
    "category": "Bathroom"
  },
  "hitsPerPage": "2",
  "menu": {
    "type": "High cabinet with mirror door, black-brown"
  },
  "multiRange": {
    "price": "100:500"
  },
  "toggle": {
    "materials": "on"
  },
  "sortBy": "index_name",
  "query": "chair",
  "page": 2
}
```