### PR TITLE
chore(searchbox): Make the theme use @shipow's mixin [react-instantsearch]

### DIFF
--- a/packages/react-instantsearch-theme-algolia/mixins/_searchbox.shipow.scss
+++ b/packages/react-instantsearch-theme-algolia/mixins/_searchbox.shipow.scss
@@ -1,0 +1,191 @@
+@function even-px($value) {
+  @if type-of($value) == 'number' {
+    @if (unitless($value)) {
+      $value: $value * 1px;
+    } @else if unit($value) == 'em' {
+      $value: ($value / 1em * 16px);
+    } @else if unit($value) == 'pts' {
+      $value: $value * 1.3333 * 1px;
+    } @else if unit($value) == '%' {
+      $value: $value * 16 / 100% * 1px;
+    };
+    $value: round($value);
+    @if ($value % 2 != 0) {
+      $value: $value + 1;
+    }
+    @return $value;
+  }
+}
+
+@mixin searchbox(
+  $font-size: 90%,
+  $input-width: 350px,
+  $input-height: $font-size * 2.4,
+  $border-width: 1px,
+  $border-radius: $input-height / 2,
+  $input-border-color: #ccc,
+  $input-focus-border-color: #1ec9ea,
+  $input-background: #f8f8f8,
+  $input-focus-background: #fff,
+  $placeholder-color: #aaa,
+  $icon: 'sbx-icon-search-1',
+  $icon-size: $input-height / 1.6,
+  $icon-position: left,
+  $icon-color: #888,
+  $icon-background: $input-focus-border-color,
+  $icon-background-opacity: .1,
+  $icon-clear: 'sbx-icon-clear-1',
+  $icon-clear-size: $font-size / 1.1
+) {
+
+  &__root {
+    display: inline-block;
+    position: relative;
+    max-width: $input-width;
+    width: 100%;
+    height: even-px($input-height);
+    white-space: nowrap;
+    box-sizing: border-box;
+    font-size: $font-size;
+  }
+
+  &__wrapper {
+    width: 100%;
+    height: 100%;
+  }
+
+  &__input {
+    @include input();
+    display: inline-block;
+    transition: box-shadow .4s ease, background .4s ease;
+    border: 1px solid $input-border-color;
+    border-radius: even-px($border-radius);
+    background: $input-background;
+    box-shadow: 0 1px 1px 0 rgba(85, 95, 110, 0.2);
+    padding: 0;
+    padding-right: if($icon-position == 'right', even-px($input-height) + even-px($icon-clear-size) + 8px, even-px($input-height * .8))
+              + if($icon-background-opacity == 0, 0, even-px($font-size));
+    padding-left: if($icon-position == 'right',
+              even-px($font-size / 2) + even-px($border-radius / 2),
+              even-px($input-height) + if($icon-background-opacity == 0, 0, even-px($font-size * 1.2)));
+    width: 100%;
+    height: 100%;
+    vertical-align: middle;
+    white-space: normal;
+    font-size: inherit;
+    appearance: none;
+
+    &::-webkit-search-decoration,
+    &::-webkit-search-cancel-button,
+    &::-webkit-search-results-button,
+    &::-webkit-search-results-decoration {
+      display: none;
+    }
+
+    &:hover,
+    &:active,
+    &:focus {
+      box-shadow: none;
+      outline: 0;
+    }
+
+    &::placeholder {
+      color: lighten($placeholder-color, 20%);
+    }
+
+  }
+
+  &__submit {
+    position: absolute;
+    top: 0;
+    @if $icon-position == 'right' {
+      right: 0;
+      left: inherit;
+    } @else {
+      right: inherit;
+      left: 0;
+    }
+    margin: 0;
+    border: 0;
+    border-radius: if($icon-position == 'right', 0 $border-radius $border-radius 0, $border-radius 0 0 $border-radius);
+    background-color: rgba($icon-background, $icon-background-opacity);
+    padding: 0;
+    width: even-px($input-height) + if($icon-background-opacity == 0, 0, even-px($font-size / 2));
+    height: 100%;
+    vertical-align: middle;
+    text-align: center;
+    font-size: inherit;
+    user-select: none;
+
+    // Helper for vertical alignement of the icon
+    &::before {
+      display: inline-block;
+      margin-right: -4px;
+      height: 100%;
+      vertical-align: middle;
+      content: ''2
+    }
+
+    &:hover,
+    &:active {
+      cursor: pointer;
+    }
+
+    &:focus {
+      outline: 0;
+    }
+
+    svg {
+      width: even-px($icon-size);
+      height: even-px($icon-size);
+      vertical-align: middle;
+      fill: $icon-color;
+    }
+  }
+
+  &__reset {
+    display: none;
+    position: absolute;
+    top: (even-px($input-height) - even-px($icon-clear-size)) / 2 - 4px;
+    right: if($icon-position == 'right',
+      even-px($input-height) + if($icon-background-opacity == 0, 0 , even-px($font-size)),
+      (even-px($input-height) - even-px($icon-clear-size)) / 2 - 4px);
+    margin: 0;
+    border: 0;
+    background: none;
+    cursor: pointer;
+    padding: 0;
+    font-size: inherit;
+    user-select: none;
+    fill: $icon-color;
+
+    &:focus {
+      outline: 0;
+    }
+
+    svg {
+      display: block;
+      margin: 4px;
+      width: even-px($icon-clear-size);
+      height: even-px($icon-clear-size);
+    }
+  }
+
+  &__input:valid ~ &__reset {
+    display: block;
+    animation-name: sbx-reset-in;
+    animation-duration: 250ms;
+  }
+
+  @at-root{
+    @keyframes sbx-reset-in {
+      0% {
+        opacity: 0;
+      }
+
+      100% {
+        opacity: 1;
+      }
+    }
+  }
+}

