### PR TITLE
docs(storybook): use 'translations' in SearchBox

### DIFF
--- a/stories/RangeInput.stories.js
+++ b/stories/RangeInput.stories.js
@@ -18,7 +18,7 @@ stories.add('default', () =>
     <RangeInput attributeName="price"
                   min={number('max', 0)}
                   max={number('max', 300)}
-                  translations={object('translate', {submit: ' go', separator: 'to'})}
+                  translations={object('translations', {submit: ' go', separator: 'to'})}
     />
   </WrapWithHits>
 ).add('with panel', () =>

--- a/stories/SearchBox.stories.js
+++ b/stories/SearchBox.stories.js
@@ -23,7 +23,7 @@ stories.add('default', () =>
       focusShortcuts={['s']}
       searchAsYouType={true}
       autoFocus={true}
-      translations={object('translate', {
+      translations={object('translations', {
         submit: null,
         reset: null,
         submitTitle: 'Submit your search query.',

--- a/stories/StarRating.stories.js
+++ b/stories/StarRating.stories.js
@@ -44,7 +44,7 @@ stories.add('default', () =>
     <StarRating
       attributeName="rating"
       max={number('max', 6)}
-      translations={object('translate', {ratingLabel: ' & Up'})}
+      translations={object('translations', {ratingLabel: ' & Up'})}
     />
   </WrapWithHits>
 );


### PR DESCRIPTION
**What project are you opening a pull request for?**
- react-instantsearch (use v2 base)

**Summary**

It was kind of confusing to realise that the actual prop to add was an object with "translations" as name, since using "translate" would cause "object is not a function" errors.

I haven't yet checked if this is the case with all of the stories, or just this one.

**Result**

the story now shows "translations" as key