### PR TITLE
fix(createConnector): updates with latest props on state change

### DIFF
--- a/packages/react-instantsearch/src/core/createConnector.js
+++ b/packages/react-instantsearch/src/core/createConnector.js
@@ -64,7 +64,7 @@ export default function createConnector(connectorDesc) {
 
       this.unsubscribe = store.subscribe(() => {
         this.setState({
-          props: this.getProvidedProps(props),
+          props: this.getProvidedProps(this.props),
         });
       });
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**What project are you opening a pull request for?**
- react-instantsearch (use v2 base)

**Summary**

Use cases: 
- Use createConnector to create a new custom connector.
- Use this new connector to create a component.
- Update the `props` of this component.
- Trigger a `state` change.
- This component still calls `getProvidedProps` with initial props.

**Result**

- Should calls `getProvidedProps` with latest props.

cc @vvo 