### PR TITLE
Fix header links, again

### DIFF
--- a/docgen/src/stylesheets/components/_documentation.scss
+++ b/docgen/src/stylesheets/components/_documentation.scss
@@ -45,17 +45,24 @@
     position: relative;
     z-index: 99;
 
+    &:not(.sidebar-header) {
+      display: inline-block;
+      width: 100%;
+      line-height: 1;
+      margin-top: -20px;
+    }
+
     &:first-of-type {
       margin-top: 0;
+
+      .content &{
+        margin-top: -10px;
+      }
     }
 
     @include small-mq {
       font-size: 22px;
     }
-  }
-
-  h3 {
-    margin-top: 32px;
   }
 
   h4 {
@@ -145,6 +152,9 @@
     }
 
     .content {
+      h2:first-of-type {
+        margin-top: -16px;
+      }
       & p:first-child {
         margin-top: 0;
       }
@@ -176,7 +186,7 @@
         content: "";
         display: block;
         height: $offset-height;
-        margin: -$offset-height 0 0;
+        margin: -($offset-height - 60) 0 0;
         position: relative;
         z-index: 0;
         pointer-events: none;

--- a/docgen/src/stylesheets/components/_fonts.scss
+++ b/docgen/src/stylesheets/components/_fonts.scss
@@ -44,6 +44,10 @@ p {
   }
 }
 
+li {
+  color: $blueish-grey;
+}
+
 /* Big titles
 ======================*/
 h2.title {


### PR DESCRIPTION
To fix the issue I had to play a lot with margin values, and to increase a bit the distance between titles and paragraphs. 

| Before  | After |
| ------------- | ------------- |
| ![](https://puu.sh/txMjO/dd84b2ce6b.png)  | ![](https://puu.sh/txMlf/c1b739334b.png) |


But I don't think it looks that bad after all. 

So now, all the "anchors / links" issues should be fixed :) 
Next time we should consider using Javascript to make anchors, to get rid of this issue. 