### PR TITLE
fix(clear): clearing wasn't working with too+ same type facets selected

### DIFF
--- a/docgen/src/guide/Default_refinements.md
+++ b/docgen/src/guide/Default_refinements.md
@@ -28,24 +28,19 @@ const App = () =>
   </InstantSearch>;
 ```
 
-## What if I want some default refinements to be hidden?
+## Hiding default refinements
 
-Another frequent question that comes up is "How do I preselect some refinements but hide them in a way that it can't be
-unselected?".
+In some situations not only you want default refinements but you also do not want the user to be able to unselect them.
 
-For this, you can use a [`<VirtualWidgets/>`](guide/Virtual_widgets.html). It allows you to pre refine any widget without
-rendering anything. If you don't want a default refinement to be removed but you are using
-the [`<CurrentRefinements/>`](widgets/CurrentRefinements.html) widget or the
-[`connectCurrentRefinements`](connectors/connectCurrentRefinements.html) connector to display all the others,
-then you should use the `transformItems` props to filters the one you don't want.
+To do this, you can use a [`<VirtualWidgets/>`](guide/Virtual_widgets.html). It allows you to pre refine any widget without
+rendering anything.
 
-The following example will instantiate a search page that will show results
-that are oranges, a search box and a menu to select the oranges origin:
+Since by default the [`<CurrentRefinements/>`](widgets/CurrentRefinements.html) widget or the
+[`connectCurrentRefinements`](connectors/connectCurrentRefinements.html) will display your default refinement, you then need to filter the items inside them with `transformItems`.
 
 ```jsx
 import {InstantSearch, SearchBox, Menu} from 'react-instantsearch/dom';
 import {connectMenu} from 'react-instantsearch/connectors';
-import {filter} from 'lodash';
 
 const VirtualMenu = connectMenu(() => null);
 
@@ -57,7 +52,7 @@ const App = () =>
   >
     <div>
         <CurrentRefinements
-           transformItems={items => filter(items, item => item.currentRefinement !== 'Orange')}
+           transformItems={items => items.filter(item => item.currentRefinement !== 'Orange')}
         />
         <SearchBox/>
         <VirtualMenu attributeName="fruits" defaultRefinement={'Orange'} />

--- a/docgen/src/guide/Default_refinements.md
+++ b/docgen/src/guide/Default_refinements.md
@@ -28,6 +28,44 @@ const App = () =>
   </InstantSearch>;
 ```
 
+## What if I want some default refinements to be hidden?
+
+Another frequent question that comes up is "How do I preselect some refinements but hide them in a way that it can't be
+unselected?".
+
+For this, you can use a [`<VirtualWidgets/>`](guide/Virtual_widgets.html). It allows you to pre refine any widget without
+rendering anything. If you don't want a default refinement to be removed but you are using
+the [`<CurrentRefinements/>`](widgets/CurrentRefinements.html) widget or the
+[`connectCurrentRefinements`](connectors/connectCurrentRefinements.html) connector to display all the others,
+then you should use the `transformItems` props to filters the one you don't want.
+
+The following example will instantiate a search page that will show results
+that are oranges, a search box and a menu to select the oranges origin:
+
+```jsx
+import {InstantSearch, SearchBox, Menu} from 'react-instantsearch/dom';
+import {connectMenu} from 'react-instantsearch/connectors';
+import {filter} from 'lodash';
+
+const VirtualMenu = connectMenu(() => null);
+
+const App = () =>
+  <InstantSearch
+    appId="..."
+    apiKey="..."
+    indexName="..."
+  >
+    <div>
+        <CurrentRefinements
+           transformItems={items => filter(items, item => item.currentRefinement !== 'Orange')}
+        />
+        <SearchBox/>
+        <VirtualMenu attributeName="fruits" defaultRefinement={'Orange'} />
+        <Menu attributeName="origin" defaultRefinement={'Spain'} />
+    </div>
+  </InstantSearch>;
+```
+
 **Notes:**
 * The [search state guide](guide/Search_state.html) details all widgets and connectors state values...
 * Default refinements are handy when used as [Virtual widgets](guide/Virtual_widgets.html).

--- a/docgen/src/guide/Default_refinements.md
+++ b/docgen/src/guide/Default_refinements.md
@@ -35,8 +35,8 @@ In some situations not only you want default refinements but you also do not wan
 To do this, you can use a [`<VirtualWidgets/>`](guide/Virtual_widgets.html). It allows you to pre refine any widget without
 rendering anything.
 
-Since by default the [`<CurrentRefinements/>`](widgets/CurrentRefinements.html) widget or the
-[`connectCurrentRefinements`](connectors/connectCurrentRefinements.html) will display your default refinement, you then need to filter the items inside them with `transformItems`.
+By default the [`<CurrentRefinements/>`](widgets/CurrentRefinements.html) widget or the
+[`connectCurrentRefinements`](connectors/connectCurrentRefinements.html) connector will display your default refinements. If you want to hide them, you need to filter the items with `transformItems`.
 
 ```jsx
 import {InstantSearch, SearchBox, Menu} from 'react-instantsearch/dom';

