### PR TITLE
Fix Toggle component used with CurrentRefinements

### DIFF
--- a/packages/react-instantsearch/src/connectors/connectToggle.js
+++ b/packages/react-instantsearch/src/connectors/connectToggle.js
@@ -44,8 +44,8 @@ export default createConnector({
   },
 
   getProvidedProps(props, searchState) {
-    const checked = getCurrentRefinement(props, searchState);
-    return {checked};
+    const currentRefinement = getCurrentRefinement(props, searchState);
+    return {currentRefinement};
   },
 
   refine(props, searchState, nextChecked) {

--- a/packages/react-instantsearch/src/connectors/connectToggle.test.js
+++ b/packages/react-instantsearch/src/connectors/connectToggle.test.js
@@ -19,13 +19,13 @@ let params;
 describe('connectToggle', () => {
   it('provides the correct props to the component', () => {
     props = getProvidedProps({attributeName: 't'}, {});
-    expect(props).toEqual({checked: false});
+    expect(props).toEqual({currentRefinement: false});
 
     props = getProvidedProps({attributeName: 't'}, {toggle: {t: true}});
-    expect(props).toEqual({checked: true});
+    expect(props).toEqual({currentRefinement: true});
 
     props = getProvidedProps({defaultRefinement: true, attributeName: 't'}, {});
-    expect(props).toEqual({checked: true});
+    expect(props).toEqual({currentRefinement: true});
   });
 
   it('calling refine updates the widget\'s search state', () => {

--- a/stories/CurrentRefinements.stories.js
+++ b/stories/CurrentRefinements.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {storiesOf} from '@kadira/storybook';
-import {CurrentRefinements, RefinementList} from '../packages/react-instantsearch/dom';
+import {CurrentRefinements, RefinementList, Toggle} from '../packages/react-instantsearch/dom';
 import {withKnobs} from '@kadira/storybook-addon-knobs';
 import {WrapWithHits} from './util';
 
@@ -18,6 +18,17 @@ stories.add('default', () =>
           defaultRefinement={['Dining']}
         />
       </div>
+    </div>
+  </WrapWithHits>
+).add('with toggle', () =>
+  <WrapWithHits linkedStoryGroup="CurrentRefinements">
+    <div>
+      <CurrentRefinements />
+      <Toggle
+        attributeName="materials"
+        label="Made with solid pine"
+        value={'Solid pine'}
+      />
     </div>
   </WrapWithHits>
 );


### PR DESCRIPTION
Steps to reproduce:

1.  Use Toggle with CurrentRefinements
2.  Click on Toggle component
3.  Refinement is shown in CurrentRefinements
4.  Remove Refinement from CurrentRefinements
5.  BUG: Toggle was not unchecked.
