### PR TITLE
fix(StarRating): indicate no refinement

### DIFF
--- a/packages/react-instantsearch/src/components/StarRating.js
+++ b/packages/react-instantsearch/src/components/StarRating.js
@@ -101,6 +101,7 @@ class StarRating extends Component {
 
   render() {
     const {translate, refine, min, max, count, createURL, canRefine} = this.props;
+
     const items = [];
     for (let i = max; i >= min; i--) {
       const itemCount = count.reduce((acc, item) => {

--- a/packages/react-instantsearch/src/connectors/connectRange.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.js
@@ -97,13 +97,12 @@ export default createConnector({
       min: valueMin = min,
       max: valueMax = max,
     } = getCurrentRefinement(props, searchState);
-
     return {
       min,
       max,
       currentRefinement: {min: valueMin, max: valueMax},
       count,
-      canRefine: true,
+      canRefine: count.length > 0,
     };
   },
 

--- a/packages/react-instantsearch/src/connectors/connectRange.test.js
+++ b/packages/react-instantsearch/src/connectors/connectRange.test.js
@@ -24,7 +24,7 @@ describe('connectRange', () => {
       max: 10,
       currentRefinement: {min: 5, max: 10},
       count: [],
-      canRefine: true,
+      canRefine: false,
     });
 
     const results = {
@@ -56,7 +56,7 @@ describe('connectRange', () => {
       max: 10,
       currentRefinement: {min: 6, max: 9},
       count: [],
-      canRefine: true,
+      canRefine: false,
     });
 
     props = getProvidedProps({
@@ -71,7 +71,7 @@ describe('connectRange', () => {
       max: 10,
       currentRefinement: {min: 6, max: 9},
       count: [],
-      canRefine: true,
+      canRefine: false,
     });
 
     props = getProvidedProps({
@@ -85,7 +85,7 @@ describe('connectRange', () => {
       max: 10,
       currentRefinement: {min: 6, max: 9},
       count: [],
-      canRefine: true,
+      canRefine: false,
     });
   });
 

--- a/stories/StarRating.stories.js
+++ b/stories/StarRating.stories.js
@@ -10,18 +10,18 @@ stories.addDecorator(withKnobs);
 
 stories.add('default', () =>
   <WrapWithHits hasPlayground={true} linkedStoryGroup="StarRating">
-    <StarRating attributeName="rating" max={6}/>
+    <StarRating attributeName="rating" max={6} min={1}/>
   </WrapWithHits>
 ).add('with panel', () =>
   <WrapWithHits>
       <Panel title="Ratings">
-        <StarRating attributeName="rating" max={6}/>
+        <StarRating attributeName="rating" max={6} min={1}/>
       </Panel>
   </WrapWithHits>
 ).add('with panel but no refinement', () =>
   <WrapWithHits searchBox={false}>
       <Panel title="Ratings">
-         <StarRating attributeName="rating" max={6}/>
+         <StarRating attributeName="rating" max={6} min={1}/>
          <div style={{display: 'none'}}>
             <SearchBox defaultRefinement="ds" />
          </div>


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/6885378/22460146/e9b8e20c-e7a3-11e6-8bc6-e9975e065089.png)

will now lead to: 

![image](https://cloud.githubusercontent.com/assets/6885378/22460161/fa81b316-e7a3-11e6-9b55-d47816e900ad.png)
