### PR TITLE
feat(react-instantsearch): server-side rendering

### DIFF
--- a/packages/react-instantsearch/src/core/InstantSearch.js
+++ b/packages/react-instantsearch/src/core/InstantSearch.js
@@ -55,7 +55,8 @@ class InstantSearch extends Component {
       indexName: props.indexName,
       searchParameters: props.searchParameters,
       algoliaClient: props.algoliaClient,
-      initialState,
+      resultsState: props.resultsState,
+      initialState
     });
   }
 
@@ -139,6 +140,7 @@ InstantSearch.propTypes = {
   createURL: PropTypes.func,
 
   searchState: PropTypes.object,
+  resultsState: PropTypes.object,
   onSearchStateChange: PropTypes.func,
 
   children: PropTypes.node,

--- a/packages/react-instantsearch/src/core/createConnector.js
+++ b/packages/react-instantsearch/src/core/createConnector.js
@@ -146,6 +146,7 @@ export default function createConnector(connectorDesc) {
         metadata,
         resultsFacetValues,
       } = store.getState();
+
       const searchState = {results, searching, error};
       return connectorDesc.getProvidedProps.call(this, props, widgets, searchState, metadata, resultsFacetValues);
     };

--- a/packages/react-instantsearch/src/core/createInstantSearch.js
+++ b/packages/react-instantsearch/src/core/createInstantSearch.js
@@ -23,6 +23,7 @@ export default function createInstantSearch(defaultAlgoliaClient, root) {
       searchParameters: PropTypes.object,
       createURL: PropTypes.func,
       searchState: PropTypes.object,
+      resultsState: PropTypes.object,
       onSearchStateChange: PropTypes.func,
     };
 
