### PR TITLE
fix(StarRating): Fix UX bug #1650

### DIFF
--- a/packages/react-instantsearch/src/components/StarRating.js
+++ b/packages/react-instantsearch/src/components/StarRating.js
@@ -31,7 +31,7 @@ class StarRating extends Component {
     }
   }
 
-  buildItem({max, lowerBound, count, translate, createURL}) {
+  buildItem({max, lowerBound, count, translate, createURL, isLowest}) {
     const selected = lowerBound === this.props.currentRefinement.min &&
       max === this.props.currentRefinement.max;
     const disabled = !count;
@@ -48,6 +48,32 @@ class StarRating extends Component {
           disabled && `${iconTheme}Disabled`,
         )}
         />);
+    }
+    if (isLowest && selected) {
+      return (
+        <div {...cx(
+          'ratingLink',
+          'ratingLinkSelected',
+          disabled && 'ratingLinkDisabled')}
+           disabled={disabled}
+           key={lowerBound}
+        >
+          {icons}
+          <span {...cx(
+            'ratingLabel',
+            'ratingLabelSelected',
+            disabled && 'ratingLabelDisabled')}>
+            {translate('ratingLabel')}
+            </span>
+          <span> </span>
+          <span {...cx(
+            'ratingCount',
+            'ratingCountSelected',
+            disabled && 'ratingCountDisabled')}>
+            {count}
+          </span>
+        </div>
+      );
     }
     return (
       <a {...cx(
@@ -92,6 +118,7 @@ class StarRating extends Component {
         count: itemCount,
         translate,
         createURL,
+        isLowest: i === min,
       }));
     }
     return (

--- a/packages/react-instantsearch/src/components/StarRating.js
+++ b/packages/react-instantsearch/src/components/StarRating.js
@@ -49,41 +49,24 @@ class StarRating extends Component {
         )}
         />);
     }
-    if (isLowest && selected) {
-      return (
-        <div {...cx(
-          'ratingLink',
-          'ratingLinkSelected',
-          disabled && 'ratingLinkDisabled')}
-           disabled={disabled}
-           key={lowerBound}
-        >
-          {icons}
-          <span {...cx(
-            'ratingLabel',
-            'ratingLabelSelected',
-            disabled && 'ratingLabelDisabled')}>
-            {translate('ratingLabel')}
-            </span>
-          <span> </span>
-          <span {...cx(
-            'ratingCount',
-            'ratingCountSelected',
-            disabled && 'ratingCountDisabled')}>
-            {count}
-          </span>
-        </div>
-      );
-    }
+
+    // The last item of the list (the default item), should not
+    // be clickable if it is selected.
+    const isLastAndSelect = isLowest && selected;
+    const StarsWrapper = isLastAndSelect ? 'div' : 'a';
+    const onClickHandler = isLowest && selected ? {} : {
+      href: createURL({lowerBound, max}),
+      onClick: this.onClick.bind(this, lowerBound, max),
+    };
+
     return (
-      <a {...cx(
+      <StarsWrapper {...cx(
         'ratingLink',
         selected && 'ratingLinkSelected',
         disabled && 'ratingLinkDisabled')}
          disabled={disabled}
          key={lowerBound}
-         onClick={this.onClick.bind(this, lowerBound, max)}
-         href={createURL({lowerBound, max})}
+         {...onClickHandler}
       >
         {icons}
         <span {...cx(
@@ -99,7 +82,7 @@ class StarRating extends Component {
           disabled && 'ratingCountDisabled')}>
           {count}
         </span>
-      </a>
+      </StarsWrapper>
     );
   }
 

--- a/packages/react-instantsearch/src/components/__snapshots__/StarRating.test.js.snap
+++ b/packages/react-instantsearch/src/components/__snapshots__/StarRating.test.js.snap
@@ -109,11 +109,9 @@ exports[`StarRating applies translations 1`] = `
       14
     </span>
   </a>
-  <a
+  <div
     className="ais-StarRating__ratingLink ais-StarRating__ratingLinkSelected"
-    disabled={false}
-    href="#"
-    onClick={[Function]}>
+    disabled={false}>
     <span
       className="ais-StarRating__ratingIcon ais-StarRating__ratingIconSelected" />
     <span
@@ -135,7 +133,7 @@ exports[`StarRating applies translations 1`] = `
       className="ais-StarRating__ratingCount ais-StarRating__ratingCountSelected">
       15
     </span>
-  </a>
+  </div>
 </div>
 `;
 
@@ -250,11 +248,9 @@ exports[`StarRating supports passing max/min values 1`] = `
       14
     </span>
   </a>
-  <a
+  <div
     className="ais-StarRating__ratingLink ais-StarRating__ratingLinkSelected"
-    disabled={false}
-    href="#"
-    onClick={[Function]}>
+    disabled={false}>
     <span
       className="ais-StarRating__ratingIcon ais-StarRating__ratingIconSelected" />
     <span
@@ -276,6 +272,6 @@ exports[`StarRating supports passing max/min values 1`] = `
       className="ais-StarRating__ratingCount ais-StarRating__ratingCountSelected">
       15
     </span>
-  </a>
+  </div>
 </div>
 `;

--- a/packages/react-instantsearch/src/connectors/connectHighlight.js
+++ b/packages/react-instantsearch/src/connectors/connectHighlight.js
@@ -36,7 +36,7 @@ export default createConnector({
 
   propTypes: {},
 
-  getProps() {
+  getProvidedProps() {
     return {highlight};
   },
 


### PR DESCRIPTION
**Summary**

Fixes the ability to click even though there is no behavior triggered, when clicking on the default value and it is already selected. #1650 For reference:

![2016-12-02 18 37 16](https://cloud.githubusercontent.com/assets/393765/20927225/d6ae294c-bbc0-11e6-87da-b25bdfb57949.gif)

**Result**

Now the default value is not clickable if it is selected:

![2016-12-06 14 30 32](https://cloud.githubusercontent.com/assets/393765/20927236/e7c6cd1a-bbc0-11e6-9be7-c18477c64b6e.gif)

And it also fixes a bug introduced by the highlighting PR :(