### PR TITLE
docs(anchors): fix anchors situation

### DIFF
--- a/docgen/assets/js/sidebar.js
+++ b/docgen/assets/js/sidebar.js
@@ -44,6 +44,7 @@ function scrollSpy(sidebarContainer, headersContainer) {
       const currentHref = item.getAttribute('href');
       const anchorToFind = `#${header.getAttribute('id')}`;
       const isCurrentHeader =
+        currentHref.indexOf(anchorToFind) > 0 &&
         currentHref.indexOf(anchorToFind) ===
         currentHref.length - anchorToFind.length;
       if (isCurrentHeader) {

--- a/docgen/layouts/widget.pug
+++ b/docgen/layouts/widget.pug
@@ -44,7 +44,7 @@ block content
             td(colspan=3)!=h.markdown(type.description)
   else
     p This widget does not accept props.
-  h2#theme Classnames
+  h2#classnames Classnames
     a.anchor(href=`${navPath}#classnames`)
   if themekey
     table.api

--- a/docgen/src/stylesheets/components/_documentation.scss
+++ b/docgen/src/stylesheets/components/_documentation.scss
@@ -42,15 +42,6 @@
     border-bottom: 1px solid #d8d8d8;
     margin-top: 32px;
     padding-bottom: 8px;
-    position: relative;
-    z-index: 99;
-
-    &:not(.sidebar-header) {
-      display: inline-block;
-      width: 100%;
-      line-height: 1;
-      margin-top: -20px;
-    }
 
     &:first-of-type {
       margin-top: 0;
@@ -186,20 +177,8 @@
         content: "";
         display: block;
         height: $offset-height;
-        margin: -($offset-height - 60) 0 0;
-        position: relative;
-        z-index: 0;
-        pointer-events: none;
-      }
-      &:after {
-        content: "";
-        position: absolute;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        top: $offset-height;
-        pointer-events: all;
-        max-height: $offset-height
+        margin-top: -$offset-height;
+        box-sizing: content-box;
       }
     }
 
@@ -393,10 +372,6 @@ tr.api-entry-values {
   }
 }
 
-tr.api-entry-description {
-
-}
-
 .DocProps {
   .Prop,
   .Type .Entry {
@@ -501,9 +476,9 @@ tr.api-entry-description {
 }
 
 .storybook-section {
-  min-height: 120px;
+  margin-top: 20px;
   text-align: center;
-  line-height: 120px;
+  line-height: 42px;
 }
 
 @import "docs/method";


### PR DESCRIPTION
This commit fixes many issues around anchors:
- widget pages were not referencing right anchor for classnames
- anchors inside tables were displaying in a bad way
- anchors were adding too much top margin to most titles
- sidebar higlighting was broken