### PR TITLE
fix(Configure): onSearchStateChange when props are updated

### DIFF
--- a/packages/react-instantsearch/src/connectors/connectConfigure.js
+++ b/packages/react-instantsearch/src/connectors/connectConfigure.js
@@ -29,7 +29,8 @@ export default createConnector({
     };
   },
   cleanUp(props, searchState) {
-    const configureState = Object.keys(searchState[namespace]).reduce((acc, item) => {
+    const configureKeys = searchState[namespace] ? Object.keys(searchState[namespace]) : [];
+    const configureState = configureKeys.reduce((acc, item) => {
       if (!props[item]) {
         acc[item] = searchState[namespace][item];
       }

--- a/packages/react-instantsearch/src/core/InstantSearch.js
+++ b/packages/react-instantsearch/src/core/InstantSearch.js
@@ -80,6 +80,7 @@ class InstantSearch extends Component {
           onInternalStateUpdate: this.onWidgetsInternalStateUpdate.bind(this),
           createHrefForState: this.createHrefForState.bind(this),
           onSearchForFacetValues: this.onSearchForFacetValues.bind(this),
+          onSearchStateChange: this.onSearchStateChange.bind(this),
         },
       };
     }
@@ -99,15 +100,21 @@ class InstantSearch extends Component {
   }
 
   onWidgetsInternalStateUpdate(searchState) {
+    searchState = this.onSearchStateChange(searchState);
+
+    if (!this.isControlled) {
+      this.aisManager.onExternalStateUpdate(searchState);
+    }
+  }
+
+  onSearchStateChange(searchState) {
     searchState = this.aisManager.transitionState(searchState);
 
     if (this.props.onSearchStateChange) {
       this.props.onSearchStateChange(searchState);
     }
 
-    if (!this.isControlled) {
-      this.aisManager.onExternalStateUpdate(searchState);
-    }
+    return searchState;
   }
 
   onSearchForFacetValues(searchState) {

--- a/packages/react-instantsearch/src/core/createConnector.js
+++ b/packages/react-instantsearch/src/core/createConnector.js
@@ -106,6 +106,7 @@ export default function createConnector(connectorDesc) {
           // Since props might have changed, we need to re-run getSearchParameters
           // and getMetadata with the new props.
           this.context.ais.widgetsManager.update();
+          this.context.ais.onSearchStateChange(this.context.ais.store.getState().widgets);
         }
       }
     }

--- a/packages/react-instantsearch/src/core/createConnector.test.js
+++ b/packages/react-instantsearch/src/core/createConnector.test.js
@@ -214,6 +214,7 @@ describe('createConnector', () => {
       });
       const getSearchParameters = jest.fn(() => {
       });
+      const onSearchStateChange = jest.fn();
       const update = jest.fn();
       const Dummy = jest.fn(() => null);
       const Connected = createConnector({
@@ -233,13 +234,17 @@ describe('createConnector', () => {
               registerWidget: () => null,
               update,
             },
+            onSearchStateChange,
           },
         },
       });
+      expect(onSearchStateChange.mock.calls.length).toBe(0);
       expect(update.mock.calls.length).toBe(0);
       wrapper.setProps({hello: 'there', another: ['one', 'two']});
+      expect(onSearchStateChange.mock.calls.length).toBe(1);
       expect(update.mock.calls.length).toBe(1);
       wrapper.setProps({hello: 'there', another: ['one', 'two']});
+      expect(onSearchStateChange.mock.calls.length).toBe(1);
       expect(update.mock.calls.length).toBe(1);
     });
   });
@@ -340,6 +345,7 @@ describe('createConnector', () => {
         getId,
       })(() => null);
       const update = jest.fn();
+      const onSearchStateChange = jest.fn();
       const props = {hello: 'there'};
       const wrapper = mount(<Connected {...props} />, {context: {
         ais: {
@@ -351,11 +357,14 @@ describe('createConnector', () => {
             registerWidget: () => null,
             update,
           },
+          onSearchStateChange,
         },
       }});
       expect(update.mock.calls.length).toBe(0);
+      expect(onSearchStateChange.mock.calls.length).toBe(0);
       wrapper.setProps({hello: 'you'});
       expect(update.mock.calls.length).toBe(1);
+      expect(onSearchStateChange.mock.calls.length).toBe(1);
     });
 
     it('dont update when props dont change', () => {
@@ -365,6 +374,7 @@ describe('createConnector', () => {
         getMetadata: () => null,
         getId,
       })(() => null);
+      const onSearchStateChange = jest.fn();
       const update = jest.fn();
       const props = {hello: 'there'};
       const wrapper = mount(<Connected {...props} />, {context: {
@@ -377,10 +387,13 @@ describe('createConnector', () => {
             registerWidget: () => null,
             update,
           },
+          onSearchStateChange,
         },
       }});
+      expect(onSearchStateChange.mock.calls.length).toBe(0);
       expect(update.mock.calls.length).toBe(0);
       wrapper.setProps({hello: 'there'});
+      expect(onSearchStateChange.mock.calls.length).toBe(0);
       expect(update.mock.calls.length).toBe(0);
     });
 

--- a/stories/Configure.stories.js
+++ b/stories/Configure.stories.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import {storiesOf} from '@kadira/storybook';
+import {Configure} from '../packages/react-instantsearch/dom';
+import {WrapWithHits} from './util';
+
+const stories = storiesOf('Configure', module);
+
+stories.add('default', () =>
+    <ConfigureExample/>
+);
+
+class ConfigureExample extends React.Component {
+  constructor() {
+    super();
+    this.state = {hitsPerPage: 3};
+  }
+  onClick() {
+    const hitsPerPage = this.state.hitsPerPage === 3 ? 1 : 3;
+    this.setState({hitsPerPage});
+  }
+  render() {
+    return <WrapWithHits>
+     <Configure hitsPerPage={this.state.hitsPerPage}/>
+      <button onClick={this.onClick.bind(this)}>Toggle HitsPerPage</button>
+    </WrapWithHits>;
+  }
+}


### PR DESCRIPTION
This fix: 

- bug when cleanUp `<Configure/>`
- trigger `onSearchStateChange` when props are updated (but search state is computed only by passing through `transitionState`). 

This will not perform on `onSearchStateChange` as the first rendering. If we do this, it's a breaking change. 

Also, with this method, the `search state` is still not computed correctly at any given update. For this, we need a further refactoring in order for us to be able to call the `refine` props with the extra args pre computed. 