--- a/docgen/src/guide/Sorting_and_filtering.md
+++ b/docgen/src/guide/Sorting_and_filtering.md
@@ -11,14 +11,18 @@ A frequent question that comes up is "How do I sort or filter the items of my wi
 For this, widgets and connectors that are handling items expose a `transformItems` prop. This prop is a function that has the `items` provided 
 prop as a parameter. It will expect in return the `items` prop back.
 
+## Supported widgets and connectors
+
 This props can be found on every widgets or connectors that handle a list of `items`:
-* [`<CurrentRefinements/>`](widgets/CurrentRefinements.html) and [`connectCurrentRefinements`](connectors/connectCurrentRefinements.html)
+* [`<CurrentRefinements/>`](widgets/CurrentRefinements.html), [`<ClearAll/>`](widgets/ClearAll.html)  and [`connectCurrentRefinements`](connectors/connectCurrentRefinements.html)
 * [`<HierarchicalMenu/>`](widgets/HierarchicalMenu.html) and [`connectHierarchicalMenu`](connectors/connectHierarchicalMenu.html)
 * [`<Menu/>`](widgets/Menu.html) and [`connectMenu`](connectors/connectMenu.html)
 * [`<RefinementList/>`](widgets/RefinementList.html) and [`connectRefinementList`](connectors/connectRefinementList.html)
 * [`<SortBy/>`](widgets/SortBy.html) and [`connectSortBy`](connectors/connectSortBy.html)
 * [`<HitsPerPage/>`](widgets/HitsPerPage.html) and [`connectHitsPerPage`](connectors/connectHitsPerPage.html)
 * [`<MultiRange/>`](widgets/MultiRange.html) and [`connectMultiRange`](connectors/connectMultiRange.html)
+
+## Example
 
 The following example will show you how to change the default sort order of the [`<RefinementList/>`](widgets/RefinementList.html) widget.
 
