### PR TITLE
chore(helper): update dependency to algoliasearch-helper

### DIFF
--- a/packages/react-instantsearch/package.json
+++ b/packages/react-instantsearch/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "algoliasearch": "^3.21.1",
-    "algoliasearch-helper": "^2.18.1",
+    "algoliasearch-helper": "2.19.0",
     "classnames": "^2.2.5",
     "lodash": "^4.17.4"
   },

--- a/packages/react-instantsearch/yarn.lock
+++ b/packages/react-instantsearch/yarn.lock
@@ -24,9 +24,9 @@ agentkeepalive@^2.1.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-2.2.0.tgz#c5d1bd4b129008f1163f236f86e5faea2026e2ef"
 
-algoliasearch-helper@^2.18.1:
-  version "2.18.1"
-  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-2.18.1.tgz#ebac9f70b4aacf684d04932095c6ee5c5eb77c55"
+algoliasearch-helper@2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-2.19.0.tgz#cdc8c623720be8ff2b97216d1e57e02d9642f5a5"
   dependencies:
     events "^1.1.0"
     lodash "^4.13.1"
@@ -3206,11 +3206,7 @@ watch@~0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/watch/-/watch-0.10.0.tgz#77798b2da0f9910d595f1ace5b0c2258521f21dc"
 
-whatwg-fetch@>=0.10.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.2.tgz#fe294d1d89e36c5be8b3195057f2e4bc74fc980e"
-
-whatwg-fetch@^1.0.0:
+whatwg-fetch@>=0.10.0, whatwg-fetch@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-1.1.1.tgz#ac3c9d39f320c6dce5339969d054ef43dd333319"
 


### PR DESCRIPTION
Update algoliasearch-helper dependency to 2.19.0 which contains the access to raw results in the SearchResults. CC. @proudlygeek ;)