### PR TITLE
feat(custom client): allows to provide a custom JS client instance

### DIFF
--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -62,7 +62,7 @@ class InstantSearch extends EventEmitter {
     searchParameters = {},
     urlSync = null,
     searchFunction,
-    clientFactory = (app, key) => algoliasearch(app, key),
+    clientFactory = algoliasearch,
   }) {
     super();
     if (appId === null || apiKey === null || indexName === null) {

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -24,8 +24,10 @@ function defaultCreateURL() { return '#'; }
  * @param  {function} [options.searchFunction] A hook that will be called each time a search needs to be done, with the
  * helper as a parameter. It's your responsibility to call helper.search(). This option allows you to avoid doing
  * searches at page load for example.
- * @param   {function} [options.clientFactory] A function called upon initialization with the `options.appId`
- * and `options.apiKey` values, allowing you to return your own instance of the Algolia JS client to be used by instantsearch.js
+ * @param   {function} [options.clientFactory] A function called upon initialization with the original `algoliasearch`
+ * client factory function, the `options.appId` and `options.apiKey` values, allowing you to return your own instance of
+ * the Algolia JS client to be used by instantsearch.js.
+ * Defaults to: `clientFactory = (algoliasearch, app, key) => algoliasearch(app, key)`
  * @param  {Object} [options.searchParameters] Additional parameters to pass to
  * the Algolia API.
  * [Full documentation](https://community.algolia.com/algoliasearch-helper-js/reference.html#searchparameters)
@@ -62,7 +64,7 @@ class InstantSearch extends EventEmitter {
     searchParameters = {},
     urlSync = null,
     searchFunction,
-    clientFactory = algoliasearch,
+    clientFactory = (jsClientFactory, app, key) => jsClientFactory(app, key),
   }) {
     super();
     if (appId === null || apiKey === null || indexName === null) {
@@ -75,7 +77,7 @@ Usage: instantsearch({
       throw new Error(usage);
     }
 
-    const client = clientFactory(appId, apiKey);
+    const client = clientFactory(algoliasearch, appId, apiKey);
     client.addAlgoliaAgent(`instantsearch.js ${version}`);
 
     this.client = client;

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -66,7 +66,7 @@ class InstantSearch extends EventEmitter {
     searchParameters = {},
     urlSync = null,
     searchFunction,
-    createAlgoliaClient = (customOrInteralAlgoliasearch, appId, apiKey) => customOrInternalAlgoliasearch(appId, apiKey),
+    createAlgoliaClient = (customOrInternalAlgoliasearch, appId, apiKey) => customOrInternalAlgoliasearch(appId, apiKey),
   }) {
     super();
     if (appId === null || apiKey === null || indexName === null) {

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -26,7 +26,7 @@ function defaultCreateURL() { return '#'; }
  * searches at page load for example.
  * @param   {function} [options.createAlgoliaClient] Allows you to provide your own algolia client instead of
  * the one instantiated internally by instantsearch.js. Useful in situations where you need
- * to setup complex option on the client or if you need to share it easily.
+ * to setup complex options on the client or if you need to share it easily.
  * Usage:
  * `createAlgoliaClient: function(algoliasearch, appId, apiKey) { return anyCustomClient; }`
  * We forward `algoliasearch` which is the original algoliasearch module imported inside instantsearch.js

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -24,6 +24,8 @@ function defaultCreateURL() { return '#'; }
  * @param  {function} [options.searchFunction] A hook that will be called each time a search needs to be done, with the
  * helper as a parameter. It's your responsibility to call helper.search(). This option allows you to avoid doing
  * searches at page load for example.
+ * @param   {function} [options.clientInstanceFunction] A function called upon initialization with the `options.appId`
+ * and `options.apiKey` values, allowing you to return your own instance of the Algolia JS client to be used by instantsearch.js
  * @param  {Object} [options.searchParameters] Additional parameters to pass to
  * the Algolia API.
  * [Full documentation](https://community.algolia.com/algoliasearch-helper-js/reference.html#searchparameters)
@@ -60,6 +62,7 @@ class InstantSearch extends EventEmitter {
     searchParameters = {},
     urlSync = null,
     searchFunction,
+    clientInstanceFunction = (app, key) => algoliasearch(app, key),
   }) {
     super();
     if (appId === null || apiKey === null || indexName === null) {
@@ -72,7 +75,7 @@ Usage: instantsearch({
       throw new Error(usage);
     }
 
-    const client = algoliasearch(appId, apiKey);
+    const client = clientInstanceFunction(appId, apiKey);
     client.addAlgoliaAgent(`instantsearch.js ${version}`);
 
     this.client = client;

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -13,6 +13,7 @@ import version from './version.js';
 import createHelpers from './createHelpers.js';
 
 function defaultCreateURL() { return '#'; }
+const defaultCreateAlgoliaClient = (algoliasearch, appId, apiKey) => algoliasearch(appId, apiKey);
 
 /**
  * @function instantsearch
@@ -66,7 +67,7 @@ class InstantSearch extends EventEmitter {
     searchParameters = {},
     urlSync = null,
     searchFunction,
-    createAlgoliaClient = (customOrInternalAlgoliasearch, appId, apiKey) => customOrInternalAlgoliasearch(appId, apiKey),
+    createAlgoliaClient = defaultCreateAlgoliaClient,
   }) {
     super();
     if (appId === null || apiKey === null || indexName === null) {

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -24,10 +24,12 @@ function defaultCreateURL() { return '#'; }
  * @param  {function} [options.searchFunction] A hook that will be called each time a search needs to be done, with the
  * helper as a parameter. It's your responsibility to call helper.search(). This option allows you to avoid doing
  * searches at page load for example.
- * @param   {function} [options.clientFactory] A function called upon initialization with the original `algoliasearch`
- * client factory function, the `options.appId` and `options.apiKey` values, allowing you to return your own instance of
- * the Algolia JS client to be used by instantsearch.js.
- * Defaults to: `clientFactory = (algoliasearch, app, key) => algoliasearch(app, key)`
+ * @param   {function} [options.createAlgoliaClient] Allows you to provide your own algolia client instead of
+ * the one instantiated internally by instantsearch.js. Useful in situations where you need
+ * to setup complex option on the client or if you need to share it easily.
+ * Usage:
+ * `createAlgoliaClient: function(algoliasearch, appId, apiKey) { return anyCustomClient; }`
+ * We forward `algoliasearch` which is the original algoliasearch module imported inside instantsearch.js
  * @param  {Object} [options.searchParameters] Additional parameters to pass to
  * the Algolia API.
  * [Full documentation](https://community.algolia.com/algoliasearch-helper-js/reference.html#searchparameters)
@@ -64,7 +66,7 @@ class InstantSearch extends EventEmitter {
     searchParameters = {},
     urlSync = null,
     searchFunction,
-    clientFactory = (jsClientFactory, app, key) => jsClientFactory(app, key),
+    createAlgoliaClient = (customOrInteralAlgoliasearch, appId, apiKey) => customOrInternalAlgoliasearch(appId, apiKey),
   }) {
     super();
     if (appId === null || apiKey === null || indexName === null) {
@@ -77,7 +79,7 @@ Usage: instantsearch({
       throw new Error(usage);
     }
 
-    const client = clientFactory(algoliasearch, appId, apiKey);
+    const client = createAlgoliaClient(algoliasearch, appId, apiKey);
     client.addAlgoliaAgent(`instantsearch.js ${version}`);
 
     this.client = client;

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -24,7 +24,7 @@ function defaultCreateURL() { return '#'; }
  * @param  {function} [options.searchFunction] A hook that will be called each time a search needs to be done, with the
  * helper as a parameter. It's your responsibility to call helper.search(). This option allows you to avoid doing
  * searches at page load for example.
- * @param   {function} [options.clientInstanceFunction] A function called upon initialization with the `options.appId`
+ * @param   {function} [options.clientFactory] A function called upon initialization with the `options.appId`
  * and `options.apiKey` values, allowing you to return your own instance of the Algolia JS client to be used by instantsearch.js
  * @param  {Object} [options.searchParameters] Additional parameters to pass to
  * the Algolia API.
@@ -62,7 +62,7 @@ class InstantSearch extends EventEmitter {
     searchParameters = {},
     urlSync = null,
     searchFunction,
-    clientInstanceFunction = (app, key) => algoliasearch(app, key),
+    clientFactory = (app, key) => algoliasearch(app, key),
   }) {
     super();
     if (appId === null || apiKey === null || indexName === null) {
@@ -75,7 +75,7 @@ Usage: instantsearch({
       throw new Error(usage);
     }
 
-    const client = clientInstanceFunction(appId, apiKey);
+    const client = clientFactory(appId, apiKey);
     client.addAlgoliaAgent(`instantsearch.js ${version}`);
 
     this.client = client;

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -13,7 +13,7 @@ import version from './version.js';
 import createHelpers from './createHelpers.js';
 
 function defaultCreateURL() { return '#'; }
-const defaultCreateAlgoliaClient = (algoliasearch, appId, apiKey) => algoliasearch(appId, apiKey);
+const defaultCreateAlgoliaClient = (defaultAlgoliasearch, appId, apiKey) => defaultAlgoliasearch(appId, apiKey);
 
 /**
  * @function instantsearch

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -85,6 +85,42 @@ describe('InstantSearch lifecycle', () => {
     expect(algoliasearchHelper.notCalled).toBe(true, 'algoliasearchHelper not yet called');
   });
 
+  context('when providing a custom client instance', () => {
+    let customClientInstanceFunction;
+    let customAppID;
+    let customApiKey;
+
+    beforeEach(() => {
+      // InstantSearch is being called once at the top-level context, so reset the `algoliasearch` spy 
+      algoliasearch.reset();
+
+      // Create a spy to act as a clientInstanceFunction that returns a custom client 
+      customClientInstanceFunction = sinon.stub().returns(client);
+      customAppID = 'customAppID';
+      customApiKey = 'customAPIKey';
+
+      // Create a new InstantSearch instance with custom client function
+      search = new InstantSearch({
+        appId: customAppID,
+        apiKey: customApiKey,
+        indexName,
+        searchParameters,
+        urlSync: {},
+        clientInstanceFunction: customClientInstanceFunction,
+      });
+    });
+
+    it('does not call algoliasearch directly', () => {
+      expect(algoliasearch.calledOnce).toBe(false, 'algoliasearch not called');
+    });
+
+    it('calls clientInstanceFunction(appId, apiKey)', () => {
+      expect(customClientInstanceFunction.calledOnce).toBe(true, 'clientInstanceFunction called once');
+      expect(customClientInstanceFunction.args[0])
+        .toEqual([customAppID, customApiKey]);
+    });
+  });
+
   context('when adding a widget without render and init', () => {
     let widget;
 

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -85,8 +85,8 @@ describe('InstantSearch lifecycle', () => {
     expect(algoliasearchHelper.notCalled).toBe(true, 'algoliasearchHelper not yet called');
   });
 
-  context('when providing a custom client instance', () => {
-    let clientFactory;
+  context('when providing a custom client module', () => {
+    let createAlgoliaClient;
     let customAppID;
     let customApiKey;
 
@@ -95,7 +95,7 @@ describe('InstantSearch lifecycle', () => {
       algoliasearch.reset();
 
       // Create a spy to act as a clientInstanceFunction that returns a custom client
-      clientFactory = sinon.stub().returns(client);
+      createAlgoliaClient = sinon.stub().returns(client);
       customAppID = 'customAppID';
       customApiKey = 'customAPIKey';
 
@@ -106,7 +106,7 @@ describe('InstantSearch lifecycle', () => {
         indexName,
         searchParameters,
         urlSync: {},
-        clientFactory,
+        createAlgoliaClient,
       });
     });
 
@@ -114,9 +114,9 @@ describe('InstantSearch lifecycle', () => {
       expect(algoliasearch.calledOnce).toBe(false, 'algoliasearch not called');
     });
 
-    it('calls clientFactory(appId, apiKey)', () => {
-      expect(clientFactory.calledOnce).toBe(true, 'clientInstanceFunction called once');
-      expect(clientFactory.args[0])
+    it('calls createAlgoliaClient(appId, apiKey)', () => {
+      expect(createAlgoliaClient.calledOnce).toBe(true, 'clientInstanceFunction called once');
+      expect(createAlgoliaClient.args[0])
         .toEqual([algoliasearch, customAppID, customApiKey]);
     });
   });

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -91,10 +91,10 @@ describe('InstantSearch lifecycle', () => {
     let customApiKey;
 
     beforeEach(() => {
-      // InstantSearch is being called once at the top-level context, so reset the `algoliasearch` spy 
+      // InstantSearch is being called once at the top-level context, so reset the `algoliasearch` spy
       algoliasearch.reset();
 
-      // Create a spy to act as a clientInstanceFunction that returns a custom client 
+      // Create a spy to act as a clientInstanceFunction that returns a custom client
       customClientInstanceFunction = sinon.stub().returns(client);
       customAppID = 'customAppID';
       customApiKey = 'customAPIKey';

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -86,7 +86,7 @@ describe('InstantSearch lifecycle', () => {
   });
 
   context('when providing a custom client instance', () => {
-    let customClientInstanceFunction;
+    let clientFactory;
     let customAppID;
     let customApiKey;
 
@@ -95,7 +95,7 @@ describe('InstantSearch lifecycle', () => {
       algoliasearch.reset();
 
       // Create a spy to act as a clientInstanceFunction that returns a custom client
-      customClientInstanceFunction = sinon.stub().returns(client);
+      clientFactory = sinon.stub().returns(client);
       customAppID = 'customAppID';
       customApiKey = 'customAPIKey';
 
@@ -106,7 +106,7 @@ describe('InstantSearch lifecycle', () => {
         indexName,
         searchParameters,
         urlSync: {},
-        clientInstanceFunction: customClientInstanceFunction,
+        clientFactory,
       });
     });
 
@@ -114,9 +114,9 @@ describe('InstantSearch lifecycle', () => {
       expect(algoliasearch.calledOnce).toBe(false, 'algoliasearch not called');
     });
 
-    it('calls clientInstanceFunction(appId, apiKey)', () => {
-      expect(customClientInstanceFunction.calledOnce).toBe(true, 'clientInstanceFunction called once');
-      expect(customClientInstanceFunction.args[0])
+    it('calls clientFactory(appId, apiKey)', () => {
+      expect(clientFactory.calledOnce).toBe(true, 'clientInstanceFunction called once');
+      expect(clientFactory.args[0])
         .toEqual([customAppID, customApiKey]);
     });
   });

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -117,7 +117,7 @@ describe('InstantSearch lifecycle', () => {
     it('calls clientFactory(appId, apiKey)', () => {
       expect(clientFactory.calledOnce).toBe(true, 'clientInstanceFunction called once');
       expect(clientFactory.args[0])
-        .toEqual([customAppID, customApiKey]);
+        .toEqual([algoliasearch, customAppID, customApiKey]);
     });
   });
 


### PR DESCRIPTION
**What project are you opening a pull request for?**
- instantsearch.js (use develop base)

**Summary**
This PR allows one to provide his own Algolia JS client instance to instantsearch.js, instead of letting it create an internal one.  
This can be useful in different scenarios... Some that come to mind:
- when hosts/other options need to be overriden
- when Algolia is needed in another context than instantsearch only

**Result**
You just have to pass a new option to the initialization function:

```js
let search = instantsearch({
  appId: 'appId',
  apiKey: 'apiKey',
  // ...
  clientInstanceFunction: (appID, apiKey) => algoliasearch(appID, apiKey, { timeout: 4000  }),
});
```

Open to feedback of course!
Things we could consider:
- another name for the option?
- provide the same mechanism for the internal JS helper instance?