@@ -38,8 +42,9 @@ const App = () =>
   </InstantSearch>;
 ```
 
-**Notes:**
-* The example shows how to sort items, but you can also filter them
+## Common use cases
+* Sorting items
+* Filtering items
 
 <div class="guide-nav">
     <div class="guide-nav-left">

--- a/packages/react-instantsearch/src/connectors/connectHierarchicalMenu.js
+++ b/packages/react-instantsearch/src/connectors/connectHierarchicalMenu.js
@@ -210,7 +210,7 @@ export default createConnector({
         attributeName: rootAttribute,
         value: nextState => ({
           ...nextState,
-          [namespace]: {[id]: ''},
+          [namespace]: {...nextState[namespace], [id]: ''},
         }),
         currentRefinement,
       }],

--- a/packages/react-instantsearch/src/connectors/connectHierarchicalMenu.test.js
+++ b/packages/react-instantsearch/src/connectors/connectHierarchicalMenu.test.js
@@ -209,9 +209,14 @@ describe('connectHierarchicalMenu', () => {
         value: metadata.items[0].value,
       }],
     });
+  });
 
-    const searchState = metadata.items[0].value({hierarchicalMenu: {ok: 'wat'}});
-    expect(searchState).toEqual({hierarchicalMenu: {ok: ''}});
+  it('items value function should clear it from the search state', () => {
+    const metadata = getMetadata({attributes: ['one']}, {hierarchicalMenu: {one: 'one', two: 'two'}});
+
+    const searchState = metadata.items[0].value({hierarchicalMenu: {one: 'one', two: 'two'}});
+
+    expect(searchState).toEqual({hierarchicalMenu: {one: '', two: 'two'}});
   });
 
   it('should return the right searchState when clean up', () => {

--- a/packages/react-instantsearch/src/connectors/connectMenu.js
+++ b/packages/react-instantsearch/src/connectors/connectMenu.js
@@ -143,7 +143,7 @@ export default createConnector({
         attributeName: props.attributeName,
         value: nextState => ({
           ...nextState,
-          [namespace]: {[id]: ''},
+          [namespace]: {...nextState[namespace], [id]: ''},
         }),
         currentRefinement,
       }],

--- a/packages/react-instantsearch/src/connectors/connectMenu.test.js
+++ b/packages/react-instantsearch/src/connectors/connectMenu.test.js
@@ -184,9 +184,14 @@ describe('connectMenu', () => {
         value: metadata.items[0].value,
       }],
     });
+  });
 
-    const searchState = metadata.items[0].value({menu: {wot: 'wat'}});
-    expect(searchState).toEqual({menu: {wot: ''}});
+  it('items value function should clear it from the search state', () => {
+    const metadata = getMetadata({attributeName: 'one'}, {menu: {one: 'one', two: 'two'}});
+
+    const searchState = metadata.items[0].value({menu: {one: 'one', two: 'two'}});
+
+    expect(searchState).toEqual({menu: {one: '', two: 'two'}});
   });
 
   it('should return the right searchState when clean up', () => {

--- a/packages/react-instantsearch/src/connectors/connectMultiRange.js
+++ b/packages/react-instantsearch/src/connectors/connectMultiRange.js
@@ -132,7 +132,7 @@ export default createConnector({
         currentRefinement: label,
         value: nextState => ({
           ...nextState,
-          [namespace]: {[id]: ''},
+          [namespace]: {...nextState[namespace], [id]: ''},
         }),
       });
     }

--- a/packages/react-instantsearch/src/connectors/connectMultiRange.test.js
+++ b/packages/react-instantsearch/src/connectors/connectMultiRange.test.js
@@ -144,9 +144,24 @@ describe('connectMultiRange', () => {
         currentRefinement: 'YAY',
       }],
     });
+  });
 
-    const searchState = metadata.items[0].value({multiRange: {wot: '100:200'}});
-    expect(searchState).toEqual({multiRange: {wot: ''}});
+  it('items value function should clear it from the search state', () => {
+    const metadata = getMetadata(
+      {
+        attributeName: 'one',
+        items: [{
+          label: 'YAY',
+          start: 100,
+          end: 200,
+        }],
+      },
+      {multiRange: {one: '100:200', two: '200:400'}}
+    );
+
+    const searchState = metadata.items[0].value({multiRange: {one: '100:200', two: '200:400'}});
+
+    expect(searchState).toEqual({multiRange: {one: '', two: '200:400'}});
   });
 
   it('should return the right searchState when clean up', () => {

--- a/packages/react-instantsearch/src/connectors/connectPagination.js
+++ b/packages/react-instantsearch/src/connectors/connectPagination.js
@@ -80,9 +80,6 @@ export default createConnector({
   },
 
   getMetadata() {
-    const id = getId();
-    return {
-      id,
-    };
+    return {id: getId()};
   },
 });

--- a/packages/react-instantsearch/src/connectors/connectRange.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.js
@@ -157,7 +157,7 @@ export default createConnector({
         attributeName: props.attributeName,
         value: nextState => ({
           ...nextState,
-          [namespace]: {[id]: {}},
+          [namespace]: {...nextState[namespace], [id]: {}},
         }),
       };
     }

--- a/packages/react-instantsearch/src/connectors/connectRange.test.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.test.js
@@ -161,6 +161,14 @@ describe('connectRange', () => {
     });
   });
 
+  it('items value function should clear it from the search state', () => {
+    const metadata = getMetadata({attributeName: 'one'}, {range: {one: {min: 5}, two: {max: 4}}});
+
+    const searchState = metadata.items[0].value({range: {one: {min: 5}, two: {max: 4}}});
+
+    expect(searchState).toEqual({range: {one: {}, two: {max: 4}}});
+  });
+
   it('should return the right searchState when clean up', () => {
     let searchState = cleanUp({attributeName: 'name'}, {
       range: {name: 'searchState', name2: 'searchState'},

--- a/packages/react-instantsearch/src/connectors/connectRefinementList.js
+++ b/packages/react-instantsearch/src/connectors/connectRefinementList.js
@@ -185,7 +185,7 @@ export default createConnector({
         currentRefinement: getCurrentRefinement(props, searchState),
         value: nextState => ({
           ...nextState,
-          [namespace]: {[id]: ''},
+          [namespace]: {...nextState[namespace], [id]: ''},
         }),
         items: getCurrentRefinement(props, searchState).map(item => ({
           label: `${item}`,
@@ -196,7 +196,7 @@ export default createConnector({
 
             return {
               ...nextState,
-              [namespace]: {[id]: nextSelectedItems.length > 0 ? nextSelectedItems : ''},
+              [namespace]: {...nextState[namespace], [id]: nextSelectedItems.length > 0 ? nextSelectedItems : ''},
             };
           },
         })),

--- a/packages/react-instantsearch/src/connectors/connectRefinementList.test.js
+++ b/packages/react-instantsearch/src/connectors/connectRefinementList.test.js
@@ -207,11 +207,21 @@ describe('connectRefinementList', () => {
         },
       ],
     });
+  });
 
-    let searchState = metadata.items[0].items[0].value({refinementList: {wot: ['wat', 'wut']}});
-    expect(searchState).toEqual({refinementList: {wot: ['wut']}});
+  it('items value function should clear it from the search state', () => {
+    const metadata = getMetadata(
+      {attributeName: 'one'},
+      {refinementList: {one: ['one1', 'one2'], two: ['two']}}
+    );
+
+    let searchState = metadata.items[0].items[0].value({refinementList: {one: ['one1', 'one2'], two: ['two']}});
+
+    expect(searchState).toEqual({refinementList: {one: ['one2'], two: ['two']}});
+
     searchState = metadata.items[0].items[1].value(searchState);
-    expect(searchState).toEqual({refinementList: {wot: ''}});
+
+    expect(searchState).toEqual({refinementList: {one: '', two: ['two']}});
   });
 
   it('should return the right searchState when clean up', () => {

--- a/packages/react-instantsearch/src/connectors/connectToggle.js
+++ b/packages/react-instantsearch/src/connectors/connectToggle.js
@@ -95,7 +95,7 @@ export default createConnector({
         attributeName: props.attributeName,
         value: nextState => ({
           ...nextState,
-          [namespace]: {[id]: false},
+          [namespace]: {...nextState[namespace], [id]: false},
         }),
       });
     }

--- a/packages/react-instantsearch/src/connectors/connectToggle.test.js
+++ b/packages/react-instantsearch/src/connectors/connectToggle.test.js
@@ -78,9 +78,14 @@ describe('connectToggle', () => {
       ],
       id: 't',
     });
+  });
 
-    const searchState = metadata.items[0].value({toggle: {t: true}});
-    expect(searchState).toEqual({toggle: {t: false}});
+  it('items value function should clear it from the search state', () => {
+    const metadata = getMetadata({attributeName: 'one', label: 'yep'}, {toggle: {one: true, two: false}});
+
+    const searchState = metadata.items[0].value({toggle: {one: true, two: false}});
+
+    expect(searchState).toEqual({toggle: {one: false, two: false}});
   });
 
   it('should return the right searchState when clean up', () => {

--- a/packages/react-instantsearch/src/widgets/ClearAll.js
+++ b/packages/react-instantsearch/src/widgets/ClearAll.js
@@ -6,6 +6,7 @@ import ClearAllComponent from '../components/ClearAll.js';
  * to the search.
  * @name ClearAll
  * @kind widget
+ * @propType {function} [transformItems] - If provided, this function can be used to modify the `items` provided prop of the wrapped component (ex: for filtering or sorting items). this function takes the `items` prop as a parameter and expects it back in return.
  * @themeKey ais-ClearAll__root - the widget button
  * @translationKey reset - the clear all button value
  * @example


### PR DESCRIPTION
![bug-clear-all-fix](https://cloud.githubusercontent.com/assets/6885378/21844673/daf61afa-d7ef-11e6-9d52-d45c68bf89fc.gif)

Also add a guide to explain how you can hide a default refinement. Then it will not be possible to remove it. 