### PR TITLE
fix(connectHierarchicalMenu): use item.items instead of item.children

### DIFF
--- a/docgen/src/examples/e-commerce-infinite/style.css
+++ b/docgen/src/examples/e-commerce-infinite/style.css
@@ -150,7 +150,7 @@ aside .ais-HierarchicalMenu__itemLabel:before {
   content: "> "
 }
 
-aside .ais-HierarchicalMenu__itemChildren {
+aside .ais-HierarchicalMenu__itemItems {
   margin-left: 10px;
 }
 

--- a/docgen/src/examples/e-commerce/style.css
+++ b/docgen/src/examples/e-commerce/style.css
@@ -150,7 +150,7 @@ aside .ais-HierarchicalMenu__itemLabel:before {
   content: "> "
 }
 
-aside .ais-HierarchicalMenu__itemChildren {
+aside .ais-HierarchicalMenu__itemItems {
   margin-left: 10px;
 }
 

--- a/docgen/src/examples/material-ui/App.js
+++ b/docgen/src/examples/material-ui/App.js
@@ -176,7 +176,7 @@ const MaterialUiNestedList = function ({id, items, refine}) {
   return <List>
     <Subheader style={{fontSize: 18}}>{id.toUpperCase()}</Subheader>
     {items.map((item, idx) => {
-      const nestedElements = item.children ? item.children.map((child, childIdx) =>
+      const nestedElements = item.items ? item.items.map((child, childIdx) =>
           <ListItem
             primaryText={child.label}
             key={childIdx}

--- a/packages/react-instantsearch-theme-algolia/styles/_HierarchicalMenu.scss
+++ b/packages/react-instantsearch-theme-algolia/styles/_HierarchicalMenu.scss
@@ -55,7 +55,7 @@
   @include counterStyle();
 }
 
-.ais-HierarchicalMenu__itemChildren {
+.ais-HierarchicalMenu__itemItems {
   padding-left: 14px;
   font-weight: normal;
 

--- a/packages/react-instantsearch/src/components/HierarchicalMenu.enzyme.test.js
+++ b/packages/react-instantsearch/src/components/HierarchicalMenu.enzyme.test.js
@@ -16,7 +16,7 @@ describe('HierarchicalMenu', () => {
         createURL={() => '#'}
         items={[
           {value: 'white', count: 10, label: 'white',
-            children: [{value: 'white1', label: 'white1', count: 3}, {value: 'white2', label: 'white2', count: 4}]},
+            items: [{value: 'white1', label: 'white1', count: 3}, {value: 'white2', label: 'white2', count: 4}]},
           {value: 'black', count: 20, label: 'black'},
           {value: 'blue', count: 30, label: 'blue'},
         ]}

--- a/packages/react-instantsearch/src/components/HierarchicalMenu.js
+++ b/packages/react-instantsearch/src/components/HierarchicalMenu.js
@@ -11,7 +11,7 @@ const itemsPropType = PropTypes.arrayOf(PropTypes.shape({
   label: PropTypes.string.isRequired,
   value: PropTypes.string,
   count: PropTypes.number.isRequired,
-  children: (...args) => itemsPropType(...args),
+  items: (...args) => itemsPropType(...args),
 }));
 
 class HierarchicalMenu extends Component {

--- a/packages/react-instantsearch/src/components/HierarchicalMenu.test.js
+++ b/packages/react-instantsearch/src/components/HierarchicalMenu.test.js
@@ -13,7 +13,7 @@ describe('HierarchicalMenu', () => {
         createURL={() => '#'}
         items={[
           {value: 'white', count: 10, label: 'white',
-            children: [{value: 'white1', label: 'white1', count: 3}, {value: 'white2', label: 'white2', count: 4}]},
+            items: [{value: 'white1', label: 'white1', count: 3}, {value: 'white2', label: 'white2', count: 4}]},
           {value: 'black', count: 20, label: 'black'},
           {value: 'blue', count: 30, label: 'blue'},
         ]}
@@ -32,7 +32,7 @@ describe('HierarchicalMenu', () => {
         createURL={() => '#'}
         items={[
           {value: 'white', count: 10, label: 'white',
-            children: [{value: 'white1', label: 'white1', count: 3}, {value: 'white2', label: 'white2', count: 4}]},
+            items: [{value: 'white1', label: 'white1', count: 3}, {value: 'white2', label: 'white2', count: 4}]},
           {value: 'black', count: 20, label: 'black'},
           {value: 'blue', count: 30, label: 'blue'},
         ]}

--- a/packages/react-instantsearch/src/components/List.js
+++ b/packages/react-instantsearch/src/components/List.js
@@ -3,7 +3,7 @@ import React, {PropTypes, Component} from 'react';
 const itemsPropType = PropTypes.arrayOf(PropTypes.shape({
   value: PropTypes.any,
   label: PropTypes.string.isRequired,
-  children: (...args) => itemsPropType(...args),
+  items: (...args) => itemsPropType(...args),
 }));
 
 class List extends Component {
@@ -41,9 +41,9 @@ class List extends Component {
   };
 
   renderItem = item => {
-    const children = item.children &&
-      <div {...this.props.cx('itemChildren')}>
-        {item.children.slice(0, this.getLimit()).map(child =>
+    const items = item.items &&
+      <div {...this.props.cx('itemItems')}>
+        {item.items.slice(0, this.getLimit()).map(child =>
           this.renderItem(child, item)
         )}
       </div>;
@@ -54,12 +54,12 @@ class List extends Component {
         {...this.props.cx(
           'item',
           item.isRefined && 'itemSelected',
-          children && 'itemParent',
-          children && item.isRefined && 'itemSelectedParent'
+          items && 'itemParent',
+          items && item.isRefined && 'itemSelectedParent'
         )}
       >
         {this.props.renderItem(item)}
-        {children}
+        {items}
       </div>
     );
   };

--- a/packages/react-instantsearch/src/components/__snapshots__/HierarchicalMenu.test.js.snap
+++ b/packages/react-instantsearch/src/components/__snapshots__/HierarchicalMenu.test.js.snap
@@ -20,7 +20,7 @@ exports[`HierarchicalMenu applies translations 1`] = `
         </span>
       </a>
       <div
-        className="ais-HierarchicalMenu__itemChildren">
+        className="ais-HierarchicalMenu__itemItems">
         <div
           className="ais-HierarchicalMenu__item">
           <a
@@ -117,7 +117,7 @@ exports[`HierarchicalMenu default hierarchical menu 1`] = `
         </span>
       </a>
       <div
-        className="ais-HierarchicalMenu__itemChildren">
+        className="ais-HierarchicalMenu__itemItems">
         <div
           className="ais-HierarchicalMenu__item">
           <a

--- a/packages/react-instantsearch/src/connectors/connectHierarchicalMenu.js
+++ b/packages/react-instantsearch/src/connectors/connectHierarchicalMenu.js
@@ -64,7 +64,7 @@ function transformValue(value, limit, props, state) {
     value: getValue(v.path, props, state),
     count: v.count,
     isRefined: v.isRefined,
-    children: v.data && transformValue(v.data, limit, props, state),
+    items: v.data && transformValue(v.data, limit, props, state),
   }));
 }
 
@@ -89,7 +89,7 @@ const sortBy = ['name:asc'];
  * @providedPropType {function} refine - a function to toggle a refinement
  * @providedPropType {function} createURL - a function to generate a URL for the corresponding state
  * @providedPropType {string} currentRefinement - the refinement currently applied
- * @providedPropType {array.<{children: object, count: number, isRefined: boolean, label: string, value: string}>} items - the list of items the HierarchicalMenu can display. Children has the same shape as parent items.
+ * @providedPropType {array.<{items: object, count: number, isRefined: boolean, label: string, value: string}>} items - the list of items the HierarchicalMenu can display. items has the same shape as parent items.
  */
 export default createConnector({
   displayName: 'AlgoliaHierarchicalMenu',

--- a/packages/react-instantsearch/src/connectors/connectHierarchicalMenu.test.js
+++ b/packages/react-instantsearch/src/connectors/connectHierarchicalMenu.test.js
@@ -68,7 +68,7 @@ describe('connectHierarchicalMenu', () => {
         label: 'wat',
         value: 'wat',
         count: 20,
-        children: [
+        items: [
           {
             label: 'wot',
             value: 'wat > wot',
@@ -94,7 +94,7 @@ describe('connectHierarchicalMenu', () => {
         label: 'wat',
         value: 'wat',
         count: 20,
-        children: [
+        items: [
           {
             label: 'wot',
             value: 'wat > wot',
@@ -114,7 +114,7 @@ describe('connectHierarchicalMenu', () => {
         label: 'wat',
         value: 'wat',
         count: 20,
-        children: [
+        items: [
           {
             label: 'wot',
             value: 'wat > wot',

--- a/packages/react-instantsearch/src/widgets/HierarchicalMenu.js
+++ b/packages/react-instantsearch/src/widgets/HierarchicalMenu.js
@@ -25,7 +25,7 @@ import HierarchicalMenuComponent from '../components/HierarchicalMenu.js';
  * @themeKey ais-HierarchicalMenu__itemLink - the link containing the label and the count
  * @themeKey ais-HierarchicalMenu__itemLabel - the label of the entry
  * @themeKey ais-HierarchicalMenu__itemCount - the count of the entry
- * @themeKey ais-HierarchicalMenu__itemChildren - id representing a children
+ * @themeKey ais-HierarchicalMenu__itemItems - id representing a children
  * @themeKey ais-HierarchicalMenu__showMore - container for the show more button
  * @translationKey showMore - Label value of the button which toggles the number of items
  * @example


### PR DESCRIPTION
For consistency with other nested data connectors like
connectCurrentRefinements

BREAKING CHANGE:
- HierarchicalMenu ais-HierarchicalMenu__itemChildren css class name
is now ais-HierarchicalMenu__itemItems
- connectHierarchicalMenu item.children forwarded prop is now
item.items

fixes #1605