--- a/packages/react-instantsearch-theme-algolia/style.scss
+++ b/packages/react-instantsearch-theme-algolia/style.scss
@@ -159,6 +159,7 @@ $main-color: #3369e7;
 // ------------------------------------
 
 @import
+'mixins/searchbox.shipow',
 'styles/InstantSearch',
 'styles/ClearAll',
 'styles/CurrentRefinements',

--- a/packages/react-instantsearch-theme-algolia/styles/_RefinementList.scss
+++ b/packages/react-instantsearch-theme-algolia/styles/_RefinementList.scss
@@ -66,20 +66,31 @@
 .ais-RefinementList__itemCheckboxSelected{
 }
 
-.ais-RefinementList__SearchBox .ais-SearchBox__root{
-  @extends .ais-SearchBox__root;
-  width: 100%;
+$sffv-searchbox-config:(
+  input-width: 300px,
+  input-height: 32px,
+  border-width: 1px,
+  border-radius: 3px,
+  input-border-color: #D4D8E3,
+  input-focus-border-color: #D4D8E3,
+  input-background: #FFFFFF,
+  input-focus-background: #FFFFFF,
+  font-size: 14px,
+  placeholder-color: #697782,
+  icon: sbx-icon-search-13,
+  icon-size: 14px,
+  icon-position: left,
+  icon-color: #bfc7d8,
+  icon-background: #FFFFFF,
+  icon-background-opacity: 0,
+  icon-clear: sbx-icon-clear-3,
+  icon-clear-size: 12px
+);
+
+.ais-RefinementList__SearchBox {
+  margin-bottom: 3px;
 }
 
-.ais-RefinementList__SearchBox input.ais-SearchBox__input[type="search"]{
-  @extends input.ais-SearchBox__input[type="search"];
-  background: url("data:image/svg+xml;utf8,<svg viewBox=\'0 0 18 18\' xmlns=\'http://www.w3.org/2000/svg\'><path d=\'M12.5 11h-.79l-.28-.27C12.41 9.59 13 8.11 13 6.5 13 2.91 10.09 0 6.5 0S0 2.91 0 6.5 2.91 13 6.5 13c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L17.49 16l-4.99-5zm-6 0C4.01 11 2 8.99 2 6.5S4.01 2 6.5 2 11 4.01 11 6.5 8.99 11 6.5 11z\' fill=\'%23BFC7D8\' fill-rule=\'evenodd\'/></svg>")no-repeat center left 5px / 18px;
-  padding: 5px 44px;
-  margin-bottom: 5px;
-}
-
-.ais-RefinementList__SearchBox .ais-SearchBox__reset {
-  @extends .ais-SearchBox__reset;
-  top: 0.3em;
-  right: 0.55em;
+.ais-RefinementList__SearchBox .ais-SearchBox {
+  @include searchbox($sffv-searchbox-config...);
 }

--- a/packages/react-instantsearch-theme-algolia/styles/_SearchBox.scss
+++ b/packages/react-instantsearch-theme-algolia/styles/_SearchBox.scss
@@ -1,130 +1,24 @@
-.ais-SearchBox__root {
-  width: 300px;
-  * {
-    // outline: 1px solid rgba(red, 0.3)
-  }
-}
+$main-searchbox-config:(
+  input-width: 300px,
+  input-height: 45px,
+  border-width: 1px,
+  border-radius: 4px,
+  input-border-color: #D4D8E3,
+  input-focus-border-color: #D4D8E3,
+  input-background: #FFFFFF,
+  input-focus-background: #FFFFFF,
+  font-size: 14px,
+  placeholder-color: #697782,
+  icon: sbx-icon-search-13,
+  icon-size: 18px,
+  icon-position: left,
+  icon-color: #bfc7d8,
+  icon-background: #FFFFFF,
+  icon-background-opacity: 0,
+  icon-clear: sbx-icon-clear-3,
+  icon-clear-size: 12px
+);
 
-.ais-SearchBox__wrapper {
-  position: relative;
-  width: auto;
-}
-
-input.ais-SearchBox__input[type="search"] {
-  @include input();
-  width: 100%;
-  padding: 13px 44px;
-  border: solid 1px #d4d8e3;
-  font-size: 14px;
-  outline: none;
-  background: url("data:image/svg+xml;utf8,<svg viewBox=\'0 0 18 18\' xmlns=\'http://www.w3.org/2000/svg\'><path d=\'M12.5 11h-.79l-.28-.27C12.41 9.59 13 8.11 13 6.5 13 2.91 10.09 0 6.5 0S0 2.91 0 6.5 2.91 13 6.5 13c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L17.49 16l-4.99-5zm-6 0C4.01 11 2 8.99 2 6.5S4.01 2 6.5 2 11 4.01 11 6.5 8.99 11 6.5 11z\' fill=\'%23BFC7D8\' fill-rule=\'evenodd\'/></svg>")no-repeat center left 16px / 18px;
-  box-shadow: 0 1px 1px 0 rgba(85, 95, 110, 0.2);
-  transition: box-shadow 0.3s ease;
-  color: #697782;
-
-  @include placeholder {
-    font-size: 14px;
-  }
-
-  &:hover,
-  &:active,
-  &:focus {
-    box-shadow: none
-  }
-
-  &:not(:placeholder-shown) ~ .ais-SearchBox__reset,
-  &:not([value=""]) ~ .ais-SearchBox__reset {
-    transform: scale(1);
-  }
-
-  // I cannot really explain why I'm forced to do this
-  // for firefox. The over rule should have worked
-  // I think it's the :placeholder-shown rule that
-  // disable all the css in firefox.
-  @supports (display: -moz-box) {
-    &:not([value=""]) ~ .ais-SearchBox__reset{
-      transform: scale(1);
-    }
-  }
-  // And for ipads/iphones
-  @supports (font: -apple-system-headline) {
-    &:not([value=""]) ~ .ais-SearchBox__reset{
-      transform: scale(1);
-    }
-  }
-}
-
-.ais-SearchBox__input::-webkit-search-decoration, .input::-webkit-search-cancel-button, .input::-webkit-search-results-button, .input::-webkit-search-results-decoration {
-  display: none;
-}
-
-input[type="search"].ais-SearchBox__input::-webkit-search-decoration,
-input[type="search"].ais-SearchBox__input::-webkit-search-cancel-button,
-input[type="search"].ais-SearchBox__input::-webkit-search-results-button,
-input[type="search"].ais-SearchBox__input::-webkit-search-results-decoration {
-  display: none;
-}
-.ais-SearchBox__input:hover {
-
-}
-
-.ais-SearchBox__input:focus, .input:active {
-
-}
-
-.ais-SearchBox__input::placeholder {
-
-}
-
-.ais-SearchBox__submit {
-
-}
-
-
-.ais-SearchBox__submit::before {
-
-}
-
-.ais-SearchBox__reset {
-  @include buttonTernary();
-  position: absolute;
-  top: 1em;
-  right: 1.5em;
-  width: 24px;
-  height: 24px;
-  transform: scale(0);
-  transition: transform 0.3s ease;
-  outline: none;
-
-  svg {
-    path {fill: #bfc7d8; }
-    position: absolute;
-    top: 50%;
-    transform: translateY(-50%);
-  }
-
-  &:active svg,
-  &:focus svg {
-    path {fill: darken(#bfc7d8, 5%)}
-  }
-}
-
-.ais-SearchBox__reset svg {
-
-}
-.ais-SearchBox__input:valid ~ .reset {
-  display: block;
-  animation-name: ais-Searchbox__sbx-reset-in;
-  animation-duration: .15s;
-}
-
-@keyframes ais-Searchbox__sbx-reset-in {
-  0% {
-    transform: translate3d(-20%, 0, 0);
-    opacity: 0;
-  }
-  100% {
-    transform: none;
-    opacity: 1;
-  }
+.ais-SearchBox {
+  @include searchbox($main-searchbox-config...);
 }

--- a/packages/react-instantsearch/src/components/SearchBox.js
+++ b/packages/react-instantsearch/src/components/SearchBox.js
@@ -4,16 +4,6 @@ import classNames from './classNames.js';
 
 const cx = classNames('SearchBox');
 
-/* eslint-disable max-len */
-const ResetIcon = () =>
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 26 26">
-    <g fill="none" fillRule="evenodd">
-      <path
-        d="M12.99883 9.92647L22.22236.70294c.85882-.85647 2.2306-.84706 3.08235 0 .8518.85412.8471 2.22588 0 3.0753l-9.2329 9.22353 9.22353 9.22353c.85648.85882.84707 2.23058 0 3.08235-.8541.85176-2.22587.84706-3.0753 0l-9.22116-9.23294-9.22353 9.22357c-.85646.85647-2.22823.84706-3.07764 0-.85413-.85412-.84707-2.2259 0-3.0753l9.22823-9.22117L.70235 3.77823C-.1541 2.92177-.1541 1.55.69295.69588c.85647-.85176 2.22823-.84706 3.07764 0l9.2282 9.2353v-.0047z"/>
-    </g>
-  </svg>;
-/* eslint-enable max-len */
-
 class SearchBox extends Component {
   static propTypes = {
     currentRefinement: PropTypes.string,
@@ -154,6 +144,7 @@ class SearchBox extends Component {
     } = this.props;
     const query = this.getQuery();
 
+    /* eslint-disable max-len */
     return (
       <form
         noValidate
@@ -161,6 +152,15 @@ class SearchBox extends Component {
         onReset={this.onReset}
         {...cx('root')}
       >
+        <svg xmlns="http://www.w3.org/2000/svg" style={{display: 'none'}}>
+          <symbol xmlns="http://www.w3.org/2000/svg" id="sbx-icon-search-13" viewBox="0 0 40 40">
+            <path d="M26.804 29.01c-2.832 2.34-6.465 3.746-10.426 3.746C7.333 32.756 0 25.424 0 16.378 0 7.333 7.333 0 16.378 0c9.046 0 16.378 7.333 16.378 16.378 0 3.96-1.406 7.594-3.746 10.426l10.534 10.534c.607.607.61 1.59-.004 2.202-.61.61-1.597.61-2.202.004L26.804 29.01zm-10.426.627c7.323 0 13.26-5.936 13.26-13.26 0-7.32-5.937-13.257-13.26-13.257C9.056 3.12 3.12 9.056 3.12 16.378c0 7.323 5.936 13.26 13.258 13.26z"
+            fillRule="evenodd" />
+          </symbol>
+          <symbol xmlns="http://www.w3.org/2000/svg" id="sbx-icon-clear-3" viewBox="0 0 20 20">
+            <path d="M8.114 10L.944 2.83 0 1.885 1.886 0l.943.943L10 8.113l7.17-7.17.944-.943L20 1.886l-.943.943-7.17 7.17 7.17 7.17.943.944L18.114 20l-.943-.943-7.17-7.17-7.17 7.17-.944.943L0 18.114l.943-.943L8.113 10z" fillRule="evenodd" />
+          </symbol>
+        </svg>
         <div
           role="search"
           {...cx('wrapper')}
@@ -176,17 +176,20 @@ class SearchBox extends Component {
             onChange={this.onChange}
             {...cx('input')}
           />
-          <button
-            type="reset"
-            title={translate('resetTitle')}
-            {...cx('reset')}
-          >
-            {translate('reset')}
-            {<ResetIcon/>}
+          <button type="submit" title={translate('submitTitle')} {...cx('submit')}>
+            <svg role="img">
+              <use href="#sbx-icon-search-13"></use>
+            </svg>
+          </button>
+          <button type="reset" title={translate('resetTitle')} {...cx('reset')} onClick={this.onReset}>
+            <svg role="img">
+              <use href="#sbx-icon-clear-3"></use>
+            </svg>
           </button>
         </div>
       </form>
     );
+    /* eslint-enable */
   }
 }
 
@@ -194,5 +197,6 @@ export default translatable({
   submit: null,
   reset: null,
   resetTitle: 'Clear the search query.',
+  submitTitle: 'Submit your search query.',
   placeholder: 'Search here…',
 })(SearchBox);

--- a/packages/react-instantsearch/src/components/__snapshots__/RefinementList.test.js.snap
+++ b/packages/react-instantsearch/src/components/__snapshots__/RefinementList.test.js.snap
@@ -7,6 +7,30 @@ exports[`RefinementList applies translations 1`] = `
       noValidate={true}
       onReset={[Function]}
       onSubmit={[Function]}>
+      <svg
+        style={
+          Object {
+            "display": "none",
+          }
+        }
+        xmlns="http://www.w3.org/2000/svg">
+        <symbol
+          id="sbx-icon-search-13"
+          viewBox="0 0 40 40"
+          xmlns="http://www.w3.org/2000/svg">
+          <path
+            d="M26.804 29.01c-2.832 2.34-6.465 3.746-10.426 3.746C7.333 32.756 0 25.424 0 16.378 0 7.333 7.333 0 16.378 0c9.046 0 16.378 7.333 16.378 16.378 0 3.96-1.406 7.594-3.746 10.426l10.534 10.534c.607.607.61 1.59-.004 2.202-.61.61-1.597.61-2.202.004L26.804 29.01zm-10.426.627c7.323 0 13.26-5.936 13.26-13.26 0-7.32-5.937-13.257-13.26-13.257C9.056 3.12 3.12 9.056 3.12 16.378c0 7.323 5.936 13.26 13.258 13.26z"
+            fillRule="evenodd" />
+        </symbol>
+        <symbol
+          id="sbx-icon-clear-3"
+          viewBox="0 0 20 20"
+          xmlns="http://www.w3.org/2000/svg">
+          <path
+            d="M8.114 10L.944 2.83 0 1.885 1.886 0l.943.943L10 8.113l7.17-7.17.944-.943L20 1.886l-.943.943-7.17 7.17 7.17 7.17.943.944L18.114 20l-.943-.943-7.17-7.17-7.17 7.17-.944.943L0 18.114l.943-.943L8.113 10z"
+            fillRule="evenodd" />
+        </symbol>
+      </svg>
       <div
         className="ais-SearchBox__wrapper"
         role="search">
@@ -20,18 +44,24 @@ exports[`RefinementList applies translations 1`] = `
           type="search"
           value="" />
         <button
+          className="ais-SearchBox__submit"
+          title="Submit your search query."
+          type="submit">
+          <svg
+            role="img">
+            <use
+              href="#sbx-icon-search-13" />
+          </svg>
+        </button>
+        <button
           className="ais-SearchBox__reset"
+          onClick={[Function]}
           title="Clear the search query."
           type="reset">
           <svg
-            viewBox="0 0 26 26"
-            xmlns="http://www.w3.org/2000/svg">
-            <g
-              fill="none"
-              fillRule="evenodd">
-              <path
-                d="M12.99883 9.92647L22.22236.70294c.85882-.85647 2.2306-.84706 3.08235 0 .8518.85412.8471 2.22588 0 3.0753l-9.2329 9.22353 9.22353 9.22353c.85648.85882.84707 2.23058 0 3.08235-.8541.85176-2.22587.84706-3.0753 0l-9.22116-9.23294-9.22353 9.22357c-.85646.85647-2.22823.84706-3.07764 0-.85413-.85412-.84707-2.2259 0-3.0753l9.22823-9.22117L.70235 3.77823C-.1541 2.92177-.1541 1.55.69295.69588c.85647-.85176 2.22823-.84706 3.07764 0l9.2282 9.2353v-.0047z" />
-            </g>
+            role="img">
+            <use
+              href="#sbx-icon-clear-3" />
           </svg>
         </button>
       </div>
@@ -177,6 +207,30 @@ exports[`RefinementList refinement list with search for facet values 1`] = `
       noValidate={true}
       onReset={[Function]}
       onSubmit={[Function]}>
+      <svg
+        style={
+          Object {
+            "display": "none",
+          }
+        }
+        xmlns="http://www.w3.org/2000/svg">
+        <symbol
+          id="sbx-icon-search-13"
+          viewBox="0 0 40 40"
+          xmlns="http://www.w3.org/2000/svg">
+          <path
+            d="M26.804 29.01c-2.832 2.34-6.465 3.746-10.426 3.746C7.333 32.756 0 25.424 0 16.378 0 7.333 7.333 0 16.378 0c9.046 0 16.378 7.333 16.378 16.378 0 3.96-1.406 7.594-3.746 10.426l10.534 10.534c.607.607.61 1.59-.004 2.202-.61.61-1.597.61-2.202.004L26.804 29.01zm-10.426.627c7.323 0 13.26-5.936 13.26-13.26 0-7.32-5.937-13.257-13.26-13.257C9.056 3.12 3.12 9.056 3.12 16.378c0 7.323 5.936 13.26 13.258 13.26z"
+            fillRule="evenodd" />
+        </symbol>
+        <symbol
+          id="sbx-icon-clear-3"
+          viewBox="0 0 20 20"
+          xmlns="http://www.w3.org/2000/svg">
+          <path
+            d="M8.114 10L.944 2.83 0 1.885 1.886 0l.943.943L10 8.113l7.17-7.17.944-.943L20 1.886l-.943.943-7.17 7.17 7.17 7.17.943.944L18.114 20l-.943-.943-7.17-7.17-7.17 7.17-.944.943L0 18.114l.943-.943L8.113 10z"
+            fillRule="evenodd" />
+        </symbol>
+      </svg>
       <div
         className="ais-SearchBox__wrapper"
         role="search">
@@ -190,18 +244,24 @@ exports[`RefinementList refinement list with search for facet values 1`] = `
           type="search"
           value="" />
         <button
+          className="ais-SearchBox__submit"
+          title="Submit your search query."
+          type="submit">
+          <svg
+            role="img">
+            <use
+              href="#sbx-icon-search-13" />
+          </svg>
+        </button>
+        <button
           className="ais-SearchBox__reset"
+          onClick={[Function]}
           title="Clear the search query."
           type="reset">
           <svg
-            viewBox="0 0 26 26"
-            xmlns="http://www.w3.org/2000/svg">
-            <g
-              fill="none"
-              fillRule="evenodd">
-              <path
-                d="M12.99883 9.92647L22.22236.70294c.85882-.85647 2.2306-.84706 3.08235 0 .8518.85412.8471 2.22588 0 3.0753l-9.2329 9.22353 9.22353 9.22353c.85648.85882.84707 2.23058 0 3.08235-.8541.85176-2.22587.84706-3.0753 0l-9.22116-9.23294-9.22353 9.22357c-.85646.85647-2.22823.84706-3.07764 0-.85413-.85412-.84707-2.2259 0-3.0753l9.22823-9.22117L.70235 3.77823C-.1541 2.92177-.1541 1.55.69295.69588c.85647-.85176 2.22823-.84706 3.07764 0l9.2282 9.2353v-.0047z" />
-            </g>
+            role="img">
+            <use
+              href="#sbx-icon-clear-3" />
           </svg>
         </button>
       </div>

--- a/packages/react-instantsearch/src/components/__snapshots__/SearchBox.test.js.snap
+++ b/packages/react-instantsearch/src/components/__snapshots__/SearchBox.test.js.snap
@@ -4,6 +4,30 @@ exports[`SearchBox applies its default props 1`] = `
   noValidate={true}
   onReset={[Function]}
   onSubmit={[Function]}>
+  <svg
+    style={
+      Object {
+        "display": "none",
+      }
+    }
+    xmlns="http://www.w3.org/2000/svg">
+    <symbol
+      id="sbx-icon-search-13"
+      viewBox="0 0 40 40"
+      xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M26.804 29.01c-2.832 2.34-6.465 3.746-10.426 3.746C7.333 32.756 0 25.424 0 16.378 0 7.333 7.333 0 16.378 0c9.046 0 16.378 7.333 16.378 16.378 0 3.96-1.406 7.594-3.746 10.426l10.534 10.534c.607.607.61 1.59-.004 2.202-.61.61-1.597.61-2.202.004L26.804 29.01zm-10.426.627c7.323 0 13.26-5.936 13.26-13.26 0-7.32-5.937-13.257-13.26-13.257C9.056 3.12 3.12 9.056 3.12 16.378c0 7.323 5.936 13.26 13.258 13.26z"
+        fillRule="evenodd" />
+    </symbol>
+    <symbol
+      id="sbx-icon-clear-3"
+      viewBox="0 0 20 20"
+      xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M8.114 10L.944 2.83 0 1.885 1.886 0l.943.943L10 8.113l7.17-7.17.944-.943L20 1.886l-.943.943-7.17 7.17 7.17 7.17.943.944L18.114 20l-.943-.943-7.17-7.17-7.17 7.17-.944.943L0 18.114l.943-.943L8.113 10z"
+        fillRule="evenodd" />
+    </symbol>
+  </svg>
   <div
     className="ais-SearchBox__wrapper"
     role="search">
@@ -17,18 +41,24 @@ exports[`SearchBox applies its default props 1`] = `
       type="search"
       value="" />
     <button
+      className="ais-SearchBox__submit"
+      title="Submit your search query."
+      type="submit">
+      <svg
+        role="img">
+        <use
+          href="#sbx-icon-search-13" />
+      </svg>
+    </button>
+    <button
       className="ais-SearchBox__reset"
+      onClick={[Function]}
       title="Clear the search query."
       type="reset">
       <svg
-        viewBox="0 0 26 26"
-        xmlns="http://www.w3.org/2000/svg">
-        <g
-          fill="none"
-          fillRule="evenodd">
-          <path
-            d="M12.99883 9.92647L22.22236.70294c.85882-.85647 2.2306-.84706 3.08235 0 .8518.85412.8471 2.22588 0 3.0753l-9.2329 9.22353 9.22353 9.22353c.85648.85882.84707 2.23058 0 3.08235-.8541.85176-2.22587.84706-3.0753 0l-9.22116-9.23294-9.22353 9.22357c-.85646.85647-2.22823.84706-3.07764 0-.85413-.85412-.84707-2.2259 0-3.0753l9.22823-9.22117L.70235 3.77823C-.1541 2.92177-.1541 1.55.69295.69588c.85647-.85176 2.22823-.84706 3.07764 0l9.2282 9.2353v-.0047z" />
-        </g>
+        role="img">
+        <use
+          href="#sbx-icon-clear-3" />
       </svg>
     </button>
   </div>
@@ -41,6 +71,30 @@ exports[`SearchBox lets you customize its theme 1`] = `
   noValidate={true}
   onReset={[Function]}
   onSubmit={[Function]}>
+  <svg
+    style={
+      Object {
+        "display": "none",
+      }
+    }
+    xmlns="http://www.w3.org/2000/svg">
+    <symbol
+      id="sbx-icon-search-13"
+      viewBox="0 0 40 40"
+      xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M26.804 29.01c-2.832 2.34-6.465 3.746-10.426 3.746C7.333 32.756 0 25.424 0 16.378 0 7.333 7.333 0 16.378 0c9.046 0 16.378 7.333 16.378 16.378 0 3.96-1.406 7.594-3.746 10.426l10.534 10.534c.607.607.61 1.59-.004 2.202-.61.61-1.597.61-2.202.004L26.804 29.01zm-10.426.627c7.323 0 13.26-5.936 13.26-13.26 0-7.32-5.937-13.257-13.26-13.257C9.056 3.12 3.12 9.056 3.12 16.378c0 7.323 5.936 13.26 13.258 13.26z"
+        fillRule="evenodd" />
+    </symbol>
+    <symbol
+      id="sbx-icon-clear-3"
+      viewBox="0 0 20 20"
+      xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M8.114 10L.944 2.83 0 1.885 1.886 0l.943.943L10 8.113l7.17-7.17.944-.943L20 1.886l-.943.943-7.17 7.17 7.17 7.17.943.944L18.114 20l-.943-.943-7.17-7.17-7.17 7.17-.944.943L0 18.114l.943-.943L8.113 10z"
+        fillRule="evenodd" />
+    </symbol>
+  </svg>
   <div
     className="ais-SearchBox__wrapper"
     role="search">
@@ -54,18 +108,24 @@ exports[`SearchBox lets you customize its theme 1`] = `
       type="search"
       value="" />
     <button
+      className="ais-SearchBox__submit"
+      title="Submit your search query."
+      type="submit">
+      <svg
+        role="img">
+        <use
+          href="#sbx-icon-search-13" />
+      </svg>
+    </button>
+    <button
       className="ais-SearchBox__reset"
+      onClick={[Function]}
       title="Clear the search query."
       type="reset">
       <svg
-        viewBox="0 0 26 26"
-        xmlns="http://www.w3.org/2000/svg">
-        <g
-          fill="none"
-          fillRule="evenodd">
-          <path
-            d="M12.99883 9.92647L22.22236.70294c.85882-.85647 2.2306-.84706 3.08235 0 .8518.85412.8471 2.22588 0 3.0753l-9.2329 9.22353 9.22353 9.22353c.85648.85882.84707 2.23058 0 3.08235-.8541.85176-2.22587.84706-3.0753 0l-9.22116-9.23294-9.22353 9.22357c-.85646.85647-2.22823.84706-3.07764 0-.85413-.85412-.84707-2.2259 0-3.0753l9.22823-9.22117L.70235 3.77823C-.1541 2.92177-.1541 1.55.69295.69588c.85647-.85176 2.22823-.84706 3.07764 0l9.2282 9.2353v-.0047z" />
-        </g>
+        role="img">
+        <use
+          href="#sbx-icon-clear-3" />
       </svg>
     </button>
   </div>
@@ -78,6 +138,30 @@ exports[`SearchBox lets you customize its translations 1`] = `
   noValidate={true}
   onReset={[Function]}
   onSubmit={[Function]}>
+  <svg
+    style={
+      Object {
+        "display": "none",
+      }
+    }
+    xmlns="http://www.w3.org/2000/svg">
+    <symbol
+      id="sbx-icon-search-13"
+      viewBox="0 0 40 40"
+      xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M26.804 29.01c-2.832 2.34-6.465 3.746-10.426 3.746C7.333 32.756 0 25.424 0 16.378 0 7.333 7.333 0 16.378 0c9.046 0 16.378 7.333 16.378 16.378 0 3.96-1.406 7.594-3.746 10.426l10.534 10.534c.607.607.61 1.59-.004 2.202-.61.61-1.597.61-2.202.004L26.804 29.01zm-10.426.627c7.323 0 13.26-5.936 13.26-13.26 0-7.32-5.937-13.257-13.26-13.257C9.056 3.12 3.12 9.056 3.12 16.378c0 7.323 5.936 13.26 13.258 13.26z"
+        fillRule="evenodd" />
+    </symbol>
+    <symbol
+      id="sbx-icon-clear-3"
+      viewBox="0 0 20 20"
+      xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M8.114 10L.944 2.83 0 1.885 1.886 0l.943.943L10 8.113l7.17-7.17.944-.943L20 1.886l-.943.943-7.17 7.17 7.17 7.17.943.944L18.114 20l-.943-.943-7.17-7.17-7.17 7.17-.944.943L0 18.114l.943-.943L8.113 10z"
+        fillRule="evenodd" />
+    </symbol>
+  </svg>
   <div
     className="ais-SearchBox__wrapper"
     role="search">
@@ -91,19 +175,24 @@ exports[`SearchBox lets you customize its translations 1`] = `
       type="search"
       value="" />
     <button
+      className="ais-SearchBox__submit"
+      title="Submit your search query."
+      type="submit">
+      <svg
+        role="img">
+        <use
+          href="#sbx-icon-search-13" />
+      </svg>
+    </button>
+    <button
       className="ais-SearchBox__reset"
+      onClick={[Function]}
       title="RESET_TITLE"
       type="reset">
-      RESET
       <svg
-        viewBox="0 0 26 26"
-        xmlns="http://www.w3.org/2000/svg">
-        <g
-          fill="none"
-          fillRule="evenodd">
-          <path
-            d="M12.99883 9.92647L22.22236.70294c.85882-.85647 2.2306-.84706 3.08235 0 .8518.85412.8471 2.22588 0 3.0753l-9.2329 9.22353 9.22353 9.22353c.85648.85882.84707 2.23058 0 3.08235-.8541.85176-2.22587.84706-3.0753 0l-9.22116-9.23294-9.22353 9.22357c-.85646.85647-2.22823.84706-3.07764 0-.85413-.85412-.84707-2.2259 0-3.0753l9.22823-9.22117L.70235 3.77823C-.1541 2.92177-.1541 1.55.69295.69588c.85647-.85176 2.22823-.84706 3.07764 0l9.2282 9.2353v-.0047z" />
-        </g>
+        role="img">
+        <use
+          href="#sbx-icon-clear-3" />
       </svg>
     </button>
   </div>
@@ -116,6 +205,30 @@ exports[`SearchBox transfers the autoFocus prop to the underlying input element 
   noValidate={true}
   onReset={[Function]}
   onSubmit={[Function]}>
+  <svg
+    style={
+      Object {
+        "display": "none",
+      }
+    }
+    xmlns="http://www.w3.org/2000/svg">
+    <symbol
+      id="sbx-icon-search-13"
+      viewBox="0 0 40 40"
+      xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M26.804 29.01c-2.832 2.34-6.465 3.746-10.426 3.746C7.333 32.756 0 25.424 0 16.378 0 7.333 7.333 0 16.378 0c9.046 0 16.378 7.333 16.378 16.378 0 3.96-1.406 7.594-3.746 10.426l10.534 10.534c.607.607.61 1.59-.004 2.202-.61.61-1.597.61-2.202.004L26.804 29.01zm-10.426.627c7.323 0 13.26-5.936 13.26-13.26 0-7.32-5.937-13.257-13.26-13.257C9.056 3.12 3.12 9.056 3.12 16.378c0 7.323 5.936 13.26 13.258 13.26z"
+        fillRule="evenodd" />
+    </symbol>
+    <symbol
+      id="sbx-icon-clear-3"
+      viewBox="0 0 20 20"
+      xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M8.114 10L.944 2.83 0 1.885 1.886 0l.943.943L10 8.113l7.17-7.17.944-.943L20 1.886l-.943.943-7.17 7.17 7.17 7.17.943.944L18.114 20l-.943-.943-7.17-7.17-7.17 7.17-.944.943L0 18.114l.943-.943L8.113 10z"
+        fillRule="evenodd" />
+    </symbol>
+  </svg>
   <div
     className="ais-SearchBox__wrapper"
     role="search">
@@ -129,18 +242,24 @@ exports[`SearchBox transfers the autoFocus prop to the underlying input element 
       type="search"
       value="" />
     <button
+      className="ais-SearchBox__submit"
+      title="Submit your search query."
+      type="submit">
+      <svg
+        role="img">
+        <use
+          href="#sbx-icon-search-13" />
+      </svg>
+    </button>
+    <button
       className="ais-SearchBox__reset"
+      onClick={[Function]}
       title="Clear the search query."
       type="reset">
       <svg
-        viewBox="0 0 26 26"
-        xmlns="http://www.w3.org/2000/svg">
-        <g
-          fill="none"
-          fillRule="evenodd">
-          <path
-            d="M12.99883 9.92647L22.22236.70294c.85882-.85647 2.2306-.84706 3.08235 0 .8518.85412.8471 2.22588 0 3.0753l-9.2329 9.22353 9.22353 9.22353c.85648.85882.84707 2.23058 0 3.08235-.8541.85176-2.22587.84706-3.0753 0l-9.22116-9.23294-9.22353 9.22357c-.85646.85647-2.22823.84706-3.07764 0-.85413-.85412-.84707-2.2259 0-3.0753l9.22823-9.22117L.70235 3.77823C-.1541 2.92177-.1541 1.55.69295.69588c.85647-.85176 2.22823-.84706 3.07764 0l9.2282 9.2353v-.0047z" />
-        </g>
+        role="img">
+        <use
+          href="#sbx-icon-clear-3" />
       </svg>
     </button>
   </div>
@@ -153,6 +272,30 @@ exports[`SearchBox treats its query prop as its input value 1`] = `
   noValidate={true}
   onReset={[Function]}
   onSubmit={[Function]}>
+  <svg
+    style={
+      Object {
+        "display": "none",
+      }
+    }
+    xmlns="http://www.w3.org/2000/svg">
+    <symbol
+      id="sbx-icon-search-13"
+      viewBox="0 0 40 40"
+      xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M26.804 29.01c-2.832 2.34-6.465 3.746-10.426 3.746C7.333 32.756 0 25.424 0 16.378 0 7.333 7.333 0 16.378 0c9.046 0 16.378 7.333 16.378 16.378 0 3.96-1.406 7.594-3.746 10.426l10.534 10.534c.607.607.61 1.59-.004 2.202-.61.61-1.597.61-2.202.004L26.804 29.01zm-10.426.627c7.323 0 13.26-5.936 13.26-13.26 0-7.32-5.937-13.257-13.26-13.257C9.056 3.12 3.12 9.056 3.12 16.378c0 7.323 5.936 13.26 13.258 13.26z"
+        fillRule="evenodd" />
+    </symbol>
+    <symbol
+      id="sbx-icon-clear-3"
+      viewBox="0 0 20 20"
+      xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M8.114 10L.944 2.83 0 1.885 1.886 0l.943.943L10 8.113l7.17-7.17.944-.943L20 1.886l-.943.943-7.17 7.17 7.17 7.17.943.944L18.114 20l-.943-.943-7.17-7.17-7.17 7.17-.944.943L0 18.114l.943-.943L8.113 10z"
+        fillRule="evenodd" />
+    </symbol>
+  </svg>
   <div
     className="ais-SearchBox__wrapper"
     role="search">
@@ -166,18 +309,24 @@ exports[`SearchBox treats its query prop as its input value 1`] = `
       type="search"
       value="QUERY1" />
     <button
+      className="ais-SearchBox__submit"
+      title="Submit your search query."
+      type="submit">
+      <svg
+        role="img">
+        <use
+          href="#sbx-icon-search-13" />
+      </svg>
+    </button>
+    <button
       className="ais-SearchBox__reset"
+      onClick={[Function]}
       title="Clear the search query."
       type="reset">
       <svg
-        viewBox="0 0 26 26"
-        xmlns="http://www.w3.org/2000/svg">
-        <g
-          fill="none"
-          fillRule="evenodd">
-          <path
-            d="M12.99883 9.92647L22.22236.70294c.85882-.85647 2.2306-.84706 3.08235 0 .8518.85412.8471 2.22588 0 3.0753l-9.2329 9.22353 9.22353 9.22353c.85648.85882.84707 2.23058 0 3.08235-.8541.85176-2.22587.84706-3.0753 0l-9.22116-9.23294-9.22353 9.22357c-.85646.85647-2.22823.84706-3.07764 0-.85413-.85412-.84707-2.2259 0-3.0753l9.22823-9.22117L.70235 3.77823C-.1541 2.92177-.1541 1.55.69295.69588c.85647-.85176 2.22823-.84706 3.07764 0l9.2282 9.2353v-.0047z" />
-        </g>
+        role="img">
+        <use
+          href="#sbx-icon-clear-3" />
       </svg>
     </button>
   </div>
@@ -190,6 +339,30 @@ exports[`SearchBox treats its query prop as its input value 2`] = `
   noValidate={true}
   onReset={[Function]}
   onSubmit={[Function]}>
+  <svg
+    style={
+      Object {
+        "display": "none",
+      }
+    }
+    xmlns="http://www.w3.org/2000/svg">
+    <symbol
+      id="sbx-icon-search-13"
+      viewBox="0 0 40 40"
+      xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M26.804 29.01c-2.832 2.34-6.465 3.746-10.426 3.746C7.333 32.756 0 25.424 0 16.378 0 7.333 7.333 0 16.378 0c9.046 0 16.378 7.333 16.378 16.378 0 3.96-1.406 7.594-3.746 10.426l10.534 10.534c.607.607.61 1.59-.004 2.202-.61.61-1.597.61-2.202.004L26.804 29.01zm-10.426.627c7.323 0 13.26-5.936 13.26-13.26 0-7.32-5.937-13.257-13.26-13.257C9.056 3.12 3.12 9.056 3.12 16.378c0 7.323 5.936 13.26 13.258 13.26z"
+        fillRule="evenodd" />
+    </symbol>
+    <symbol
+      id="sbx-icon-clear-3"
+      viewBox="0 0 20 20"
+      xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M8.114 10L.944 2.83 0 1.885 1.886 0l.943.943L10 8.113l7.17-7.17.944-.943L20 1.886l-.943.943-7.17 7.17 7.17 7.17.943.944L18.114 20l-.943-.943-7.17-7.17-7.17 7.17-.944.943L0 18.114l.943-.943L8.113 10z"
+        fillRule="evenodd" />
+    </symbol>
+  </svg>
   <div
     className="ais-SearchBox__wrapper"
     role="search">
@@ -203,18 +376,24 @@ exports[`SearchBox treats its query prop as its input value 2`] = `
       type="search"
       value="QUERY2" />
     <button
+      className="ais-SearchBox__submit"
+      title="Submit your search query."
+      type="submit">
+      <svg
+        role="img">
+        <use
+          href="#sbx-icon-search-13" />
+      </svg>
+    </button>
+    <button
       className="ais-SearchBox__reset"
+      onClick={[Function]}
       title="Clear the search query."
       type="reset">
       <svg
-        viewBox="0 0 26 26"
-        xmlns="http://www.w3.org/2000/svg">
-        <g
-          fill="none"
-          fillRule="evenodd">
-          <path
-            d="M12.99883 9.92647L22.22236.70294c.85882-.85647 2.2306-.84706 3.08235 0 .8518.85412.8471 2.22588 0 3.0753l-9.2329 9.22353 9.22353 9.22353c.85648.85882.84707 2.23058 0 3.08235-.8541.85176-2.22587.84706-3.0753 0l-9.22116-9.23294-9.22353 9.22357c-.85646.85647-2.22823.84706-3.07764 0-.85413-.85412-.84707-2.2259 0-3.0753l9.22823-9.22117L.70235 3.77823C-.1541 2.92177-.1541 1.55.69295.69588c.85647-.85176 2.22823-.84706 3.07764 0l9.2282 9.2353v-.0047z" />
-        </g>
+        role="img">
+        <use
+          href="#sbx-icon-clear-3" />
       </svg>
     </button>
   </div>


### PR DESCRIPTION
Instead of using the generated css. This makes some customization
easier, for example in the search for facet value input in the
refinement list. Also we reuse the knowledge that is already in there


and make us able to provide feedback to shipow's work.

**Result**

It's almost the same, I will see with @LukyVj for the small changes (mainly the icons). I also fixed the animation of the reset button, which was too much.

Old:

![2017-01-03 13 45 35](https://cloud.githubusercontent.com/assets/393765/21608137/f9fa8674-d1ba-11e6-9f5f-6422a8abe1d1.gif)

New:

![2017-01-03 13 47 13](https://cloud.githubusercontent.com/assets/393765/21608162/3563bbe0-d1bb-11e6-8a00-86f4d1a916ee.gif)
