### PR TITLE
fix(Highlight): remove infinite loop

### DIFF
--- a/packages/react-instantsearch/src/connectors/connectHighlight.js
+++ b/packages/react-instantsearch/src/connectors/connectHighlight.js
@@ -1,17 +1,13 @@
 import createConnector from '../core/createConnector';
 import parseAlgoliaHit from '../core/highlight';
 
-const timestamp = Date.now().toString();
-const config = {
-  highlightPreTag: `<ais-highlight-${timestamp}>`,
-  highlightPostTag: `</ais-highlight-${timestamp}>`,
-};
+import highlightTags from '../core/highlightTags.js';
 
 const highlight = ({attributeName, hit}) => parseAlgoliaHit({
   pathToAttribute: attributeName,
   hit,
-  preTag: config.highlightPreTag,
-  postTag: config.highlightPostTag,
+  preTag: highlightTags.highlightPreTag,
+  postTag: highlightTags.highlightPostTag,
 });
 
 /**
@@ -38,9 +34,5 @@ export default createConnector({
 
   getProvidedProps() {
     return {highlight};
-  },
-
-  getSearchParameters(searchParameters) {
-    return searchParameters.setQueryParameters(config);
   },
 });

--- a/packages/react-instantsearch/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch/src/core/createInstantSearchManager.js
@@ -2,6 +2,7 @@ import algoliasearchHelper, {SearchParameters} from 'algoliasearch-helper';
 
 import createWidgetsManager from './createWidgetsManager';
 import createStore from './createStore';
+import highlightTags from './highlightTags.js';
 
 /**
  * Creates a new instance of the InstantSearchManager which controls the widgets and
@@ -48,6 +49,7 @@ export default function createInstantSearchManager({
     const baseSP = new SearchParameters({
       ...searchParameters,
       index: indexName,
+      ...highlightTags,
     });
     const widgetSearchParameters = getSearchParameters(baseSP);
 

--- a/packages/react-instantsearch/src/core/highlightTags.js
+++ b/packages/react-instantsearch/src/core/highlightTags.js
@@ -1,0 +1,6 @@
+const timestamp = Date.now().toString();
+
+export default {
+  highlightPreTag: `<ais-highlight-${timestamp}>`,
+  highlightPostTag: `</ais-highlight-${timestamp}>`,
+};


### PR DESCRIPTION
Before this commit, when using `<Highlight>` inside `<Hit>` or any
`connectHits` we ended up in an infinite loop.

This loop was hard to notice because it was doing some network at each
iteration.

We will open new issues related to this bug because it's not just the
`Highlight` widget fault, it's the current design of computing
searchParameters and dynamic mounting that is failing.

This needs a deeper investigation and is actually why server side
today is not really supported.