### PR TITLE
fix(starRating): call createURL with the right interface (min/max)

### DIFF
--- a/packages/react-instantsearch/src/components/StarRating.js
+++ b/packages/react-instantsearch/src/components/StarRating.js
@@ -55,7 +55,7 @@ class StarRating extends Component {
     const isLastAndSelect = isLowest && selected;
     const StarsWrapper = isLastAndSelect ? 'div' : 'a';
     const onClickHandler = isLastAndSelect ? {} : {
-      href: createURL({lowerBound, max}),
+      href: createURL({min: lowerBound, max}),
       onClick: this.onClick.bind(this, lowerBound, max),
     };
 

--- a/packages/react-instantsearch/src/components/StarRating.test.js
+++ b/packages/react-instantsearch/src/components/StarRating.test.js
@@ -47,27 +47,38 @@ describe('StarRating', () => {
   });
 
   const refine = jest.fn();
-  const wrapper = mount(
-      <StarRating
-        createURL={() => '#'}
-        refine={refine}
-        min={1}
-        max={5}
-        currentRefinement={{min: 1, max: 5}}
-        count={[{value: '1', count: 1},
-          {value: '2', count: 2},
-          {value: '3', count: 3},
-          {value: '4', count: 3},
-          {value: '5', count: 0}]}
-      />
-    );
+  const createURL = jest.fn();
+  const starRating = <StarRating
+    createURL={createURL}
+    refine={refine}
+    min={1}
+    max={5}
+    currentRefinement={{min: 1, max: 5}}
+    count={[{value: '1', count: 1},
+      {value: '2', count: 2},
+      {value: '3', count: 3},
+      {value: '4', count: 3},
+      {value: '5', count: 0}]}
+  />;
+  const wrapper = mount(starRating);
 
   beforeEach(() => {
     refine.mockClear();
+    createURL.mockClear();
   });
 
   afterAll(() => {
     wrapper.unmount();
+  });
+
+  it('should create an URL for each row except for the largest: the default selected one', () => {
+    mount(starRating);
+
+    expect(createURL.mock.calls.length).toBe(4);
+    expect(createURL.mock.calls[0][0]).toEqual({min: 5, max: 5});
+    expect(createURL.mock.calls[1][0]).toEqual({min: 4, max: 5});
+    expect(createURL.mock.calls[2][0]).toEqual({min: 3, max: 5});
+    expect(createURL.mock.calls[3][0]).toEqual({min: 2, max: 5});
   });
 
   it('refines its value on change', () => {
@@ -83,31 +94,31 @@ describe('StarRating', () => {
     expect(refine.mock.calls[0][0]).toEqual({min: 5, max: 5});
 
     selectedLink = wrapper
-        .find('.ais-StarRating__ratingLinkSelected');
+      .find('.ais-StarRating__ratingLinkSelected');
     expect(selectedLink).toBeDefined();
 
     refine.mockClear();
 
     const disabledLink = wrapper
-        .find('.ais-StarRating__ratingLinkDisabled')
-        .find('.ais-StarRating__ratingIcon');
+      .find('.ais-StarRating__ratingLinkDisabled')
+      .find('.ais-StarRating__ratingIcon');
 
     expect(disabledLink.length).toBe(5);
   });
 
   it('should display the right number of stars', () => {
     wrapper
-        .find('.ais-StarRating__ratingLink')
-        .last()
-        .simulate('click');
+      .find('.ais-StarRating__ratingLink')
+      .last()
+      .simulate('click');
 
     const selectedLink = wrapper
-        .find('.ais-StarRating__ratingLinkSelected');
+      .find('.ais-StarRating__ratingLinkSelected');
 
     const fullIcon = selectedLink
-        .find('.ais-StarRating__ratingIcon');
+      .find('.ais-StarRating__ratingIcon');
     const emptyIcon = selectedLink
-        .first().find('.ais-StarRating__ratingIconEmpty');
+      .first().find('.ais-StarRating__ratingIconEmpty');
 
     expect(fullIcon.length).toBe(1);
     expect(emptyIcon.length).toBe(4);

--- a/packages/react-instantsearch/src/connectors/connectRange.test.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.test.js
@@ -93,6 +93,14 @@ describe('connectRange', () => {
     });
   });
 
+  it('calling refine with non finite values should fail', () => {
+    function shouldNotRefine() {
+      refine({attributeName: 'ok'},
+        {otherKey: 'val', range: {otherKey: {min: 1, max: 2}}}, {min: NaN, max: 5});
+    }
+    expect(shouldNotRefine).toThrowError('You can\'t provide non finite values to the range connector');
+  });
+
   it('refines the corresponding numeric facet', () => {
     params = getSP(
       new SearchParameters(),


### PR DESCRIPTION
By adding a check to non finite values in the `connectRange` connector, a bug was highlighted inside the starRating widget. createURL function was called with the following format {lowerbound, max}, instead of {min, max}. 