### PR TITLE
fix(connectSearchBox): provide currentRefinement instead of query

### DIFF
--- a/docgen/src/examples/e-commerce-infinite/App.js
+++ b/docgen/src/examples/e-commerce-infinite/App.js
@@ -123,10 +123,10 @@ const RefinementListWithTitle = ({title, item}) =>
     {item}
   </div>;
 
-const CustomCheckbox = ({query, refine}) =>
+const CustomSearchBox = ({currentRefinement, refine}) =>
     <div className="input-group">
       <input type="text"
-             value={query}
+             value={currentRefinement}
              onChange={e => refine(e.target.value)}
              className="form-control"
              id="q"/>
@@ -292,6 +292,6 @@ const PriceRange = ({label, value, onClick}) =>
     </a>
   </li>;
 
-const ConnectedSearchBox = connectSearchBox(CustomCheckbox);
+const ConnectedSearchBox = connectSearchBox(CustomSearchBox);
 const ConnectedColorRefinementList = connectRefinementList(CustomColorRefinementList);
 const ConnectedHits = connectInfiniteHits(CustomHits);

--- a/docgen/src/examples/e-commerce/App.js
+++ b/docgen/src/examples/e-commerce/App.js
@@ -125,10 +125,10 @@ const RefinementListWithTitle = ({title, item}) =>
     {item}
   </div>;
 
-const CustomCheckbox = ({query, refine}) =>
+const CustomSearchBox = ({currentRefinement, refine}) =>
     <div className="input-group">
       <input type="text"
-             value={query}
+             value={currentRefinement}
              onChange={e => refine(e.target.value)}
              className="form-control"
              id="q"/>
@@ -291,7 +291,7 @@ const PriceRange = ({label, value, onClick}) =>
     </a>
   </li>;
 
-const ConnectedSearchBox = connectSearchBox(CustomCheckbox);
+const ConnectedSearchBox = connectSearchBox(CustomSearchBox);
 const ConnectedColorRefinementList = connectRefinementList(CustomColorRefinementList);
 const ConnectedHits = connectHits(CustomHits);
 

--- a/docgen/src/examples/material-ui/App.js
+++ b/docgen/src/examples/material-ui/App.js
@@ -126,8 +126,8 @@ const Content = React.createClass({
   },
 });
 
