### PR TITLE
feat(analytics-widget): add a new parameter "pushInitialSearch"

### DIFF
--- a/dev/app.js
+++ b/dev/app.js
@@ -54,6 +54,7 @@ search.addWidget(
       // }]);
     },
     triggerOnUIInteraction: true,
+    pushInitialSearch: false,
   })
 );
 

--- a/docs/_includes/widget-jsdoc/analytics.md
+++ b/docs/_includes/widget-jsdoc/analytics.md
@@ -14,5 +14,10 @@
   <span class="attr-infos">Default:<code class="attr-default">false</code>(<code>boolean</code>)</span>
 </p>
 <p class="attr-description">Trigger pushFunction after click on page or redirecting the page</p>
+<p class="attr-name">
+<span class='attr-optional'>`options.pushInitialSearch`<span class="show-description">…</span></span>
+  <span class="attr-infos">Default:<code class="attr-default">true</code>(<code>boolean</code>)</span>
+</p>
+<p class="attr-description">Trigger pushFunction after the initial search</p>
 
 <p class="attr-legend">* <span>Required</span></p>

--- a/src/widgets/analytics/analytics.js
+++ b/src/widgets/analytics/analytics.js
@@ -4,18 +4,21 @@
  * @param  {Function} [options.pushFunction] Push function called when data are supposed to be pushed to analytic service
  * @param  {int} [options.delay=3000] Number of milliseconds between last search key stroke and calling pushFunction
  * @param  {boolean} [options.triggerOnUIInteraction=false] Trigger pushFunction after click on page or redirecting the page
+ * @param  {boolean} [options.pushInitialSearch=true] Trigger pushFunction after the initial search
  * @return {Object}
  */
 const usage = `Usage:
 analytics({
   pushFunction,
   [ delay=3000 ],
-  [ triggerOnUIInteraction=false ]
+  [ triggerOnUIInteraction=false ],
+  [ pushInitialSearch=true ]
 })`;
 function analytics({
   pushFunction,
   delay = 3000,
   triggerOnUIInteraction = false,
+  pushInitialSearch = true,
 } = {}) {
   if (!pushFunction) {
     throw new Error(usage);
@@ -106,6 +109,11 @@ function analytics({
 
   let pushTimeout;
 
+  let isInitialSearch = true;
+  if (pushInitialSearch === true) {
+    isInitialSearch = false;
+  }
+
   return {
     init() {
       if (triggerOnUIInteraction === true) {
@@ -119,6 +127,12 @@ function analytics({
       }
     },
     render({results, state}) {
+      if (isInitialSearch === true) {
+        isInitialSearch = false;
+
+        return;
+      }
+
       cachedState = {results, state};
 
       if (pushTimeout) {


### PR DESCRIPTION
**What project are you opening a pull request for?**
- instantsearch.js

**Summary**

Right now on some websites the statistics might got screwed by initial searches.
The PR adds a parameter to analytics widget which decides whether the `pushFunction` should be called after the very first search. Setting it to false prevents the `pushFunction` to be called after the first search.

**Result**

```js
search.addWidget(
  instantsearch.widgets.analytics({
    pushFunction(/* formattedParameters, state, results*/) {
      // your analytics code
    },
    triggerOnUIInteraction: true,
    pushInitialSearch: false,
  })
);
```
