### PR TITLE
fix(SFFV): correct propTypes and add missing default values

### DIFF
--- a/packages/react-instantsearch/src/components/List.js
+++ b/packages/react-instantsearch/src/components/List.js
@@ -21,7 +21,11 @@ class List extends Component {
     limit: PropTypes.number,
     show: PropTypes.func,
     searchForFacetValues: PropTypes.func,
-    isFromSearch: PropTypes.bool.isRequired,
+    isFromSearch: PropTypes.bool,
+  };
+
+  defaultProps= {
+    isFromSearch: false,
   };
 
   constructor() {


### PR DESCRIPTION
A warning was thrown for `<HierarchicalMenu/>` and `<MultiRange/>` because the `isFromSearch` prop was marked as required. 