### PR TITLE
doc(getting-started): Some links are unclickable

### DIFF
--- a/docgen/src/stylesheets/components/_documentation.scss
+++ b/docgen/src/stylesheets/components/_documentation.scss
@@ -169,7 +169,7 @@
     }
 
 
-    h2, h3, .api-entry, .css-class {
+    h3, .api-entry, .css-class {
       &:before {
         content: "";
         display: block;

--- a/docgen/src/stylesheets/components/_documentation.scss
+++ b/docgen/src/stylesheets/components/_documentation.scss
@@ -44,6 +44,7 @@
     padding-bottom: 8px;
     position: relative;
     z-index: 0;
+    pointer-events: none;
 
     &:first-of-type {
       margin-top: 0;
@@ -169,7 +170,7 @@
     }
 
 
-    h3, .api-entry, .css-class {
+    h2, h3, .api-entry, .css-class {
       &:before {
         content: "";
         display: block;


### PR DESCRIPTION
**What project are you opening a pull request for?**
- react-instantsearch docs

**Summary**
In the docs, [links that are followed by an `h2`](https://community.algolia.com/instantsearch.js/react/Getting_started.html#load-the-theme) are not clickable:

![clicking-issue](https://cloud.githubusercontent.com/assets/428280/22030871/4c640104-dcdf-11e6-9954-8d30d1e6d626.png)

This prevents the user from accessing them.
This is due to the `h2:before` overflowing the underlying text.

**Result**

After removing `h2:before`, the block doesn't overflow the text anymore:
![slice](https://cloud.githubusercontent.com/assets/428280/22031294/8297a842-dce0-11e6-866a-9a185088360a.png)
 