### PR TITLE
chore(website): fix production website paths

### DIFF
--- a/docgen/config.js
+++ b/docgen/config.js
@@ -4,8 +4,8 @@ import {rootPath} from './path';
 const configs = {
   production: {
     docsDist: rootPath('docs-production/react'),
-    storyBookPublicPath: '/react/storybook/',
-    publicPath: '/react/',
+    storyBookPublicPath: 'storybook/',
+    publicPath: '/instantsearch.js/react/',
   },
   development: {
     docsDist: rootPath('docs/react'),

--- a/docgen/rootFiles/_redirects
+++ b/docgen/rootFiles/_redirects
@@ -1,1 +1,1 @@
-/ /react 301
+/ /instantsearch.js/react 301

--- a/scripts/docs:build-preview.sh
+++ b/scripts/docs:build-preview.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
 NODE_ENV=production yarn docs:build &&
-mv docs-production/react/_redirects docs-production/_redirects # This is necessary so that the deployed preview lives at /react/
+mkdir -p docs-production/instantsearch.js/ &&
+mv docs-production/react/_redirects docs-production/ && # This is necessary so that the deployed preview lives at /react/
+mv docs-production/react docs-production/instantsearch.js

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -79,9 +79,10 @@ git tag "v$newVersion"
 printf "\n\nRelease: almost done, check everything in another terminal tab if you want.\n"
 read -p "=> Release: when ready, press [ENTER] to push to github and publish the package"
 
-printf "\n\nRelease: pushed to github, publish on npm"
 git push origin v2
 git push origin --tags
+
+printf "\n\nRelease: pushed to github, publish on npm"
 
 (
 cd packages/react-instantsearch


### PR DESCRIPTION
Before this commit I messed up with the production website and made
the base href path /react/ instead of /instantsearch.js/react/

Now both the preview and production website will reside at
/instantsearch.js/react/.