### PR TITLE
fix(SearchBox): Safari can only have <use> with xlinkHref

### DIFF
--- a/packages/react-instantsearch/src/components/SearchBox.js
+++ b/packages/react-instantsearch/src/components/SearchBox.js
@@ -178,12 +178,12 @@ class SearchBox extends Component {
           />
           <button type="submit" title={translate('submitTitle')} {...cx('submit')}>
             <svg role="img">
-              <use href="#sbx-icon-search-13"></use>
+              <use xlinkHref="#sbx-icon-search-13"></use>
             </svg>
           </button>
           <button type="reset" title={translate('resetTitle')} {...cx('reset')} onClick={this.onReset}>
             <svg role="img">
-              <use href="#sbx-icon-clear-3"></use>
+              <use xlinkHref="#sbx-icon-clear-3"></use>
             </svg>
           </button>
         </div>

--- a/packages/react-instantsearch/src/components/__snapshots__/Menu.test.js.snap
+++ b/packages/react-instantsearch/src/components/__snapshots__/Menu.test.js.snap
@@ -51,7 +51,7 @@ exports[`Menu Menu with search inside items but no search results 1`] = `
           <svg
             role="img">
             <use
-              href="#sbx-icon-search-13" />
+              xlinkHref="#sbx-icon-search-13" />
           </svg>
         </button>
         <button
@@ -62,7 +62,7 @@ exports[`Menu Menu with search inside items but no search results 1`] = `
           <svg
             role="img">
             <use
-              href="#sbx-icon-clear-3" />
+              xlinkHref="#sbx-icon-clear-3" />
           </svg>
         </button>
       </div>
@@ -178,7 +178,7 @@ exports[`Menu Menu with search inside items with search results 1`] = `
           <svg
             role="img">
             <use
-              href="#sbx-icon-search-13" />
+              xlinkHref="#sbx-icon-search-13" />
           </svg>
         </button>
         <button
@@ -189,7 +189,7 @@ exports[`Menu Menu with search inside items with search results 1`] = `
           <svg
             role="img">
             <use
-              href="#sbx-icon-clear-3" />
+              xlinkHref="#sbx-icon-clear-3" />
           </svg>
         </button>
       </div>
@@ -269,7 +269,7 @@ exports[`Menu applies translations 1`] = `
           <svg
             role="img">
             <use
-              href="#sbx-icon-search-13" />
+              xlinkHref="#sbx-icon-search-13" />
           </svg>
         </button>
         <button
@@ -280,7 +280,7 @@ exports[`Menu applies translations 1`] = `
           <svg
             role="img">
             <use
-              href="#sbx-icon-clear-3" />
+              xlinkHref="#sbx-icon-clear-3" />
           </svg>
         </button>
       </div>

--- a/packages/react-instantsearch/src/components/__snapshots__/RefinementList.test.js.snap
+++ b/packages/react-instantsearch/src/components/__snapshots__/RefinementList.test.js.snap
@@ -52,7 +52,7 @@ exports[`RefinementList applies translations 1`] = `
             <svg
               role="img">
               <use
-                href="#sbx-icon-search-13" />
+                xlinkHref="#sbx-icon-search-13" />
             </svg>
           </button>
           <button
@@ -63,7 +63,7 @@ exports[`RefinementList applies translations 1`] = `
             <svg
               role="img">
               <use
-                href="#sbx-icon-clear-3" />
+                xlinkHref="#sbx-icon-clear-3" />
             </svg>
           </button>
         </div>
@@ -252,7 +252,7 @@ exports[`RefinementList refinement list with search inside items but no search r
             <svg
               role="img">
               <use
-                href="#sbx-icon-search-13" />
+                xlinkHref="#sbx-icon-search-13" />
             </svg>
           </button>
           <button
@@ -263,7 +263,7 @@ exports[`RefinementList refinement list with search inside items but no search r
             <svg
               role="img">
               <use
-                href="#sbx-icon-clear-3" />
+                xlinkHref="#sbx-icon-clear-3" />
             </svg>
           </button>
         </div>
@@ -393,7 +393,7 @@ exports[`RefinementList refinement list with search inside items with search res
             <svg
               role="img">
               <use
-                href="#sbx-icon-search-13" />
+                xlinkHref="#sbx-icon-search-13" />
             </svg>
           </button>
           <button
@@ -404,7 +404,7 @@ exports[`RefinementList refinement list with search inside items with search res
             <svg
               role="img">
               <use
-                href="#sbx-icon-clear-3" />
+                xlinkHref="#sbx-icon-clear-3" />
             </svg>
           </button>
         </div>

--- a/packages/react-instantsearch/src/components/__snapshots__/SearchBox.test.js.snap
+++ b/packages/react-instantsearch/src/components/__snapshots__/SearchBox.test.js.snap
@@ -47,7 +47,7 @@ exports[`SearchBox applies its default props 1`] = `
       <svg
         role="img">
         <use
-          href="#sbx-icon-search-13" />
+          xlinkHref="#sbx-icon-search-13" />
       </svg>
     </button>
     <button
@@ -58,7 +58,7 @@ exports[`SearchBox applies its default props 1`] = `
       <svg
         role="img">
         <use
-          href="#sbx-icon-clear-3" />
+          xlinkHref="#sbx-icon-clear-3" />
       </svg>
     </button>
   </div>
@@ -114,7 +114,7 @@ exports[`SearchBox lets you customize its theme 1`] = `
       <svg
         role="img">
         <use
-          href="#sbx-icon-search-13" />
+          xlinkHref="#sbx-icon-search-13" />
       </svg>
     </button>
     <button
@@ -125,7 +125,7 @@ exports[`SearchBox lets you customize its theme 1`] = `
       <svg
         role="img">
         <use
-          href="#sbx-icon-clear-3" />
+          xlinkHref="#sbx-icon-clear-3" />
       </svg>
     </button>
   </div>
@@ -181,7 +181,7 @@ exports[`SearchBox lets you customize its translations 1`] = `
       <svg
         role="img">
         <use
-          href="#sbx-icon-search-13" />
+          xlinkHref="#sbx-icon-search-13" />
       </svg>
     </button>
     <button
@@ -192,7 +192,7 @@ exports[`SearchBox lets you customize its translations 1`] = `
       <svg
         role="img">
         <use
-          href="#sbx-icon-clear-3" />
+          xlinkHref="#sbx-icon-clear-3" />
       </svg>
     </button>
   </div>
@@ -248,7 +248,7 @@ exports[`SearchBox transfers the autoFocus prop to the underlying input element 
       <svg
         role="img">
         <use
-          href="#sbx-icon-search-13" />
+          xlinkHref="#sbx-icon-search-13" />
       </svg>
     </button>
     <button
@@ -259,7 +259,7 @@ exports[`SearchBox transfers the autoFocus prop to the underlying input element 
       <svg
         role="img">
         <use
-          href="#sbx-icon-clear-3" />
+          xlinkHref="#sbx-icon-clear-3" />
       </svg>
     </button>
   </div>
@@ -315,7 +315,7 @@ exports[`SearchBox treats its query prop as its input value 1`] = `
       <svg
         role="img">
         <use
-          href="#sbx-icon-search-13" />
+          xlinkHref="#sbx-icon-search-13" />
       </svg>
     </button>
     <button
@@ -326,7 +326,7 @@ exports[`SearchBox treats its query prop as its input value 1`] = `
       <svg
         role="img">
         <use
-          href="#sbx-icon-clear-3" />
+          xlinkHref="#sbx-icon-clear-3" />
       </svg>
     </button>
   </div>
@@ -382,7 +382,7 @@ exports[`SearchBox treats its query prop as its input value 2`] = `
       <svg
         role="img">
         <use
-          href="#sbx-icon-search-13" />
+          xlinkHref="#sbx-icon-search-13" />
       </svg>
     </button>
     <button
@@ -393,7 +393,7 @@ exports[`SearchBox treats its query prop as its input value 2`] = `
       <svg
         role="img">
         <use
-          href="#sbx-icon-clear-3" />
+          xlinkHref="#sbx-icon-clear-3" />
       </svg>
     </button>
   </div>


### PR DESCRIPTION

**What project are you opening a pull request for?**
- react-instantsearch (use v2 base)

**Summary**

Safari can’t have <use> with href, it needs xlink:href. Relevant [MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/href)

**Result**

Since React [0.14](https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html#notable-enhancements) it's allowed to use all svg features, and thus also those that are usuallly written
with a colon.

closes #1968

before|after
---|---
<img width="414" alt="screen shot 2017-02-11 at 14 49 51" src="https://cloud.githubusercontent.com/assets/6270048/22854201/7831b400-f069-11e6-83fa-02ce3ff768da.png"> | <img width="329" alt="screen shot 2017-02-11 at 14 49 58" src="https://cloud.githubusercontent.com/assets/6270048/22854202/7dde951c-f069-11e6-852c-b462b5e562be.png">