### PR TITLE
fix(*List): disable shortcuts in *List SearchBoxes

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,9 @@
   "engines": {
     "node": "^6.x.x || ^7.x.x"
   },
+  "jest": {
+    "notify": true
+  },
   "license": "MIT",
   "author": {
     "name": "Algolia, Inc.",

--- a/packages/react-instantsearch/src/components/List.js
+++ b/packages/react-instantsearch/src/components/List.js
@@ -101,6 +101,7 @@ class List extends Component {
             this.setState({query: value});
             searchForFacetValues(value);
           }}
+          focusShortcuts={[]}
           translate={translate}
           onSubmit={e => {
             e.preventDefault();


### PR DESCRIPTION
Before this commit, when using searchForFacetValues,
the default SearchBox shortcuts would be listening for shortcuts.

Thus when hitting `/` or `s` it would try to focus
the SearchBox of RefinementList instead of something else.

fixes #1920

Note: we are not testing List.js right now, we need to fix that.