### PR TITLE
fix(range): when unfinite numbers are passed, use search results instead.

### DIFF
--- a/packages/react-instantsearch/src/connectors/connectRange.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.js
@@ -103,6 +103,9 @@ export default createConnector({
   },
 
   refine(props, searchState, nextRefinement) {
+    if (!isFinite(nextRefinement.min) || !isFinite(nextRefinement.max)) {
+      throw new Error('You can\'t provide non finite values to the range connector');
+    }
     return {
       ...searchState,
       [namespace]: {...searchState[namespace], [getId(props)]: nextRefinement},

--- a/packages/react-instantsearch/src/connectors/connectRange.test.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.test.js
@@ -85,10 +85,11 @@ describe('connectRange', () => {
   });
 
   it('calling refine updates the widget\'s search state', () => {
-    const nextState = refine({attributeName: 'ok'}, {otherKey: 'val', range: {otherKey: 'val'}}, 'yep');
+    const nextState = refine({attributeName: 'ok'},
+      {otherKey: 'val', range: {otherKey: {min: 1, max: 2}}}, {min: 3, max: 5});
     expect(nextState).toEqual({
       otherKey: 'val',
-      range: {ok: 'yep', otherKey: 'val'},
+      range: {ok: {min: 3, max: 5}, otherKey: {min: 1, max: 2}},
     });
   });
 

--- a/packages/react-instantsearch/src/widgets/RangeSlider.js
+++ b/packages/react-instantsearch/src/widgets/RangeSlider.js
@@ -28,12 +28,17 @@ import React from 'react';
     return {currentValues: {min: this.props.min, max: this.props.max}};
   },
 
+  componentWillReceiveProps(sliderState) {
+    this.setState({currentValues: {min: sliderState.currentRefinement.min, max: sliderState.currentRefinement.max}});
+  },
+
   onValuesUpdated(sliderState) {
     this.setState({currentValues: {min: sliderState.values[0], max: sliderState.values[1]}});
   },
 
   onChange(sliderState) {
-    if (sliderState.values[0] !== this.props.min || sliderState.values[1] !== this.props.max) {
+    if (this.props.currentRefinement.min !== sliderState.values[0] ||
+      this.props.currentRefinement.max !== sliderState.values[1]) {
       this.props.refine({min: sliderState.values[0], max: sliderState.values[1]});
     }
   },

--- a/stories/3rdPartiesIntegration.stories.js
+++ b/stories/3rdPartiesIntegration.stories.js
@@ -24,18 +24,25 @@ const Range = React.createClass({
     return {currentValues: {min: this.props.min, max: this.props.max}};
   },
 
+  componentWillReceiveProps(sliderState) {
+    this.setState({currentValues: {min: sliderState.currentRefinement.min, max: sliderState.currentRefinement.max}});
+  },
+
   onValuesUpdated(sliderState) {
     this.setState({currentValues: {min: sliderState.values[0], max: sliderState.values[1]}});
   },
 
   onChange(sliderState) {
-    this.props.refine({min: sliderState.values[0], max: sliderState.values[1]});
+    if (this.props.currentRefinement.min !== sliderState.values[0] ||
+      this.props.currentRefinement.max !== sliderState.values[1]) {
+      this.props.refine({min: sliderState.values[0], max: sliderState.values[1]});
+    }
   },
 
   render() {
     const {min, max, currentRefinement} = this.props;
     const {currentValues} = this.state;
-    return (
+    return min !== max ?
       <div>
         <Rheostat
           min={min}
@@ -48,8 +55,7 @@ const Range = React.createClass({
           <div>{currentValues.min}</div>
           <div>{currentValues.max}</div>
         </div>
-      </div>
-    );
+      </div> : null;
   },
 });
 


### PR DESCRIPTION
Behavior: when using NaN as min/max current values of a range, an infinite loop is triggered. 

This fix check inside the connector if the values are finite, if not, we are defaulting to the one provided to the widget (either by hand ou by using the search results). 

=> We discovered this behavior when using the rheostat slider widget. For an unknown reason when you have the same value for Min/Max, the slider gaves you NaN/NaN instead of the real value. 
The consequence for react-instantsearch is that when the 'shouldComponentUpdate' hook of the range connector is triggered, equality will never be reached as the currentRefinement contains 'null' value. 