### PR TITLE
docs(examples): add autocomplete recipe

### DIFF
--- a/docgen/src/guide/Autocomplete_menu.md
+++ b/docgen/src/guide/Autocomplete_menu.md
@@ -1,0 +1,27 @@
+---
+title: Autocomplete menu
+mainTitle: Guide
+layout: main.pug
+category: guide
+navWeight: 20
+---
+
+You can build with React InstantSearch an autocomplete menu that uses an external autocomplete component.
+
+[Read the examples](https://github.com/algolia/instantsearch.js/tree/v2/packages/react-instantsearch/examples/autocomplete)
+ showing you how to build an autocomplete menu that will:
+* display hits and facet values from the same index
+* display hits from different indices
+
+Those examples use advanced concepts from React InstantSearch. If you're not familiar with
+them you can read their guide first:
+
+* [Custom connectors](guide/Custom_connectors.html)
+* [Virtual widgets](guide/Virtual_widgets.html)
+* [Multi Index](guide/Multi_index.html)
+
+<div class="guide-nav">
+    <div class="guide-nav-left">
+        Previous: <a href="guide/Server-Side_rendering.html">← Server-side Rendering</a>
+    </div>
+</div>

--- a/docgen/src/guide/Server-side_rendering.md
+++ b/docgen/src/guide/Server-side_rendering.md
@@ -13,4 +13,7 @@ right now. We will soon provide API entries to handle this usecase.
     <div class="guide-nav-left">
         Previous: <a href="guide/React_native.html">← React Native</a>
     </div>
+    <div class="guide-nav-right">
+            Next: <a href="guide//Autocomplete_menu.html">Autocomplete menu →</a>
+    </div>
 </div>

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "qs": "^6.3.0",
     "react": "^15.4.1",
     "react-addons-test-utils": "^15.4.1",
+    "react-autosuggest": "^7.0.2",
     "react-dev-utils": "^0.4.2",
     "react-dom": "^15.4.1",
     "react-hot-loader": "^3.0.0-beta.4",

--- a/packages/react-instantsearch/examples/autocomplete/README.md
+++ b/packages/react-instantsearch/examples/autocomplete/README.md
@@ -1,0 +1,14 @@
+This example shows how to use an external autocomplete component with react-instantsearch
+It uses [react-autosuggest](https://github.com/moroshko/react-autosuggest) as the autocomplete external component.
+
+You will find two use cases:
+
+* How to build an autocomplete displaying hits and facet values from the same index.
+* How to build an autocomplete displaying hits from different indices
+
+To start the example:
+
+* npm install
+* npm start
+
+Read more about react-instantsearch [in our documentation](https://community.algolia.com/instantsearch.js/react/).

--- a/packages/react-instantsearch/examples/autocomplete/package.json
+++ b/packages/react-instantsearch/examples/autocomplete/package.json
@@ -1,0 +1,19 @@
+{
+  "private": true,
+  "devDependencies": {
+    "react-scripts": "0.7.0"
+  },
+  "dependencies": {
+    "lodash": "^4.16.6",
+    "react-autosuggest": "^7.0.1",
+    "react": "^15.3.2",
+    "react-dom": "^15.3.2",
+    "react-instantsearch": "file:../../dist",
+    "react-instantsearch-theme-algolia": "file:../../../react-instantsearch-theme-algolia"
+  },
+  "scripts": {
+    "start": "react-scripts start"
+  },
+  "main": "index.js",
+  "license": "MIT"
+}

--- a/packages/react-instantsearch/examples/autocomplete/public/index.html
+++ b/packages/react-instantsearch/examples/autocomplete/public/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>autocomplete with react-instantsearch</title>
+    <link rel="stylesheet" type="text/css" href="%PUBLIC_URL%/style.css">
+  </head>
+  <body>
+    <h2>Autocomplete targetting multiple indices</h2>
+    <div id="autocomplete-with-multi-indices"></div>
+    <h2>Autocomplete displaying hits and facets</h2>
+    <div id="autocomplete-with-facets"></div>
+  </body>
+</html>

--- a/packages/react-instantsearch/examples/autocomplete/public/style.css
+++ b/packages/react-instantsearch/examples/autocomplete/public/style.css
@@ -1,0 +1,72 @@
+body {
+    font-family: Helvetica, sans-serif;
+}
+
+.react-autosuggest__container {
+    position: relative;
+}
+
+.react-autosuggest__input {
+    width: 600px;
+    height: 30px;
+    padding: 10px 20px;
+    font-family: Helvetica, sans-serif;
+    font-weight: 300;
+    font-size: 16px;
+    border: 1px solid #aaa;
+    border-radius: 4px;
+}
+
+.react-autosuggest__input:focus {
+    outline: none;
+}
+
+.react-autosuggest__container--open .react-autosuggest__input {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+}
+
+.react-autosuggest__suggestions-container {
+    display: none;
+}
+
+.react-autosuggest__container--open .react-autosuggest__suggestions-container {
+    display: block;
+    position: absolute;
+    top: 51px;
+    width: 640px;
+    border: 1px solid #aaa;
+    background-color: #fff;
+    font-family: Helvetica, sans-serif;
+    font-weight: 300;
+    font-size: 16px;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    z-index: 2;
+}
+
+.react-autosuggest__suggestions-list {
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+}
+
+.react-autosuggest__suggestion {
+    cursor: pointer;
+    padding: 10px 20px;
+}
+
+.react-autosuggest__suggestion--focused {
+    background-color: #ddd;
+}
+
+.react-autosuggest__section-title {
+    padding: 10px 0 0 10px;
+    font-size: 12px;
+    color: #777;
+    border-top: 1px dashed #ccc;
+}
+
+.react-autosuggest__section-container:first-child .react-autosuggest__section-title {
+    border-top: 0;
+}

--- a/packages/react-instantsearch/examples/autocomplete/src/App-Hits-And-Facets.js
+++ b/packages/react-instantsearch/examples/autocomplete/src/App-Hits-And-Facets.js
@@ -1,0 +1,113 @@
+import React, {Component} from 'react';
+import {InstantSearch} from 'react-instantsearch/dom';
+import {createConnector} from 'react-instantsearch';
+import {connectSearchBox, connectRefinementList} from 'react-instantsearch/connectors';
+import Autosuggest from 'react-autosuggest';
+import {forOwn} from 'lodash';
+/* eslint-disable import/no-unresolved */
+import 'react-instantsearch-theme-algolia/style.css';
+/* eslint-enable import/no-unresolved */
+
+class App extends Component {
+  render() {
+    return (
+      <InstantSearch
+        appId="latency"
+        apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+        indexName="bestbuy"
+        searchParameters={{hitsPerPage: 3}}
+      >
+        <div>
+          <VirtualSearchBox/>
+          <VirtualRefinementList attributeName="manufacturer"/>
+          <VirtualRefinementList attributeName="category"/>
+          <ConnectedAutoComplete attributes={['manufacturer', 'category']}/>
+        </div>
+      </InstantSearch>
+    );
+  }
+}
+
+const VirtualSearchBox = connectSearchBox(() => null);
+const VirtualRefinementList = connectRefinementList(() => null);
+
+const connectAutoComplete = createConnector({
+  displayName: 'AutoComplete',
+
+  /*
+   We retrieve all the values needed:
+   - Current query
+   - Hits
+   - Facet values (given an array of attributes provided to the component)
+   To work properly, you need to use Virtual Widgets for the SearchBox and all the
+   facets you want the value of.
+   */
+  getProvidedProps(props, state, search) {
+    const hits = search.results ? search.results.hits : [];
+    const facets = props.attributes.reduce((acc, attributeName) => {
+      if (search.results) {
+        acc[attributeName] = search.results
+          .getFacetValues(attributeName)
+          .slice(0, 3)
+          .map(v => ({
+            name: v.name,
+          }));
+      }
+      return acc;
+    }, {});
+    return {
+      hits, query: state.query !== undefined ? state.query : '', facets,
+    };
+  },
+
+  // we update the state of <InstantSearch/> to trigger a new search.
+  refine(props, searchState, nextQuery) {
+    return {
+      ...searchState,
+      query: nextQuery,
+    };
+  },
+});
+
+class AutoComplete extends React.Component {
+  formatHitsForAutoSuggest(props) {
+    const hits = [];
+    forOwn({...props.facets, hits: props.hits}, (value, key) => {
+      hits.push({title: key, hits: value});
+    });
+    return hits;
+  }
+
+  render() {
+    return <Autosuggest
+      suggestions={this.formatHitsForAutoSuggest(this.props)}
+      multiSection={true}
+      onSuggestionsFetchRequested={({value}) => this.props.refine(value)}
+      onSuggestionsClearRequested={() => this.props.refine('')}
+      getSuggestionValue={hit => hit.name}
+      renderSuggestion={hit =>
+        <div>
+          <div>{hit.name}</div>
+        </div>
+      }
+      inputProps={{
+        placeholder: 'Type a product',
+        value: this.props.query,
+        onChange: () => {
+        },
+      }}
+      renderSectionTitle={section => section.title}
+      getSectionSuggestions={section => section.hits}
+    />;
+  }
+}
+
+AutoComplete.propTypes = {
+  refine: React.PropTypes.func.isRequired,
+  query: React.PropTypes.string.isRequired,
+};
+
+const ConnectedAutoComplete = connectAutoComplete(AutoComplete);
+
+export default App;
+

--- a/packages/react-instantsearch/examples/autocomplete/src/App-Multi-Index.js
+++ b/packages/react-instantsearch/examples/autocomplete/src/App-Multi-Index.js
@@ -1,0 +1,183 @@
+import React, {Component} from 'react';
+import {InstantSearch, Highlight} from 'react-instantsearch/dom';
+import {createConnector} from 'react-instantsearch';
+import {connectSearchBox} from 'react-instantsearch/connectors';
+import Autosuggest from 'react-autosuggest';
+import {isEqual, forOwn} from 'lodash';
+/* eslint-disable import/no-unresolved */
+import 'react-instantsearch-theme-algolia/style.css';
+/* eslint-enable import/no-unresolved */
+
+class App extends Component {
+  constructor(props) {
+    super(props);
+    this.onProps = this.onProps.bind(this);
+    this.onSearchStateChange = this.onSearchStateChange.bind(this);
+    this.state = {searchState: {}, hits: {}, query: ''};
+  }
+
+  onSearchStateChange(searchState) {
+    this.setState({searchState: {...this.state.searchState, ...searchState}});
+  }
+
+  /*
+  We need this function to gather all the data coming from several <InstantSearch/> indices.
+  In this example we are using the `indexName` to namespace those data to avoid erasing them
+  each time an instance is updated. You can choose to use any namespace of your choice, if the
+  `indexName` is not a differentiator.
+   */
+  onProps(props) {
+    this.setState({hits: {...this.state.hits, [props.indexName]: props.hits}, query: props.query});
+  }
+
+  formatHitsForAutoSuggest() {
+    const hits = [];
+    forOwn(this.state.hits, (value, key) => {
+      hits.push({title: key, hits: value});
+    });
+    return hits;
+  }
+
+  render() {
+    return (
+      <div>
+        <FirstResults onProps={this.onProps}
+                      searchState={this.state.searchState}
+                      onSearchStateChange={this.onSearchStateChange}/>
+        <SecondResults onProps={this.onProps} searchState={this.state.searchState}
+                       onSearchStateChange={this.onSearchStateChange}/>
+        {/* The AutoSuggest component is inside an <InstantSearch/> instance only to
+        take advantage of the <Highlight/> widget */}
+        <InstantSearch
+          appId="latency"
+          apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+          indexName="bestbuy"
+        >
+          <Autosuggest
+            suggestions={this.formatHitsForAutoSuggest()}
+            multiSection={true}
+            onSuggestionsFetchRequested={({value}) => this.onSearchStateChange({query: value})}
+            onSuggestionsClearRequested={() => this.onSearchStateChange({query: ''})}
+            getSuggestionValue={hit => hit.name}
+            renderSuggestion={hit => {
+              let description = '';
+              if (hit._highlightResult.description) {
+                description = <Highlight attributeName="description" hit={hit}/>;
+              } else if (hit._highlightResult.shortDescription) {
+                description = <Highlight attributeName="shortDescription" hit={hit}/>;
+              }
+              return (
+                <div style={{display: 'flex'}}>
+                  <div style={{maginRight: 5}}>
+                    <img alt="product" width="50px" height="50px" src={`${hit.image}`}/>
+                  </div>
+                  <div style={{display: 'flex', flexDirection: 'column'}}>
+                    <div style={{marginBottom: 5}}><Highlight attributeName="name" hit={hit}/></div>
+                    <div style={{marginBottom: 5}}>{description}</div>
+                  </div>
+                </div>
+              );
+            }}
+            inputProps={{
+              placeholder: 'Type a product',
+              value: this.state.query,
+              onChange: () => {
+              },
+            }}
+            renderSectionTitle={section => section.title}
+            getSectionSuggestions={section => section.hits}
+          />
+        </InstantSearch>
+      </div>
+    );
+  }
+}
+
+class FirstResults extends React.Component {
+  shouldComponentUpdate(nextProps) {
+    return !isEqual(this.props.searchState, nextProps.searchState);
+  }
+
+  render() {
+    return <InstantSearch
+      appId="latency"
+      apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+      indexName="bestbuy"
+      searchState={this.props.searchState}
+      onSearchStateChange={this.props.onSearchStateChange}
+      searchParameters={{hitsPerPage: 3}}
+    >
+      <div>
+        <VirtualSearchBox/>
+        <VirtualAutoSuggest indexName="bestbuy" onProps={this.props.onProps}/>
+      </div>
+    </InstantSearch>;
+  }
+}
+
+FirstResults.propTypes = {
+  searchState: React.PropTypes.object.isRequired,
+  onSearchStateChange: React.PropTypes.func.isRequired,
+  onProps: React.PropTypes.func.isRequired,
+};
+
+class SecondResults extends React.Component {
+  shouldComponentUpdate(nextProps) {
+    return !isEqual(this.props.searchState, nextProps.searchState);
+  }
+
+  render() {
+    return <InstantSearch
+      appId="latency"
+      apiKey="6be0576ff61c053d5f9a3225e2a90f76"
+      indexName="ikea"
+      searchState={this.props.searchState}
+      onSearchStateChange={this.props.onSearchStateChange}
+      searchParameters={{hitsPerPage: 3}}
+    >
+      <div>
+        <VirtualSearchBox/>
+        <VirtualAutoSuggest onProps={this.props.onProps} indexName="ikea"/>
+      </div>
+    </InstantSearch>;
+  }
+}
+
+SecondResults.propTypes = {
+  searchState: React.PropTypes.object.isRequired,
+  onSearchStateChange: React.PropTypes.func.isRequired,
+  onProps: React.PropTypes.func.isRequired,
+};
+
+const VirtualSearchBox = connectSearchBox(() => null);
+
+const connectAutoComplete = createConnector({
+  displayName: 'AutoComplete',
+
+  getProvidedProps(props, state, search) {
+    const hits = search.results ? search.results.hits : [];
+    return {
+      hits, query: state.query !== undefined ? state.query : '',
+    };
+  },
+});
+
+class AutoComplete extends React.Component {
+  // We trigger an update of the autocomplete if the props changed.
+  componentWillReceiveProps(nextProps) {
+    this.props.onProps(nextProps);
+  }
+
+  render() {
+    return null;
+  }
+}
+
+AutoComplete.propTypes = {
+  onProps: React.PropTypes.func.isRequired,
+};
+
+const VirtualAutoSuggest = connectAutoComplete(AutoComplete);
+
+export default App;
+

--- a/packages/react-instantsearch/examples/autocomplete/src/index.js
+++ b/packages/react-instantsearch/examples/autocomplete/src/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from './App-Multi-Index';
+import App2 from './App-Hits-And-Facets';
+
+ReactDOM.render(<App/>, document.getElementById('autocomplete-with-multi-indices'));
+ReactDOM.render(<App2/>, document.getElementById('autocomplete-with-facets'));


### PR DESCRIPTION
Those examples shows how to use an external react autocomplete component with react-instantsearch with two use cases: 
* targetting multiple indices 
* displaying both hits and facet values. 

Those examples are boilerplate but will serve to derive the right API to perform the same thing.

![kapture 2016-12-16 at 13 57 16](https://cloud.githubusercontent.com/assets/6885378/21263546/b596bb78-c397-11e6-9232-5ad12a84c3a2.gif)
