### PR TITLE
feat(api): make hitsPerPage/SortBy connector consistent

### DIFF
--- a/packages/react-instantsearch/src/components/HitsPerPage.enzyme.test.js
+++ b/packages/react-instantsearch/src/components/HitsPerPage.enzyme.test.js
@@ -19,17 +19,38 @@ describe('HitsPerPage behavior', () => {
           {value: 6, label: '6 hits per page'},
           {value: 8, label: '8 hits per page'}]}
         refine={refine}
-        currentRefinement={111}
+        currentRefinement={2}
       />
     );
 
     const selectedValue = wrapper
       .find('.ais-HitsPerPage__root');
     expect(selectedValue.find('option').length).toBe(4);
+    expect(selectedValue.find('option').first().text()).toBe('2 hits per page');
 
     selectedValue.find('select').simulate('change', {target: {value: '6'}});
 
     expect(refine.mock.calls.length).toBe(1);
     expect(refine.mock.calls[0][0]).toEqual('6');
+  });
+
+  it('should use value if no label provided', () => {
+    const refine = jest.fn();
+    const wrapper = mount(
+      <HitsPerPage
+        createURL={() => '#'}
+        items={[{value: 2},
+          {value: 4},
+          {value: 6},
+          {value: 8}]}
+        refine={refine}
+        currentRefinement={2}
+      />
+    );
+
+    const selectedValue = wrapper
+      .find('.ais-HitsPerPage__root');
+    expect(selectedValue.find('option').length).toBe(4);
+    expect(selectedValue.find('option').first().text()).toBe('2');
   });
 });

--- a/packages/react-instantsearch/src/components/HitsPerPage.js
+++ b/packages/react-instantsearch/src/components/HitsPerPage.js
@@ -19,7 +19,7 @@ class HitsPerPage extends Component {
         /**
          * Label to display on the option.
          */
-        label: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+        label: PropTypes.string,
       })
     ),
   };
@@ -30,7 +30,6 @@ class HitsPerPage extends Component {
       refine,
       items,
     } = this.props;
