### PR TITLE
fix(searchBox): avoid unwanted cursor jumps on hashchange

### DIFF
--- a/src/lib/url-sync.js
+++ b/src/lib/url-sync.js
@@ -31,11 +31,24 @@ function timerMaker(t0) {
  * @type {UrlUtil}
  */
 const hashUrlUtils = {
+  ignoreNextPopState: false,
   character: '#',
   onpopstate(cb) {
-    window.addEventListener('hashchange', cb);
+    window.addEventListener('hashchange', hash => {
+      if (this.ignoreNextPopState) {
+        this.ignoreNextPopState = false;
+        return;
+      }
+
+      cb(hash);
+    });
   },
   pushState(qs) {
+    // hash change or location assign does trigger an hashchange event
+    // so everytime we change it manually, we inform the code
+    // to ignore the next hashchange event
+    // see https://github.com/algolia/instantsearch.js/issues/2012
+    this.ignoreNextPopState = true;
     window.location.assign(getFullURL(this.createURL(qs)));
   },
   createURL(qs) {


### PR DESCRIPTION
The effect was there since the begining but only visible since the move
to "only update url every 700ms". Since you can definitely move the
search box cursor back in 700ms, you would see the input cursor move to
the end of the search box from time to time.

The bug fix is done by ignoring any hashchange event occuring after a
manual url hash update.

fixes #2012