### PR TITLE
fix(highlight): highlight should work even if the attribute is missing

### DIFF
--- a/packages/react-instantsearch/src/core/highlight.js
+++ b/packages/react-instantsearch/src/core/highlight.js
@@ -23,11 +23,10 @@ export default function parseAlgoliaHit({
 }) {
   if (!hit) throw new Error('`hit`, the matching record, must be provided');
 
-  const highlightedValue = get(hit._highlightResult, attributeName);
-  if (!highlightedValue) throw new Error(
-    `\`attributeName\`=${attributeName} must resolve to an highlighted attribute in the record`);
+  const highlightObject = get(hit._highlightResult, attributeName);
+  const highlightedValue = !highlightObject ? '' : highlightObject.value;
 
-  return parseHighlightedAttribute({preTag, postTag, highlightedValue: highlightedValue.value});
+  return parseHighlightedAttribute({preTag, postTag, highlightedValue});
 }
 
 /**

--- a/packages/react-instantsearch/src/core/highlight.test.js
+++ b/packages/react-instantsearch/src/core/highlight.test.js
@@ -2,6 +2,12 @@
 import parseAlgoliaHit from './highlight.js';
 
 describe('parseAlgoliaHit()', () => {
+  it('it does not break when there is a missing attribute', () => {
+    const attributeName = 'attr';
+    const out = parseAlgoliaHit({attributeName, hit: {}});
+    expect(out).toEqual([]);
+  });
+
   it('creates a single element when there is no tag', () => {
     const value = 'foo bar baz';
     const attributeName = 'attr';
@@ -59,15 +65,6 @@ describe('parseAlgoliaHit()', () => {
       {value: 'lo', isHighlighted: true},
       {value: 'utre', isHighlighted: false},
     ]);
-  });
-
-  it('throws when the attribute is not highlighted in the hit', () => {
-    expect(parseAlgoliaHit.bind(null, {
-      attributeName: 'notHighlightedAttribute',
-      hit: {notHighlightedAttribute: 'some value'},
-    })).toThrowError(
-      '`attributeName`=notHighlightedAttribute must resolve to an highlighted attribute in the record'
-    );
   });
 
   it('throws when hit is `null`', () => {


### PR DESCRIPTION
**What project are you opening a pull request for?**
- react-instantsearch (use v2 base)

**Summary**

Since algolia does not enforce a schema on the records, it is possible
that an highlighted value is only available on some of them. This means
that react-instantsearch should not throw when highlighting an attribute
that is missing from the hit.

fix #1790 