### PR TITLE
docs(sidebar): fix display when screen is cut in half

### DIFF
--- a/docgen/src/stylesheets/components/_documentation.scss
+++ b/docgen/src/stylesheets/components/_documentation.scss
@@ -50,6 +50,7 @@
       width: 100%;
       line-height: 1;
       margin-top: -20px;
+      z-index: 0;
     }
 
     &:first-of-type {


### PR DESCRIPTION
Previous behavior: 

![image](https://cloud.githubusercontent.com/assets/6885378/22294625/374e4f8c-e314-11e6-9daa-3a80b8aa7c19.png)
