### PR TITLE
feat(InfiniteHits): Add class to load more button

### DIFF
--- a/packages/react-instantsearch/src/components/InfiniteHits.js
+++ b/packages/react-instantsearch/src/components/InfiniteHits.js
@@ -10,8 +10,8 @@ class InfiniteHits extends Component {
       <ItemComponent key={hit.objectID} hit={hit} />
     );
     const loadMoreButton = hasMore ?
-      <button onClick={() => refine()}>Load more</button> :
-      <button disabled>Load more</button>;
+      <button {...cx('reset')} onClick={() => refine()}>Load more</button> :
+      <button {...cx('reset')} disabled>Load more</button>;
 
     return (
       <div {...cx('root')}>

--- a/packages/react-instantsearch/src/components/InfiniteHits.test.js
+++ b/packages/react-instantsearch/src/components/InfiniteHits.test.js
@@ -36,7 +36,7 @@ describe('Hits', () => {
         />
       );
     expect(mockedRefine.mock.calls.length).toBe(0);
-    wrapped.find('button').simulate('click');
+    wrapped.find('.ais-InfiniteHits__reset').simulate('click');
     expect(mockedRefine.mock.calls.length).toBe(1);
   });
 
@@ -50,6 +50,6 @@ describe('Hits', () => {
           hasMore={false}
         />
       );
-    expect(wrapped.find('button').props().disabled).toBe(true);
+    expect(wrapped.find('.ais-InfiniteHits__reset').props().disabled).toBe(true);
   });
 });

--- a/packages/react-instantsearch/src/components/__snapshots__/InfiniteHits.test.js.snap
+++ b/packages/react-instantsearch/src/components/__snapshots__/InfiniteHits.test.js.snap
@@ -20,6 +20,7 @@ exports[`Hits accepts a hitComponent prop 1`] = `
       }
     } />
   <button
+    className="ais-InfiniteHits__reset"
     disabled={true}>
     Load more
   </button>


### PR DESCRIPTION
**What project are you opening a pull request for?**
- react-instantsearch (use v2 base)

**Summary**

When styling load more button from InfiniteHits I want to have a specific class to it so I can specifically target it

**Result**

Tests are passing and are updated and wrapper now get the new classname instead of a generic button  
