### PR TITLE
feat(widgets): add transformItems to be able to sort and filter

### DIFF
--- a/docgen/src/guide/Connectors.md
+++ b/docgen/src/guide/Connectors.md
@@ -71,7 +71,7 @@ Provided props always follow the same pattern for ease of use:
 
 <div class="guide-nav">
     <div class="guide-nav-left">
-        Previous: <a href="guide/i18n.html">← i18n</a>
+        Previous: <a href="guide/Sorting_and_filtering.html">← Sorting and filtering items</a>
     </div>
     <div class="guide-nav-right">
         Next: <a href="guide/Default_refinements.html">Default refinements →</a>

--- a/docgen/src/guide/Sorting_and_filtering.md
+++ b/docgen/src/guide/Sorting_and_filtering.md
@@ -1,0 +1,51 @@
+---
+title: Sorting and filtering items
+mainTitle: Guide
+layout: main.pug
+category: guide
+navWeight: 78
+---
+
+A frequent question that comes up is "How do I sort or filter the items of my widget".
+
+For this, widgets and connectors that are handling items expose a `transformItems` prop. This prop is a function that has the `items` provided 
+prop as a parameter. It will expect in return the `items` prop back.
+
+This props can be found on every widgets or connectors that handle a list of `items`:
+* [`<CurrentRefinements/>`](widgets/CurrentRefinements.html) and [`connectCurrentRefinements`](connectors/connectCurrentRefinements.html)
+* [`<HierarchicalMenu/>`](widgets/HierarchicalMenu.html) and [`connectHierarchicalMenu`](connectors/connectHierarchicalMenu.html)
+* [`<Menu/>`](widgets/Menu.html) and [`connectMenu`](connectors/connectMenu.html)
+* [`<RefinementList/>`](widgets/RefinementList.html) and [`connectRefinementList`](connectors/connectRefinementList.html)
+* [`<SortBy/>`](widgets/SortBy.html) and [`connectSortBy`](connectors/connectSortBy.html)
+* [`<HitsPerPage/>`](widgets/HitsPerPage.html) and [`connectHitsPerPage`](connectors/connectHitsPerPage.html)
+* [`<MultiRange/>`](widgets/MultiRange.html) and [`connectMultiRange`](connectors/connectMultiRange.html)
+
+The following example will show you how to change the default sort order of the [`<RefinementList/>`](widgets/RefinementList.html) widget.
+
+```jsx
+import {InstantSearch, RefinementList} from 'react-instantsearch/dom';
+import {orderBy} from 'lodash';
+
+const App = () =>
+  <InstantSearch
+    appId="..."
+    apiKey="..."
+    indexName="..."
+  >
+    <SearchBox defaultRefinement="hi" />
+    <RefinementList attributeName="category"
+                    transformItems={items => orderBy(items, ['label', 'count'], ['asc', 'desc'])}/>
+  </InstantSearch>;
+```
+
+**Notes:**
+* The example shows how to sort items, but you can also filter them
+
+<div class="guide-nav">
+    <div class="guide-nav-left">
+        Previous: <a href="guide/i18n.html">← i18n</a>
+    </div>
+    <div class="guide-nav-right">
+        Next: <a href="guide/Connectors.html">Connectors →</a>
+    </div>
+</div>

--- a/docgen/src/guide/i18n.md
+++ b/docgen/src/guide/i18n.md
@@ -36,6 +36,6 @@ const App = () =>
         Previous: <a href="guide/Highlighting_results.html">← Highlighting Results</a>
     </div>
     <div class="guide-nav-right">
-        Next: <a href="guide/Connectors.html">Connectors →</a>
+        Next: <a href="guide/Sorting_and_filtering.html">Sorting and filtering items →</a>
     </div>
 </div>

--- a/packages/react-instantsearch/src/components/CurrentRefinements.js
+++ b/packages/react-instantsearch/src/components/CurrentRefinements.js
@@ -12,6 +12,7 @@ class CurrentRefinements extends Component {
       label: PropTypes.string,
     })).isRequired,
     refine: PropTypes.func.isRequired,
