### PR TITLE
fix(InfiniteHits): better classname to loadmore btn

### DIFF
--- a/packages/react-instantsearch/src/components/InfiniteHits.js
+++ b/packages/react-instantsearch/src/components/InfiniteHits.js
@@ -10,8 +10,8 @@ class InfiniteHits extends Component {
       <ItemComponent key={hit.objectID} hit={hit} />
     );
     const loadMoreButton = hasMore ?
-      <button {...cx('reset')} onClick={() => refine()}>Load more</button> :
-      <button {...cx('reset')} disabled>Load more</button>;
+      <button {...cx('loadMore')} onClick={() => refine()}>Load more</button> :
+      <button {...cx('loadMore')} disabled>Load more</button>;
 
     return (
       <div {...cx('root')}>

--- a/packages/react-instantsearch/src/components/InfiniteHits.test.js
+++ b/packages/react-instantsearch/src/components/InfiniteHits.test.js
@@ -36,7 +36,7 @@ describe('Hits', () => {
         />
       );
     expect(mockedRefine.mock.calls.length).toBe(0);
-    wrapped.find('.ais-InfiniteHits__reset').simulate('click');
+    wrapped.find('.ais-InfiniteHits__loadMore').simulate('click');
     expect(mockedRefine.mock.calls.length).toBe(1);
   });
 
@@ -50,6 +50,6 @@ describe('Hits', () => {
           hasMore={false}
         />
       );
-    expect(wrapped.find('.ais-InfiniteHits__reset').props().disabled).toBe(true);
+    expect(wrapped.find('.ais-InfiniteHits__loadMore').props().disabled).toBe(true);
   });
 });

--- a/packages/react-instantsearch/src/components/__snapshots__/InfiniteHits.test.js.snap
+++ b/packages/react-instantsearch/src/components/__snapshots__/InfiniteHits.test.js.snap
@@ -20,7 +20,7 @@ exports[`Hits accepts a hitComponent prop 1`] = `
       }
     } />
   <button
-    className="ais-InfiniteHits__reset"
+    className="ais-InfiniteHits__loadMore"
     disabled={true}>
     Load more
   </button>


### PR DESCRIPTION
**What project are you opening a pull request for?**
- react-instantsearch (use v2 base)

**Summary**

Used wrongly `reset` instead of `loadMore` 
@bobylito Sorry about the typo, just fixed it as the previous PR was merged