-
     return (
       <Select
         onSelect={refine}

--- a/packages/react-instantsearch/src/components/SortBy.enzyme.test.js
+++ b/packages/react-instantsearch/src/components/SortBy.enzyme.test.js
@@ -1,0 +1,56 @@
+/* eslint-env jest, jasmine */
+
+// @TODO re-include this test in the normal .test.js
+// when React 15.4 is out: https://github.com/facebook/react/issues/7386
+
+import React from 'react';
+import {mount} from 'enzyme';
+
+import SortBy from './SortBy';
+
+describe('SortBy behavior', () => {
+  it('refines its value on change', () => {
+    const refine = jest.fn();
+    const wrapper = mount(
+      <SortBy
+        createURL={() => '#'}
+        items={[{value: 'index1', label: 'index name 1'},
+          {value: 'index2', label: 'index name 2'},
+          {value: 'index3', label: 'index name 3'},
+          {value: 'index4', label: 'index name 4'}]}
+        currentRefinement={'index1'}
+        refine={refine}
+      />
+    );
+
+    const selectedValue = wrapper
+      .find('.ais-SortBy__root');
+    expect(selectedValue.find('option').length).toBe(4);
+    expect(selectedValue.find('option').first().text()).toBe('index name 1');
+
+    selectedValue.find('select').simulate('change', {target: {value: 'index3'}});
+
+    expect(refine.mock.calls.length).toBe(1);
+    expect(refine.mock.calls[0][0]).toEqual('index3');
+  });
+
+  it('should use value if no label provided', () => {
+    const refine = jest.fn();
+    const wrapper = mount(
+      <SortBy
+        createURL={() => '#'}
+        items={[{value: 'index1'},
+          {value: 'index2'},
+          {value: 'index3'},
+          {value: 'index4'}]}
+        refine={refine}
+        currentRefinement={'index1'}
+      />
+    );
+
+    const selectedValue = wrapper
+      .find('.ais-SortBy__root');
+    expect(selectedValue.find('option').length).toBe(4);
+    expect(selectedValue.find('option').first().text()).toBe('index1');
+  });
+});

--- a/packages/react-instantsearch/src/components/SortBy.js
+++ b/packages/react-instantsearch/src/components/SortBy.js
@@ -9,7 +9,7 @@ class SortBy extends Component {
     refine: PropTypes.func.isRequired,
 
     items: PropTypes.arrayOf(PropTypes.shape({
-      label: PropTypes.string.isRequired,
+      label: PropTypes.string,
       value: PropTypes.string.isRequired,
     })).isRequired,
 

--- a/packages/react-instantsearch/src/connectors/connectHitsPerPage.js
+++ b/packages/react-instantsearch/src/connectors/connectHitsPerPage.js
@@ -1,3 +1,4 @@
+import {PropTypes} from 'react';
 import createConnector from '../core/createConnector';
 import {omit} from 'lodash';
 
@@ -22,17 +23,30 @@ function getCurrentRefinement(props, state) {
  * @name connectHitsPerPage
  * @kind connector
  * @propType {number} defaultRefinement - The number of items selected by default
- * @propType {{value, label}[]|number[]} items - List of hits per page options. Passing a list of numbers [n] is a shorthand for [{value: n, label: n}].
+ * @propType {{value: number, label: string}[]} items - List of hits per page options.
  * @providedPropType {function} refine - a function to remove a single filter
  * @providedPropType {function} createURL - a function to generate a URL for the corresponding state
  * @providedPropType {string} currentRefinement - the refinement currently applied
+ * @providedPropType {array.<{isRefined: boolean, label?: string, value: number}>} items - the list of items the HitsPerPage can display. If no label provided, the value will be displayed.
  */
 export default createConnector({
   displayName: 'AlgoliaHitsPerPage',
 
+  propTypes: {
+    defaultRefinement: PropTypes.number.isRequired,
+    items: PropTypes.arrayOf(PropTypes.shape({
+      label: PropTypes.string,
+      value: PropTypes.number.isRequired,
+    })).isRequired,
+  },
+
   getProvidedProps(props, state) {
+    const currentRefinement = getCurrentRefinement(props, state);
+    const items = props.items.map(item => item.value === currentRefinement
+      ? {...item, isRefined: true} : {...item, isRefined: false});
     return {
-      currentRefinement: getCurrentRefinement(props, state),
+      items,
+      currentRefinement,
     };
   },
 

--- a/packages/react-instantsearch/src/connectors/connectHitsPerPage.test.js
+++ b/packages/react-instantsearch/src/connectors/connectHitsPerPage.test.js
@@ -17,12 +17,23 @@ let props;
 let params;
 
 describe('connectHitsPerPage', () => {
+  const items = [{label: '10', value: 10}, {label: '20', value: 20}];
   it('provides the correct props to the component', () => {
-    props = getProvidedProps({}, {hitsPerPage: '10'});
-    expect(props).toEqual({currentRefinement: 10});
+    props = getProvidedProps({items}, {hitsPerPage: '10'});
+    expect(props).toEqual({
+      currentRefinement: 10,
+      items: [{label: '10', value: 10, isRefined: true}, {
+        label: '20', value: 20, isRefined: false,
+      }],
+    });
 
-    props = getProvidedProps({defaultRefinement: 20}, {});
-    expect(props).toEqual({currentRefinement: 20});
+    props = getProvidedProps({defaultRefinement: 20, items}, {});
+    expect(props).toEqual({
+      currentRefinement: 20,
+      items: [{
+        label: '10', value: 10, isRefined: false,
+      }, {label: '20', value: 20, isRefined: true}],
+    });
   });
 
   it('calling refine updates the widget\'s state', () => {

--- a/packages/react-instantsearch/src/connectors/connectSortBy.js
+++ b/packages/react-instantsearch/src/connectors/connectSortBy.js
@@ -28,18 +28,27 @@ function getCurrentRefinement(props, state) {
  * @providedPropType {function} refine - a function to remove a single filter
  * @providedPropType {function} createURL - a function to generate a URL for the corresponding state
  * @providedPropType {string[]} currentRefinement - the refinement currently applied
- * @providedPropType {array.<{label: string, value: string}>} items - the list of indexes the SortBy can display.
+ * @providedPropType {array.<{isRefined: boolean, label?: string, value: string}>} items - the list of items the HitsPerPage can display.  If no label provided, the value will be displayed.
  */
 export default createConnector({
   displayName: 'AlgoliaSortBy',
 
   propTypes: {
     defaultRefinement: PropTypes.string,
+    items: PropTypes.arrayOf(PropTypes.shape({
+      label: PropTypes.string,
+      value: PropTypes.string.isRequired,
+    })).isRequired,
   },
 
   getProvidedProps(props, state) {
     const currentRefinement = getCurrentRefinement(props, state);
-    return {currentRefinement};
+    const items = props.items.map(item => item.value === currentRefinement
+      ? {...item, isRefined: true} : {...item, isRefined: false});
+    return {
+      items,
+      currentRefinement,
+    };
   },
 
   refine(props, state, nextRefinement) {

--- a/packages/react-instantsearch/src/connectors/connectSortBy.test.js
+++ b/packages/react-instantsearch/src/connectors/connectSortBy.test.js
@@ -18,14 +18,14 @@ let params;
 
 describe('connectSortBy', () => {
   it('provides the correct props to the component', () => {
-    props = getProvidedProps({}, {});
-    expect(props).toEqual({currentRefinement: null});
+    props = getProvidedProps({items: [{value: 'yep'}, {value: 'yop'}]}, {sortBy: 'yep'});
+    expect(props).toEqual({
+      items: [{value: 'yep', isRefined: true}, {value: 'yop', isRefined: false}],
+      currentRefinement: 'yep',
+    });
 
-    props = getProvidedProps({}, {sortBy: 'yep'});
-    expect(props).toEqual({currentRefinement: 'yep'});
-
-    props = getProvidedProps({defaultRefinement: 'yep'}, {});
-    expect(props).toEqual({currentRefinement: 'yep'});
+    props = getProvidedProps({items: [{value: 'yep'}], defaultRefinement: 'yep'}, {});
+    expect(props).toEqual({items: [{value: 'yep', isRefined: true}], currentRefinement: 'yep'});
   });
 
   it('calling refine updates the widget\'s state', () => {

--- a/stories/HitsPerPage.stories.js
+++ b/stories/HitsPerPage.stories.js
@@ -17,6 +17,15 @@ stories.add('default', () =>
         {value: 6, label: '6 hits per page'},
         {value: 8, label: '8 hits per page'}]}/>
   </WrapWithHits>
+).add('without label', () =>
+  <WrapWithHits linkedStoryGroup="HitsPerPage" >
+    <HitsPerPage
+      defaultRefinement={4}
+      items={[{value: 2},
+        {value: 4},
+        {value: 6},
+        {value: 8}]}/>
+  </WrapWithHits>
 ).add('playground', () =>
     <WrapWithHits >
       <HitsPerPage

--- a/stories/SortBy.stories.js
+++ b/stories/SortBy.stories.js
@@ -19,4 +19,15 @@ stories.add('default', () =>
       defaultRefinement="ikea"
     />
   </WrapWithHits>
+).add('without label', () =>
+  <WrapWithHits >
+    <SortBy
+      items={[
+        {value: 'ikea'},
+        {value: 'ikea_price_asc'},
+        {value: 'ikea_price_desc'},
+      ]}
+      defaultRefinement="ikea"
+    />
+  </WrapWithHits>
 );


### PR DESCRIPTION
* connectHitsPerPage must provide isRefined in items data
* connectHitsPerPage must disallow configuring with only numbers (HitsPerPage items=[10,20,30]). We should always force using the object form. For consistency and single way to do one thing.