### PR TITLE
feat(SearchForFacetValues): connector functions + refinementList implementation

### DIFF
--- a/docgen/layouts/widget.pug
+++ b/docgen/layouts/widget.pug
@@ -56,8 +56,7 @@ block content
               div.api-entry(id=themeId)=type.key
                 a.anchor(href=`${navPath}#${themeId}`)
           tr.api-entry-description
-            td
-              p=type.description
+            td(colspan=3)!=h.markdown(type.description)
   else
     p This widget does not accept theme.
   h2#translations Translation keys
@@ -72,7 +71,6 @@ block content
               div.api-entry(id=themeId)=type.key
                 a.anchor(href=`${navPath}#${themeId}`)
           tr.api-entry-description
-            td
-              p=type.description
+            td(colspan=3)!=h.markdown(type.description)
   else
     p This widget does not have translations.

--- a/docgen/src/examples/e-commerce-infinite/App.js
+++ b/docgen/src/examples/e-commerce-infinite/App.js
@@ -75,9 +75,14 @@ const Facets = () =>
         title="Refine by"
         items={[
           <RefinementListWithTitle
+            title="Type"
+            key="Type"
+            item={<RefinementList attributeName="type" operator="or" limitMin={5} searchForFacetValues/>}
+          />,
+          <RefinementListWithTitle
             title="Materials"
             key="Materials"
-            item={<RefinementList attributeName="materials" operator="or" limitMin={10}/>}
+            item={<RefinementList attributeName="materials" operator="or" limitMin={5} searchForFacetValues/>}
           />,
           <RefinementListWithTitle
             title="Color"

--- a/docgen/src/examples/e-commerce/App.js
+++ b/docgen/src/examples/e-commerce/App.js
@@ -77,9 +77,14 @@ const Facets = () =>
         title="Refine by"
         items={[
           <RefinementListWithTitle
+            title="Type"
+            key="Type"
+            item={<RefinementList attributeName="type" operator="or" limitMin={5} searchForFacetValues/>}
+          />,
+          <RefinementListWithTitle
             title="Materials"
             key="Materials"
-            item={<RefinementList attributeName="materials" operator="or" limitMin={10}/>}
+            item={<RefinementList attributeName="materials" operator="or" limitMin={5} searchForFacetValues/>}
           />,
           <RefinementListWithTitle
             title="Color"
@@ -190,8 +195,8 @@ const Hit = ({item}) => {
         <div className="product-picture"><img src={`${item.image}`}/></div>
       </div>
       <div className="product-desc-wrapper">
-        <div className="product-name"><Highlight attributeName="name" hit={item} /></div>
-        <div className="product-type"><Highlight attributeName="type" hit={item} /></div>
+        <div className="product-name"><Highlight attributeName="name" hit={item}/></div>
+        <div className="product-type"><Highlight attributeName="type" hit={item}/></div>
         <div className="ais-StarRating__ratingLink">
           {icons}
           <div className="product-price">${item.price}</div>

--- a/docgen/src/guide/Custom_connectors.md
+++ b/docgen/src/guide/Custom_connectors.md
@@ -12,7 +12,7 @@ If you wish to implement features that are not covered by the default widgets co
 
 Those properties are directly applied to the higher-order component. Providing a `displayName` is mandatory.
 
-## getProvidedProps(props, searchState, searchResults, meta)
+## getProvidedProps(props, searchState, searchResults, meta, searchForFacetValuesResults)
 
 This method should return the props to forward to the composed component.
 
@@ -23,6 +23,8 @@ This method should return the props to forward to the composed component.
 `searchResults` holds the search results, search errors and search loading state, with the shape `{results: ?SearchResults, error: ?Error, loading: bool}`. The `SearchResults` type is described in the [Helper's documentation](https://community.algolia.com/algoliasearch-helper-js/reference.html#searchresults).
 
 `meta` is the list of metadata from all widgets whose connector defines a `getMetadata` method.
+
+`searchForFacetValuesResults` holds the search for facet values results.
 
 ## refine(props, searchState, ...args)
 
@@ -174,6 +176,22 @@ const CoolWidget = createConnector({
 })(Widget);
 ```
 
+## searchForFacetValues(props, searchState, nextRefinement)
+
+This method needs to be implemented if you want to have the ability to perform a search for facet values inside your widget. 
+
+It takes in the current props of the higher-order component, the [search state](guide/Search_state.html) of all widgets, as well as all arguments passed to the `searchForFacetValues` props of stateful widgets, and returns an 
+object of the shape: `{facetName: string, query: string}`
+
+```javascript
+const CoolWidget = createConnector({
+  // displayName, getProvidedProps, refine, getSearchParameters, getMetadata
+
+  searchForFacetValues(props, searchState, nextRefinement) {
+    return {facetName: props.attributeName, query: nextRefinement};
+  },
+})(Widget);
+```
 ## cleanUp(props, searchState)
 
 This method is called when a widget is about to unmount in order to clean the searchState.

--- a/docgen/src/guide/Default_refinements.md
+++ b/docgen/src/guide/Default_refinements.md
@@ -29,13 +29,14 @@ const App = () =>
 ```
 
 **Notes:**
-* The [search state guide](guide/Search_state.html) details all widgets and connectors state values.._* Default refinements are handy when used as [Virtual widgets](guide/Virtual_widgets.html).
+* The [search state guide](guide/Search_state.html) details all widgets and connectors state values...
+* Default refinements are handy when used as [Virtual widgets](guide/Virtual_widgets.html).
 
 <div class="guide-nav">
     <div class="guide-nav-left">
         Previous: <a href="guide/Connectors.html">← Connectors</a>
     </div>
     <div class="guide-nav-right">
-        Next: <a href="guide/Virtual_widgets.html">Virtual Widgets →</a>
+        Next: <a href="guide/Search_for_facet_values.html">Search for facet values →</a>
     </div>
 </div>

--- a/docgen/src/guide/Search_for_facet_values.md
+++ b/docgen/src/guide/Search_for_facet_values.md
@@ -1,0 +1,71 @@
+---
+title: Search for facet values
+mainTitle: Guide
+layout: main.pug
+category: guide
+navWeight: 68
+---
+
+If you use the [`<RefinementList/>`](widgets/RefinementList.html) widget or the [`connectRefinementList`](connectors/connectRefinementList.html)
+connector then the end user can choose multiple values for a specific facet. If a facet has a lot of possible values then you can decide 
+to let the end user search inside them before selecting them. This feature is called search for facet values. 
+
+## with widgets
+
+To activate the search for facet values when using the [`<RefinementList/>`](widgets/RefinementList.html) widget you need to pass the `searchForFacetValues` 
+boolean as a prop.
+
+If activated, the refinement list should display an input to search for facet values.
+
+```javascript
+<RefinementList attributeName="attributeName" searchForFacetValues/>
+```
+
+<a class="btn" href="https://community.algolia.com/instantsearch.js/react/storybook/?selectedKind=RefinementList&selectedStory=with%20search%20for%20facets%20value" target="_blank">View in Storybook</a>
+
+## with connectors
+
+When using the [`connectRefinementList`](connectors/connectRefinementList.html) connector, you have two provided props related to the search
+for facet values behavior:
+
+* `isSearchFrom`, If `true` this boolean indicate that the `items` prop contains the search for facet values results. 
+* `searchForFacetValues`, a function to call when triggering the search for facet values. It takes one parameter, the search 
+for facet values query. 
+
+You will also need to pass the `searchForFacetValues` boolean as a prop.
+
+```javascript
+import {connectRefinementList} from '../packages/react-instantsearch/connectors';
+import {Highlight} from '../packages/react-instantsearch/dom';
+
+const RefinementListWithSFFV = connectRefinementList(props => {
+  const values = props.items.map(item => {
+    const label = item._highlightResult
+      ? <Highlight attributeName="label" hit={item}/>
+      : item.label;
+      
+    return <li key={item.value}>
+      <a onClick={() => props.refine(item.value)}>
+        {label} {item.isRefined ? '- selected' : ''}
+      </a>
+    </li>;
+  });
+  return (
+    <div>
+      <input type="search" onChange={e => props.searchForFacetValues(e.target.value)}/>
+      <ul>{values}</ul>
+    </div>
+  );
+});
+
+<RefinementListWithSFFV attributeName="attributeName" searchForFacetValues/>
+```
+
+<div class="guide-nav">
+    <div class="guide-nav-left">
+        Previous: <a href="guide/Default_refinements.html">← Default refinements</a>
+    </div>
+    <div class="guide-nav-right">
+        Next: <a href="guide/Virtual_widgets.html">Virtual widgets →</a>
+    </div>
+</div>

--- a/docgen/src/guide/Search_for_facet_values.md
+++ b/docgen/src/guide/Search_for_facet_values.md
@@ -28,7 +28,7 @@ If activated, the refinement list should display an input to search for facet va
 When using the [`connectRefinementList`](connectors/connectRefinementList.html) connector, you have two provided props related to the search
 for facet values behavior:
 
-* `isSearchFrom`, If `true` this boolean indicate that the `items` prop contains the search for facet values results. 
+* `isFromSearch`, If `true` this boolean indicate that the `items` prop contains the search for facet values results. 
 * `searchForFacetValues`, a function to call when triggering the search for facet values. It takes one parameter, the search 
 for facet values query. 
 

--- a/docgen/src/guide/Virtual_widgets.md
+++ b/docgen/src/guide/Virtual_widgets.md
@@ -36,7 +36,7 @@ const App = () =>
 
 <div class="guide-nav">
     <div class="guide-nav-left">
-        Previous: <a href="guide/Default_refinements.html">← Default Refinements</a>
+        Previous: <a href="guide/Search_for_facet_values.html">← Search for facet values</a>
     </div>
     <div class="guide-nav-right">
         Next: <a href="guide/Routing.html">Routing →</a>

--- a/packages/react-instantsearch-theme-algolia/styles/_RefinementList.scss
+++ b/packages/react-instantsearch-theme-algolia/styles/_RefinementList.scss
@@ -65,3 +65,16 @@
 
 .ais-RefinementList__itemCheckboxSelected{
 }
+
+.ais-RefinementList__SearchBox input.ais-SearchBox__input[type="search"]{
+  @extends input.ais-SearchBox__input[type="search"];
+  background: url("data:image/svg+xml;utf8,<svg viewBox=\'0 0 18 18\' xmlns=\'http://www.w3.org/2000/svg\'><path d=\'M12.5 11h-.79l-.28-.27C12.41 9.59 13 8.11 13 6.5 13 2.91 10.09 0 6.5 0S0 2.91 0 6.5 2.91 13 6.5 13c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L17.49 16l-4.99-5zm-6 0C4.01 11 2 8.99 2 6.5S4.01 2 6.5 2 11 4.01 11 6.5 8.99 11 6.5 11z\' fill=\'%23BFC7D8\' fill-rule=\'evenodd\'/></svg>")no-repeat center left 5px / 18px;
+  padding: 5px 44px;
+  margin-bottom: 5px;
+}
+
+.ais-RefinementList__SearchBox .ais-SearchBox__reset {
+  @extends .ais-SearchBox__reset;
+  top: 0.3em;
+  right: 0.55em;
+}

--- a/packages/react-instantsearch-theme-algolia/styles/_SearchBox.scss
+++ b/packages/react-instantsearch-theme-algolia/styles/_SearchBox.scss
@@ -1,6 +1,4 @@
 .ais-SearchBox__root {
-  width: 300px;
-
   * {
     // outline: 1px solid rgba(red, 0.3)
   }

--- a/packages/react-instantsearch/src/components/RefinementList.js
+++ b/packages/react-instantsearch/src/components/RefinementList.js
@@ -3,13 +3,20 @@ import {pick} from 'lodash';
 import translatable from '../core/translatable';
 import List from './List';
 import classNames from './classNames.js';
-
+import Highlight from '../widgets/Highlight';
+import SearchBox from '../components/SearchBox';
 const cx = classNames('RefinementList');
 
 class RefinementList extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {query: ''};
+  }
+
   static propTypes = {
     translate: PropTypes.func.isRequired,
     refine: PropTypes.func.isRequired,
+    searchForFacetValues: PropTypes.func,
     createURL: PropTypes.func.isRequired,
     items: PropTypes.arrayOf(PropTypes.shape({
       label: PropTypes.string.isRequired,
@@ -17,33 +24,43 @@ class RefinementList extends Component {
       count: PropTypes.number.isRequired,
       isRefined: PropTypes.bool.isRequired,
     })),
+    isFromSearch: PropTypes.bool.isRequired,
     showMore: PropTypes.bool,
     limitMin: PropTypes.number,
     limitMax: PropTypes.number,
   };
 
-  renderItem = item =>
+  selectItem = item => {
+    this.props.refine(item.value);
+  };
+
+  renderItem = item => {
+    const label = item._highlightResult
+      ? <Highlight attributeName="label" hit={item}/>
+      : item.label;
+
+    return (
       <label>
         <input
           {...cx('itemCheckbox', item.isRefined && 'itemCheckboxSelected')}
           type="checkbox"
           checked={item.isRefined}
-          onChange={() => this.props.refine(item.value)}
+          onChange={() => this.selectItem(item)}
         />
         <span {...cx('itemBox', 'itemBox', item.isRefined && 'itemBoxSelected')}></span>
         <span {...cx('itemLabel', 'itemLabel', item.isRefined && 'itemLabelSelected')}>
-          {item.label}
+          {label}
         </span>
         {' '}
         <span {...cx('itemCount', item.isRefined && 'itemCountSelected')}>
           {item.count}
         </span>
-      </label>
-    ;
+      </label>);
+  };
 
   render() {
-    return (
-      <List
+    const facets = this.props.items.length > 0
+      ? <List
         renderItem={this.renderItem}
         cx={cx}
         {...pick(this.props, [
@@ -54,10 +71,38 @@ class RefinementList extends Component {
           'limitMax',
         ])}
       />
+      : <div>{this.props.translate('noResults')}</div>;
+
+    const searchBox = this.props.searchForFacetValues ?
+      <div {...cx('SearchBox')}>
+        <SearchBox
+          currentRefinement={this.props.isFromSearch ? this.state.query : ''}
+          refine={value => {
+            this.setState({query: value});
+            this.props.searchForFacetValues(value);
+          }}
+          translate={this.props.translate}
+          onSubmit={e => {
+            e.preventDefault();
+            e.stopPropagation();
+            if (this.props.isFromSearch) {
+              this.selectItem(this.props.items[0]);
+            }
+          }}
+        />
+      </div> : null;
+
+    return (
+      <div>
+        {searchBox}
+        {facets}
+      </div>
     );
   }
 }
 
 export default translatable({
   showMore: extended => extended ? 'Show less' : 'Show more',
+  noResults: 'No Results',
 })(RefinementList);
+

--- a/packages/react-instantsearch/src/components/RefinementList.test.js
+++ b/packages/react-instantsearch/src/components/RefinementList.test.js
@@ -6,6 +6,8 @@ import {mount} from 'enzyme';
 
 import RefinementList from './RefinementList';
 
+jest.mock('../widgets/Highlight');
+
 describe('RefinementList', () => {
   it('default refinement list', () => {
     const tree = renderer.create(
@@ -20,6 +22,24 @@ describe('RefinementList', () => {
         limitMin={2}
         limitMax={4}
         showMore={true}
+        isFromSearch={false}
+      />
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('refinement list with search for facet values', () => {
+    const tree = renderer.create(
+      <RefinementList
+        refine={() => null}
+        searchForFacetValues={() => null}
+        createURL={() => '#'}
+        items={[
+          {label: 'white', value: ['white'], count: 10, isRefined: true},
+          {label: 'black', value: ['black'], count: 20, isRefined: false},
+          {label: 'blue', value: ['blue'], count: 30, isRefined: false},
+        ]}
+        isFromSearch={false}
       />
     ).toJSON();
     expect(tree).toMatchSnapshot();
@@ -29,14 +49,17 @@ describe('RefinementList', () => {
     const tree = renderer.create(
       <RefinementList
         refine={() => null}
+        searchForFacetValues={() => null}
         createURL={() => '#'}
         items={[
           {label: 'white', value: ['white'], count: 10, isRefined: false},
           {label: 'black', value: ['black'], count: 20, isRefined: false},
           {label: 'blue', value: ['blue'], count: 30, isRefined: false},
         ]}
+        isFromSearch={true}
         translations={{
           showMore: ' display more',
+          noResults: ' no results',
         }}
       />
     ).toJSON();
@@ -46,16 +69,18 @@ describe('RefinementList', () => {
   it('refines its value on change', () => {
     const refine = jest.fn();
     const wrapper = mount(
-        <RefinementList
-          refine={refine}
-          createURL={() => '#'}
-          items={[
-            {label: 'white', value: ['white'], count: 10, isRefined: false},
-            {label: 'black', value: ['black'], count: 20, isRefined: false},
-            {label: 'blue', value: ['blue'], count: 30, isRefined: false},
-          ]}
-        />
-      );
+      <RefinementList
+        refine={refine}
+        searchForFacetValues={() => null}
+        createURL={() => '#'}
+        items={[
+          {label: 'white', value: ['white'], count: 10, isRefined: false},
+          {label: 'black', value: ['black'], count: 20, isRefined: false},
+          {label: 'blue', value: ['blue'], count: 30, isRefined: false},
+        ]}
+        isFromSearch={false}
+      />
+    );
 
     const items = wrapper.find('.ais-RefinementList__item');
 
@@ -74,21 +99,23 @@ describe('RefinementList', () => {
   it('should respect defined limits', () => {
     const refine = jest.fn();
     const wrapper = mount(
-        <RefinementList
-          refine={refine}
-          createURL={() => '#'}
-          items={[
-            {label: 'white', value: ['white'], count: 10, isRefined: false},
-            {label: 'black', value: ['black'], count: 20, isRefined: false},
-            {label: 'blue', value: ['blue'], count: 30, isRefined: false},
-            {label: 'red', value: ['red'], count: 30, isRefined: false},
-            {label: 'green', value: ['green'], count: 30, isRefined: false},
-          ]}
-          limitMin={2}
-          limitMax={4}
-          showMore={true}
-        />
-      );
+      <RefinementList
+        refine={refine}
+        searchForFacetValues={() => null}
+        createURL={() => '#'}
+        items={[
+          {label: 'white', value: ['white'], count: 10, isRefined: false},
+          {label: 'black', value: ['black'], count: 20, isRefined: false},
+          {label: 'blue', value: ['blue'], count: 30, isRefined: false},
+          {label: 'red', value: ['red'], count: 30, isRefined: false},
+          {label: 'green', value: ['green'], count: 30, isRefined: false},
+        ]}
+        limitMin={2}
+        limitMax={4}
+        showMore={true}
+        isFromSearch={false}
+      />
+    );
 
     const items = wrapper.find('.ais-RefinementList__item');
 
@@ -104,18 +131,20 @@ describe('RefinementList', () => {
   it('should disabled show more when no more item to display', () => {
     const refine = jest.fn();
     const wrapper = mount(
-        <RefinementList
-          refine={refine}
-          createURL={() => '#'}
-          items={[
-            {label: 'white', value: ['white'], count: 10, isRefined: false},
-            {label: 'black', value: ['black'], count: 20, isRefined: false},
-          ]}
-          limitMin={2}
-          limitMax={4}
-          showMore={true}
-        />
-      );
+      <RefinementList
+        refine={refine}
+        searchForFacetValues={() => null}
+        createURL={() => '#'}
+        items={[
+          {label: 'white', value: ['white'], count: 10, isRefined: false},
+          {label: 'black', value: ['black'], count: 20, isRefined: false},
+        ]}
+        limitMin={2}
+        limitMax={4}
+        showMore={true}
+        isFromSearch={false}
+      />
+    );
 
     const items = wrapper.find('.ais-RefinementList__item');
 
@@ -124,5 +153,77 @@ describe('RefinementList', () => {
     expect(wrapper.find('.ais-RefinementList__showMoreDisabled')).toBeDefined();
 
     wrapper.unmount();
+  });
+
+  describe('search for facets value', () => {
+    const refine = jest.fn();
+    const searchForFacetValues = jest.fn();
+    const refinementList = <RefinementList
+      refine={refine}
+      searchForFacetValues={searchForFacetValues}
+      createURL={() => '#'}
+      items={[
+        {
+          label: 'white', value: ['white'], count: 10, isRefined: false, _highlightResult: {label: {value: 'white'}},
+        },
+        {
+          label: 'black', value: ['black'], count: 20, isRefined: false, _highlightResult: {label: {value: 'black'}},
+        },
+      ]}
+      isFromSearch={true}
+    />;
+
+    it('a searchbox should be displayed if the feature is activated', () => {
+      const wrapper = mount(refinementList);
+
+      const searchBox = wrapper.find('.ais-RefinementList__SearchBox');
+
+      expect(searchBox).toBeDefined();
+
+      wrapper.unmount();
+    });
+
+    it('searching for a value should call searchForFacetValues', () => {
+      const wrapper = mount(refinementList);
+
+      wrapper.find('.ais-RefinementList__SearchBox input').simulate('change', {target: {value: 'query'}});
+
+      expect(searchForFacetValues.mock.calls.length).toBe(1);
+      expect(searchForFacetValues.mock.calls[0][0]).toBe('query');
+
+      wrapper.unmount();
+    });
+
+    it('should refine the selected value and display selected refinement back', () => {
+      const wrapper = mount(refinementList);
+
+      const firstItem = wrapper.find('.ais-RefinementList__item').first().find('.ais-RefinementList__itemCheckbox');
+      firstItem.simulate('change', {target: {checked: true}});
+
+      expect(refine.mock.calls.length).toBe(1);
+      expect(refine.mock.calls[0][0]).toEqual(['white']);
+      expect(wrapper.find('.ais-RefinementList__SearchBox input').props().value).toBe('');
+
+      const selectedRefinements = wrapper.find('.ais-RefinementList__item');
+      expect(selectedRefinements.length).toBe(2);
+
+      wrapper.unmount();
+    });
+
+    it('hit enter on the search values results list should refine the first facet value', () => {
+      refine.mockClear();
+      const wrapper = mount(refinementList);
+
+      wrapper.find('form').simulate('submit');
+
+      expect(refine.mock.calls.length).toBe(1);
+      expect(refine.mock.calls[0][0]).toEqual(['white']);
+      expect(wrapper.find('.ais-RefinementList__SearchBox input').props().value).toBe('');
+
+      const selectedRefinements = wrapper.find('.ais-RefinementList__item');
+      expect(selectedRefinements.length).toBe(2);
+
+      wrapper.unmount();
+    });
   });
 });

--- a/packages/react-instantsearch/src/components/SearchBox.js
+++ b/packages/react-instantsearch/src/components/SearchBox.js
@@ -27,6 +27,7 @@ class SearchBox extends Component {
     autoFocus: PropTypes.bool,
 
     searchAsYouType: PropTypes.bool,
+    onSubmit: PropTypes.func,
 
     // For testing purposes
     __inputRef: PropTypes.func,
@@ -156,7 +157,7 @@ class SearchBox extends Component {
     return (
       <form
         noValidate
-        onSubmit={this.onSubmit}
+        onSubmit={this.props.onSubmit ? this.props.onSubmit : this.onSubmit}
         onReset={this.onReset}
         {...cx('root')}
       >

--- a/packages/react-instantsearch/src/components/SearchBox.test.js
+++ b/packages/react-instantsearch/src/components/SearchBox.test.js
@@ -103,6 +103,22 @@ describe('SearchBox', () => {
     wrapper.unmount();
   });
 
+  it('onSubmit behavior should be override if provided as props', () => {
+    const onSubmit = jest.fn();
+    const refine = jest.fn();
+    const wrapper = mount(
+      <SearchBox
+        searchAsYouType={false}
+        onSubmit={onSubmit}
+        refine={refine}
+      />
+    );
+    wrapper.find('form').simulate('submit');
+    expect(onSubmit.mock.calls.length).toBe(1);
+    expect(refine.mock.calls.length).toBe(0);
+    wrapper.unmount();
+  });
+
   it('focuses the input when one of the keys in focusShortcuts is pressed', () => {
     let input;
     mount(

--- a/packages/react-instantsearch/src/components/__snapshots__/RefinementList.test.js.snap
+++ b/packages/react-instantsearch/src/components/__snapshots__/RefinementList.test.js.snap
@@ -1,128 +1,280 @@
 exports[`RefinementList applies translations 1`] = `
-<div
-  className="ais-RefinementList__root">
+<div>
   <div
-    className="ais-RefinementList__items">
-    <div
-      className="ais-RefinementList__item">
-      <label>
+    className="ais-RefinementList__SearchBox">
+    <form
+      className="ais-SearchBox__root"
+      noValidate={true}
+      onReset={[Function]}
+      onSubmit={[Function]}>
+      <div
+        className="ais-SearchBox__wrapper"
+        role="search">
         <input
-          checked={false}
-          className="ais-RefinementList__itemCheckbox"
+          autoComplete="off"
+          autoFocus={false}
+          className="ais-SearchBox__input"
           onChange={[Function]}
-          type="checkbox" />
-        <span
-          className="ais-RefinementList__itemBox ais-RefinementList__itemBox" />
-        <span
-          className="ais-RefinementList__itemLabel ais-RefinementList__itemLabel">
-          white
-        </span>
-         
-        <span
-          className="ais-RefinementList__itemCount">
-          10
-        </span>
-      </label>
-    </div>
+          placeholder="Search here…"
+          required={true}
+          type="search"
+          value="" />
+        <button
+          className="ais-SearchBox__reset"
+          title="Clear the search query."
+          type="reset">
+          <svg
+            viewBox="0 0 26 26"
+            xmlns="http://www.w3.org/2000/svg">
+            <g
+              fill="none"
+              fillRule="evenodd">
+              <path
+                d="M12.99883 9.92647L22.22236.70294c.85882-.85647 2.2306-.84706 3.08235 0 .8518.85412.8471 2.22588 0 3.0753l-9.2329 9.22353 9.22353 9.22353c.85648.85882.84707 2.23058 0 3.08235-.8541.85176-2.22587.84706-3.0753 0l-9.22116-9.23294-9.22353 9.22357c-.85646.85647-2.22823.84706-3.07764 0-.85413-.85412-.84707-2.2259 0-3.0753l9.22823-9.22117L.70235 3.77823C-.1541 2.92177-.1541 1.55.69295.69588c.85647-.85176 2.22823-.84706 3.07764 0l9.2282 9.2353v-.0047z" />
+            </g>
+          </svg>
+        </button>
+      </div>
+    </form>
+  </div>
+  <div
+    className="ais-RefinementList__root">
     <div
-      className="ais-RefinementList__item">
-      <label>
-        <input
-          checked={false}
-          className="ais-RefinementList__itemCheckbox"
-          onChange={[Function]}
-          type="checkbox" />
-        <span
-          className="ais-RefinementList__itemBox ais-RefinementList__itemBox" />
-        <span
-          className="ais-RefinementList__itemLabel ais-RefinementList__itemLabel">
-          black
-        </span>
-         
-        <span
-          className="ais-RefinementList__itemCount">
-          20
-        </span>
-      </label>
-    </div>
-    <div
-      className="ais-RefinementList__item">
-      <label>
-        <input
-          checked={false}
-          className="ais-RefinementList__itemCheckbox"
-          onChange={[Function]}
-          type="checkbox" />
-        <span
-          className="ais-RefinementList__itemBox ais-RefinementList__itemBox" />
-        <span
-          className="ais-RefinementList__itemLabel ais-RefinementList__itemLabel">
-          blue
-        </span>
-         
-        <span
-          className="ais-RefinementList__itemCount">
-          30
-        </span>
-      </label>
+      className="ais-RefinementList__items">
+      <div
+        className="ais-RefinementList__item">
+        <label>
+          <input
+            checked={false}
+            className="ais-RefinementList__itemCheckbox"
+            onChange={[Function]}
+            type="checkbox" />
+          <span
+            className="ais-RefinementList__itemBox ais-RefinementList__itemBox" />
+          <span
+            className="ais-RefinementList__itemLabel ais-RefinementList__itemLabel">
+            white
+          </span>
+           
+          <span
+            className="ais-RefinementList__itemCount">
+            10
+          </span>
+        </label>
+      </div>
+      <div
+        className="ais-RefinementList__item">
+        <label>
+          <input
+            checked={false}
+            className="ais-RefinementList__itemCheckbox"
+            onChange={[Function]}
+            type="checkbox" />
+          <span
+            className="ais-RefinementList__itemBox ais-RefinementList__itemBox" />
+          <span
+            className="ais-RefinementList__itemLabel ais-RefinementList__itemLabel">
+            black
+          </span>
+           
+          <span
+            className="ais-RefinementList__itemCount">
+            20
+          </span>
+        </label>
+      </div>
+      <div
+        className="ais-RefinementList__item">
+        <label>
+          <input
+            checked={false}
+            className="ais-RefinementList__itemCheckbox"
+            onChange={[Function]}
+            type="checkbox" />
+          <span
+            className="ais-RefinementList__itemBox ais-RefinementList__itemBox" />
+          <span
+            className="ais-RefinementList__itemLabel ais-RefinementList__itemLabel">
+            blue
+          </span>
+           
+          <span
+            className="ais-RefinementList__itemCount">
+            30
+          </span>
+        </label>
+      </div>
     </div>
   </div>
 </div>
 `;
 
 exports[`RefinementList default refinement list 1`] = `
-<div
-  className="ais-RefinementList__root">
+<div>
   <div
-    className="ais-RefinementList__items">
+    className="ais-RefinementList__root">
     <div
-      className="ais-RefinementList__item ais-RefinementList__itemSelected">
-      <label>
-        <input
-          checked={true}
-          className="ais-RefinementList__itemCheckbox ais-RefinementList__itemCheckboxSelected"
-          onChange={[Function]}
-          type="checkbox" />
-        <span
-          className="ais-RefinementList__itemBox ais-RefinementList__itemBox ais-RefinementList__itemBoxSelected" />
-        <span
-          className="ais-RefinementList__itemLabel ais-RefinementList__itemLabel ais-RefinementList__itemLabelSelected">
-          white
-        </span>
-         
-        <span
-          className="ais-RefinementList__itemCount ais-RefinementList__itemCountSelected">
-          10
-        </span>
-      </label>
+      className="ais-RefinementList__items">
+      <div
+        className="ais-RefinementList__item ais-RefinementList__itemSelected">
+        <label>
+          <input
+            checked={true}
+            className="ais-RefinementList__itemCheckbox ais-RefinementList__itemCheckboxSelected"
+            onChange={[Function]}
+            type="checkbox" />
+          <span
+            className="ais-RefinementList__itemBox ais-RefinementList__itemBox ais-RefinementList__itemBoxSelected" />
+          <span
+            className="ais-RefinementList__itemLabel ais-RefinementList__itemLabel ais-RefinementList__itemLabelSelected">
+            white
+          </span>
+           
+          <span
+            className="ais-RefinementList__itemCount ais-RefinementList__itemCountSelected">
+            10
+          </span>
+        </label>
+      </div>
+      <div
+        className="ais-RefinementList__item">
+        <label>
+          <input
+            checked={false}
+            className="ais-RefinementList__itemCheckbox"
+            onChange={[Function]}
+            type="checkbox" />
+          <span
+            className="ais-RefinementList__itemBox ais-RefinementList__itemBox" />
+          <span
+            className="ais-RefinementList__itemLabel ais-RefinementList__itemLabel">
+            black
+          </span>
+           
+          <span
+            className="ais-RefinementList__itemCount">
+            20
+          </span>
+        </label>
+      </div>
     </div>
-    <div
-      className="ais-RefinementList__item">
-      <label>
+    <button
+      className="ais-RefinementList__showMore"
+      disabled={false}
+      onClick={[Function]}>
+      Show more
+    </button>
+  </div>
+</div>
+`;
+
+exports[`RefinementList refinement list with search for facet values 1`] = `
+<div>
+  <div
+    className="ais-RefinementList__SearchBox">
+    <form
+      className="ais-SearchBox__root"
+      noValidate={true}
+      onReset={[Function]}
+      onSubmit={[Function]}>
+      <div
+        className="ais-SearchBox__wrapper"
+        role="search">
         <input
-          checked={false}
-          className="ais-RefinementList__itemCheckbox"
+          autoComplete="off"
+          autoFocus={false}
+          className="ais-SearchBox__input"
           onChange={[Function]}
-          type="checkbox" />
-        <span
-          className="ais-RefinementList__itemBox ais-RefinementList__itemBox" />
-        <span
-          className="ais-RefinementList__itemLabel ais-RefinementList__itemLabel">
-          black
-        </span>
-         
-        <span
-          className="ais-RefinementList__itemCount">
-          20
-        </span>
-      </label>
+          placeholder="Search here…"
+          required={true}
+          type="search"
+          value="" />
+        <button
+          className="ais-SearchBox__reset"
+          title="Clear the search query."
+          type="reset">
+          <svg
+            viewBox="0 0 26 26"
+            xmlns="http://www.w3.org/2000/svg">
+            <g
+              fill="none"
+              fillRule="evenodd">
+              <path
+                d="M12.99883 9.92647L22.22236.70294c.85882-.85647 2.2306-.84706 3.08235 0 .8518.85412.8471 2.22588 0 3.0753l-9.2329 9.22353 9.22353 9.22353c.85648.85882.84707 2.23058 0 3.08235-.8541.85176-2.22587.84706-3.0753 0l-9.22116-9.23294-9.22353 9.22357c-.85646.85647-2.22823.84706-3.07764 0-.85413-.85412-.84707-2.2259 0-3.0753l9.22823-9.22117L.70235 3.77823C-.1541 2.92177-.1541 1.55.69295.69588c.85647-.85176 2.22823-.84706 3.07764 0l9.2282 9.2353v-.0047z" />
+            </g>
+          </svg>
+        </button>
+      </div>
+    </form>
+  </div>
+  <div
+    className="ais-RefinementList__root">
+    <div
+      className="ais-RefinementList__items">
+      <div
+        className="ais-RefinementList__item ais-RefinementList__itemSelected">
+        <label>
+          <input
+            checked={true}
+            className="ais-RefinementList__itemCheckbox ais-RefinementList__itemCheckboxSelected"
+            onChange={[Function]}
+            type="checkbox" />
+          <span
+            className="ais-RefinementList__itemBox ais-RefinementList__itemBox ais-RefinementList__itemBoxSelected" />
+          <span
+            className="ais-RefinementList__itemLabel ais-RefinementList__itemLabel ais-RefinementList__itemLabelSelected">
+            white
+          </span>
+           
+          <span
+            className="ais-RefinementList__itemCount ais-RefinementList__itemCountSelected">
+            10
+          </span>
+        </label>
+      </div>
+      <div
+        className="ais-RefinementList__item">
+        <label>
+          <input
+            checked={false}
+            className="ais-RefinementList__itemCheckbox"
+            onChange={[Function]}
+            type="checkbox" />
+          <span
+            className="ais-RefinementList__itemBox ais-RefinementList__itemBox" />
+          <span
+            className="ais-RefinementList__itemLabel ais-RefinementList__itemLabel">
+            black
+          </span>
+           
+          <span
+            className="ais-RefinementList__itemCount">
+            20
+          </span>
+        </label>
+      </div>
+      <div
+        className="ais-RefinementList__item">
+        <label>
+          <input
+            checked={false}
+            className="ais-RefinementList__itemCheckbox"
+            onChange={[Function]}
+            type="checkbox" />
+          <span
+            className="ais-RefinementList__itemBox ais-RefinementList__itemBox" />
+          <span
+            className="ais-RefinementList__itemLabel ais-RefinementList__itemLabel">
+            blue
+          </span>
+           
+          <span
+            className="ais-RefinementList__itemCount">
+            30
+          </span>
+        </label>
+      </div>
     </div>
   </div>
-  <button
-    className="ais-RefinementList__showMore"
-    disabled={false}
-    onClick={[Function]}>
-    Show more
-  </button>
 </div>
 `;

--- a/packages/react-instantsearch/src/connectors/connectRefinementList.js
+++ b/packages/react-instantsearch/src/connectors/connectRefinementList.js
@@ -56,7 +56,7 @@ function getValue(name, props, searchState) {
  * @providedPropType {function} searchForFacetValues - a function to toggle a search for facet values
  * @providedPropType {string[]} currentRefinement - the refinement currently applied
  * @providedPropType {array.<{count: number, isRefined: boolean, label: string, value: string}>} items - the list of items the RefinementList can display.
- * @providedPropType {boolean} isSearchFrom - a boolean that says if the `items` props contains facet values from the global search or from the search for facet values results.
+ * @providedPropType {boolean} isFromSearch - a boolean that says if the `items` props contains facet values from the global search or from the search for facet values results.
  */
 
 const sortBy = ['isRefined', 'count:desc', 'name:asc'];

--- a/packages/react-instantsearch/src/core/InstantSearch.js
+++ b/packages/react-instantsearch/src/core/InstantSearch.js
@@ -23,14 +23,7 @@ function validateNextProps(props, nextProps) {
  * @propType {string} appId - The Algolia application id.
  * @propType {string} apiKey - Your Algolia Search-Only API key.
  * @propType {string} indexName - The index in which to search.
- * @propType {object} [searchParameters] - Object containing query parameters to be sent to Algolia.
- * It will be overriden by the search parameters resolved via the widgets.
- *
- * Typical use case: setting the distinct setting is done by providing an object like: `{distinct: 1}`.
- * For more information about the kind of object that can be provided on the
- * [official API documentation](https://www.algolia.com/doc/rest-api/search#full-text-search-parameters).
- *
- * Read the [search parameters guide](guide/Search_parameters.html).
+ * @propType {object} [searchParameters] - Object containing query parameters to be sent to Algolia. It will be overriden by the search parameters resolved via the widgets. Typical use case: setting the distinct setting is done by providing an object like: `{distinct: 1}`. For more information about the kind of object that can be provided on the [official API documentation](https://www.algolia.com/doc/rest-api/search#full-text-search-parameters). Read the [search parameters guide](guide/Search_parameters.html).
  * @propType {func} onSearchStateChange - See [URL Routing](guide/Routing.html).
  * @propType {object} searchState - See [URL Routing](guide/Routing.html).
  * @propType {func} createURL - See [URL Routing](guide/Routing.html).
@@ -81,6 +74,7 @@ class InstantSearch extends Component {
         ais: {
           onInternalStateUpdate: this.onWidgetsInternalStateUpdate.bind(this),
           createHrefForState: this.createHrefForState.bind(this),
+          onSearchForFacetValues: this.onSearchForFacetValues.bind(this),
         },
       };
     }
@@ -109,6 +103,10 @@ class InstantSearch extends Component {
     if (!this.isControlled) {
       this.aisManager.onExternalStateUpdate(searchState);
     }
+  }
+
+  onSearchForFacetValues(searchState) {
+    this.aisManager.onSearchForFacetValues(searchState);
   }
 
   getKnownKeys() {

--- a/packages/react-instantsearch/src/core/InstantSearch.test.js
+++ b/packages/react-instantsearch/src/core/InstantSearch.test.js
@@ -231,5 +231,22 @@ describe('InstantSearch', () => {
       const outputURL = createHrefForState({a: 1});
       expect(outputURL).toBe('#');
     });
+
+    it('search for facet values should be called if triggered', () => {
+      const ism = {
+        onSearchForFacetValues: jest.fn(),
+      };
+      createInstantSearchManager.mockImplementation(() => ism);
+      const wrapper = mount(
+          <InstantSearch
+            {...DEFAULT_PROPS}
+          >
+            <div />
+          </InstantSearch>
+        );
+      const {ais: {onSearchForFacetValues}} = wrapper.instance().getChildContext();
+      onSearchForFacetValues({a: 1});
+      expect(ism.onSearchForFacetValues.mock.calls[0][0]).toEqual({a: 1});
+    });
   });
 });

--- a/packages/react-instantsearch/src/core/createConnector.js
+++ b/packages/react-instantsearch/src/core/createConnector.js
@@ -36,6 +36,7 @@ export default function createConnector(connectorDesc) {
   }
 
   const hasRefine = has(connectorDesc, 'refine');
+  const hasSearchForFacetValues = has(connectorDesc, 'searchForFacetValues');
   const hasSearchParameters = has(connectorDesc, 'getSearchParameters');
   const hasMetadata = has(connectorDesc, 'getMetadata');
   const hasTransitionState = has(connectorDesc, 'transitionState');
@@ -143,14 +144,25 @@ export default function createConnector(connectorDesc) {
         error,
         widgets,
         metadata,
+        resultsFacetValues,
       } = store.getState();
       const searchState = {results, searching, error};
-      return connectorDesc.getProvidedProps.call(this, props, widgets, searchState, metadata);
+      return connectorDesc.getProvidedProps.call(this, props, widgets, searchState, metadata, resultsFacetValues);
     };
 
     refine = (...args) => {
       this.context.ais.onInternalStateUpdate(
         connectorDesc.refine(
+          this.props,
+          this.context.ais.store.getState().widgets,
+          ...args
+        )
+      );
+    };
+
+    searchForFacetValues = (...args) => {
+      this.context.ais.onSearchForFacetValues(
+        connectorDesc.searchForFacetValues(
           this.props,
           this.context.ais.store.getState().widgets,
           ...args
@@ -177,8 +189,13 @@ export default function createConnector(connectorDesc) {
       const refineProps = hasRefine ?
         {refine: this.refine, createURL: this.createURL} :
         {};
+      const searchForFacetValuesProps = hasSearchForFacetValues ?
+        {searchForFacetValues: this.searchForFacetValues} :
+        {};
+
       return (
         <Composed
+          {...searchForFacetValuesProps}
           {...this.props}
           {...this.state.props}
           {...refineProps}

--- a/packages/react-instantsearch/src/core/createConnector.test.js
+++ b/packages/react-instantsearch/src/core/createConnector.test.js
@@ -419,4 +419,41 @@ describe('createConnector', () => {
       expect(createHrefForState.mock.calls[0][0]).toBe(nextState);
     });
   });
+
+  describe('searchForFacetValues', () => {
+    it('passes a searchForFacetValues method to the component', () => {
+      const Dummy = () => null;
+      const searchState = {};
+      const widgets = {};
+      const searchForFacetValues = jest.fn(() => searchState);
+      const Connected = createConnector({
+        displayName: 'CoolConnector',
+        getProvidedProps: () => ({}),
+        searchForFacetValues,
+        getId,
+      })(Dummy);
+      const onSearchForFacetValues = jest.fn();
+      const props = {hello: 'there'};
+      const wrapper = mount(<Connected {...props} />, {context: {
+        ais: {
+          store: {
+            getState: () => ({
+              widgets,
+            }),
+            subscribe: () => null,
+          },
+          onSearchForFacetValues,
+        },
+      }});
+      const passedProps = wrapper.find(Dummy).props();
+      const facetName = 'facetName';
+      const query = 'query';
+      passedProps.searchForFacetValues(facetName, query);
+      expect(searchForFacetValues.mock.calls[0][0]).toEqual(props);
+      expect(searchForFacetValues.mock.calls[0][1]).toBe(widgets);
+      expect(searchForFacetValues.mock.calls[0][2]).toBe(facetName);
+      expect(searchForFacetValues.mock.calls[0][3]).toBe(query);
+      expect(onSearchForFacetValues.mock.calls[0][0]).toBe(searchState);
+    });
+  });
 });

--- a/packages/react-instantsearch/src/core/createInstantSearchManager.result.test.js
+++ b/packages/react-instantsearch/src/core/createInstantSearchManager.result.test.js
@@ -13,6 +13,7 @@ jest.mock('algoliasearch-helper/src/algoliasearch.helper.js', () => {
   Helper.prototype._handleResponse = function(state) {
     this.emit('result', {count: count++}, state);
   };
+  Helper.prototype.searchForFacetValues = () => Promise.resolve({facetHits: 'results'});
   return Helper;
 });
 
@@ -83,6 +84,28 @@ describe('createInstantSearchManager', () => {
         const store = ism.store.getState();
         expect(store.results).toEqual({count: 2});
         expect(store.error).toBe(null);
+      });
+    });
+    describe('on search for facet values', () => {
+      it.only('updates the store and searches', () => {
+        const ism = createInstantSearchManager({
+          indexName: 'index',
+          initialState: {},
+          searchParameters: {},
+          algoliaClient: client,
+        });
+
+        ism.onSearchForFacetValues({facetName: 'facetName', query: 'query'});
+
+        expect(ism.store.getState().results).toBe(null);
+
+        jest.runAllTimers();
+
+        return Promise.resolve().then(() => {
+          const store = ism.store.getState();
+          expect(store.resultsFacetValues).toEqual({facetName: 'results'});
+          expect(store.searchingForFacetValues).toBe(false);
+        });
       });
     });
   });

--- a/packages/react-instantsearch/src/widgets/RefinementList.js
+++ b/packages/react-instantsearch/src/widgets/RefinementList.js
@@ -8,12 +8,12 @@ import RefinementListComponent from '../components/RefinementList.js';
  * @propType {string} attributeName - the name of the attribute in the record
  * @propType {string} [operator=or] - How to apply the refinements. Possible values: 'or' or 'and'.
  * @propType {boolean} [showMore=false] - true if the component should display a button that will expand the number of items
- * @propType {number} [limitMin=10] - the minimum number of diplayed items
- * @propType {number} [limitMax=20] - the maximun number of displayed items. Only used when showMore is set to `true`
+ * @propType {number} [limitMin=10] - the minimum number of displayed items
+ * @propType {number} [limitMax=20] - the maximum number of displayed items. Only used when showMore is set to `true`
  * @propType {string[]} defaultRefinement - the values of the items selected by default
+ * @propType {boolean} [searchForFacetValues=false] - true if the component should display an input to search for facet values
  * @themeKey ais-RefinementList__root - the root of the component
  * @themeKey ais-RefinementList__items - the container of all items in the list
- * @themeKey ais-RefinementList__item - a single item
  * @themeKey ais-RefinementList__itemSelected - the selected list item
  * @themeKey ais-RefinementList__itemCheckbox - the item checkbox
  * @themeKey ais-RefinementList__itemCheckboxSelected - the selected item checkbox
@@ -22,6 +22,7 @@ import RefinementListComponent from '../components/RefinementList.js';
  * @themeKey RefinementList__itemCount - the item count
  * @themeKey RefinementList__itemCountSelected - the selected item count
  * @themeKey ais-RefinementList__showMore - the button that let the user toggle more results
+ * @themeKey ais-RefinementList__SearchBox - the container of the search for facet values searchbox. See [the SearchBox documentation](widgets/SearchBox.html#classnames) for the classnames and translation keys of the SearchBox.
  * @translationkey showMore - The label of the show more button. Accepts one parameters, a boolean that is true if the values are expanded
  * @example
  * import React from 'react';

--- a/stories/RefinementList.stories.js
+++ b/stories/RefinementList.stories.js
@@ -28,6 +28,10 @@ stories.add('default', () =>
       showMore={true}
     />
   </WrapWithHits>
+).add('with search for facets value', () =>
+  <WrapWithHits>
+    <RefinementList attributeName="category" searchForFacetValues/>
+  </WrapWithHits>
 ).add('playground', () =>
   <WrapWithHits >
     <RefinementList


### PR DESCRIPTION
![sfvv](https://cloud.githubusercontent.com/assets/6885378/21593619/6a947072-d119-11e6-898e-9675df8836fd.gif)


You can run the storybook, to see the widget live. 


**New API entry:** 

- make the <RefinementList/> widget have the search for facet values: 
```
    <RefinementList attributeName="category" searchForFacetValues/>
```

- use search for facet values inside a custom RefinementList
   * a new exposed prop **searchForFacetValues**: a boolean that if set to true will add the `searchForFacetValues` to the provided props. 

   * a new provided prop **isFromSearch**: a boolean that says if the `items` props contains facets values from the global search, or searchForFacetValues results. 
   * a new provided prop **searchForFacetValues**: a function that take a query as a parameter. To call for searching facet values. 

- create a connector that will propose search for facet values:
  * a new **searchForFacetValuesResults** parameter inside the getProvidedProps
  * a new function **searchForFacetValues** to implement

```
export default createConnector({

  getProvidedProps(props, searchState, searchResults, metadata, searchForFacetValuesResults) {
        ... 
        return props;
  }

  searchForFacetValues(props, searchState, nextRefinement) {
    return {facetName: props.attributeName, query: nextRefinement};
  }
})
```

The next step about this PR are:
* should we keep the facetQuery in our searchState (on another PR if needed)
* [x] Should we merge both searchResults and searchForFacetValuesResults?
* [x] Merge #1765 and add tests to check the call from the helper to SFFV
* [x] Fix the naming once the API is stable
* [x] Add the jsdoc & guide
* [x] Add this feature into one of our example