### PR TITLE
feat(Configure): add configure parameters in search state

### DIFF
--- a/packages/react-instantsearch/src/connectors/connectConfigure.js
+++ b/packages/react-instantsearch/src/connectors/connectConfigure.js
@@ -1,11 +1,40 @@
 import createConnector from '../core/createConnector.js';
-import omit from 'lodash/omit';
+import {omit, isEmpty} from 'lodash';
+
+const namespace = 'configure';
+
+function getCurrentRefinement(props, searchState) {
+  return Object.keys(props).reduce((acc, item) => {
+    acc[item] = searchState[namespace] && searchState[namespace][item]
+     ? searchState[namespace][item] : props[item];
+    return acc;
+  }, {});
+}
 
 export default createConnector({
   displayName: 'AlgoliaConfigure',
-  getProvidedProps() { return {}; },
-  getSearchParameters(searchParameters, props) {
-    const configuration = omit(props, 'children');
+  getProvidedProps() {
+    return {};
+  },
+  getSearchParameters(searchParameters, props, searchState) {
+    const items = omit(props, 'children');
+    const configuration = getCurrentRefinement(items, searchState);
     return searchParameters.setQueryParameters(configuration);
+  },
+  transitionState(props, prevSearchState, nextSearchState) {
+    const items = omit(props, 'children');
+    return {
+      ...nextSearchState,
+      [namespace]: {...items, ...nextSearchState[namespace]},
+    };
+  },
+  cleanUp(props, searchState) {
+    const configureState = Object.keys(searchState[namespace]).reduce((acc, item) => {
+      if (!props[item]) {
+        acc[item] = searchState[namespace][item];
+      }
+      return acc;
+    }, {});
+    return isEmpty(configureState) ? omit(searchState, namespace) : {...searchState, [namespace]: configureState};
   },
 });

--- a/packages/react-instantsearch/src/connectors/connectConfigure.test.js
+++ b/packages/react-instantsearch/src/connectors/connectConfigure.test.js
@@ -4,16 +4,58 @@ import {SearchParameters} from 'algoliasearch-helper';
 import connect from './connectConfigure.js';
 jest.mock('../core/createConnector');
 
-const {getSearchParameters} = connect;
+const {getSearchParameters, transitionState, cleanUp} = connect;
 
 describe('connectConfigure', () => {
   it('it propagates the props to the SearchParameters without children', () => {
     const searchParameters = getSearchParameters(
       new SearchParameters(),
-      {distinct: 1, whatever: 'please', children: 'whatever'}
+      {distinct: 1, whatever: 'please', children: 'whatever'},
+      {}
     );
     expect(searchParameters.getQueryParameter('distinct')).toEqual(1);
     expect(searchParameters.getQueryParameter('whatever')).toEqual('please');
     expect(searchParameters.getQueryParameter.bind(searchParameters, 'children')).toThrow();
+  });
+
+  it('configure parameters that are in the search state should override the default one', () => {
+    const searchParameters = getSearchParameters(
+      new SearchParameters(),
+      {distinct: 1, whatever: 'please', children: 'whatever'},
+      {configure: {whatever: 'priority'}}
+    );
+    expect(searchParameters.getQueryParameter('distinct')).toEqual(1);
+    expect(searchParameters.getQueryParameter('whatever')).toEqual('priority');
+    expect(searchParameters.getQueryParameter.bind(searchParameters, 'children')).toThrow();
+  });
+
+  it('calling transitionState should add configure parameters to the search state', () => {
+    let searchState = transitionState(
+      {distinct: 1, whatever: 'please', children: 'whatever'},
+      {},
+      {}
+    );
+    expect(searchState).toEqual({configure: {distinct: 1, whatever: 'please'}});
+
+    searchState = transitionState(
+      {distinct: 1, whatever: 'please', children: 'whatever'},
+      {configure: {distinct: 1, whatever: 'please'}},
+      {configure: {distinct: 1, whatever: 'whatever'}},
+    );
+    expect(searchState).toEqual({configure: {distinct: 1, whatever: 'whatever'}});
+  });
+
+  it('calling cleanUp should remove configure parameters from the search state', () => {
+    let searchState = cleanUp(
+      {distinct: 1, whatever: 'please', children: 'whatever'},
+      {configure: {distinct: 1, whatever: 'please', another: 'parameters'}}
+    );
+    expect(searchState).toEqual({configure: {another: 'parameters'}});
+
+    searchState = cleanUp(
+      {distinct: 1, whatever: 'please', children: 'whatever'},
+      {configure: {distinct: 1, whatever: 'please'}}
+    );
+    expect(searchState).toEqual({});
   });
 });

--- a/stories/Stats.stories.js
+++ b/stories/Stats.stories.js
@@ -12,12 +12,10 @@ stories.add('default', () =>
   <WrapWithHits linkedStoryGroup="Stats">
     <div>
       <Stats />
-      <div style={{display: 'none'}}>
         <RefinementList
           attributeName="category"
           defaultRefinement={['Dining']}
         />
-      </div>
     </div>
   </WrapWithHits>
 );


### PR DESCRIPTION
This PR add to the search state all configure parameters. That way, if you perform some changes to them when listening to `onSearchStateChange` it will be taken into account. 

I used the `transitionState` function of the connector to be able to add those parameters to the state without the need of calling refine (that triggers a new search). It might not be the most obvious name though. 