@@ -51,6 +52,7 @@ export default function createInstantSearch(defaultAlgoliaClient, root) {
           searchState={this.props.searchState}
           onSearchStateChange={this.props.onSearchStateChange}
           root={root}
+          resultsState={this.props.resultsState}
           algoliaClient={this.client}
           children={this.props.children}
         />

--- a/packages/react-instantsearch/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch/src/core/createInstantSearchManager.js
@@ -18,6 +18,7 @@ export default function createInstantSearchManager({
   initialState = {},
   algoliaClient,
   searchParameters = {},
+  resultsState = null
 }) {
   const baseSP = new SearchParameters({
     ...searchParameters,
@@ -36,7 +37,7 @@ export default function createInstantSearchManager({
   const store = createStore({
     widgets: initialState,
     metadata: [],
-    results: null,
+    results: resultsState,
     error: null,
     searching: false,
   });


### PR DESCRIPTION
**Summary**
This proposes a simple solution to support server-side rendering. The idea is to remove the need to do async actions from `<InstantSearch/>` when rendering on the server side. Instead, we let the user fetch algolia results themselves, and inject them into `<InstantSearch/>` through a new `resultsState` prop.

Links to #1687, #1531, #1869

**Result**
Here is a snippet from a server. `index` uses the bestbuy example:

```js
function handleRender(req, res) {
  index.search('').then(state => {
    const html = renderToStaticMarkup(
        <InstantSearch
          appId="latency"
          apiKey="3d9875e51fbd20c7754e65422f7ce5e1"
          indexName="bestbuy"
          resultsState={state}
        >
          <SearchBox/>
          <Hits hitComponent={Product}/>
        </InstantSearch>
    )

    res.send(renderFullPage(html))
  })
}
```

The rendered result is:
```
<!DOCTYPE html>
<html>
<head>
	<title>Server-side rendering example</title>
</head>
<body>
	<div id="root">
		<div class="ais-InstantSearch__root">
			<form class="ais-SearchBox__root" novalidate="">
				<svg style="display:none;" xmlns="http://www.w3.org/2000/svg">
				<symbol id="sbx-icon-search-13" viewbox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
					<path d="M26.804 29.01c-2.832 2.34-6.465 3.746-10.426 3.746C7.333 32.756 0 25.424 0 16.378 0 7.333 7.333 0 16.378 0c9.046 0 16.378 7.333 16.378 16.378 0 3.96-1.406 7.594-3.746 10.426l10.534 10.534c.607.607.61 1.59-.004 2.202-.61.61-1.597.61-2.202.004L26.804 29.01zm-10.426.627c7.323 0 13.26-5.936 13.26-13.26 0-7.32-5.937-13.257-13.26-13.257C9.056 3.12 3.12 9.056 3.12 16.378c0 7.323 5.936 13.26 13.258 13.26z" fill-rule="evenodd"></path>
				</symbol>
				<symbol id="sbx-icon-clear-3" viewbox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
					<path d="M8.114 10L.944 2.83 0 1.885 1.886 0l.943.943L10 8.113l7.17-7.17.944-.943L20 1.886l-.943.943-7.17 7.17 7.17 7.17.943.944L18.114 20l-.943-.943-7.17-7.17-7.17 7.17-.944.943L0 18.114l.943-.943L8.113 10z" fill-rule="evenodd"></path>
				</symbol></svg>
				<div class="ais-SearchBox__wrapper" role="search">
					<input autocomplete="off" class="ais-SearchBox__input" placeholder="Search here…" required="" type="search" value=""><button class="ais-SearchBox__submit" title="Submit your search query." type="submit"><svg role="img">
					<use href="#sbx-icon-search-13"></use></svg></button><button class="ais-SearchBox__reset" title="Clear the search query." type="reset"><svg role="img">
					<use href="#sbx-icon-clear-3"></use></svg></button>
				</div>
			</form>
			<div class="ais-Hits__root">
				<div>
					Webroot SecureAnywhere Internet Security (3-Device) (1-Year Subscription) - Mac/Windows
				</div>
				<div>
					Geek Squad® - Tech Support Membership (1 Year)
				</div>
				<div>
					Apple® - 3.3&#x27; Lightning-to-USB 2.0 Cable
				</div>
				<div>
					Google - Chromecast HDMI Streaming Media Player
				</div>
				<div>
					Kaspersky Internet Security (3-Device) (1-Year Subscription) - Mac/Windows
				</div>
				<div>
					Logitech - Marathon Mouse M705 Wireless Laser Mouse - Black
				</div>
				<div>
					Toshiba - Satellite 15.6&quot; Laptop - Intel Celeron - 4GB Memory - 500GB Hard Drive - Jet Black
				</div>
				<div>
					SanDisk - Cruzer 16GB USB 2.0 Flash Drive - Black
				</div>
				<div>
					SanDisk - Ultra Plus 16GB SDHC Class 10 UHS-1 Memory Card
				</div>
				<div>
					Office Home &amp; Student 2013 - Windows
				</div>
				<div>
					Apple® - TV
				</div>
				<div>
					Monthly Accidental Protection Plan - Geek Squad
				</div>
				<div>
					Insignia™ - 4&#x27; Lightning Charge-and-Sync Cable
				</div>
				<div>
					Apple® - EarPods™ with Remote and Mic - White
				</div>
				<div>
					HP - 564XL Ink Cartridge - Black
				</div>
				<div>
					SanDisk - Ultra Plus 32GB SDHC Class 10 UHS-1 Memory Card
				</div>
				<div>
					SanDisk - Cruzer 32GB USB 2.0 Flash Drive - Black
				</div>
				<div>
					SanDisk - Ultra Plus 32GB microSDHC Class 10 UHS-1 Memory Card
				</div>
				<div>
					The Raid 2 (2 Disc) (Unrated) (Ultraviolet Digital Copy) (Blu-ray Disc)
				</div>
				<div>
					Dynex™ - 6&#x27; HDMI Cable
				</div>
			</div>
		</div>
	</div>
	<script src="/public/vendor.bundle.js">
	</script> 
	<script src="/public/bundle.js">
	</script>
</body>
</html>
```

Would love to discuss about suggestions/other ways of handling server-side rendering!