### PR TITLE
chore: rollback to previous version of node-sass (3 instead of 4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "metalsmith-navigation": "^0.2.9",
     "metalsmith-sass": "^1.3.0",
     "ms-webpack": "^2.0.0-alpha.1",
-    "node-sass": "^4.0.0",
+    "node-sass": "^3.13.0",
     "postcss": "^5.2.6",
     "postcss-loader": "^1.2.1",
     "postcss-scss": "^0.4.0",


### PR DESCRIPTION
Updating to node-sass 4 makes the documentation crash at least with macos x. 