### PR TITLE
fix(createConnector): rename getProps into getProvidedProps

### DIFF
--- a/docgen/src/examples/e-commerce-infinite/App.js
+++ b/docgen/src/examples/e-commerce-infinite/App.js
@@ -204,7 +204,7 @@ const Hit = ({item}) => {
 const CustomResults = createConnector({
   displayName: 'CustomResults',
 
-  getProps(props, state, search) {
+  getProvidedProps(props, state, search) {
     const noResults = search.results ? search.results.nbHits === 0 : false;
     return {query: state.query, noResults};
   },

--- a/docgen/src/examples/e-commerce/App.js
+++ b/docgen/src/examples/e-commerce/App.js
@@ -202,7 +202,7 @@ const Hit = ({item}) => {
 const CustomResults = createConnector({
   displayName: 'CustomResults',
 
-  getProps(props, state, search) {
+  getProvidedProps(props, state, search) {
     const noResults = search.results ? search.results.nbHits === 0 : false;
     return {query: state.query, noResults};
   },

--- a/docgen/src/guide/Conditional display.md
+++ b/docgen/src/guide/Conditional display.md
@@ -14,7 +14,7 @@ conditionally display content based on the search state.
 ```javascript
 const Content = createConnector({
     displayName: 'ConditionalQuery',
-    getProps(props, state) {
+    getProvidedProps(props, state) {
       return {query: state.query};
     },
  })(({query}) => {
@@ -30,7 +30,7 @@ const Content = createConnector({
 ```javascript
 const content = createConnector({
     displayName: 'ConditionalResults',
-    getProps(props, state, search) {
+    getProvidedProps(props, state, search) {
       const noResults = search.results ? search.results.nbHits === 0 : false;
       return {query: state.query, noResults};
     },
@@ -47,7 +47,7 @@ const content = createConnector({
 ```javascript
 const content = createConnector({
     displayName: 'ConditionalError',
-    getProps(props, state, search) {
+    getProvidedProps(props, state, search) {
       return {error: search.error};
     },
  })(({error}) => {
@@ -65,7 +65,7 @@ In slow user network situations you might want to know when the search results a
 ```javascript
 const content = createConnector({
     displayName: 'ConditionalError',
-    getProps(props, state, search) {
+    getProvidedProps(props, state, search) {
       return {loading: search.loading};
     },
 })(({loading}) => {

--- a/docgen/src/guide/Custom connectors.md
+++ b/docgen/src/guide/Custom connectors.md
@@ -12,7 +12,7 @@ If you wish to implement features that are not covered by the default widgets co
 
 Those properties are directly applied to the higher-order component. Providing a `displayName` is mandatory.
 
-## getProps(props, searchState, searchResults, meta)
+## getProvidedProps(props, searchState, searchResults, meta)
 
 This method should return the props to forward to the composed component.
 
@@ -34,7 +34,7 @@ It takes in the current props of the higher-order component, the [search state](
 const CoolWidget = createConnector({
   displayName: 'CoolWidget',
 
-  getProps(props, state) {
+  getProvidedProps(props, state) {
     // Since the `queryAndPage` state entry isn't necessarily defined, we need
     // to default its value.
     const [query, page] = state.queryAndPage || ['', 0];
@@ -94,7 +94,7 @@ As such, the `getSearchParameters` method allows you to describe how the state a
 
 ```javascript
 const CoolWidget = createConnector({
-  // displayName, getProps, refine
+  // displayName, getProvidedProps, refine
 
   getSearchParameters(searchParameters, props, state) {
     // Since the `queryAndPage` state entry isn't necessarily defined, we need
@@ -116,13 +116,13 @@ This method allows the widget to register a custom `metadata` object for any pro
 
 If your widget is stateful, the corresponding URL key should be declared on the metadata object as the `id` property, so that the `InstantSearch` component can determine which URL keys it controls and which are foreign and should be left intact.
 
-The metadata object also allows you to declare any data that you would like to pass down to all other widgets. The list of metadata objects of all components is available as the fourth argument to the `getProps` method.
+The metadata object also allows you to declare any data that you would like to pass down to all other widgets. The list of metadata objects of all components is available as the fourth argument to the `getProvidedProps` method.
 
 The `CurrentRefinements` widget leverages this mechanism in order to allow any widget to declare the filters it has applied. If you want to add your own filter, declare a `filters` property on your widget's metadata object:
 
 ```javascript
 const CoolWidget = createConnector({
-  // displayName, getProps, refine, getSearchParameters
+  // displayName, getProvidedProps, refine, getSearchParameters
 
   getMetadata(props, state) {
     // Since the `queryAndPage` state entry isn't necessarily defined, we need
@@ -188,7 +188,7 @@ It takes in the current props of the higher-order component and the state of all
 import {omit} from 'lodash';
 
 const CoolWidget = createConnector({
-  // displayName, getProps, refine, getSearchParameters, getMetadata
+  // displayName, getProvidedProps, refine, getSearchParameters, getMetadata
 
   cleanUp(props, state) {
     return omit('queryAndPage', state)

--- a/packages/react-instantsearch/src/connectors/connectCurrentRefinements.js
+++ b/packages/react-instantsearch/src/connectors/connectCurrentRefinements.js
@@ -12,7 +12,7 @@ import createConnector from '../core/createConnector';
 export default createConnector({
   displayName: 'AlgoliaCurrentRefinements',
 
-  getProps(props, state, search, metadata) {
+  getProvidedProps(props, state, search, metadata) {
     return {
       items: metadata.reduce((res, meta) =>
           typeof meta.items !== 'undefined' ? res.concat(meta.items) : res

--- a/packages/react-instantsearch/src/connectors/connectCurrentRefinements.test.js
+++ b/packages/react-instantsearch/src/connectors/connectCurrentRefinements.test.js
@@ -3,11 +3,11 @@
 import connect from './connectCurrentRefinements.js';
 jest.mock('../core/createConnector');
 
-const {refine, getProps} = connect;
+const {refine, getProvidedProps} = connect;
 
 describe('connectCurrentRefinements', () => {
   it('provides the correct props to the component', () => {
-    const props = getProps(null, null, null, [
+    const props = getProvidedProps(null, null, null, [
       {items: ['one']},
       {items: ['two']},
       {items: ['three']},

--- a/packages/react-instantsearch/src/connectors/connectHierarchicalMenu.js
+++ b/packages/react-instantsearch/src/connectors/connectHierarchicalMenu.js
@@ -123,7 +123,7 @@ export default createConnector({
     showParentLevel: true,
   },
 
-  getProps(props, state, search) {
+  getProvidedProps(props, state, search) {
     const {showMore, limitMin, limitMax} = props;
     const id = getId(props);
     const {results} = search;

--- a/packages/react-instantsearch/src/connectors/connectHierarchicalMenu.test.js
+++ b/packages/react-instantsearch/src/connectors/connectHierarchicalMenu.test.js
@@ -6,7 +6,7 @@ import connect from './connectHierarchicalMenu';
 jest.mock('../core/createConnector');
 
 const {
-  getProps,
+  getProvidedProps,
   refine,
   getSearchParameters: getSP,
   getMetadata,
@@ -24,15 +24,15 @@ describe('connectHierarchicalMenu', () => {
     };
 
     results.getFacetValues.mockImplementationOnce(() => ({}));
-    props = getProps({attributes: ['ok']}, {hierarchicalMenu: {ok: 'wat'}}, {results});
+    props = getProvidedProps({attributes: ['ok']}, {hierarchicalMenu: {ok: 'wat'}}, {results});
     expect(props).toEqual({items: [], currentRefinement: 'wat'});
 
     results.getFacetValues.mockImplementationOnce(() => ({}));
-    props = getProps({attributes: ['ok'], defaultRefinement: 'wat'}, {}, {results});
+    props = getProvidedProps({attributes: ['ok'], defaultRefinement: 'wat'}, {}, {results});
     expect(props).toEqual({items: [], currentRefinement: 'wat'});
 
     results.getFacetValues.mockImplementationOnce(() => ({}));
-    props = getProps({attributes: ['ok']}, {}, {results});
+    props = getProvidedProps({attributes: ['ok']}, {}, {results});
     expect(props).toEqual({items: [], currentRefinement: null});
 
     results.getFacetValues.mockClear();
@@ -62,7 +62,7 @@ describe('connectHierarchicalMenu', () => {
         },
       ],
     }));
-    props = getProps({attributes: ['ok']}, {}, {results});
+    props = getProvidedProps({attributes: ['ok']}, {}, {results});
     expect(props.items).toEqual([
       {
         label: 'wat',
@@ -88,7 +88,7 @@ describe('connectHierarchicalMenu', () => {
       },
     ]);
 
-    props = getProps({attributes: ['ok'], limitMin: 1}, {}, {results});
+    props = getProvidedProps({attributes: ['ok'], limitMin: 1}, {}, {results});
     expect(props.items).toEqual([
       {
         label: 'wat',
@@ -104,7 +104,7 @@ describe('connectHierarchicalMenu', () => {
       },
     ]);
 
-    props = getProps(
+    props = getProvidedProps(
       {attributes: ['ok'], showMore: true, limitMin: 0, limitMax: 1},
       {},
       {results}
@@ -126,7 +126,7 @@ describe('connectHierarchicalMenu', () => {
   });
 
   it('doesn\'t render when no results are available', () => {
-    props = getProps({attributes: ['ok']}, {}, {});
+    props = getProvidedProps({attributes: ['ok']}, {}, {});
     expect(props).toBe(null);
   });
 

--- a/packages/react-instantsearch/src/connectors/connectHits.js
+++ b/packages/react-instantsearch/src/connectors/connectHits.js
@@ -19,7 +19,7 @@ export default createConnector({
     hitsPerPage: PropTypes.number,
   },
 
-  getProps(props, state, search) {
+  getProvidedProps(props, state, search) {
     if (!search.results) {
       return null;
     }

--- a/packages/react-instantsearch/src/connectors/connectHits.test.js
+++ b/packages/react-instantsearch/src/connectors/connectHits.test.js
@@ -4,17 +4,17 @@ import {SearchParameters} from 'algoliasearch-helper';
 import connect from './connectHits.js';
 jest.mock('../core/createConnector');
 
-const {getSearchParameters, getProps} = connect;
+const {getSearchParameters, getProvidedProps} = connect;
 
 describe('connectHits', () => {
   it('provides the current hits to the component', () => {
     const hits = {};
-    const props = getProps(null, null, {results: {hits}});
+    const props = getProvidedProps(null, null, {results: {hits}});
     expect(props.hits).toBe(hits);
   });
 
   it('doesn\'t render when no hits are available', () => {
-    const props = getProps(null, null, {results: null});
+    const props = getProvidedProps(null, null, {results: null});
     expect(props).toBe(null);
   });
 

--- a/packages/react-instantsearch/src/connectors/connectHitsPerPage.js
+++ b/packages/react-instantsearch/src/connectors/connectHitsPerPage.js
@@ -30,7 +30,7 @@ function getCurrentRefinement(props, state) {
 export default createConnector({
   displayName: 'AlgoliaHitsPerPage',
 
-  getProps(props, state) {
+  getProvidedProps(props, state) {
     return {
       currentRefinement: getCurrentRefinement(props, state),
     };

--- a/packages/react-instantsearch/src/connectors/connectHitsPerPage.test.js
+++ b/packages/react-instantsearch/src/connectors/connectHitsPerPage.test.js
@@ -6,7 +6,7 @@ import connect from './connectHitsPerPage';
 jest.mock('../core/createConnector');
 
 const {
-  getProps,
+  getProvidedProps,
   refine,
   getSearchParameters: getSP,
   getMetadata,
@@ -18,10 +18,10 @@ let params;
 
 describe('connectHitsPerPage', () => {
   it('provides the correct props to the component', () => {
-    props = getProps({}, {hitsPerPage: '10'});
+    props = getProvidedProps({}, {hitsPerPage: '10'});
     expect(props).toEqual({currentRefinement: 10});
 
-    props = getProps({defaultRefinement: 20}, {});
+    props = getProvidedProps({defaultRefinement: 20}, {});
     expect(props).toEqual({currentRefinement: 20});
   });
 

--- a/packages/react-instantsearch/src/connectors/connectInfiniteHits.js
+++ b/packages/react-instantsearch/src/connectors/connectInfiniteHits.js
@@ -24,7 +24,7 @@ export default createConnector({
     hitsPerPage: PropTypes.number,
   },
 
-  getProps(componentProps, allWidgetsState, resultsStruct) {
+  getProvidedProps(componentProps, allWidgetsState, resultsStruct) {
     if (!resultsStruct.results) {
       this._allResults = [];
       return {

--- a/packages/react-instantsearch/src/connectors/connectInfiniteHits.test.js
+++ b/packages/react-instantsearch/src/connectors/connectInfiniteHits.test.js
@@ -9,7 +9,7 @@ describe.only('connectInfiniteHits', () => {
   it('provides the current hits to the component', () => {
     const providedThis = {};
     const hits = [{}];
-    const props = connect.getProps.call(providedThis, null, null, {
+    const props = connect.getProvidedProps.call(providedThis, null, null, {
       results: {hits, page: 0, hitsPerPage: 2, nbPages: 3},
     });
     expect(props.hits).toEqual(hits);
@@ -19,12 +19,12 @@ describe.only('connectInfiniteHits', () => {
     const providedThis = {};
     const hits = [{}, {}];
     const hits2 = [{}, {}];
-    const res1 = connect.getProps.call(providedThis, null, null, {
+    const res1 = connect.getProvidedProps.call(providedThis, null, null, {
       results: {hits, page: 0, hitsPerPage: 2, nbPages: 3},
     });
     expect(res1.hits).toEqual(hits);
     expect(res1.hasMore).toBe(true);
-    const res2 = connect.getProps.call(providedThis, null, null, {
+    const res2 = connect.getProvidedProps.call(providedThis, null, null, {
       results: {hits: hits2, page: 1, hitsPerPage: 2, nbPages: 3}
     });
     expect(res2.hits).toEqual([...hits, ...hits2]);
@@ -39,7 +39,7 @@ describe.only('connectInfiniteHits', () => {
     for (let page = 0; page < nbPages - 1; page++) {
       const hits = [{}, {}];
       allHits = [...allHits, ...hits];
-      const res = connect.getProps.call(providedThis, null, null, {
+      const res = connect.getProvidedProps.call(providedThis, null, null, {
         results: {
           hits,
           page,
@@ -54,7 +54,7 @@ describe.only('connectInfiniteHits', () => {
 
     const hits = [{}, {}];
     allHits = [...allHits, ...hits];
-    const res = connect.getProps.call(providedThis, null, null, {
+    const res = connect.getProvidedProps.call(providedThis, null, null, {
       results: {
         hits,
         page: nbPages - 1,
@@ -72,9 +72,13 @@ describe.only('connectInfiniteHits', () => {
     const hits = [{}, {}];
     const hits2 = [{}, {}];
     const hits3 = [{}];
-    connect.getProps.call(providedThis, null, null, {results: {hits, page: 0, hitsPerPage: 2, nbPages: 3}});
-    connect.getProps.call(providedThis, null, null, {results: {hits: hits2, page: 1, hitsPerPage: 2, nbPages: 3}});
-    const props = connect.getProps.call(providedThis, null, null, {
+    connect.getProvidedProps.call(providedThis, null, null, {
+      results: {hits, page: 0, hitsPerPage: 2, nbPages: 3}
+    });
+    connect.getProvidedProps.call(providedThis, null, null, {
+      results: {hits: hits2, page: 1, hitsPerPage: 2, nbPages: 3}
+    });
+    const props = connect.getProvidedProps.call(providedThis, null, null, {
       results: {hits: hits3, page: 2, hitsPerPage: 2, nbPages: 3}
     });
     expect(props.hits).toEqual([...hits, ...hits2, ...hits3]);

--- a/packages/react-instantsearch/src/connectors/connectMenu.js
+++ b/packages/react-instantsearch/src/connectors/connectMenu.js
@@ -62,7 +62,7 @@ export default createConnector({
     limitMax: 20,
   },
 
-  getProps(props, state, search) {
+  getProvidedProps(props, state, search) {
     const {results} = search;
     const {attributeName, showMore, limitMin, limitMax} = props;
     const limit = showMore ? limitMax : limitMin;

--- a/packages/react-instantsearch/src/connectors/connectMenu.test.js
+++ b/packages/react-instantsearch/src/connectors/connectMenu.test.js
@@ -7,7 +7,7 @@ import connect from './connectMenu';
 jest.mock('../core/createConnector');
 
 const {
-  getProps,
+  getProvidedProps,
   refine,
   getSearchParameters: getSP,
   getMetadata,
@@ -24,16 +24,16 @@ describe('connectMenu', () => {
       getFacetByName: () => true,
     };
 
-    props = getProps({attributeName: 'ok'}, {menu: {ok: 'wat'}}, {results});
+    props = getProvidedProps({attributeName: 'ok'}, {menu: {ok: 'wat'}}, {results});
     expect(props).toEqual({items: [], currentRefinement: 'wat'});
 
-    props = getProps({attributeName: 'ok'}, {menu: {ok: 'wat'}}, {results});
+    props = getProvidedProps({attributeName: 'ok'}, {menu: {ok: 'wat'}}, {results});
     expect(props).toEqual({items: [], currentRefinement: 'wat'});
 
-    props = getProps({attributeName: 'ok', defaultRefinement: 'wat'}, {}, {results});
+    props = getProvidedProps({attributeName: 'ok', defaultRefinement: 'wat'}, {}, {results});
     expect(props).toEqual({items: [], currentRefinement: 'wat'});
 
-    props = getProps({attributeName: 'ok'}, {}, {results});
+    props = getProvidedProps({attributeName: 'ok'}, {}, {results});
     expect(props).toEqual({items: [], currentRefinement: null});
 
     results.getFacetValues.mockClear();
@@ -49,7 +49,7 @@ describe('connectMenu', () => {
         count: 10,
       },
     ]);
-    props = getProps({attributeName: 'ok'}, {}, {results});
+    props = getProvidedProps({attributeName: 'ok'}, {}, {results});
     expect(props.items).toEqual([
       {
         value: 'wat',
@@ -65,7 +65,7 @@ describe('connectMenu', () => {
       },
     ]);
 
-    props = getProps({attributeName: 'ok', limitMin: 1}, {}, {results});
+    props = getProvidedProps({attributeName: 'ok', limitMin: 1}, {}, {results});
     expect(props.items).toEqual([
       {
         value: 'wat',
@@ -75,7 +75,7 @@ describe('connectMenu', () => {
       },
     ]);
 
-    props = getProps(
+    props = getProvidedProps(
       {attributeName: 'ok', showMore: true, limitMin: 0, limitMax: 1},
       {},
       {results}
@@ -103,7 +103,7 @@ describe('connectMenu', () => {
       },
     ]);
 
-    props = getProps({attributeName: 'ok'}, {menu: {ok: 'wat'}}, {results});
+    props = getProvidedProps({attributeName: 'ok'}, {menu: {ok: 'wat'}}, {results});
 
     expect(props.items).toEqual([{
       value: '',
@@ -114,7 +114,7 @@ describe('connectMenu', () => {
   });
 
   it('doesn\'t render when no results are available', () => {
-    props = getProps({attributeName: 'ok'}, {}, {});
+    props = getProvidedProps({attributeName: 'ok'}, {}, {});
     expect(props).toBe(null);
   });
 

--- a/packages/react-instantsearch/src/connectors/connectMultiRange.js
+++ b/packages/react-instantsearch/src/connectors/connectMultiRange.js
@@ -65,7 +65,7 @@ export default createConnector({
     })).isRequired,
   },
 
-  getProps(props, state) {
+  getProvidedProps(props, state) {
     const {items} = props;
     const currentRefinement = getCurrentRefinement(props, state);
 

--- a/packages/react-instantsearch/src/connectors/connectMultiRange.test.js
+++ b/packages/react-instantsearch/src/connectors/connectMultiRange.test.js
@@ -6,7 +6,7 @@ import connect from './connectMultiRange';
 jest.mock('../core/createConnector');
 
 const {
-  getProps,
+  getProvidedProps,
   refine,
   getSearchParameters: getSP,
   getMetadata,
@@ -18,7 +18,7 @@ let params;
 
 describe('connectMultiRange', () => {
   it('provides the correct props to the component', () => {
-    props = getProps({
+    props = getProvidedProps({
       items: [
         {label: 'All'},
       ],
@@ -30,7 +30,7 @@ describe('connectMultiRange', () => {
       currentRefinement: '',
     });
 
-    props = getProps({
+    props = getProvidedProps({
       items: [
         {label: 'All'},
         {label: 'Ok', start: 100},
@@ -44,7 +44,7 @@ describe('connectMultiRange', () => {
       currentRefinement: '',
     });
 
-    props = getProps({
+    props = getProvidedProps({
       items: [
         {label: 'All'},
         {label: 'Not ok', end: 200},
@@ -58,7 +58,7 @@ describe('connectMultiRange', () => {
       currentRefinement: '',
     });
 
-    props = getProps({
+    props = getProvidedProps({
       items: [
         {label: 'All'},
         {label: 'Ok', start: 100},
@@ -76,13 +76,13 @@ describe('connectMultiRange', () => {
       currentRefinement: '',
     });
 
-    props = getProps({attributeName: 'ok', items: []}, {multiRange: {ok: 'wat'}});
+    props = getProvidedProps({attributeName: 'ok', items: []}, {multiRange: {ok: 'wat'}});
     expect(props).toEqual({items: [], currentRefinement: 'wat'});
 
-    props = getProps({attributeName: 'ok', items: []}, {multiRange: {ok: 'wat'}});
+    props = getProvidedProps({attributeName: 'ok', items: []}, {multiRange: {ok: 'wat'}});
     expect(props).toEqual({items: [], currentRefinement: 'wat'});
 
-    props = getProps({attributeName: 'ok', items: [], defaultRefinement: 'wat'}, {});
+    props = getProvidedProps({attributeName: 'ok', items: [], defaultRefinement: 'wat'}, {});
     expect(props).toEqual({items: [], currentRefinement: 'wat'});
   });
 

--- a/packages/react-instantsearch/src/connectors/connectPagination.js
+++ b/packages/react-instantsearch/src/connectors/connectPagination.js
@@ -40,7 +40,7 @@ function getCurrentRefinement(props, state) {
 export default createConnector({
   displayName: 'AlgoliaPagination',
 
-  getProps(props, state, search) {
+  getProvidedProps(props, state, search) {
     if (!search.results) {
       return null;
     }

--- a/packages/react-instantsearch/src/connectors/connectPagination.test.js
+++ b/packages/react-instantsearch/src/connectors/connectPagination.test.js
@@ -6,7 +6,7 @@ import connect from './connectPagination';
 jest.mock('../core/createConnector');
 
 const {
-  getProps,
+  getProvidedProps,
   refine,
   getSearchParameters: getSP,
   transitionState,
@@ -20,18 +20,18 @@ let state;
 
 describe('connectPagination', () => {
   it('provides the correct props to the component', () => {
-    props = getProps({}, {}, {results: {nbPages: 666}});
+    props = getProvidedProps({}, {}, {results: {nbPages: 666}});
     expect(props).toEqual({currentRefinement: 1, nbPages: 666});
 
-    props = getProps({}, {page: 5}, {results: {nbPages: 666}});
+    props = getProvidedProps({}, {page: 5}, {results: {nbPages: 666}});
     expect(props).toEqual({currentRefinement: 5, nbPages: 666});
 
-    props = getProps({}, {page: '5'}, {results: {nbPages: 666}});
+    props = getProvidedProps({}, {page: '5'}, {results: {nbPages: 666}});
     expect(props).toEqual({currentRefinement: 5, nbPages: 666});
   });
 
   it('doesn\'t render when no results are available', () => {
-    props = getProps({}, {}, {});
+    props = getProvidedProps({}, {}, {});
     expect(props).toBe(null);
   });
 

--- a/packages/react-instantsearch/src/connectors/connectPoweredBy.js
+++ b/packages/react-instantsearch/src/connectors/connectPoweredBy.js
@@ -12,7 +12,7 @@ export default createConnector({
 
   propTypes: {},
 
-  getProps() {
+  getProvidedProps() {
     const url = 'https://www.algolia.com/?' +
       'utm_source=instantsearch.js&' +
       'utm_medium=website&' +

--- a/packages/react-instantsearch/src/connectors/connectPoweredBy.test.js
+++ b/packages/react-instantsearch/src/connectors/connectPoweredBy.test.js
@@ -3,12 +3,12 @@
 import connect from './connectPoweredBy';
 jest.mock('../core/createConnector');
 
-const {getProps} = connect;
+const {getProvidedProps} = connect;
 
 let props;
 describe('connectPoweredBy', () => {
   it('provides the correct props to the component', () => {
-    props = getProps();
+    props = getProvidedProps();
     expect(props).toEqual({url: 'https://www.algolia.com/?utm_source=instantsearch.js&utm_medium=website&utm_content=&utm_campaign=poweredby'});
   });
 });

--- a/packages/react-instantsearch/src/connectors/connectRange.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.js
@@ -55,7 +55,7 @@ export default createConnector({
     max: PropTypes.number,
   },
 
-  getProps(props, state, search) {
+  getProvidedProps(props, state, search) {
     const {attributeName} = props;
     let {min, max} = props;
 

--- a/packages/react-instantsearch/src/connectors/connectRange.test.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.test.js
@@ -6,7 +6,7 @@ import connect from './connectRange';
 jest.mock('../core/createConnector');
 
 const {
-  getProps,
+  getProvidedProps,
   refine,
   getSearchParameters: getSP,
   getMetadata,
@@ -18,7 +18,7 @@ let params;
 
 describe('connectRange', () => {
   it('provides the correct props to the component', () => {
-    props = getProps({attributeName: 'ok', min: 5, max: 10}, {}, {});
+    props = getProvidedProps({attributeName: 'ok', min: 5, max: 10}, {}, {});
     expect(props).toEqual({
       min: 5,
       max: 10,
@@ -31,7 +31,7 @@ describe('connectRange', () => {
       getFacetValues: () => [{name: '5', count: 10}, {name: '2', count: 20}],
       getFacetByName: () => true,
     };
-    props = getProps({attributeName: 'ok'}, {}, {results});
+    props = getProvidedProps({attributeName: 'ok'}, {}, {results});
     expect(props).toEqual({
       min: 5,
       max: 10,
@@ -39,10 +39,10 @@ describe('connectRange', () => {
       count: [{value: '5', count: 10}, {value: '2', count: 20}],
     });
 
-    props = getProps({attributeName: 'ok'}, {ok: {min: 6, max: 9}}, {});
+    props = getProvidedProps({attributeName: 'ok'}, {ok: {min: 6, max: 9}}, {});
     expect(props).toBe(null);
 
-    props = getProps({
+    props = getProvidedProps({
       attributeName: 'ok',
       min: 5,
       max: 10,
@@ -56,7 +56,7 @@ describe('connectRange', () => {
       count: [],
     });
 
-    props = getProps({
+    props = getProvidedProps({
       attributeName: 'ok',
       min: 5,
       max: 10,
@@ -70,7 +70,7 @@ describe('connectRange', () => {
       count: [],
     });
 
-    props = getProps({
+    props = getProvidedProps({
       attributeName: 'ok',
       min: 5,
       max: 10,

--- a/packages/react-instantsearch/src/connectors/connectRefinementList.js
+++ b/packages/react-instantsearch/src/connectors/connectRefinementList.js
@@ -77,7 +77,7 @@ export default createConnector({
     limitMax: 20,
   },
 
-  getProps(props, state, search) {
+  getProvidedProps(props, state, search) {
     const {results} = search;
     const {attributeName, showMore, limitMin, limitMax} = props;
     const limit = showMore ? limitMax : limitMin;

--- a/packages/react-instantsearch/src/connectors/connectRefinementList.test.js
+++ b/packages/react-instantsearch/src/connectors/connectRefinementList.test.js
@@ -7,7 +7,7 @@ import connect from './connectRefinementList';
 jest.mock('../core/createConnector');
 
 const {
-  getProps,
+  getProvidedProps,
   refine,
   getSearchParameters: getSP,
   getMetadata,
@@ -24,13 +24,13 @@ describe('connectRefinementList', () => {
       getFacetByName: () => true,
     };
 
-    props = getProps({attributeName: 'ok'}, {}, {results});
+    props = getProvidedProps({attributeName: 'ok'}, {}, {results});
     expect(props).toEqual({items: [], currentRefinement: []});
 
-    props = getProps({attributeName: 'ok'}, {refinementList: {ok: ['wat']}}, {results});
+    props = getProvidedProps({attributeName: 'ok'}, {refinementList: {ok: ['wat']}}, {results});
     expect(props).toEqual({items: [], currentRefinement: ['wat']});
 
-    props = getProps({attributeName: 'ok', defaultRefinement: ['wat']}, {}, {results});
+    props = getProvidedProps({attributeName: 'ok', defaultRefinement: ['wat']}, {}, {results});
     expect(props).toEqual({items: [], currentRefinement: ['wat']});
 
     results.getFacetValues.mockClear();
@@ -46,7 +46,7 @@ describe('connectRefinementList', () => {
         count: 10,
       },
     ]);
-    props = getProps({attributeName: 'ok'}, {}, {results});
+    props = getProvidedProps({attributeName: 'ok'}, {}, {results});
     expect(props.items).toEqual([
       {
         value: ['wat'],
@@ -62,7 +62,7 @@ describe('connectRefinementList', () => {
       },
     ]);
 
-    props = getProps({attributeName: 'ok', limitMin: 1}, {}, {results});
+    props = getProvidedProps({attributeName: 'ok', limitMin: 1}, {}, {results});
     expect(props.items).toEqual([
       {
         value: ['wat'],
@@ -72,7 +72,7 @@ describe('connectRefinementList', () => {
       },
     ]);
 
-    props = getProps(
+    props = getProvidedProps(
       {attributeName: 'ok', showMore: true, limitMin: 0, limitMax: 1},
       {},
       {results}
@@ -88,7 +88,7 @@ describe('connectRefinementList', () => {
   });
 
   it('doesn\'t render when no results are available', () => {
-    props = getProps({attributeName: 'ok'}, {}, {});
+    props = getProvidedProps({attributeName: 'ok'}, {}, {});
     expect(props).toBe(null);
   });
 

--- a/packages/react-instantsearch/src/connectors/connectScrollTo.js
+++ b/packages/react-instantsearch/src/connectors/connectScrollTo.js
@@ -21,7 +21,7 @@ export default createConnector({
     scrollOn: 'page',
   },
 
-  getProps(props, state) {
+  getProvidedProps(props, state) {
     const value = state[props.scrollOn];
     return {value};
   },

--- a/packages/react-instantsearch/src/connectors/connectScrollTo.test.js
+++ b/packages/react-instantsearch/src/connectors/connectScrollTo.test.js
@@ -3,15 +3,15 @@
 import connect from './connectScrollTo';
 jest.mock('../core/createConnector');
 
-const {getProps} = connect;
+const {getProvidedProps} = connect;
 
 let props;
 describe('connectScrollTo', () => {
   it('provides the correct props to the component', () => {
-    props = getProps({scrollOn: 'p'}, {p: 1});
+    props = getProvidedProps({scrollOn: 'p'}, {p: 1});
     expect(props).toEqual({value: 1});
 
-    props = getProps({scrollOn: 'anything'}, {anything: 2});
+    props = getProvidedProps({scrollOn: 'anything'}, {anything: 2});
     expect(props).toEqual({value: 2});
   });
 });

--- a/packages/react-instantsearch/src/connectors/connectSearchBox.js
+++ b/packages/react-instantsearch/src/connectors/connectSearchBox.js
@@ -25,7 +25,7 @@ function getCurrentRefinement(props, state) {
 export default createConnector({
   displayName: 'AlgoliaSearchBox',
 
-  getProps(props, state) {
+  getProvidedProps(props, state) {
     return {
       query: getCurrentRefinement(props, state),
     };

--- a/packages/react-instantsearch/src/connectors/connectSearchBox.test.js
+++ b/packages/react-instantsearch/src/connectors/connectSearchBox.test.js
@@ -6,7 +6,7 @@ import connect from './connectSearchBox';
 jest.mock('../core/createConnector');
 
 const {
-  getProps,
+  getProvidedProps,
   refine,
   getSearchParameters: getSP,
   cleanUp,
@@ -17,10 +17,10 @@ let params;
 
 describe('connectSearchBox', () => {
   it('provides the correct props to the component', () => {
-    props = getProps({}, {});
+    props = getProvidedProps({}, {});
     expect(props).toEqual({query: ''});
 
-    props = getProps({}, {query: 'yep'});
+    props = getProvidedProps({}, {query: 'yep'});
     expect(props).toEqual({query: 'yep'});
   });
 

--- a/packages/react-instantsearch/src/connectors/connectSortBy.js
+++ b/packages/react-instantsearch/src/connectors/connectSortBy.js
@@ -37,7 +37,7 @@ export default createConnector({
     defaultRefinement: PropTypes.string,
   },
 
-  getProps(props, state) {
+  getProvidedProps(props, state) {
     const currentRefinement = getCurrentRefinement(props, state);
     return {currentRefinement};
   },

--- a/packages/react-instantsearch/src/connectors/connectSortBy.test.js
+++ b/packages/react-instantsearch/src/connectors/connectSortBy.test.js
@@ -6,7 +6,7 @@ import connect from './connectSortBy';
 jest.mock('../core/createConnector');
 
 const {
-  getProps,
+  getProvidedProps,
   refine,
   getSearchParameters: getSP,
   getMetadata,
@@ -18,13 +18,13 @@ let params;
 
 describe('connectSortBy', () => {
   it('provides the correct props to the component', () => {
-    props = getProps({}, {});
+    props = getProvidedProps({}, {});
     expect(props).toEqual({currentRefinement: null});
 
-    props = getProps({}, {sortBy: 'yep'});
+    props = getProvidedProps({}, {sortBy: 'yep'});
     expect(props).toEqual({currentRefinement: 'yep'});
 
-    props = getProps({defaultRefinement: 'yep'}, {});
+    props = getProvidedProps({defaultRefinement: 'yep'}, {});
     expect(props).toEqual({currentRefinement: 'yep'});
   });
 

--- a/packages/react-instantsearch/src/connectors/connectStats.js
+++ b/packages/react-instantsearch/src/connectors/connectStats.js
@@ -11,7 +11,7 @@ import createConnector from '../core/createConnector';
 export default createConnector({
   displayName: 'AlgoliaStats',
 
-  getProps(props, state, search) {
+  getProvidedProps(props, state, search) {
     if (!search.results) {
       return null;
     }

--- a/packages/react-instantsearch/src/connectors/connectStats.test.js
+++ b/packages/react-instantsearch/src/connectors/connectStats.test.js
@@ -3,15 +3,15 @@
 import connect from './connectStats';
 jest.mock('../core/createConnector');
 
-const {getProps} = connect;
+const {getProvidedProps} = connect;
 
 let props;
 describe('connectStats', () => {
   it('provides the correct props to the component', () => {
-    props = getProps(null, null, {});
+    props = getProvidedProps(null, null, {});
     expect(props).toBe(null);
 
-    props = getProps(null, null, {results: {nbHits: 666, processingTimeMS: 1}});
+    props = getProvidedProps(null, null, {results: {nbHits: 666, processingTimeMS: 1}});
     expect(props).toEqual({nbHits: 666, processingTimeMS: 1});
   });
 });

--- a/packages/react-instantsearch/src/connectors/connectToggle.js
+++ b/packages/react-instantsearch/src/connectors/connectToggle.js
@@ -43,7 +43,7 @@ export default createConnector({
     defaultRefinement: PropTypes.bool,
   },
 
-  getProps(props, state) {
+  getProvidedProps(props, state) {
     const checked = getCurrentRefinement(props, state);
     return {checked};
   },

--- a/packages/react-instantsearch/src/connectors/connectToggle.test.js
+++ b/packages/react-instantsearch/src/connectors/connectToggle.test.js
@@ -6,7 +6,7 @@ import connect from './connectToggle';
 jest.mock('../core/createConnector');
 
 const {
-  getProps,
+  getProvidedProps,
   refine,
   getSearchParameters: getSP,
   getMetadata,
@@ -18,13 +18,13 @@ let params;
 
 describe('connectToggle', () => {
   it('provides the correct props to the component', () => {
-    props = getProps({attributeName: 't'}, {});
+    props = getProvidedProps({attributeName: 't'}, {});
     expect(props).toEqual({checked: false});
 
-    props = getProps({attributeName: 't'}, {toggle: {t: true}});
+    props = getProvidedProps({attributeName: 't'}, {toggle: {t: true}});
     expect(props).toEqual({checked: true});
 
-    props = getProps({defaultRefinement: true, attributeName: 't'}, {});
+    props = getProvidedProps({defaultRefinement: true, attributeName: 't'}, {});
     expect(props).toEqual({checked: true});
   });
 

--- a/packages/react-instantsearch/src/core/createConnector.js
+++ b/packages/react-instantsearch/src/core/createConnector.js
@@ -10,7 +10,7 @@ import {shallowEqual, getDisplayName} from './utils';
  * @property {function} getSearchParameters - function transforming the local state to a SearchParameters
  * @property {function} getMetadata - metadata of the widget
  * @property {function} transitionState - hook after the state has changed
- * @property {function} getProps - transform the state into props passed to the wrapped component.
+ * @property {function} getProvidedProps - transform the state into props passed to the wrapped component.
  * Receives (props, widgetStates, searchState, metadata) and returns the local state.
  * @property {function} getId - Receives props and return the id that will be used to identify the widget
  * @property {function} cleanUp - hook when the widget will unmount. Receives (props, searchState) and return a cleaned state.
@@ -63,12 +63,12 @@ export default function createConnector(connectorDesc) {
 
       const {ais: {store, widgetsManager}} = context;
       this.state = {
-        props: this.getProps(props),
+        props: this.getProvidedProps(props),
       };
 
       this.unsubscribe = store.subscribe(() => {
         this.setState({
-          props: this.getProps(this.props),
+          props: this.getProvidedProps(this.props),
         });
       });
 
@@ -103,7 +103,7 @@ export default function createConnector(connectorDesc) {
     componentWillReceiveProps(nextProps) {
       if (!shallowEqual(this.props, nextProps)) {
         this.setState({
-          props: this.getProps(nextProps),
+          props: this.getProvidedProps(nextProps),
         });
 
         if (isWidget) {
@@ -140,7 +140,7 @@ export default function createConnector(connectorDesc) {
       return !propsEqual || !shallowEqual(this.state.props, nextState.props);
     }
 
-    getProps = props => {
+    getProvidedProps = props => {
       const {ais: {store}} = this.context;
       const {
         results,
@@ -150,7 +150,7 @@ export default function createConnector(connectorDesc) {
         metadata,
       } = store.getState();
       const searchState = {results, searching, error};
-      return connectorDesc.getProps.call(this, props, widgets, searchState, metadata);
+      return connectorDesc.getProvidedProps.call(this, props, widgets, searchState, metadata);
     };
 
     refine = (...args) => {

--- a/packages/react-instantsearch/src/core/createConnector.test.js
+++ b/packages/react-instantsearch/src/core/createConnector.test.js
@@ -20,11 +20,11 @@ describe('createConnector', () => {
   const getId = () => 'id';
   describe('state', () => {
     it('computes passed props from props and state', () => {
-      const getProps = jest.fn(props => ({gotProps: props}));
+      const getProvidedProps = jest.fn(props => ({gotProps: props}));
       const Dummy = () => null;
       const Connected = createConnector({
         displayName: 'CoolConnector',
-        getProps,
+        getProvidedProps,
         getId,
       })(Dummy);
       const state = createState();
@@ -39,7 +39,7 @@ describe('createConnector', () => {
           },
         },
       }});
-      const args = getProps.mock.calls[0];
+      const args = getProvidedProps.mock.calls[0];
       expect(args[0]).toEqual(props);
       expect(args[1]).toBe(state.widgets);
       expect(args[2].results).toBe(state.results);
@@ -50,11 +50,11 @@ describe('createConnector', () => {
     });
 
     it('updates on props change', () => {
-      const getProps = jest.fn(props => ({gotProps: props}));
+      const getProvidedProps = jest.fn(props => ({gotProps: props}));
       const Dummy = () => null;
       const Connected = createConnector({
         displayName: 'CoolConnector',
-        getProps,
+        getProvidedProps,
         getId,
       })(Dummy);
       const state = createState();
@@ -69,8 +69,8 @@ describe('createConnector', () => {
       }});
       props = {hello: 'you'};
       wrapper.setProps(props);
-      expect(getProps.mock.calls.length).toBe(2);
-      const args = getProps.mock.calls[1];
+      expect(getProvidedProps.mock.calls.length).toBe(2);
+      const args = getProvidedProps.mock.calls[1];
       expect(args[0]).toEqual(props);
       expect(args[1]).toBe(state.widgets);
       expect(args[2].results).toBe(state.results);
@@ -81,11 +81,11 @@ describe('createConnector', () => {
     });
 
     it('updates on state change', () => {
-      const getProps = jest.fn((props, state) => state);
+      const getProvidedProps = jest.fn((props, state) => state);
       const Dummy = () => null;
       const Connected = createConnector({
         displayName: 'CoolConnector',
-        getProps,
+        getProvidedProps,
         getId,
       })(Dummy);
       let state = {
@@ -116,8 +116,8 @@ describe('createConnector', () => {
         },
       };
       listener();
-      expect(getProps.mock.calls.length).toBe(2);
-      const args = getProps.mock.calls[1];
+      expect(getProvidedProps.mock.calls.length).toBe(2);
+      const args = getProvidedProps.mock.calls[1];
       expect(args[0]).toEqual(props);
       expect(args[1]).toBe(state.widgets);
       expect(args[2].results).toBe(state.results);
@@ -130,7 +130,7 @@ describe('createConnector', () => {
     it('unsubscribes from the store on unmount', () => {
       const Connected = createConnector({
         displayName: 'CoolConnector',
-        getProps: () => null,
+        getProvidedProps: () => null,
         getId,
       })(() => null);
       const unsubscribe = jest.fn();
@@ -148,11 +148,11 @@ describe('createConnector', () => {
     });
 
     it('doesn\'t update the component when passed props don\'t change', () => {
-      const getProps = jest.fn(() => {});
+      const getProvidedProps = jest.fn(() => {});
       const Dummy = jest.fn(() => null);
       const Connected = createConnector({
         displayName: 'CoolConnector',
-        getProps,
+        getProvidedProps,
         getId,
       })(Dummy);
       const wrapper = mount(<Connected />, {context: {
@@ -175,7 +175,7 @@ describe('createConnector', () => {
     it('doesn\'t register itself as a widget when neither getMetadata nor getSearchParameters are present', () => {
       const Connected = createConnector({
         displayName: 'CoolConnector',
-        getProps: () => null,
+        getProvidedProps: () => null,
         getId,
       })(() => null);
       const registerWidget = jest.fn();
@@ -198,7 +198,7 @@ describe('createConnector', () => {
       const getMetadata = jest.fn(() => metadata);
       const Connected = createConnector({
         displayName: 'CoolConnector',
-        getProps: () => null,
+        getProvidedProps: () => null,
         getMetadata,
         getId,
       })(() => null);
@@ -229,7 +229,7 @@ describe('createConnector', () => {
       const getSearchParameters = jest.fn(() => sp);
       const Connected = createConnector({
         displayName: 'CoolConnector',
-        getProps: () => null,
+        getProvidedProps: () => null,
         getSearchParameters,
         getId,
       })(() => null);
@@ -262,7 +262,7 @@ describe('createConnector', () => {
     it('calls update when props change', () => {
       const Connected = createConnector({
         displayName: 'CoolConnector',
-        getProps: () => null,
+        getProvidedProps: () => null,
         getMetadata: () => null,
         getId,
       })(() => null);
@@ -288,7 +288,7 @@ describe('createConnector', () => {
     it('dont update when props dont change', () => {
       const Connected = createConnector({
         displayName: 'CoolConnector',
-        getProps: () => null,
+        getProvidedProps: () => null,
         getMetadata: () => null,
         getId,
       })(() => null);
@@ -314,7 +314,7 @@ describe('createConnector', () => {
     it('unregisters itself on unmount', () => {
       const Connected = createConnector({
         displayName: 'CoolConnector',
-        getProps: () => null,
+        getProvidedProps: () => null,
         getMetadata: () => null,
         cleanUp: () => ({another: {state: 'state'}}),
       })(() => null);
@@ -356,7 +356,7 @@ describe('createConnector', () => {
       const refine = jest.fn(() => nextState);
       const Connected = createConnector({
         displayName: 'CoolConnector',
-        getProps: () => ({}),
+        getProvidedProps: () => ({}),
         refine,
         getId,
       })(Dummy);
@@ -391,7 +391,7 @@ describe('createConnector', () => {
       const refine = jest.fn(() => nextState);
       const Connected = createConnector({
         displayName: 'CoolConnector',
-        getProps: () => ({}),
+        getProvidedProps: () => ({}),
         refine,
         getId,
       })(Dummy);

--- a/stories/Conditional.stories.js
+++ b/stories/Conditional.stories.js
@@ -8,7 +8,7 @@ const stories = storiesOf('Conditionals', module);
 stories.add('NoResults/HasResults', () => {
   const Content = createConnector({
     displayName: 'ConditionalResults',
-    getProps(props, state, search) {
+    getProvidedProps(props, state, search) {
       const noResults = search.results ? search.results.nbHits === 0 : false;
       return {query: state.query, noResults};
     },
@@ -24,7 +24,7 @@ stories.add('NoResults/HasResults', () => {
 }).add('NoQuery/HasQuery', () => {
   const Content = createConnector({
     displayName: 'ConditionalQuery',
-    getProps(props, state) {
+    getProvidedProps(props, state) {
       return {query: state.query};
     },
   })(({query}) => {


### PR DESCRIPTION
Every time I wrote connectors I felt like "What is `getProps` again?".
Let's rename it to `getProvidedProps` so that's it's precise on what it manipulates.

BREAKING CHANGE: When creating custom connectors, getProps is now named
getProvidedProps