### PR TITLE
fix(example): link to instantsearch/react

### DIFF
--- a/docgen/src/examples/e-commerce-infinite/App.js
+++ b/docgen/src/examples/e-commerce-infinite/App.js
@@ -41,7 +41,7 @@ export default function App() {
 
 const Header = () =>
   <header className="content-wrapper">
-    <a href="https://community.algolia.com/instantsearch.js/" className="is-logo"><img
+    <a href="https://community.algolia.com/instantsearch.js/react" className="is-logo"><img
       src="https://res.cloudinary.com/hilnmyskv/image/upload/w_100,h_100,dpr_2.0//v1461180087/logo-instantsearchjs-avatar.png"
       width={40}/></a>
     <a href="./" className="logo">aeki</a>

--- a/docgen/src/examples/e-commerce/App.js
+++ b/docgen/src/examples/e-commerce/App.js
@@ -43,7 +43,7 @@ const App = props =>
 
 const Header = () =>
   <header className="content-wrapper">
-    <a href="https://community.algolia.com/instantsearch.js/" className="is-logo"><img
+    <a href="https://community.algolia.com/instantsearch.js/react" className="is-logo"><img
       src="https://res.cloudinary.com/hilnmyskv/image/upload/w_100,h_100,dpr_2.0//v1461180087/logo-instantsearchjs-avatar.png"
       width={40}/></a>
     <a href="./" className="logo">aeki</a>


### PR DESCRIPTION
**What project are you opening a pull request for?**
- react-instantsearch (use v2 base)

**Summary**

link to instantsearch/react instead of instantsearch/ in header of ecom example

**Result**

link is correct