### PR TITLE
fix(createInstantsearch): fix missing props

### DIFF
--- a/packages/react-instantsearch/src/core/__snapshots__/createInstantSearch.test.js.snap
+++ b/packages/react-instantsearch/src/core/__snapshots__/createInstantSearch.test.js.snap
@@ -4,9 +4,13 @@ Object {
     "addAlgoliaAgent": [Function],
   },
   "children": undefined,
+  "createURL": undefined,
   "indexName": "name",
+  "onSearchStateChange": undefined,
   "root": Object {
     "Root": "div",
   },
+  "searchParameters": undefined,
+  "searchState": undefined,
 }
 `;

--- a/packages/react-instantsearch/src/core/createInstantSearch.js
+++ b/packages/react-instantsearch/src/core/createInstantSearch.js
@@ -20,6 +20,10 @@ export default function createInstantSearch(defaultAlgoliaClient, root) {
         React.PropTypes.node,
       ]),
       indexName: PropTypes.string.isRequired,
+      searchParameters: PropTypes.object,
+      createURL: PropTypes.func,
+      searchState: PropTypes.object,
+      onSearchStateChange: PropTypes.func,
     };
 
     constructor(props) {
@@ -41,7 +45,11 @@ export default function createInstantSearch(defaultAlgoliaClient, root) {
     render() {
       return (
         <InstantSearch
+          createURL={this.props.createURL}
           indexName={this.props.indexName}
+          searchParameters={this.props.searchParameters}
+          searchState={this.props.searchState}
+          onSearchStateChange={this.props.onSearchStateChange}
           root={root}
           algoliaClient={this.client}
           children={this.props.children}


### PR DESCRIPTION
Based on @zackify findings: add back the missing props types and forward
them to InstantSearch. This commit adds them explicitly.

Fixes #1849 