### PR TITLE
fix(InstantSearch): add specific `react-instantsearch ${version}` agent

### DIFF
--- a/packages/react-instantsearch/.babelrc
+++ b/packages/react-instantsearch/.babelrc
@@ -1,0 +1,6 @@
+{
+  "extends": "../../.babelrc",
+  "plugins": [
+    ["inline-json-import", {}]
+  ]
+}

--- a/packages/react-instantsearch/package.json
+++ b/packages/react-instantsearch/package.json
@@ -22,6 +22,7 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "babel-plugin-inline-json-import": "^0.1.6",
     "enzyme": "^2.7.0",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",

--- a/packages/react-instantsearch/src/core/__snapshots__/createInstantSearch.test.js.snap
+++ b/packages/react-instantsearch/src/core/__snapshots__/createInstantSearch.test.js.snap
@@ -1,0 +1,12 @@
+exports[`createInstantSearch wraps InstantSearch 1`] = `
+Object {
+  "algoliaClient": Object {
+    "addAlgoliaAgent": [Function],
+  },
+  "children": undefined,
+  "indexName": "name",
+  "root": Object {
+    "Root": "div",
+  },
+}
+`;

--- a/packages/react-instantsearch/src/core/createInstantSearch.js
+++ b/packages/react-instantsearch/src/core/createInstantSearch.js
@@ -1,5 +1,6 @@
 import React, {Component, PropTypes} from 'react';
 import InstantSearch from './InstantSearch';
+import pkg from '../../package.json';
 
 /**
  * Creates a specialized root InstantSearch component. It accepts
@@ -24,6 +25,7 @@ export default function createInstantSearch(defaultAlgoliaClient, root) {
     constructor(props) {
       super();
       this.client = props.algoliaClient || defaultAlgoliaClient(props.appId, props.apiKey);
+      this.client.addAlgoliaAgent(`react-instantsearch ${pkg.version}`);
     }
 
     componentWillReceiveProps(nextProps) {
@@ -33,6 +35,7 @@ export default function createInstantSearch(defaultAlgoliaClient, root) {
       } else if (props.appId !== nextProps.appId || props.apiKey !== nextProps.apiKey) {
         this.client = defaultAlgoliaClient(nextProps.appId, nextProps.apiKey);
       }
+      this.client.addAlgoliaAgent(`react-instantsearch ${pkg.version}`);
     }
 
     render() {

--- a/packages/react-instantsearch/yarn.lock
+++ b/packages/react-instantsearch/yarn.lock
@@ -305,6 +305,12 @@ babel-plugin-external-helpers@^6.18.0:
   dependencies:
     babel-runtime "^6.0.0"
 
+babel-plugin-inline-json-import@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/babel-plugin-inline-json-import/-/babel-plugin-inline-json-import-0.1.6.tgz#b16b5aab87f7ea6a41a4db8193b9ba39d49d1c76"
+  dependencies:
+    decache "^4.1.0"
+
 babel-plugin-react-transform@2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-react-transform/-/babel-plugin-react-transform-2.0.2.tgz#515bbfa996893981142d90b1f9b1635de2995109"
@@ -822,6 +828,10 @@ bytes@2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.4.0.tgz#7d97196f9d5baf7f6935e25985549edd2a6c2339"
 
+callsite@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/callsite/-/callsite-1.0.0.tgz#280398e5d664bd74038b6f0905153e6e8af1bc20"
+
 camelcase@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
@@ -1096,6 +1106,12 @@ debug@~2.2.0:
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
   dependencies:
     ms "0.7.1"
+
+decache@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/decache/-/decache-4.1.0.tgz#2037d5edf756dda230c85023659e7c3d1d6e0105"
+  dependencies:
+    callsite "^1.0.0"
 
 decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"


### PR DESCRIPTION
Before this commit we were not identifying react-instantsearch
in Algolia analytics, now we are.