### PR TITLE
transfer a user defined object to hitComponent

### DIFF
--- a/packages/react-instantsearch/src/components/Hits.js
+++ b/packages/react-instantsearch/src/components/Hits.js
@@ -5,11 +5,11 @@ const cx = classNames('Hits');
 
 class Hits extends Component {
   render() {
-    const {hitComponent: ItemComponent, hits} = this.props;
+    const {hitComponent: ItemComponent, hits, userObj} = this.props;
     return (
       <div {...cx('root')}>
         {hits.map(hit =>
-          <ItemComponent key={hit.objectID} hit={hit} />
+          <ItemComponent key={hit.objectID} hit={hit} userObj={userObj}/>
         )}
       </div>
     );


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**What project are you opening a pull request for?**
- react-instantsearch

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
When using multi index is usual to want to pass informations of the index to the `hitComponent`.
But there is no way to transfer props from a `Hits` component to a personal `hitComponent`. Only `hits` are passed.  

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

and then you can do stuff like
```js
<Hits userObj={{index: algoliaConf.indexNames[i]}} hitComponent={AlgoliaHit}/>
...
export class AlgoliaHit extends Component {

  constructor(props) {
    super(props)
    this.handleClick = this.handleClick.bind(this)
  }

  handleClick(e) {
    e.preventDefault()
    console.log('click from index: ', this.props.userObj.index);
  }

  render() {
    return (
      <div style={{marginTop: 10}} onClick={this.handleClick}>
        <span className="hit-name">
          <Highlight attributeName="title" hit={this.props.hit} />
        </span>
      </div>
    )
  }
}


```
