### PR TITLE
fix(widgets): replace setImmediate use with Promise use when update is needed

### DIFF
--- a/packages/react-instantsearch/src/core/createInstantSearchManager.test.js
+++ b/packages/react-instantsearch/src/core/createInstantSearchManager.test.js
@@ -129,18 +129,19 @@ describe('createInstantSearchManager', () => {
         algoliaClient: client,
       });
 
-      ism.widgetsManager.registerWidget({getMetadata: () => ({id: 'a'})});
-      ism.widgetsManager.registerWidget({getMetadata: () => ({id: 'b'})});
-      ism.widgetsManager.registerWidget({getMetadata: () => ({id: 'c'})});
-      ism.widgetsManager.registerWidget({getMetadata: () => ({id: 'd'})});
-
       const widgetIDsT0 = ism.getWidgetsIds().sort();
       expect(widgetIDsT0).toEqual([]);
 
-      jest.runAllTimers();
+      ism.widgetsManager.registerWidget({getMetadata: () => ({id: 'a'})});
+      ism.widgetsManager.registerWidget({getMetadata: () => ({id: 'b'})});
+      ism.widgetsManager.registerWidget({getMetadata: () => ({id: 'c'})});
 
-      const widgetIDsT1 = ism.getWidgetsIds().sort();
-      expect(widgetIDsT1).toEqual(['a', 'b', 'c', 'd']);
+      ism.widgetsManager.registerWidget({getMetadata: () => ({id: 'd'})});
+
+      return Promise.resolve().then(() => {
+        const widgetIDsT1 = ism.getWidgetsIds().sort();
+        expect(widgetIDsT1).toEqual(['a', 'b', 'c', 'd']);
+      });
     });
   });
 });

--- a/packages/react-instantsearch/src/core/createWidgetsManager.js
+++ b/packages/react-instantsearch/src/core/createWidgetsManager.js
@@ -1,3 +1,5 @@
+import {defer} from './utils';
+
 export default function createWidgetsManager(onWidgetsUpdate) {
   const widgets = [];
   // Is an update scheduled?
@@ -10,7 +12,7 @@ export default function createWidgetsManager(onWidgetsUpdate) {
       return;
     }
     scheduled = true;
-    setImmediate(() => {
+    defer(() => {
       scheduled = false;
       onWidgetsUpdate();
     });

--- a/packages/react-instantsearch/src/core/createWidgetsManager.test.js
+++ b/packages/react-instantsearch/src/core/createWidgetsManager.test.js
@@ -20,29 +20,23 @@ describe('createWidgetsManager', () => {
     });
 
     it('schedules an update', () => {
-      jest.useFakeTimers();
       const onUpdate = jest.fn();
       const wm = createWidgetsManager(onUpdate);
-      jest.runAllImmediates();
       wm.registerWidget({});
-      expect(onUpdate.mock.calls.length).toBe(0);
-      jest.runAllImmediates();
-      expect(onUpdate.mock.calls.length).toBe(1);
-      jest.useRealTimers();
+      return Promise.resolve().then(() => {
+        expect(onUpdate.mock.calls.length).toBe(1);
+      });
     });
   });
 
   describe('update', () => {
     it('schedules an update', () => {
-      jest.useFakeTimers();
       const onUpdate = jest.fn();
       const wm = createWidgetsManager(onUpdate);
-      jest.runAllImmediates();
       wm.update();
-      expect(onUpdate.mock.calls.length).toBe(0);
-      jest.runAllImmediates();
-      expect(onUpdate.mock.calls.length).toBe(1);
-      jest.useRealTimers();
+      return Promise.resolve().then(() => {
+        expect(onUpdate.mock.calls.length).toBe(1);
+      });
     });
   });
 });

--- a/packages/react-instantsearch/src/core/utils.js
+++ b/packages/react-instantsearch/src/core/utils.js
@@ -58,3 +58,6 @@ export function assertFacetDefined(searchParameters, searchResults, facet) {
 export function getDisplayName(Component) {
   return Component.displayName || Component.name || 'UnknownComponent';
 }
+
+const resolved = Promise.resolve();
+export const defer = f => { resolved.then(f); };

--- a/packages/react-instantsearch/src/core/utils.test.js
+++ b/packages/react-instantsearch/src/core/utils.test.js
@@ -7,6 +7,7 @@ import {
   capitalize,
   assertFacetDefined,
   getDisplayName,
+  defer,
 } from './utils';
 
 import {SearchParameters, SearchResults} from 'algoliasearch-helper';
@@ -83,7 +84,9 @@ describe('utils', () => {
 
     it('gets the right displayName from React.createClass', () => {
       const SuperComponent = React.createClass({
-        render() { return null; },
+        render() {
+          return null;
+        },
         displayName: 'SuperComponent',
       });
 
@@ -94,4 +97,18 @@ describe('utils', () => {
       expect(getDisplayName(() => null)).toBe('UnknownComponent');
     });
   });
+  describe('defer', () => {
+    it('calling a function asynchronously, should be done as soon as possible.', () => {
+      let count = 0;
+
+      defer(() => {
+        count = 1;
+      });
+
+      return Promise.resolve().then(() => {
+        expect(count).toEqual(1);
+      });
+    });
+  });
 });
+


### PR DESCRIPTION
See https://github.com/algolia/instantsearch.js/issues/1807 => usage of react-instantsearch is not possible with Meteor without the use of a `setImmediate` polyfill.

Previously we already add a problem using `process.nextTicks` with react-native.

I tested this version with our react-native example and also a Meteor small app. 