### PR TITLE
fix(Highlight): error message now says "attributeName" as it's the public prop

### DIFF
--- a/packages/react-instantsearch/src/components/Highlight.test.js
+++ b/packages/react-instantsearch/src/components/Highlight.test.js
@@ -8,7 +8,7 @@ import parseAlgoliaHit from '../core/highlight';
 
 describe('Highlight', () => {
   it('parses an highlighted attribute of hit object', () => {
-    const hit = {
+    const hitFromAPI = {
       objectID: 0,
       deep: {attribute: {value: 'awesome highlighted hit!'}},
       _highlightResult: {
@@ -20,14 +20,16 @@ describe('Highlight', () => {
         }}},
       },
     };
-    const highlight = config => parseAlgoliaHit({
+
+    const highlight = ({hit, attributeName}) => parseAlgoliaHit({
       preTag: '<ais-highlight>',
       postTag: '</ais-highlight>',
-      pathToAttribute: config.attributeName,
-      hit: config.hit,
+      attributeName,
+      hit,
     });
+
     const tree = renderer.create(
-      <Highlight attributeName="deep.attribute.value" hit={hit} highlight={highlight}/>
+      <Highlight attributeName="deep.attribute.value" hit={hitFromAPI} highlight={highlight}/>
     );
     expect(tree.toJSON()).toMatchSnapshot();
   });

--- a/packages/react-instantsearch/src/connectors/connectHighlight.js
+++ b/packages/react-instantsearch/src/connectors/connectHighlight.js
@@ -4,7 +4,7 @@ import parseAlgoliaHit from '../core/highlight';
 import highlightTags from '../core/highlightTags.js';
 
 const highlight = ({attributeName, hit}) => parseAlgoliaHit({
-  pathToAttribute: attributeName,
+  attributeName,
   hit,
   preTag: highlightTags.highlightPreTag,
   postTag: highlightTags.highlightPostTag,

--- a/packages/react-instantsearch/src/core/highlight.js
+++ b/packages/react-instantsearch/src/core/highlight.js
@@ -1,7 +1,7 @@
 import {get} from 'lodash';
 
 /**
- * Find an highlighted attribute give a path `pathToAttribute`, parses it,
+ * Find an highlighted attribute give a path `attributeName`, parses it,
  * and provided an array of objects with the string value and a boolean if this
  * value is highlighted.
  *
@@ -11,21 +11,21 @@ import {get} from 'lodash';
  *
  * @param {string} preTag - string used to identify the start of an highlighted value
  * @param {string} postTag - string used to identify the end of an highlighted value
- * @param {string} pathToAttribute - path to the highlighted attribute in the results
+ * @param {string} attributeName - path to the highlighted attribute in the results
  * @param {object} hit - the actual hit returned by Algolia.
  * @return {object[]} - An array of {value: string, isDefined: boolean}.
  */
 export default function parseAlgoliaHit({
   preTag = '<em>',
   postTag = '</em>',
-  pathToAttribute,
+  attributeName,
   hit,
 }) {
   if (!hit) throw new Error('`hit`, the matching record, must be provided');
 
-  const highlightedValue = get(hit._highlightResult, pathToAttribute);
+  const highlightedValue = get(hit._highlightResult, attributeName);
   if (!highlightedValue) throw new Error(
-    `\`pathToAttribute\`=${pathToAttribute} must resolve to an highlighted attribute in the record`);
+    `\`attributeName\`=${attributeName} must resolve to an highlighted attribute in the record`);
 
   return parseHighlightedAttribute({preTag, postTag, highlightedValue: highlightedValue.value});
 }

--- a/packages/react-instantsearch/src/core/highlight.test.js
+++ b/packages/react-instantsearch/src/core/highlight.test.js
@@ -4,16 +4,16 @@ import parseAlgoliaHit from './highlight.js';
 describe('parseAlgoliaHit()', () => {
   it('creates a single element when there is no tag', () => {
     const value = 'foo bar baz';
-    const attribute = 'attr';
-    const out = parseAlgoliaHit({pathToAttribute: attribute, hit: createHit(attribute, value)});
+    const attributeName = 'attr';
+    const out = parseAlgoliaHit({attributeName, hit: createHit(attributeName, value)});
     expect(out).toEqual([{isHighlighted: false, value}]);
   });
 
   it('creates a single element when there is only a tag', () => {
     const textValue = 'foo bar baz';
     const value = `<em>${textValue}</em>`;
-    const attribute = 'attr';
-    const out = parseAlgoliaHit({pathToAttribute: attribute, hit: createHit(attribute, value)});
+    const attributeName = 'attr';
+    const out = parseAlgoliaHit({attributeName, hit: createHit(attributeName, value)});
     expect(out).toEqual([{value: textValue, isHighlighted: true}]);
   });
 
@@ -26,14 +26,14 @@ describe('parseAlgoliaHit()', () => {
         lvl0: {lvl1: {lvl2: {value}}},
       },
     };
-    const out = parseAlgoliaHit({pathToAttribute: 'lvl0.lvl1.lvl2', hit});
+    const out = parseAlgoliaHit({attributeName: 'lvl0.lvl1.lvl2', hit});
     expect(out).toEqual([{value: textValue, isHighlighted: true}]);
   });
 
   it('parses the string and returns the part that are highlighted - 1 big highlight', () => {
     const str = 'like <em>al</em>golia does <em>al</em>golia';
     const hit = createHit('attr', str);
-    const parsed = parseAlgoliaHit({pathToAttribute: 'attr', hit});
+    const parsed = parseAlgoliaHit({attributeName: 'attr', hit});
     expect(parsed).toEqual([
       {value: 'like ', isHighlighted: false},
       {value: 'al', isHighlighted: true},
@@ -49,7 +49,7 @@ describe('parseAlgoliaHit()', () => {
     const parsed = parseAlgoliaHit({
       preTag: '**',
       postTag: '**',
-      pathToAttribute: 'attr',
+      attributeName: 'attr',
       hit,
     });
     expect(parsed).toEqual([
@@ -63,23 +63,23 @@ describe('parseAlgoliaHit()', () => {
 
   it('throws when the attribute is not highlighted in the hit', () => {
     expect(parseAlgoliaHit.bind(null, {
-      pathToAttribute: 'notHighlightedAttribute',
+      attributeName: 'notHighlightedAttribute',
       hit: {notHighlightedAttribute: 'some value'},
     })).toThrowError(
-      '`pathToAttribute`=notHighlightedAttribute must resolve to an highlighted attribute in the record'
+      '`attributeName`=notHighlightedAttribute must resolve to an highlighted attribute in the record'
     );
   });
 
   it('throws when hit is `null`', () => {
     expect(parseAlgoliaHit.bind(null, {
-      pathToAttribute: 'unknownattribute',
+      attributeName: 'unknownattribute',
       hit: null,
     })).toThrowError('`hit`, the matching record, must be provided');
   });
 
   it('throws when hit is `undefined`', () => {
     expect(parseAlgoliaHit.bind(null, {
-      pathToAttribute: 'unknownAttribute',
+      attributeName: 'unknownAttribute',
       hit: undefined,
     })).toThrowError('`hit`, the matching record, must be provided');
   });


### PR DESCRIPTION
pathToAttribute was a legacy implementation of attributeName on
Highlight

Took the opportunity to only use attributeName in Highlight. Let's
agree that attributeName everywhere in the API right now is a path to
any attribute in your object. Like Algolia API does