### PR TITLE
chore(website): fixed URL to react-instantsearch

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -15,7 +15,7 @@ navigation:
  - text: About
    url: /about/
  - text: React InstantSearch
-   url: https://community.algolia.com/instantsearch.js/react/
+   url: /react/
 # Build settings
 markdown: kramdown
 


### PR DESCRIPTION
Current generated link is `https://community.algolia.com/instantsearch.jshttps://community.algolia.com/instantsearch.js/react/`