### PR TITLE
docs(website): fix dropdowns to allow clicking on ꜜ

### DIFF
--- a/docgen/assets/js/dropdowns.js
+++ b/docgen/assets/js/dropdowns.js
@@ -29,7 +29,7 @@ function dropdowns() {
     // Check if the clicked element is the
     // dropdown toggler, if not, close the dropdown
     document.body.addEventListener('click', e => {
-      if (e.target !== element) {
+      if (!element.contains(e.target)) {
         theDropdown.classList.remove('opened');
       }
     });


### PR DESCRIPTION
Before this commit you could not click on the ꜜ next to API.