### PR TITLE
fix(publish): publish react-instantsearch/dist instead of root

### DIFF
--- a/packages/react-instantsearch-theme-algolia/package.json
+++ b/packages/react-instantsearch-theme-algolia/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "scripts": {
     "build": "babel-node scripts/build.js",
-    "prepublish": "yarn build"
+    "build-and-publish": "./scripts/build-and-publish.sh"
   },
   "devDependencies": {
     "autoprefixer": "^6.6.1",

--- a/packages/react-instantsearch-theme-algolia/scripts/build-and-publish.sh
+++ b/packages/react-instantsearch-theme-algolia/scripts/build-and-publish.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+yarn build &&
+npm publish

--- a/packages/react-instantsearch/package.json
+++ b/packages/react-instantsearch/package.json
@@ -8,7 +8,7 @@
   "version": "2.2.3",
   "scripts": {
     "build": "./scripts/build.sh",
-    "prepublish": "yarn build && rm -rf dist/"
+    "build-and-publish": "./scripts/build-and-publish.sh"
   },
   "homepage": "https://community.algolia.com/instantsearch.js/react/",
   "repository": {

--- a/packages/react-instantsearch/scripts/build-and-publish.sh
+++ b/packages/react-instantsearch/scripts/build-and-publish.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+yarn build &&
+cd dist/ &&
+npm publish &&
+rm -rf dist/

--- a/packages/react-instantsearch/scripts/build.sh
+++ b/packages/react-instantsearch/scripts/build.sh
@@ -1,13 +1,11 @@
 #!/usr/bin/env bash
 
-set -e # exit when error
-
-mkdir -p dist/
-rm -rf dist/*
-cp package.json dist/
-cp README.md dist/
-babel -q index.js -o dist/index.js
-babel -q dom.js -o dist/dom.js
-babel -q connectors.js -o dist/connectors.js
-babel -q native.js -o dist/native.js
+mkdir -p dist/ &&
+rm -rf dist/* &&
+cp package.json dist/ &&
+cp README.md dist/ &&
+babel -q index.js -o dist/index.js &&
+babel -q dom.js -o dist/dom.js &&
+babel -q connectors.js -o dist/connectors.js &&
+babel -q native.js -o dist/native.js &&
 babel -q --ignore test.js,__mocks__ --out-dir dist/src src

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -85,12 +85,12 @@ git push origin --tags
 
 (
 cd packages/react-instantsearch
-npm publish # This cannot be moved to yarn yet
+npm run build-and-publish
 )
 
 (
 cd packages/react-instantsearch-theme-algolia
-npm publish  # This cannot be moved to yarn yet
+npm run build-and-publish
 )
 
 printf "Release:


### PR DESCRIPTION
Before this commit, we broke the publishing process