### PR TITLE
feat(hitsPerPage): hitsPerPage is now only configured by HitsPerPage

### DIFF
--- a/docgen/src/examples/e-commerce-infinite/App.js
+++ b/docgen/src/examples/e-commerce-infinite/App.js
@@ -26,6 +26,7 @@ export default function App() {
       appId="latency"
       apiKey="6be0576ff61c053d5f9a3225e2a90f76"
       indexName="ikea"
+      searchParameters={{hitsPerPage: 16}}
     >
       <div>
         <Header />
@@ -234,7 +235,7 @@ const CustomResults = createConnector({
           </div>
           <Stats />
         </section>
-        <ConnectedHits hitsPerPage={16}/>
+        <ConnectedHits/>
       </div>
     );
   }

--- a/docgen/src/examples/e-commerce/App.js
+++ b/docgen/src/examples/e-commerce/App.js
@@ -30,6 +30,7 @@ const App = props =>
     state={props.state}
     createURL={props.createURL.bind(this)}
     onStateChange={props.onStateChange.bind(this)}
+    searchParameters={{hitsPerPage: 16}}
   >
     <div>
       <Header />
@@ -232,7 +233,7 @@ const CustomResults = createConnector({
           </div>
           <Stats />
         </section>
-        <ConnectedHits hitsPerPage={16}/>
+        <ConnectedHits/>
         <footer><Pagination showLast={true}/></footer>
       </div>
     );

--- a/docgen/src/examples/material-ui/App.js
+++ b/docgen/src/examples/material-ui/App.js
@@ -50,6 +50,7 @@ const MaterialUiExample = props =>
     state={props.state}
     createURL={props.createURL.bind(this)}
     onStateChange={props.onStateChange.bind(this)}
+    searchParameters={{hitsPerPage: 16}}
   >
     <Content/>
   </InstantSearch>;
@@ -115,7 +116,6 @@ const Content = React.createClass({
           <div className="Content__hits">
             <ConnectedSearchBox marginLeft={marginLeft}/>
             <ConnectedHits
-              hitsPerPage={20}
               marginLeft={marginLeft}
             />
           </div>

--- a/docgen/src/examples/media/App.js
+++ b/docgen/src/examples/media/App.js
@@ -22,6 +22,7 @@ const App = props =>
     state={props.state}
     createURL={props.createURL.bind(this)}
     onStateChange={props.onStateChange.bind(this)}
+    searchParameters={{hitsPerPage: 10}}
   >
     <div>
       <Header/>
@@ -122,7 +123,7 @@ const Results = () =>
   <article>
     <div id="stats" className="text-right text-muted"><Stats/></div>
     <hr />
-    <div id="hits"><Hits itemComponent={Hit} hitsPerPage={10}/></div>
+    <div id="hits"><Hits itemComponent={Hit} /></div>
     <div id="pagination" className="text-center"><Pagination /></div>
   </article>;
 

--- a/docgen/src/guide/Routing.md
+++ b/docgen/src/guide/Routing.md
@@ -22,5 +22,5 @@ need to return a string.
 changes and inject state appropriately.
 
 <div class="guide-nav">
-Next: <a href="/guide/Algolia parameters.html">Algolia parameters →</a>
+Next: <a href="/guide/Search parameters.html">Search parameters →</a>
 </div>

--- a/docgen/src/guide/Search parameters.md
+++ b/docgen/src/guide/Search parameters.md
@@ -1,5 +1,5 @@
 ---
-title: Algolia parameters
+title: Search parameters
 mainTitle: Guide
 layout: main.pug
 category: guide
@@ -22,6 +22,8 @@ Here's an example configuring the [distinct parameter](https://www.algolia.com/d
 
 **Notes:**
 * There's a dedicated guide showing how to [configure default refinements](/guide/Default%20refinements.html) on widgets.
+* You could also pass `hitsPerPage: 20` to configure the number of hits being shown when not using
+the [`<HitsPerPage>` widget](/widgets/HitsPerPage.html).
 
 <div class="guide-nav">
 Next: <a href="/guide/Search state.html">Search state →</a>

--- a/packages/react-instantsearch/src/connectors/connectHits.js
+++ b/packages/react-instantsearch/src/connectors/connectHits.js
@@ -1,23 +1,19 @@
-import {PropTypes} from 'react';
-
 import createConnector from '../core/createConnector';
 
 /**
  * connectHits connector provides the logic to create connected
- * components that will render the results retrived from
+ * components that will render the results retrieved from
  * Algolia.
+ *
+ * To configure the number of hits retrieved, use [HitsPerPage widget](/widgets/HitsPerPage.html),
+ * [connectHitsPerPage connector](/connectors/connectHitsPerPage.html) or pass the hitsPerPage
+ * parameter to the [searchParameters](/guide/Search%20parameters.html) prop on `<InstantSearch/>`.
  * @name connectHits
  * @kind connector
- * @propType {number} hitsPerPage - How many hits should be displayed for every page.
- *   Ignored when a `HitsPerPage` component is also present.
  * @providedPropType {array.<object>} hits - the records that matched the search state
  */
 export default createConnector({
   displayName: 'AlgoliaHits',
-
-  propTypes: {
-    hitsPerPage: PropTypes.number,
-  },
 
   getProvidedProps(props, state, search) {
     if (!search.results) {
@@ -27,15 +23,5 @@ export default createConnector({
     return {
       hits: search.results.hits,
     };
-  },
-
-  getSearchParameters(searchParameters, props) {
-    if (
-      typeof props.hitsPerPage !== 'undefined' &&
-      typeof searchParameters.hitsPerPage === 'undefined'
-    ) {
-      return searchParameters.setHitsPerPage(props.hitsPerPage);
-    }
-    return searchParameters;
   },
 });

--- a/packages/react-instantsearch/src/connectors/connectHits.test.js
+++ b/packages/react-instantsearch/src/connectors/connectHits.test.js
@@ -1,10 +1,9 @@
 /* eslint-env jest, jasmine */
 
-import {SearchParameters} from 'algoliasearch-helper';
 import connect from './connectHits.js';
 jest.mock('../core/createConnector');
 
-const {getSearchParameters, getProvidedProps} = connect;
+const {getProvidedProps} = connect;
 
 describe('connectHits', () => {
   it('provides the current hits to the component', () => {
@@ -16,13 +15,5 @@ describe('connectHits', () => {
   it('doesn\'t render when no hits are available', () => {
     const props = getProvidedProps(null, null, {results: null});
     expect(props).toBe(null);
-  });
-
-  it('defaults hitsPerPage to its hitsPerPage prop, use the state otherwise', () => {
-    const params = new SearchParameters();
-    const params2 = getSearchParameters(params, {hitsPerPage: 666});
-    expect(params2.hitsPerPage).toBe(666);
-    const params3 = getSearchParameters(params2, {hitsPerPage: 777});
-    expect(params3.hitsPerPage).toBe(666);
   });
 });

--- a/packages/react-instantsearch/src/connectors/connectInfiniteHits.js
+++ b/packages/react-instantsearch/src/connectors/connectInfiniteHits.js
@@ -1,5 +1,3 @@
-import {PropTypes} from 'react';
-
 import createConnector from '../core/createConnector';
 
 function getId() {
@@ -12,17 +10,11 @@ function getId() {
  * Algolia. This connector provides a function to load more results.
  * @name connectInfiniteHits
  * @kind connector
- * @propType {number} hitsPerPage - How many hits should be displayed for every page.
- *   Ignored when a `HitsPerPage` component is also present.
  * @providedPropType {array.<object>} hits - the records that matched the search state
  * @providedPropType {boolean} hasMore - indicates if there are more pages to load
  */
 export default createConnector({
   displayName: 'AlgoliaInfiniteHits',
-
-  propTypes: {
-    hitsPerPage: PropTypes.number,
-  },
 
   getProvidedProps(componentProps, allWidgetsState, resultsStruct) {
     if (!resultsStruct.results) {
@@ -64,11 +56,9 @@ export default createConnector({
     const currentPage = widgetsState[id] ?
       widgetsState[id] :
       0;
-    const isHitsPerPageDefined = typeof searchParameters.hitsPerPage !== 'undefined';
 
     return searchParameters.setQueryParameters({
       page: currentPage,
-      hitsPerPage: isHitsPerPageDefined ? searchParameters.hitsPerPage : props.hitsPerPage,
     });
   },
 

--- a/packages/react-instantsearch/src/connectors/connectInfiniteHits.test.js
+++ b/packages/react-instantsearch/src/connectors/connectInfiniteHits.test.js
@@ -1,7 +1,5 @@
 /* eslint-env jest, jasmine */
-/* eslint-disable comma-dangle */
 
-import {SearchParameters} from 'algoliasearch-helper';
 import connect from './connectInfiniteHits.js';
 jest.mock('../core/createConnector');
 
@@ -25,7 +23,7 @@ describe.only('connectInfiniteHits', () => {
     expect(res1.hits).toEqual(hits);
     expect(res1.hasMore).toBe(true);
     const res2 = connect.getProvidedProps.call(providedThis, null, null, {
-      results: {hits: hits2, page: 1, hitsPerPage: 2, nbPages: 3}
+      results: {hits: hits2, page: 1, hitsPerPage: 2, nbPages: 3},
     });
     expect(res2.hits).toEqual([...hits, ...hits2]);
     expect(res2.hasMore).toBe(true);
@@ -44,7 +42,7 @@ describe.only('connectInfiniteHits', () => {
           hits,
           page,
           hitsPerPage: hits.length,
-          nbPages
+          nbPages,
         },
       });
       expect(res.hits).toEqual(allHits);
@@ -59,7 +57,7 @@ describe.only('connectInfiniteHits', () => {
         hits,
         page: nbPages - 1,
         hitsPerPage: hits.length,
-        nbPages
+        nbPages,
       },
     });
     expect(res.hits.length).toEqual(nbPages * 2);
@@ -73,24 +71,16 @@ describe.only('connectInfiniteHits', () => {
     const hits2 = [{}, {}];
     const hits3 = [{}];
     connect.getProvidedProps.call(providedThis, null, null, {
-      results: {hits, page: 0, hitsPerPage: 2, nbPages: 3}
+      results: {hits, page: 0, hitsPerPage: 2, nbPages: 3},
     });
     connect.getProvidedProps.call(providedThis, null, null, {
-      results: {hits: hits2, page: 1, hitsPerPage: 2, nbPages: 3}
+      results: {hits: hits2, page: 1, hitsPerPage: 2, nbPages: 3},
     });
     const props = connect.getProvidedProps.call(providedThis, null, null, {
-      results: {hits: hits3, page: 2, hitsPerPage: 2, nbPages: 3}
+      results: {hits: hits3, page: 2, hitsPerPage: 2, nbPages: 3},
     });
     expect(props.hits).toEqual([...hits, ...hits2, ...hits3]);
     expect(props.hasMore).toBe(false);
-  });
-
-  it('use the state for hitsPerPage, defaults to props, ', () => {
-    const params = new SearchParameters();
-    const params2 = connect.getSearchParameters(params, {hitsPerPage: 666}, {});
-    expect(params2.hitsPerPage).toBe(666);
-    const params3 = connect.getSearchParameters(params2, {hitsPerPage: 777}, {});
-    expect(params3.hitsPerPage).toBe(666);
   });
 
   it('adds 1 to page when calling refine', () => {

--- a/packages/react-instantsearch/src/widgets/Hits.js
+++ b/packages/react-instantsearch/src/widgets/Hits.js
@@ -3,10 +3,13 @@ import HitsComponent from '../components/Hits.js';
 
 /**
  * Displays the list of hits for the current search parameters.
+ *
+ * To configure the number of hits being shown, use [HitsPerPage widget](/widgets/HitsPerPage.html),
+ * [connectHitsPerPage connector](/connectors/connectHitsPerPage.html) or pass the hitsPerPage
+ * parameter to the [searchParameters](/guide/Search%20parameters.html) prop on `<InstantSearch/>`.
+ *
  * @name Hits
  * @kind widget
- * @propType {number} hitsPerPage - How many hits should be displayed for every page.
- *   Ignored when a `HitsPerPage` component is also present.
  * @propType {Component} itemComponent - Component used for rendering each hit from
  *   the results. If it is not provided the rendering defaults to displaying the
  *   hit in its JSON form. The component will be called with a `hit` prop.

--- a/packages/react-instantsearch/src/widgets/InfiniteHits.js
+++ b/packages/react-instantsearch/src/widgets/InfiniteHits.js
@@ -6,10 +6,13 @@ import InfiniteHitsComponent from '../components/InfiniteHits.js';
  * will also render a **load more** button that will add one to the current
  * page and will trigger the search. The new results will be append in the
  * list of results.
+ *
+ * To configure the number of hits being shown, use [HitsPerPage widget](/widgets/HitsPerPage.html),
+ * [connectHitsPerPage connector](/connectors/connectHitsPerPage.html) or pass the hitsPerPage
+ * parameter to the [searchParameters](/guide/Search%20parameters.html) prop on `<InstantSearch/>`.
+ *
  * @name InfiniteHits
  * @kind widget
- * @propType {number} hitsPerPage - How many hits should be displayed for every page.
- *   Ignored when a `HitsPerPage` component is also present.
  * @propType {Component} itemComponent - Component used for rendering each hit from
  *   the results. If it is not provided the rendering defaults to displaying the
  *   hit in its JSON form. The component will be called with a `hit` prop.

--- a/packages/react-instantsearch/src/widgets/ScrollTo.js
+++ b/packages/react-instantsearch/src/widgets/ScrollTo.js
@@ -20,7 +20,7 @@ import ScrollToComponent from '../components/ScrollTo.js';
  *       indexName="ikea"
  *     >
  *       <ScrollTo >
- *            <Hits hitsPerPage={5}/>
+ *            <Hits />
  *       </ScrollTo>
  *     </InstantSearch>
  *   );

--- a/stories/Hits.stories.js
+++ b/stories/Hits.stories.js
@@ -12,8 +12,4 @@ stories.add('default', () =>
   <WrapWithHits linkedStoryGroup="Hits">
     <Hits />
   </WrapWithHits>
-).add('with max hits per page', () =>
-  <WrapWithHits >
-    <Hits hitsPerPage={5}/>
-  </WrapWithHits>
 );

--- a/stories/ScrollTo.stories.js
+++ b/stories/ScrollTo.stories.js
@@ -9,9 +9,9 @@ const stories = storiesOf('ScrollTo', module);
 stories.addDecorator(withKnobs);
 
 stories.add('default', () =>
-  <WrapWithHits linkedStoryGroup="ScrollTo" >
+  <WrapWithHits linkedStoryGroup="ScrollTo" searchParameters={{hitsPerPage: 5}}>
     <ScrollTo >
-      <Hits hitsPerPage={5}/>
+      <Hits/>
     </ScrollTo>
   </WrapWithHits>
 );

--- a/stories/util.js
+++ b/stories/util.js
@@ -23,7 +23,14 @@ Wrap.propTypes = {
   children: React.PropTypes.node,
 };
 
-const WrapWithHits = ({children, searchBox = true, hasPlayground = false, linkedStoryGroup, pagination = true}) => {
+const WrapWithHits = ({
+  searchParameters: askedSearchParameters = {},
+  children,
+  searchBox = true,
+  hasPlayground = false,
+  linkedStoryGroup,
+  pagination = true,
+}) => {
   const sourceCodeUrl = `https://github.com/algolia/instantsearch.js/tree/v2/stories/${linkedStoryGroup}.stories.js`;
   const playgroundLink = hasPlayground
     ? <button onClick={linkTo(linkedStoryGroup, 'playground')}
@@ -45,11 +52,17 @@ const WrapWithHits = ({children, searchBox = true, hasPlayground = false, linked
       </div>
       : null;
 
+  const searchParameters = {
+    hitsPerPage: 3,
+    ...askedSearchParameters,
+  };
+
   return <InstantSearch
     className="container-fluid"
     appId="latency"
     apiKey="6be0576ff61c053d5f9a3225e2a90f76"
     indexName="ikea"
+    searchParameters={{...searchParameters}}
   >
     <div>
       <div className="container widget-container">
@@ -66,7 +79,7 @@ const WrapWithHits = ({children, searchBox = true, hasPlayground = false, linked
                 translations={{reset: 'Clear all filters'}}
               />
           </div>
-          <CustomHits hitsPerPage={3}/>
+          <CustomHits />
           <div className="hit-pagination">{pagination ? <Pagination showLast={true}/> : null}</div>
         </div>
         {footer}
@@ -104,6 +117,7 @@ WrapWithHits.propTypes = {
   linkedStoryGroup: React.PropTypes.string,
   hasPlayground: React.PropTypes.boolean,
   pagination: React.PropTypes.boolean,
+  searchParameters: React.PropTypes.object,
 };
 
 export {


### PR DESCRIPTION
Before this commit, Hits, connectHits, InfinitHits,
connectInfiniteHits, HitsPerPage, connectHitsPerPage were responsible
for dealing with the hitsPerPage parameter.

This encouraged usages like:

```jsx
Hits hitsPerPage=20
HitsPerPage items={[{value: 20, value:30}]}
```

Leading to confusions and conflict handling if both Hits's hitsPerPage
and items of HitsPerPage are different.

Now only HitsPerPage or the searchParameters prop (InstantSearch prop)
are able to control it.

Our goal being to always emphasis on the best UX, providing a way to
choose the number of hits to be shown by the user should be something
we push for. Therefore this PR removing hitsPerPage parameter on Hits
(and InfiniteHits).

This also removes inconsistency because utlimately <Hits
hitsPerPage={20}> should have been <Hits defaultRefinement={20}> if
they followed our connector rules/API.