### PR TITLE
move development info into contributing and add install info

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,84 @@
+[![React InstantSearch logo][readme-logo]][react-doc]
+
+First of all, thanks for wanting to help out with InstantSearch :tada:!
+
+Here's some information you can use to contribute to InstantSearch
+
+Currently we support [React](https://facebook.github.io/react/)
+and plain JavaScript (or Vanilla) via:
+- ⚛ React and React Native ➡️ [React InstantSearch][react-doc]
+- 🍦 Vanilla ➡️ [InstantSearch.js][vanilla-doc]
+
+## Development
+
+We use the [documentation website][react-doc] as the main way to develop
+React InstantSearch.
+
+```sh
+yarn boot
+yarn start
+```
+
+Go to <http://localhost:3000>.
+
+## Test
+
+We have unit tests for all `packages/`:
+
+```sh
+yarn test # one shot run, also lint and tries to build the documentation
+```
+
+```sh
+yarn dev # unit tests watch mode, no lint
+```
+
+## Lint
+
+```sh
+yarn lint # only changed files in dev, all files in CI
+yarn lint:fix
+```
+
+## Release
+
+```sh
+npm run release
+```
+
+This cannot yet be moved to `yarn release` so please use `npm run release`.
+
+## Update docs
+
+```sh
+yarn docs:deploy-production
+```
+
+## Deploy a preview of docs
+
+```sh
+yarn docs:deploy-preview
+```
+
+This uses [netlify](https://www.netlify.com/).
+
+## Upgrade deps
+
+```sh
+yarn upgrade-deps
+```
+
+## See next release changelog
+
+```sh
+yarn changelog
+```
+
+[readme-logo]: ./docgen/readme-logo.png
+[react-doc]: https://community.algolia.com/instantsearch.js/react/
+[vanilla-doc]: https://community.algolia.com/instantsearch.js/
+[algolia-url]: https://www.algolia.com/
+[react-url]: https://facebook.github.io/react/
+[widgets-url]: https://community.algolia.com/instantsearch.js/react/widgets/
+[connectors-url]: https://community.algolia.com/instantsearch.js/react/widgets/connectors/
+[instantsearch.js-v1-github-url]: https://github.com/algolia/instantsearch.js/tree/develop

--- a/README.md
+++ b/README.md
@@ -14,70 +14,17 @@ and plain JavaScript (or Vanilla) via:
 This current branch (v2) holds the code for React InstantSearch,
 see [project status](#project-status) for more information on project structure.
 
-## Development
+## Installing
 
-We use the [documentation website][react-doc] as the main way to develop
-React InstantSearch.
+React InstantSearch is available in the npm registry. Install it:
 
-```sh
-yarn boot
-yarn start
+```
+yarn add react-instantsearch
 ```
 
-Go to <http://localhost:3000>.
+Note: we use yarn to install dependencies but React InstantSearch is also installable via npm.
 
-## Test
-
-We have unit tests for all `packages/`:
-
-```sh
-yarn test # one shot run, also lint and tries to build the documentation
-```
-
-```sh
-yarn dev # unit tests watch mode, no lint
-```
-
-## Lint
-
-```sh
-yarn lint # only changed files in dev, all files in CI
-yarn lint:fix
-```
-
-## Release
-
-```sh
-npm run release
-```
-
-This cannot yet be moved to `yarn release` so please use `npm run release`.
-
-## Update docs
-
-```sh
-yarn docs:deploy-production
-```
-
-## Deploy a preview of docs
-
-```sh
-yarn docs:deploy-preview
-```
-
-This uses [netlify](https://www.netlify.com/).
-
-## Upgrade deps
-
-```sh
-yarn upgrade-deps
-```
-
-## See next release changelog
-
-```sh
-yarn changelog
-```
+Detailed info on how to use InstantSearch can be found in the [documentation website](react-doc)
 
 ## Project status
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ yarn add react-instantsearch
 
 Note: we use yarn to install dependencies but React InstantSearch is also installable via npm.
 
-Detailed info on how to use InstantSearch can be found in the [documentation website](react-doc)
+Detailed info on how to use InstantSearch can be found in the [documentation website][react-doc]
+## Contributing, dev, release
+
+Read the CONTRIBUTING guide ([link](CONTRIBUTING.md))
 
 ## Project status
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Note: we use yarn to install dependencies but React InstantSearch is also instal
 Detailed info on how to use InstantSearch can be found in the [documentation website][react-doc]
 ## Contributing, dev, release
 
-Read the CONTRIBUTING guide ([link](CONTRIBUTING.md))
+We welcome all contributors, from beginner to advanced. You are only
+one command away to start the developer environement, [read our CONTRIBUTING guide](CONTRIBUTING.md).
 
 ## Project status
 


### PR DESCRIPTION
**What project are you opening a pull request for?**
- react-instantsearch (use v2 base)

**Summary**

you had to click on "getting started" on the documentation site to know how react-instantsearch is published on npm, so that was added to the main README.

In my opinion it makes more sense to have the detailed contributing information into a separate file, because it's less relevant if you just want to use it.

**Result**

The readme is now shorter, and filled with only information you really need when wanting to use `react-instantsearch`. For detailed info the documentation website is used.