### PR TITLE
doc(sidebar): fix jumping menu #1671

### DIFF
--- a/docgen/assets/js/sidebar.js
+++ b/docgen/assets/js/sidebar.js
@@ -11,19 +11,23 @@ export default function sidebar(options) {
 }
 
 function sidebarFollowScroll(sidebarContainer) {
-  const {height, navHeight, footerHeight, menuHeight, sidebarTop} = getPositionsKeyElements(sidebarContainer);
+  const linksContainer = sidebarContainer.querySelector('ul');
+  const {height, navHeight, footerHeight, menuHeight, sidebarTop, titleHeight} =
+    getPositionsKeyElements(sidebarContainer);
   const positionSidebar = () => {
     const currentScroll = window.pageYOffset;
     if (currentScroll > sidebarTop - navHeight) {
-      const fold = height - footerHeight - menuHeight - 100;
+      const fold = height - footerHeight - menuHeight - navHeight;
       if (currentScroll > fold) {
-        sidebarContainer.style.top = `${fold - currentScroll + navHeight + 20}px`;
+        sidebarContainer.style.top = `${fold - currentScroll + navHeight}px`;
       } else {
         sidebarContainer.style.top = null;
       }
       sidebarContainer.classList.add('fixed');
+      linksContainer.style.maxHeight = `calc(100vh - ${titleHeight + navHeight}px)`;
     } else {
       sidebarContainer.classList.remove('fixed');
+      linksContainer.style.maxHeight = '';
     }
   };
 
@@ -117,6 +121,7 @@ window.addEventListener('resize', () => {
 
 function getPositionsKeyElements($sidebar) {
   const sidebarBBox = $sidebar.getBoundingClientRect();
+  const title = $sidebar.querySelector('.sidebar-header');
   const bodyBBox = document.body.getBoundingClientRect();
   const sidebarTop = sidebarBBox.top - bodyBBox.top;
   const footer = document.querySelector('.ac-footer');
@@ -126,6 +131,7 @@ function getPositionsKeyElements($sidebar) {
   const navHeight = navigation.offsetHeight;
   const footerHeight = footer.offsetHeight;
   const menuHeight = menu.offsetHeight;
+  const titleHeight = title.offsetHeight;
 
-  return {sidebarTop, height, navHeight, footerHeight, menuHeight};
+  return {sidebarTop, height, navHeight, footerHeight, menuHeight, titleHeight};
 }

--- a/docgen/src/stylesheets/components/_documentation.scss
+++ b/docgen/src/stylesheets/components/_documentation.scss
@@ -87,7 +87,7 @@
     position: relative;
     left: #{$sidebar-width};
     width: calc(100% - #{$sidebar-width});
-    min-height: 890px;
+    min-height: 1000px;
     padding-left: 30px;
     padding-bottom: 200px;
     padding-top: 120px;

--- a/docgen/src/stylesheets/components/_sidebar.scss
+++ b/docgen/src/stylesheets/components/_sidebar.scss
@@ -5,7 +5,7 @@ nav.sidebar {
   position: absolute;
   max-width: $sidebar-width;
   border-right: 1px solid #d8d8d8;
-  overflow: auto;
+  overflow: hidden;
   padding-top: 120px;
 
   .sidebar-container {
@@ -14,10 +14,11 @@ nav.sidebar {
 
     &.fixed {
       position: fixed;
-      top: ($nav-height + 40px);
+      top: ($nav-height);
       z-index: 9;
-      max-height: calc(100vh - #{$nav-height});
-      overflow: auto;
+      .sidebar-elements{
+        overflow: auto;
+      }
     }
 
     h2.sidebar-header {

--- a/docgen/webpack.config.start.babel.js
+++ b/docgen/webpack.config.start.babel.js
@@ -12,7 +12,7 @@ const {
 
 export default {
   ...webpackConfig,
-  devtool: 'eval-source-map', // a lot faster than 'source-map', not ok for production though
+  devtool: 'source-map', // a lot faster than 'source-map', not ok for production though
   entry: {
     ...(
       Object


### PR DESCRIPTION
This PR is for react-instantsearch documentation.

**Summary**

When scrolling the sidebar was jumping when it was starting to follow the content.

**Result**

No jump at the start
![2016-12-08 13 55 05](https://cloud.githubusercontent.com/assets/393765/21010760/2e2bc768-bd4e-11e6-8fb0-874c5d9d8dd2.gif)

No jump at the end
![2016-12-08 13 55 34](https://cloud.githubusercontent.com/assets/393765/21010766/376170c6-bd4e-11e6-9422-ae0923634dcb.gif)

Scroll below the title of the page (not scrolling the title)
![2016-12-08 13 56 18](https://cloud.githubusercontent.com/assets/393765/21010778/486e73aa-bd4e-11e6-8a2e-7576b79faceb.gif)

