### PR TITLE
doc(getting-started): Fix anchor links 

### DIFF
--- a/docgen/src/stylesheets/components/_documentation.scss
+++ b/docgen/src/stylesheets/components/_documentation.scss
@@ -179,6 +179,15 @@
         position: relative;
         z-index: 0;
       }
+      &:after {
+        content: "";
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        top: $offset-height;
+        pointer-events: all;
+      }
     }
 
     // API tables
@@ -337,6 +346,9 @@
   h2, h3, .api-entry {
     .anchor {
       text-decoration: none;
+      position: absolute;
+      z-index: 2;
+      pointer-events: all;
     }
     .anchor:after{
       content: '#';

--- a/docgen/src/stylesheets/components/_documentation.scss
+++ b/docgen/src/stylesheets/components/_documentation.scss
@@ -169,7 +169,7 @@
     }
 
 
-    h2, h3, .api-entry, .css-class {
+    h3, .api-entry, .css-class {
       &:before {
         content: "";
         display: block;

--- a/docgen/src/stylesheets/components/_documentation.scss
+++ b/docgen/src/stylesheets/components/_documentation.scss
@@ -44,6 +44,7 @@
     padding-bottom: 8px;
     position: relative;
     z-index: 0;
+    pointer-events: none;
 
     &:first-of-type {
       margin-top: 0;
@@ -169,7 +170,7 @@
     }
 
 
-    h3, .api-entry, .css-class {
+    h2, h3, .api-entry, .css-class {
       &:before {
         content: "";
         display: block;


### PR DESCRIPTION
**Summary**
This continues #1848. It let anchors link be clickable.
It turned out to be a little trickier than expected, but  the idea was to use `point-events: all` to allow mouse events on some parts:
- The title needs to be hoverable (see the added `::after`)
- The anchor link needs to be clickable (it's now absolutely positionned on top of the `::after`)