### PR TITLE
style(widget): add badge style to Menu + open caret on HierarchicalMenu

### DIFF
--- a/packages/react-instantsearch-theme-algolia/style.scss
+++ b/packages/react-instantsearch-theme-algolia/style.scss
@@ -30,6 +30,13 @@
   }
 }
 
+@mixin openCaret() {
+  &:after {
+    top: 25%;
+    transform: rotate(90deg)
+  }
+}
+
 @mixin button(){
   background-color: #ffffff;
   box-shadow: 0 1px 1px 0 rgba(85, 95, 110, 0.2) !important;

--- a/packages/react-instantsearch-theme-algolia/styles/_HierarchicalMenu.scss
+++ b/packages/react-instantsearch-theme-algolia/styles/_HierarchicalMenu.scss
@@ -40,7 +40,8 @@
 .ais-HierarchicalMenu__itemParent {
 }
 
-.ais-HierarchicalMenu__itemSelectedParent {
+.ais-HierarchicalMenu__itemSelectedParent > .ais-HierarchicalMenu__itemLink   {
+  @include openCaret();
 }
 
 .ais-HierarchicalMenu__itemLink {

--- a/packages/react-instantsearch-theme-algolia/styles/_Menu.scss
+++ b/packages/react-instantsearch-theme-algolia/styles/_Menu.scss
@@ -31,11 +31,7 @@
 }
 
 .ais-Menu__itemCount {
-  float: right;
-  color: #697782;
-  opacity: 0.4;
-  text-align: right;
-
+  @include counterStyle()
 }
 
 .ais-Menu__showMore {


### PR DESCRIPTION
### add badge consistency to Menu
<img width="334" alt="capture d ecran 2016-12-02 a 15 25 09" src="https://cloud.githubusercontent.com/assets/6885378/20837307/d06e7a84-b8a3-11e6-9f33-5858e2c3b114.png">

### open caret when selected an item on HierarchicalMenu
![hierarchical-menu-caret](https://cloud.githubusercontent.com/assets/6885378/20837311/d6020916-b8a3-11e6-84de-563a05aa02fd.gif)
