### PR TITLE
chore(docs): isolate production publishing from dev mode

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,4 +4,5 @@ packages/react-instantsearch/examples/*/node_modules/
 coverage/
 # generated documentation website
 docs/
+docs-production/
 dist/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /docs/
+/docs-production/
 node_modules/
 dist/
 npm-debug.log

--- a/docgen/config.js
+++ b/docgen/config.js
@@ -4,7 +4,9 @@ import {rootPath} from './path';
 const prod = process.env.NODE_ENV === 'production';
 
 export default {
-  docsDist: rootPath('docs/react'),
+  docsDist: prod ?
+    rootPath('docs-production/react') : // avoids publishing an `npm start`ed build if running.
+    rootPath('docs/react'),
   storyBookPublicPath: prod ?
     'https://community.algolia.com/instantsearch.js/react/storybook/' :
     'http://localhost:6006/',

--- a/scripts/gh-pages.js
+++ b/scripts/gh-pages.js
@@ -5,7 +5,7 @@ import {join} from 'path';
 
 ghpages.clean();
 
-const site = join(__dirname, '../docs');
+const site = join(__dirname, '../docs-production');
 const logger = msg => console.log(msg);
 const end = err => {
   if (err) {


### PR DESCRIPTION
So that if an npm start script is running, we do not use its output as
a documentation website.