### PR TITLE
fix(createInstantSearchManager): drop outdated response

### DIFF
--- a/packages/react-instantsearch/src/core/createInstantSearchManager.error.test.js
+++ b/packages/react-instantsearch/src/core/createInstantSearchManager.error.test.js
@@ -1,0 +1,90 @@
+/* eslint-env jest, jasmine */
+/* eslint-disable no-console */
+
+import createInstantSearchManager from './createInstantSearchManager';
+
+import algoliaClient from 'algoliasearch';
+
+jest.useFakeTimers();
+
+jest.mock('algoliasearch-helper/src/algoliasearch.helper.js', () => {
+  let count = 0;
+  console.log('setup');
+  const Helper = require.requireActual('algoliasearch-helper/src/algoliasearch.helper.js');
+  Helper.prototype._handleResponse = function(state) {
+    this.emit('error', {count: count++}, state);
+  };
+  return Helper;
+});
+
+const client = algoliaClient('latency', '249078a3d4337a8231f1665ec5a44966');
+client.search = jest.fn((queries, cb) => {
+  if (cb) {
+    setImmediate(() => {
+      // We do not care about the returned values because we also control how
+      // it will handle in the helper
+      cb(null, null);
+    });
+    return undefined;
+  }
+
+  return new Promise(resolve => {
+    // cf comment above
+    resolve(null);
+  });
+});
+
+describe('createInstantSearchManager', () => {
+  describe('with error from algolia', () => {
+    describe('on widget lifecycle', () => {
+      it('updates the store and searches', () => {
+        const ism = createInstantSearchManager({
+          indexName: 'index',
+          initialState: {},
+          searchParameters: {},
+          algoliaClient: client,
+        });
+
+        ism.widgetsManager.registerWidget({
+          getSearchParameters: params => params.setQuery('search'),
+        });
+
+        expect(ism.store.getState().error).toBe(null);
+
+        jest.runAllTimers();
+
+        const store = ism.store.getState();
+        expect(store.error).toEqual({count: 0});
+        expect(store.results).toBe(null);
+
+        ism.widgetsManager.update();
+
+        jest.runAllTimers();
+
+        const store1 = ism.store.getState();
+        expect(store1.error).toEqual({count: 1});
+        expect(store1.results).toBe(null);
+      });
+    });
+    describe('on external updates', () => {
+      it('updates the store and searches', () => {
+        const ism = createInstantSearchManager({
+          indexName: 'index',
+          initialState: {},
+          searchParameters: {},
+          algoliaClient: client,
+        });
+
+        ism.onExternalStateUpdate({});
+
+        expect(ism.store.getState().error).toBe(null);
+
+        jest.runAllTimers();
+
+        const store = ism.store.getState();
+        expect(store.error).toEqual({count: 2});
+        expect(store.results).toBe(null);
+      });
+    });
+  });
+});

--- a/packages/react-instantsearch/src/core/createInstantSearchManager.result.test.js
+++ b/packages/react-instantsearch/src/core/createInstantSearchManager.result.test.js
@@ -1,0 +1,89 @@
+/* eslint-env jest, jasmine */
+/* eslint-disable no-console */
+
+import createInstantSearchManager from './createInstantSearchManager';
+
+import algoliaClient from 'algoliasearch';
+
+jest.useFakeTimers();
+
+jest.mock('algoliasearch-helper/src/algoliasearch.helper.js', () => {
+  let count = 0;
+  const Helper = require.requireActual('algoliasearch-helper/src/algoliasearch.helper.js');
+  Helper.prototype._handleResponse = function(state) {
+    this.emit('result', {count: count++}, state);
+  };
+  return Helper;
+});
+
+const client = algoliaClient('latency', '249078a3d4337a8231f1665ec5a44966');
+client.search = jest.fn((queries, cb) => {
+  if (cb) {
+    setImmediate(() => {
+      // We do not care about the returned values because we also control how
+      // it will handle in the helper
+      cb(null, null);
+    });
+    return undefined;
+  }
+
+  return new Promise(resolve => {
+    // cf comment above
+    resolve(null);
+  });
+});
+
+describe('createInstantSearchManager', () => {
+  describe('with correct result from algolia', () => {
+    describe('on widget lifecycle', () => {
+      it('updates the store and searches', () => {
+        const ism = createInstantSearchManager({
+          indexName: 'index',
+          initialState: {},
+          searchParameters: {},
+          algoliaClient: client,
+        });
+
+        ism.widgetsManager.registerWidget({
+          getSearchParameters: params => params.setQuery('search'),
+        });
+
+        expect(ism.store.getState().results).toBe(null);
+
+        jest.runAllTimers();
+
+        const store = ism.store.getState();
+        expect(store.results).toEqual({count: 0});
+        expect(store.error).toBe(null);
+
+        ism.widgetsManager.update();
+
+        jest.runAllTimers();
+
+        const store1 = ism.store.getState();
+        expect(store1.results).toEqual({count: 1});
+        expect(store1.error).toBe(null);
+      });
+    });
+    describe('on external updates', () => {
+      it('updates the store and searches', () => {
+        const ism = createInstantSearchManager({
+          indexName: 'index',
+          initialState: {},
+          searchParameters: {},
+          algoliaClient: client,
+        });
+
+        ism.onExternalStateUpdate({});
+
+        expect(ism.store.getState().results).toBe(null);
+
+        jest.runAllTimers();
+
+        const store = ism.store.getState();
+        expect(store.results).toEqual({count: 2});
+        expect(store.error).toBe(null);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR is for **React-InstantSearch**

The event model for the helper is implemented in a way that it will drop outdated requests.
This change makes react-instantsearch use the event model. This mechanism ensures reliability in the algolia answers.

It also results in some fewer instanciations of objects for callbacks and the base search parameters.

## Details of what was done

The previous implementation was based on `searchOnce`. This method does not protect you from responses that come back unordered because it is based on the cb / promise from the algolia client which will always call the callback even if they are unordered.

## NOW

Use the helper properly with events and its protection against this kind of behaviour.

**The tests are now up to date 🍾 **

## A note about the test 🤔 

The tests were based on mocks that were making a lot of assumptions about the internals. That's why they were all broken after my changes. I tried to redo them by making less assumptions about the internals, and use the external API as much as possible.

That being said, this refactoring is now based on the event API of the helper, which is very hard to manipulate without some heavy mocking. Writing those tests I also learned a bit about the jest magic concerning the mocks and their limitations. For example you can't change the implementation on the fly (calling again jest.mock doesn't do anything) nor can you reference a closed variable. That's why I ended up with three test files, instead of one (one without mocks and two with different behaviours for the mocks)

If you have any other solution about how to make those tests I would be very grateful 🙇 Thanks 🤓 