-const MaterialUiSearchBox = ({query, refine, marginLeft}) => {
-  const clear = query ?
+const MaterialUiSearchBox = ({currentRefinement, refine, marginLeft}) => {
+  const clear = currentRefinement ?
     <FontIcon style={{color: 'lightgrey'}}
               className="material-icons"
               onTouchTap={() => refine('')}>clear</FontIcon>
@@ -135,7 +135,7 @@ const MaterialUiSearchBox = ({query, refine, marginLeft}) => {
   return (
     <div style={{marginLeft}} className="Header__searchBox">
       <FontIcon style={{color: 'lightgrey'}} className="material-icons">search</FontIcon>
-      <TextField value={query}
+      <TextField value={currentRefinement}
                  onChange={e => refine(e.target.value)}
                  id="SearchBox"
                  hintText="Search for a product..."

--- a/docgen/src/examples/media/App.js
+++ b/docgen/src/examples/media/App.js
@@ -43,11 +43,11 @@ const Header = () =>
   </header>;
 
 const SearchBox = connectSearchBox(
-  ({query, refine}) =>
+  ({currentRefinement, refine}) =>
     <div className="searchbox-container">
       <div className="input-group">
         <input type="text"
-               value={query}
+               value={currentRefinement}
                onChange={e => refine(e.target.value)}
                className="form-control"
         />

--- a/docgen/src/guide/Connectors.md
+++ b/docgen/src/guide/Connectors.md
@@ -34,15 +34,15 @@ If you want to create your own search box, you will need to use the [`connectSea
 ```javascript
 import {connectSearchBox} from 'react-instantsearch/connectors';
 
-const MySearchBox = props =>
+const MySearchBox = ({currentRefinement, refine}) =>
   <input
     type="text"
-    value={props.query}
-    onChange={e => props.refine(e.target.value)}
+    value={currentRefinement}
+    onChange={e => refine(e.target.value)}
   />;
 
 // `ConnectedSearchBox` renders a `<MySearchBox>` component that is connected to
-// the <InstantSearch> state, providing it with `query` and `refine` props for
+// the <InstantSearch> state, providing it with `currentRefinement` and `refine` props for
 // reading and manipulating the current query of the search.
 // Note that this `ConnectedSearchBox` component will only work when rendered
 // as a child or a descendant of the `<InstantSearch>` component.

--- a/docgen/src/guide/React native.md
+++ b/docgen/src/guide/React native.md
@@ -39,11 +39,11 @@ export default InfiniteSearch = () =>
     </InstantSearch>
   </View>;
 
-const SearchBox = connectSearchBox(() =>
+const SearchBox = connectSearchBox(({currentRefinement, refine}) =>
   <TextInput
     style={{height: 40, borderColor: 'gray', borderWidth: 1}}
-    onChangeText={(text) => this.props.refine(text)}
-    value={this.props.query}
+    onChangeText={(text) => refine(text)}
+    value={currentRefinement}
   />
 );
 

--- a/packages/react-instantsearch/src/components/SearchBox.enzyme.test.js
+++ b/packages/react-instantsearch/src/components/SearchBox.enzyme.test.js
@@ -16,7 +16,7 @@ let wrapper;
 describe('SearchBox', () => {
   it('treats query as a default value when searchAsYouType=false', () => {
     wrapper = mount(
-      <SearchBox refine={() => null} query="QUERY1" searchAsYouType={false} />
+      <SearchBox refine={() => null} currentRefinement="QUERY1" searchAsYouType={false} />
     );
     expect(wrapper.find('input').props().value).toBe('QUERY1');
     wrapper.find('input').simulate('change', {target: {value: 'QUERY2'}});

--- a/packages/react-instantsearch/src/components/SearchBox.js
+++ b/packages/react-instantsearch/src/components/SearchBox.js
@@ -15,7 +15,7 @@ const ResetIcon = () =>
 
 class SearchBox extends Component {
   static propTypes = {
-    query: PropTypes.string,
+    currentRefinement: PropTypes.string,
     refine: PropTypes.func.isRequired,
     translate: PropTypes.func.isRequired,
 
@@ -32,7 +32,7 @@ class SearchBox extends Component {
   };
 
   static defaultProps = {
-    query: '',
+    currentRefinement: '',
     focusShortcuts: ['s', '/'],
     autoFocus: false,
     searchAsYouType: true,
@@ -42,7 +42,7 @@ class SearchBox extends Component {
     super();
 
     this.state = {
-      query: props.searchAsYouType ? null : props.query,
+      query: props.searchAsYouType ? null : props.currentRefinement,
     };
   }
 
@@ -61,17 +61,17 @@ class SearchBox extends Component {
     // new search has been triggered.
     if (
       !nextProps.searchAsYouType &&
-      nextProps.query !== this.props.query
+      nextProps.currentRefinement !== this.props.currentRefinement
     ) {
       this.setState({
-        query: nextProps.query,
+        query: nextProps.currentRefinement,
       });
     }
   }
 
   getQuery = () =>
     this.props.searchAsYouType ?
-      this.props.query :
+      this.props.currentRefinement :
       this.state.query;
 
   setQuery = val => {

--- a/packages/react-instantsearch/src/components/SearchBox.test.js
+++ b/packages/react-instantsearch/src/components/SearchBox.test.js
@@ -24,12 +24,12 @@ describe('SearchBox', () => {
 
   it('treats its query prop as its input value', () => {
     const inst = renderer.create(
-      <SearchBox refine={() => null} query="QUERY1" />
+      <SearchBox refine={() => null} currentRefinement="QUERY1" />
     );
     expect(inst.toJSON()).toMatchSnapshot();
 
     inst.update(
-      <SearchBox refine={() => null} query="QUERY2" />
+      <SearchBox refine={() => null} currentRefinement="QUERY2" />
     );
     expect(inst.toJSON()).toMatchSnapshot();
   });

--- a/packages/react-instantsearch/src/connectors/connectSearchBox.js
+++ b/packages/react-instantsearch/src/connectors/connectSearchBox.js
@@ -20,14 +20,14 @@ function getCurrentRefinement(props, state) {
  * @kind connector
  * @providedPropType {function} refine - a function to remove a single filter
  * @providedPropType {function} createURL - a function to generate a URL for the corresponding state
- * @providedPropType {string} query - the query to search for.
+ * @providedPropType {string} currentRefinement - the query to search for.
  */
 export default createConnector({
   displayName: 'AlgoliaSearchBox',
 
   getProvidedProps(props, state) {
     return {
-      query: getCurrentRefinement(props, state),
+      currentRefinement: getCurrentRefinement(props, state),
     };
   },
 

--- a/packages/react-instantsearch/src/connectors/connectSearchBox.test.js
+++ b/packages/react-instantsearch/src/connectors/connectSearchBox.test.js
@@ -18,10 +18,10 @@ let params;
 describe('connectSearchBox', () => {
   it('provides the correct props to the component', () => {
     props = getProvidedProps({}, {});
-    expect(props).toEqual({query: ''});
+    expect(props).toEqual({currentRefinement: ''});
 
     props = getProvidedProps({}, {query: 'yep'});
-    expect(props).toEqual({query: 'yep'});
+    expect(props).toEqual({currentRefinement: 'yep'});
   });
 
   it('calling refine updates the widget\'s state', () => {


### PR DESCRIPTION
Connectors are following the currentRefinement, refine pattern.
Somehow connectSearchBox was missed.

BREAKING CHANGE:
- connectSearchBox now forward the query as props.currentRefinement
like any other connector