### PR TITLE
fix(Hits): limit the hitComponent to be only a function

### DIFF
--- a/packages/react-instantsearch/src/components/Hits.js
+++ b/packages/react-instantsearch/src/components/Hits.js
@@ -18,11 +18,7 @@ class Hits extends Component {
 
 Hits.propTypes = {
   hits: PropTypes.array,
-
-  hitComponent: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-  ]).isRequired,
+  hitComponent: PropTypes.func.isRequired,
 };
 
 Hits.defaultProps = {

--- a/packages/react-instantsearch/src/components/Hits.test.js
+++ b/packages/react-instantsearch/src/components/Hits.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest, jasmine */
 
-import React from 'react';
+import React, {PropTypes} from 'react';
 import renderer from 'react-test-renderer';
 
 import Hits from './Hits';
@@ -8,7 +8,10 @@ import Hits from './Hits';
 describe('Hits', () => {
   it('accepts a hitComponent prop', () => {
     const hits = [{objectID: 0}, {objectID: 1}, {objectID: 2}];
-    const Hit = 'Hit';
+    const Hit = ({hit}) => <div id={hit.objectID}/>;
+    Hit.propTypes = {
+      hit: PropTypes.object,
+    };
     const tree = renderer.create(
       <Hits
         hitComponent={Hit}

--- a/packages/react-instantsearch/src/components/__snapshots__/Hits.test.js.snap
+++ b/packages/react-instantsearch/src/components/__snapshots__/Hits.test.js.snap
@@ -1,23 +1,11 @@
 exports[`Hits accepts a hitComponent prop 1`] = `
 <div
   className="ais-Hits__root">
-  <Hit
-    hit={
-      Object {
-        "objectID": 0,
-      }
-    } />
-  <Hit
-    hit={
-      Object {
-        "objectID": 1,
-      }
-    } />
-  <Hit
-    hit={
-      Object {
-        "objectID": 2,
-      }
-    } />
+  <div
+    id={0} />
+  <div
+    id={1} />
+  <div
+    id={2} />
 </div>
 `;


### PR DESCRIPTION
**What project are you opening a pull request for?**
- react-instantsearch (use v2 base)

**Summary**
This merge request limits the `hitComponent` prop of `<Hits>` to be only a function. It keeps the API simple, and will now print a warning if the user pass a string.

**Result**
Passing a string to `hitComponent` now makes React complain about it.
