### PR TITLE
docs(guide): how to style svgs

### DIFF
--- a/docgen/src/guide/Styling_widgets.md
+++ b/docgen/src/guide/Styling_widgets.md
@@ -13,7 +13,9 @@ The format for those class names is `ais-NameOfWidget__elementModifier`.
 The different class names used by every widgets are described on their respective documentation page. You
 can also inspect the underlying DOM and style accordingly.
 
-You can also style the icons in for example the `SearchBox`, but since those are svg elements, you'll use css like this:
+## Styling icons
+
+You can style icons colors too, for example the `SearchBox` ones:
 
 ```css
 .ais-SearchBox__reset svg, 

--- a/docgen/src/guide/Styling_widgets.md
+++ b/docgen/src/guide/Styling_widgets.md
@@ -13,6 +13,15 @@ The format for those class names is `ais-NameOfWidget__elementModifier`.
 The different class names used by every widgets are described on their respective documentation page. You
 can also inspect the underlying DOM and style accordingly.
 
+You can also style the icons in for example the `SearchBox`, but since those are svg elements, you'll use css like this:
+
+```css
+.ais-SearchBox__reset svg, 
+.ais-SearchBox__button svg { 
+  fill: red
+}
+```
+
 ## Loading the theme
 
 We do not load any CSS into your page automatically but we provide an Algolia theme that you can load


### PR DESCRIPTION
**What project are you opening a pull request for?**
- react-instantsearch (use v2 base)

**Summary**

it's not so hard, but the actual svg elements don't have a class, so you will have to target them explicitly.

SVG elements also have a different feature set, so this example should clear things up.

**Result**

Extra piece of text in the `Styling widgets` part that explains briefly that we work with svg, so it's styleable and how.

see #1981