+    transformItems: PropTypes.func,
   };
 
   render() {

--- a/packages/react-instantsearch/src/components/HierarchicalMenu.js
+++ b/packages/react-instantsearch/src/components/HierarchicalMenu.js
@@ -23,6 +23,7 @@ class HierarchicalMenu extends Component {
     showMore: PropTypes.bool,
     limitMin: PropTypes.number,
     limitMax: PropTypes.number,
+    transformItems: PropTypes.func,
   };
 
   renderItem = item => {

--- a/packages/react-instantsearch/src/components/HitsPerPage.js
+++ b/packages/react-instantsearch/src/components/HitsPerPage.js
@@ -8,7 +8,7 @@ class HitsPerPage extends Component {
   static propTypes = {
     refine: PropTypes.func.isRequired,
     currentRefinement: PropTypes.number.isRequired,
-
+    transformItems: PropTypes.func,
     items: PropTypes.arrayOf(
       PropTypes.shape({
         /**

--- a/packages/react-instantsearch/src/components/Menu.js
+++ b/packages/react-instantsearch/src/components/Menu.js
@@ -21,6 +21,7 @@ class Menu extends Component {
     showMore: PropTypes.bool,
     limitMin: PropTypes.number,
     limitMax: PropTypes.number,
+    transformItems: PropTypes.func,
   };
 
   renderItem = item => {

--- a/packages/react-instantsearch/src/components/Menu.test.js
+++ b/packages/react-instantsearch/src/components/Menu.test.js
@@ -3,7 +3,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import {mount} from 'enzyme';
-
 import Menu from './Menu';
 
 describe('Menu', () => {

--- a/packages/react-instantsearch/src/components/MultiRange.js
+++ b/packages/react-instantsearch/src/components/MultiRange.js
@@ -11,6 +11,7 @@ class MultiRange extends Component {
       value: PropTypes.string.isRequired,
     })).isRequired,
     refine: PropTypes.func.isRequired,
+    transformItems: PropTypes.func,
   };
 
   renderItem = item => {

--- a/packages/react-instantsearch/src/components/RefinementList.js
+++ b/packages/react-instantsearch/src/components/RefinementList.js
@@ -28,6 +28,7 @@ class RefinementList extends Component {
     showMore: PropTypes.bool,
     limitMin: PropTypes.number,
     limitMax: PropTypes.number,
+    transformItems: PropTypes.func,
   };
 
   selectItem = item => {

--- a/packages/react-instantsearch/src/components/SortBy.js
+++ b/packages/react-instantsearch/src/components/SortBy.js
@@ -14,6 +14,7 @@ class SortBy extends Component {
     })).isRequired,
 
     currentRefinement: PropTypes.string.isRequired,
+    transformItems: PropTypes.func,
   };
 
   onChange = e => {

--- a/packages/react-instantsearch/src/connectors/connectCurrentRefinements.js
+++ b/packages/react-instantsearch/src/connectors/connectCurrentRefinements.js
@@ -1,16 +1,21 @@
 import createConnector from '../core/createConnector';
-
+import {PropTypes} from 'react';
 /**
  * connectCurrentRefinements connector provides the logic to build a widget that will
  * give the user the ability to remove all or some of the filters that were
  * set.
  * @name connectCurrentRefinements
  * @kind connector
+ * @propType {function} [transformItems] - If provided, this function can be used to modify the `items` provided prop of the wrapped component (ex: for filtering or sorting items). this function takes the `items` prop as a parameter and expects it back in return.
  * @providedPropType {function} refine - a function to remove a single filter
  * @providedPropType {array.<{label: string, attributeName: string, currentRefinement: string || object, items: array, value: function}>} items - all the filters, the `value` is to pass to the `refine` function for removing all currentrefinements, `label` is for the display. When existing several refinements for the same atribute name, then you get a nested `items` object that contains a `label` and a `value` function to use to remove a single filter. `attributeName` and `currentRefinement` are metadata containing row values.
  */
 export default createConnector({
   displayName: 'AlgoliaCurrentRefinements',
+
+  propTypes: {
+    transformItems: PropTypes.func,
+  },
 
   getProvidedProps(props, searchState, searchResults, metadata) {
     return {

--- a/packages/react-instantsearch/src/connectors/connectHierarchicalMenu.js
+++ b/packages/react-instantsearch/src/connectors/connectHierarchicalMenu.js
@@ -85,6 +85,7 @@ const sortBy = ['name:asc'];
  * @propType {string} [separator='>'] -  Specifies the level separator used in the data.
  * @propType {string[]} [rootPath=null] - The already selected and hidden path.
  * @propType {boolean} [showParentLevel=true] - Flag to set if the parent level should be displayed.
+ * @propType {function} [transformItems] - If provided, this function can be used to modify the `items` provided prop of the wrapped component (ex: for filtering or sorting items). this function takes the `items` prop as a parameter and expects it back in return.
  * @providedPropType {function} refine - a function to toggle a refinement
  * @providedPropType {function} createURL - a function to generate a URL for the corresponding search state
  * @providedPropType {string} currentRefinement - the refinement currently applied
@@ -104,14 +105,11 @@ export default createConnector({
     separator: PropTypes.string,
     rootPath: PropTypes.string,
     showParentLevel: PropTypes.bool,
-
     defaultRefinement: PropTypes.string,
-
     showMore: PropTypes.bool,
-
     limitMin: PropTypes.number,
-
     limitMax: PropTypes.number,
+    transformItems: PropTypes.func,
   },
 
   defaultProps: {

--- a/packages/react-instantsearch/src/connectors/connectHitsPerPage.js
+++ b/packages/react-instantsearch/src/connectors/connectHitsPerPage.js
@@ -24,6 +24,7 @@ function getCurrentRefinement(props, searchState) {
  * @kind connector
  * @propType {number} defaultRefinement - The number of items selected by default
  * @propType {{value: number, label: string}[]} items - List of hits per page options.
+ * @propType {function} [transformItems] - If provided, this function can be used to modify the `items` provided prop of the wrapped component (ex: for filtering or sorting items). this function takes the `items` prop as a parameter and expects it back in return.
  * @providedPropType {function} refine - a function to remove a single filter
  * @providedPropType {function} createURL - a function to generate a URL for the corresponding search state
  * @providedPropType {string} currentRefinement - the refinement currently applied
@@ -38,6 +39,7 @@ export default createConnector({
       label: PropTypes.string,
       value: PropTypes.number.isRequired,
     })).isRequired,
+    transformItems: PropTypes.func,
   },
 
   getProvidedProps(props, searchState) {

--- a/packages/react-instantsearch/src/connectors/connectMenu.js
+++ b/packages/react-instantsearch/src/connectors/connectMenu.js
@@ -40,6 +40,7 @@ const sortBy = ['count:desc', 'name:asc'];
  * @propType {number} [limitMin=10] - the minimum number of diplayed items
  * @propType {number} [limitMax=20] - the maximun number of displayed items. Only used when showMore is set to `true`
  * @propType {string} defaultRefinement - the value of the item selected by default
+ * @propType {function} [transformItems] - If provided, this function can be used to modify the `items` provided prop of the wrapped component (ex: for filtering or sorting items). this function takes the `items` prop as a parameter and expects it back in return.
  * @providedPropType {function} refine - a function to toggle a refinement
  * @providedPropType {function} createURL - a function to generate a URL for the corresponding search state
  * @providedPropType {string} currentRefinement - the refinement currently applied
@@ -54,6 +55,7 @@ export default createConnector({
     limitMin: PropTypes.number,
     limitMax: PropTypes.number,
     defaultRefinement: PropTypes.string,
+    transformItems: PropTypes.func,
   },
 
   defaultProps: {

--- a/packages/react-instantsearch/src/connectors/connectMultiRange.js
+++ b/packages/react-instantsearch/src/connectors/connectMultiRange.js
@@ -47,6 +47,7 @@ function getCurrentRefinement(props, searchState) {
  * @propType {string} attributeName - the name of the attribute in the records
  * @propType {{label: string, start: number, end: number}[]} items - List of options. With a text label, and upper and lower bounds.
  * @propType {string} defaultRefinement - the value of the item selected by default, follow the shape of a `string` with a pattern of `'{start}:{end}'`.
+ * @propType {function} [transformItems] - If provided, this function can be used to modify the `items` provided prop of the wrapped component (ex: for filtering or sorting items). this function takes the `items` prop as a parameter and expects it back in return.
  * @providedPropType {function} refine - a function to select a range.
  * @providedPropType {function} createURL - a function to generate a URL for the corresponding search state
  * @providedPropType {string} currentRefinement - the refinement currently applied.  follow the shape of a `string` with a pattern of `'{start}:{end}'` which corresponds to the current selected item. For instance, when the selected item is `{start: 10, end: 20}`, the searchState of the widget is `'10:20'`. When `start` isn't defined, the searchState of the widget is `':{end}'`, and the same way around when `end` isn't defined. However, when neither `start` nor `end` are defined, the searchState is an empty string.
@@ -63,6 +64,7 @@ export default createConnector({
       start: PropTypes.number,
       end: PropTypes.number,
     })).isRequired,
+    transformItems: PropTypes.func,
   },
 
   getProvidedProps(props, searchState) {

--- a/packages/react-instantsearch/src/connectors/connectRefinementList.js
+++ b/packages/react-instantsearch/src/connectors/connectRefinementList.js
@@ -47,10 +47,11 @@ function getValue(name, props, searchState) {
  * @propType {string} [operator=or] - How to apply the refinements. Possible values: 'or' or 'and'.
  * @propType {string} attributeName - the name of the attribute in the record
  * @propType {boolean} [showMore=false] - true if the component should display a button that will expand the number of items
- * @propType {number} [limitMin=10] - the minimum number of diplayed items
+ * @propType {number} [limitMin=10] - the minimum number of displayed items
  * @propType {number} [limitMax=20] - the maximun number of displayed items. Only used when showMore is set to `true`
  * @propType {string[]} defaultRefinement - the values of the items selected by default. The searchState of this widget takes the form of a list of `string`s, which correspond to the values of all selected refinements. However, when there are no refinements selected, the value of the searchState is an empty string.
  * @propType {boolean} [searchForFacetValues=false] - if set to true, the searchForFacetValues function is provided
+ * @propType {function} [transformItems] - If provided, this function can be used to modify the `items` provided prop of the wrapped component (ex: for filtering or sorting items). this function takes the `items` prop as a parameter and expects it back in return.
  * @providedPropType {function} refine - a function to toggle a refinement
  * @providedPropType {function} createURL - a function to generate a URL for the corresponding search state
  * @providedPropType {function} searchForFacetValues - a function to toggle a search for facet values
@@ -72,6 +73,7 @@ export default createConnector({
     limitMax: PropTypes.number,
     defaultRefinement: PropTypes.arrayOf(PropTypes.string),
     searchForFacetValues: PropTypes.bool,
+    transformItems: PropTypes.func,
   },
 
   defaultProps: {

--- a/packages/react-instantsearch/src/connectors/connectSortBy.js
+++ b/packages/react-instantsearch/src/connectors/connectSortBy.js
@@ -25,6 +25,7 @@ function getCurrentRefinement(props, searchState) {
  * @kind connector
  * @propType {string} defaultRefinement - The default selected index.
  * @propType {{value, label}[]} items - The list of indexes to search in.
+ * @propType {function} [transformItems] - If provided, this function can be used to modify the `items` provided prop of the wrapped component (ex: for filtering or sorting items). this function takes the `items` prop as a parameter and expects it back in return.
  * @providedPropType {function} refine - a function to remove a single filter
  * @providedPropType {function} createURL - a function to generate a URL for the corresponding search state
  * @providedPropType {string[]} currentRefinement - the refinement currently applied
@@ -39,6 +40,7 @@ export default createConnector({
       label: PropTypes.string,
       value: PropTypes.string.isRequired,
     })).isRequired,
+    transformItems: PropTypes.func,
   },
 
   getProvidedProps(props, searchState) {

--- a/packages/react-instantsearch/src/core/createConnector.test.js
+++ b/packages/react-instantsearch/src/core/createConnector.test.js
@@ -31,14 +31,16 @@ describe('createConnector', () => {
       const props = {
         hello: 'there',
       };
-      const wrapper = mount(<Connected {...props} />, {context: {
-        ais: {
-          store: {
-            getState: () => state,
-            subscribe: () => null,
+      const wrapper = mount(<Connected {...props} />, {
+        context: {
+          ais: {
+            store: {
+              getState: () => state,
+              subscribe: () => null,
+            },
           },
         },
-      }});
+      });
       const args = getProvidedProps.mock.calls[0];
       expect(args[0]).toEqual(props);
       expect(args[1]).toBe(state.widgets);
@@ -59,14 +61,16 @@ describe('createConnector', () => {
       })(Dummy);
       const state = createState();
       let props = {hello: 'there'};
-      const wrapper = mount(<Connected {...props} />, {context: {
-        ais: {
-          store: {
-            getState: () => state,
-            subscribe: () => null,
+      const wrapper = mount(<Connected {...props} />, {
+        context: {
+          ais: {
+            store: {
+              getState: () => state,
+              subscribe: () => null,
+            },
           },
         },
-      }});
+      });
       props = {hello: 'you'};
       wrapper.setProps(props);
       expect(getProvidedProps.mock.calls.length).toBe(2);
@@ -98,16 +102,18 @@ describe('createConnector', () => {
         hello: 'there',
       };
       let listener;
-      const wrapper = mount(<Connected {...props} />, {context: {
-        ais: {
-          store: {
-            getState: () => state,
-            subscribe: l => {
-              listener = l;
+      const wrapper = mount(<Connected {...props} />, {
+        context: {
+          ais: {
+            store: {
+              getState: () => state,
+              subscribe: l => {
+                listener = l;
+              },
             },
           },
         },
-      }});
+      });
       expect(wrapper.find(Dummy).props()).toEqual({...props, ...state.widgets});
       state = {
         ...createState(),
@@ -134,14 +140,16 @@ describe('createConnector', () => {
         getId,
       })(() => null);
       const unsubscribe = jest.fn();
-      const wrapper = mount(<Connected />, {context: {
-        ais: {
-          store: {
-            getState: () => ({}),
-            subscribe: () => unsubscribe,
+      const wrapper = mount(<Connected />, {
+        context: {
+          ais: {
+            store: {
+              getState: () => ({}),
+              subscribe: () => unsubscribe,
+            },
           },
         },
-      }});
+      });
       expect(unsubscribe.mock.calls.length).toBe(0);
       wrapper.unmount();
       expect(unsubscribe.mock.calls.length).toBe(1);
@@ -155,14 +163,16 @@ describe('createConnector', () => {
         getProvidedProps,
         getId,
       })(Dummy);
-      const wrapper = mount(<Connected />, {context: {
-        ais: {
-          store: {
-            getState: () => ({}),
-            subscribe: () => null,
+      const wrapper = mount(<Connected />, {
+        context: {
+          ais: {
+            store: {
+              getState: () => ({}),
+              subscribe: () => null,
+            },
           },
         },
-      }});
+      });
       expect(Dummy.mock.calls.length).toBe(1);
       wrapper.setProps({hello: 'there'});
       expect(Dummy.mock.calls.length).toBe(2);
@@ -179,17 +189,19 @@ describe('createConnector', () => {
         getId,
       })(() => null);
       const registerWidget = jest.fn();
-      mount(<Connected />, {context: {
-        ais: {
-          store: {
-            getState: () => ({}),
-            subscribe: () => null,
-          },
-          widgetsManager: {
-            registerWidget,
+      mount(<Connected />, {
+        context: {
+          ais: {
+            store: {
+              getState: () => ({}),
+              subscribe: () => null,
+            },
+            widgetsManager: {
+              registerWidget,
+            },
           },
         },
-      }});
+      });
       expect(registerWidget.mock.calls.length).toBe(0);
     });
 
@@ -204,17 +216,19 @@ describe('createConnector', () => {
       })(() => null);
       const registerWidget = jest.fn();
       const props = {hello: 'there'};
-      mount(<Connected {...props} />, {context: {
-        ais: {
-          store: {
-            getState: () => ({}),
-            subscribe: () => null,
-          },
-          widgetsManager: {
-            registerWidget,
+      mount(<Connected {...props} />, {
+        context: {
+          ais: {
+            store: {
+              getState: () => ({}),
+              subscribe: () => null,
+            },
+            widgetsManager: {
+              registerWidget,
+            },
           },
         },
-      }});
+      });
       expect(registerWidget.mock.calls.length).toBe(1);
       const state = {};
       const outputMetadata = registerWidget.mock.calls[0][0].getMetadata(state);
@@ -238,17 +252,19 @@ describe('createConnector', () => {
       const state = {
         widgets: {},
       };
-      mount(<Connected {...props} />, {context: {
-        ais: {
-          store: {
-            getState: () => state,
-            subscribe: () => null,
-          },
-          widgetsManager: {
-            registerWidget,
+      mount(<Connected {...props} />, {
+        context: {
+          ais: {
+            store: {
+              getState: () => state,
+              subscribe: () => null,
+            },
+            widgetsManager: {
+              registerWidget,
+            },
           },
         },
-      }});
+      });
       expect(registerWidget.mock.calls.length).toBe(1);
       const inputSP = {};
       const outputSP = registerWidget.mock.calls[0][0].getSearchParameters(inputSP);
@@ -268,18 +284,20 @@ describe('createConnector', () => {
       })(() => null);
       const update = jest.fn();
       const props = {hello: 'there'};
-      const wrapper = mount(<Connected {...props} />, {context: {
-        ais: {
-          store: {
-            getState: () => ({}),
-            subscribe: () => null,
-          },
-          widgetsManager: {
-            registerWidget: () => null,
-            update,
+      const wrapper = mount(<Connected {...props} />, {
+        context: {
+          ais: {
+            store: {
+              getState: () => ({}),
+              subscribe: () => null,
+            },
+            widgetsManager: {
+              registerWidget: () => null,
+              update,
+            },
           },
         },
-      }});
+      });
       expect(update.mock.calls.length).toBe(0);
       wrapper.setProps({hello: 'you'});
       expect(update.mock.calls.length).toBe(1);
@@ -294,18 +312,20 @@ describe('createConnector', () => {
       })(() => null);
       const update = jest.fn();
       const props = {hello: 'there'};
-      const wrapper = mount(<Connected {...props} />, {context: {
-        ais: {
-          store: {
-            getState: () => ({}),
-            subscribe: () => null,
-          },
-          widgetsManager: {
-            registerWidget: () => null,
-            update,
+      const wrapper = mount(<Connected {...props} />, {
+        context: {
+          ais: {
+            store: {
+              getState: () => ({}),
+              subscribe: () => null,
+            },
+            widgetsManager: {
+              registerWidget: () => null,
+              update,
+            },
           },
         },
-      }});
+      });
       expect(update.mock.calls.length).toBe(0);
       wrapper.setProps({hello: 'there'});
       expect(update.mock.calls.length).toBe(0);
@@ -321,19 +341,21 @@ describe('createConnector', () => {
       const unregister = jest.fn();
       const setState = jest.fn();
       const onInternalStateUpdate = jest.fn();
-      const wrapper = mount(<Connected />, {context: {
-        ais: {
-          store: {
-            getState: () => ({widgets: {another: {state: 'state'}}}),
-            setState,
-            subscribe: () => () => null,
+      const wrapper = mount(<Connected />, {
+        context: {
+          ais: {
+            store: {
+              getState: () => ({widgets: {another: {state: 'state'}}}),
+              setState,
+              subscribe: () => () => null,
+            },
+            widgetsManager: {
+              registerWidget: () => unregister,
+            },
+            onInternalStateUpdate,
           },
-          widgetsManager: {
-            registerWidget: () => unregister,
-          },
-          onInternalStateUpdate,
         },
-      }});
+      });
       expect(unregister.mock.calls.length).toBe(0);
       expect(setState.mock.calls.length).toBe(0);
       expect(onInternalStateUpdate.mock.calls.length).toBe(0);
@@ -362,17 +384,19 @@ describe('createConnector', () => {
       })(Dummy);
       const onInternalStateUpdate = jest.fn();
       const props = {hello: 'there'};
-      const wrapper = mount(<Connected {...props} />, {context: {
-        ais: {
-          store: {
-            getState: () => ({
-              widgets,
-            }),
-            subscribe: () => null,
+      const wrapper = mount(<Connected {...props} />, {
+        context: {
+          ais: {
+            store: {
+              getState: () => ({
+                widgets,
+              }),
+              subscribe: () => null,
+            },
+            onInternalStateUpdate,
           },
-          onInternalStateUpdate,
         },
-      }});
+      });
       const passedProps = wrapper.find(Dummy).props();
       const arg1 = {};
       const arg2 = {};
@@ -397,17 +421,19 @@ describe('createConnector', () => {
       })(Dummy);
       const createHrefForState = jest.fn();
       const props = {hello: 'there'};
-      const wrapper = mount(<Connected {...props} />, {context: {
-        ais: {
-          store: {
-            getState: () => ({
-              widgets,
-            }),
-            subscribe: () => null,
+      const wrapper = mount(<Connected {...props} />, {
+        context: {
+          ais: {
+            store: {
+              getState: () => ({
+                widgets,
+              }),
+              subscribe: () => null,
+            },
+            createHrefForState,
           },
-          createHrefForState,
         },
-      }});
+      });
       const passedProps = wrapper.find(Dummy).props();
       const arg1 = {};
       const arg2 = {};
@@ -434,17 +460,19 @@ describe('createConnector', () => {
       })(Dummy);
       const onSearchForFacetValues = jest.fn();
       const props = {hello: 'there'};
-      const wrapper = mount(<Connected {...props} />, {context: {
-        ais: {
-          store: {
-            getState: () => ({
-              widgets,
-            }),
-            subscribe: () => null,
+      const wrapper = mount(<Connected {...props} />, {
+        context: {
+          ais: {
+            store: {
+              getState: () => ({
+                widgets,
+              }),
+              subscribe: () => null,
+            },
+            onSearchForFacetValues,
           },
-          onSearchForFacetValues,
         },
-      }});
+      });
       const passedProps = wrapper.find(Dummy).props();
       const facetName = 'facetName';
       const query = 'query';
@@ -454,6 +482,116 @@ describe('createConnector', () => {
       expect(searchForFacetValues.mock.calls[0][2]).toBe(facetName);
       expect(searchForFacetValues.mock.calls[0][3]).toBe(query);
       expect(onSearchForFacetValues.mock.calls[0][0]).toBe(searchState);
+    });
+  });
+
+  describe('transform items', () => {
+    it('transform items if the function exists', () => {
+      const getProvidedProps = jest.fn(() => ({items: 'some'}));
+      const Dummy = () => null;
+      const Connected = createConnector({
+        displayName: 'CoolConnector',
+        getProvidedProps,
+        getId,
+      })(Dummy);
+      const state = createState();
+      const transformItems = jest.fn(() => 'others');
+      const props = {
+        hello: 'there',
+        transformItems,
+      };
+      const wrapper = mount(<Connected {...props} />, {
+        context: {
+          ais: {
+            store: {
+              getState: () => state,
+              subscribe: () => null,
+            },
+          },
+        },
+      });
+      expect(transformItems.mock.calls[0][0]).toEqual('some');
+      expect(wrapper.find(Dummy).props()).toEqual({
+        hello: 'there',
+        transformItems,
+        items: 'others',
+      });
+    });
+
+    it('transform provided props when props are updated', () => {
+      const getProvidedProps = jest.fn(() => ({items: 'some'}));
+      const Dummy = () => null;
+      const Connected = createConnector({
+        displayName: 'CoolConnector',
+        getProvidedProps,
+        getId,
+      })(Dummy);
+      const state = createState();
+      const transformItems = jest.fn(() => 'others');
+      let props = {
+        hello: 'there',
+        transformItems,
+      };
+      const wrapper = mount(<Connected {...props} />, {
+        context: {
+          ais: {
+            store: {
+              getState: () => state,
+              subscribe: () => null,
+            },
+          },
+        },
+      });
+      props = {hello: 'you'};
+      wrapper.setProps(props);
+      expect(transformItems.mock.calls[0][0]).toEqual('some');
+      expect(wrapper.find(Dummy).props()).toEqual({
+        hello: 'you',
+        transformItems,
+        items: 'others',
+      });
+    });
+    it('updates on state change', () => {
+      const getProvidedProps = jest.fn(() => ({items: 'some'}));
+      const Dummy = () => null;
+      const Connected = createConnector({
+        displayName: 'CoolConnector',
+        getProvidedProps,
+        getId,
+      })(Dummy);
+      let state = {
+        ...createState(),
+        widgets: {
+          hoy: 'hey',
+        },
+      };
+      const transformItems = jest.fn(() => 'others');
+      const props = {
+        hello: 'there',
+        transformItems,
+      };
+      let listener;
+      const wrapper = mount(<Connected {...props} />, {
+        context: {
+          ais: {
+            store: {
+              getState: () => state,
+              subscribe: l => {
+                listener = l;
+              },
+            },
+          },
+        },
+      });
+      state = {
+        ...createState(),
+        widgets: {
+          hey: 'hoy',
+        },
+      };
+      listener();
+      expect(transformItems.mock.calls[0][0]).toEqual('some');
+      expect(wrapper.find(Dummy).props()).toEqual({...props, items: 'others'});
     });
   });
 });

--- a/packages/react-instantsearch/src/widgets/CurrentRefinements.js
+++ b/packages/react-instantsearch/src/widgets/CurrentRefinements.js
@@ -6,6 +6,7 @@ import CurrentRefinementsComponent from '../components/CurrentRefinements.js';
  * It also lets the user remove each one of them.
  * @name CurrentRefinements
  * @kind widget
+ * @propType {function} [transformItems] - If provided, this function can be used to modify the `items` provided prop of the wrapped component (ex: for filtering or sorting items). this function takes the `items` prop as a parameter and expects it back in return.
  * @themeKey ais-CurrentRefinements__root - the root div of the widget
  * @themeKey ais-CurrentRefinements__items - the container of the filters
  * @themeKey ais-CurrentRefinements__item - a single filter

--- a/packages/react-instantsearch/src/widgets/HierarchicalMenu.js
+++ b/packages/react-instantsearch/src/widgets/HierarchicalMenu.js
@@ -15,6 +15,7 @@ import HierarchicalMenuComponent from '../components/HierarchicalMenu.js';
  * @propType {string[]} [rootPath=null] - The already selected and hidden path.
  * @propType {boolean} [showParentLevel=true] - Flag to set if the parent level should be displayed.
  * @propType {string} defaultRefinement - the item value selected by default
+ * @propType {function} [transformItems] - If provided, this function can be used to modify the `items` provided prop of the wrapped component (ex: for filtering or sorting items). this function takes the `items` prop as a parameter and expects it back in return.
  * @themeKey ais-HierarchicalMenu__root - Container of the widget
  * @themeKey ais-HierarchicalMenu__items - Container of the items
  * @themeKey ais-HierarchicalMenu__item - Id for a single list item

--- a/packages/react-instantsearch/src/widgets/HitsPerPage.js
+++ b/packages/react-instantsearch/src/widgets/HitsPerPage.js
@@ -12,6 +12,7 @@ import HitsPerPageSelectComponent from '../components/HitsPerPage.js';
  * @kind widget
  * @propType {number} defaultRefinement - The number of items selected by default
  * @propType {{value, label}[]|number[]} items - List of hits per page options. Passing a list of numbers [n] is a shorthand for [{value: n, label: n}].
+ * @propType {function} [transformItems] - If provided, this function can be used to modify the `items` provided prop of the wrapped component (ex: for filtering or sorting items). this function takes the `items` prop as a parameter and expects it back in return.
  * @themeKey ais-HitsPerPage__root - the root of the component.
  * @example
  * import React from 'react';

--- a/packages/react-instantsearch/src/widgets/Menu.js
+++ b/packages/react-instantsearch/src/widgets/Menu.js
@@ -10,6 +10,7 @@ import MenuComponent from '../components/Menu.js';
  * @propType {number} [limitMin=10] - the minimum number of diplayed items
  * @propType {number} [limitMax=20] - the maximun number of displayed items. Only used when showMore is set to `true`
  * @propType {string} defaultRefinement - the value of the item selected by default
+ * @propType {function} [transformItems] - If provided, this function can be used to modify the `items` provided prop of the wrapped component (ex: for filtering or sorting items). this function takes the `items` prop as a parameter and expects it back in return.
  * @themeKey ais-Menu__root - the root of the component
  * @themeKey ais-Menu__items - the container of all items in the menu
  * @themeKey ais-Menu__item - a single item

--- a/packages/react-instantsearch/src/widgets/MultiRange.js
+++ b/packages/react-instantsearch/src/widgets/MultiRange.js
@@ -8,6 +8,7 @@ import MultiRangeComponent from '../components/MultiRange.js';
  * @propType {string} attributeName - the name of the attribute in the records
  * @propType {{label: string, start: number, end: number}[]} items - List of options. With a text label, and upper and lower bounds.
  * @propType {string} defaultRefinement - the value of the item selected by default, follow the format "min:max".
+ * @propType {function} [transformItems] - If provided, this function can be used to modify the `items` provided prop of the wrapped component (ex: for filtering or sorting items). this function takes the `items` prop as a parameter and expects it back in return.
  * @themeKey ais-MultiRange__root - The root component of the widget
  * @themeKey ais-MultiRange__items - The container of the items
  * @themeKey ais-MultiRange__item - A single item

--- a/packages/react-instantsearch/src/widgets/RefinementList.js
+++ b/packages/react-instantsearch/src/widgets/RefinementList.js
@@ -12,6 +12,7 @@ import RefinementListComponent from '../components/RefinementList.js';
  * @propType {number} [limitMax=20] - the maximum number of displayed items. Only used when showMore is set to `true`
  * @propType {string[]} defaultRefinement - the values of the items selected by default
  * @propType {boolean} [searchForFacetValues=false] - true if the component should display an input to search for facet values
+ * @propType {function} [transformItems] - If provided, this function can be used to modify the `items` provided prop of the wrapped component (ex: for filtering or sorting items). this function takes the `items` prop as a parameter and expects it back in return.
  * @themeKey ais-RefinementList__root - the root of the component
  * @themeKey ais-RefinementList__items - the container of all items in the list
  * @themeKey ais-RefinementList__itemSelected - the selected list item

--- a/packages/react-instantsearch/src/widgets/SortBy.js
+++ b/packages/react-instantsearch/src/widgets/SortBy.js
@@ -7,6 +7,7 @@ import SortByComponent from '../components/SortBy.js';
  * @kind widget
  * @propType {string} defaultRefinement - The default selected index.
  * @propType {{value, label}[]} items - The list of indexes to search in.
+ * @propType {function} [transformItems] - If provided, this function can be used to modify the `items` provided prop of the wrapped component (ex: for filtering or sorting items). this function takes the `items` prop as a parameter and expects it back in return.
  * @themeKey ais-SortBy__root - the root of the component
  * @example
  * import React from 'react';

--- a/stories/Menu.stories.js
+++ b/stories/Menu.stories.js
@@ -3,6 +3,7 @@ import {storiesOf} from '@kadira/storybook';
 import {Menu} from '../packages/react-instantsearch/dom';
 import {withKnobs, text, boolean, number} from '@kadira/storybook-addon-knobs';
 import {WrapWithHits} from './util';
+import {orderBy} from 'lodash';
 
 const stories = storiesOf('Menu', module);
 
@@ -29,6 +30,11 @@ stories.add('default', () =>
       limitMax={5}
       showMore={true}
     />
+  </WrapWithHits>
+).add('with the sort strategy changed', () =>
+  <WrapWithHits>
+    <Menu attributeName="category"
+          transformItems={items => orderBy(items, ['label', 'count'], ['asc', 'desc'])}/>
   </WrapWithHits>
 ).add('playground', () =>
   <WrapWithHits >

--- a/stories/RefinementList.stories.js
+++ b/stories/RefinementList.stories.js
@@ -3,6 +3,7 @@ import {storiesOf} from '@kadira/storybook';
 import {RefinementList} from '../packages/react-instantsearch/dom';
 import {withKnobs, boolean, number, array} from '@kadira/storybook-addon-knobs';
 import {WrapWithHits} from './util';
+import {orderBy} from 'lodash';
 
 const stories = storiesOf('RefinementList', module);
 
@@ -31,6 +32,11 @@ stories.add('default', () =>
 ).add('with search for facets value', () =>
   <WrapWithHits>
     <RefinementList attributeName="category" searchForFacetValues/>
+  </WrapWithHits>
+).add('with the sort strategy changed', () =>
+  <WrapWithHits>
+    <RefinementList attributeName="category"
+                    transformItems={items => orderBy(items, ['label', 'count'], ['asc', 'desc'])}/>
   </WrapWithHits>
 ).add('playground', () =>
   <WrapWithHits >


### PR DESCRIPTION
Usage:

```js
<RefinementList attributeName="category"
    transformItems={items => orderBy(items, ['label', 'count'], ['asc', 'desc'])}/>
```

Results: 

![image](https://cloud.githubusercontent.com/assets/6885378/21688073/c7e64d28-d36b-11e6-8781-b8c0f7dc84f4.png)
