### PR TITLE
chore(tooling) allow beta versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,16 @@ npm run release
 
 This cannot yet be moved to `yarn release` so please use `npm run release`.
 
+To publish a beta version, you have to use:
+
+```sh
+npm run release -- -b # or --beta
+```
+
+Then for the version you bump if needed, and append `-beta0` (or 1 etc for next versions).
+
+The beta website will be updated automatically.
+
 ## Update docs
 
 ```sh

--- a/packages/react-instantsearch-theme-algolia/scripts/build-and-publish.sh
+++ b/packages/react-instantsearch-theme-algolia/scripts/build-and-publish.sh
@@ -1,4 +1,14 @@
 #!/usr/bin/env bash
 
-yarn build &&
-npm publish
+npmFlags=''
+yarnFlags=''
+while getopts 'n:y:' flag; do
+  case "${flag}" in
+    n) npmFlags="${OPTARG}" ;;
+    y) yarnFlags="${OPTARG}" ;;
+    *) error "Unexpected option ${flag}" ;;
+  esac
+done
+
+yarn build $yarnFlags &&
+npm publish $npmFlags

--- a/packages/react-instantsearch/scripts/build-and-publish.sh
+++ b/packages/react-instantsearch/scripts/build-and-publish.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 
-yarn build &&
+npmFlags=''
+yarnFlags=''
+while getopts 'n:y:' flag; do
+  case "${flag}" in
+    n) npmFlags="${OPTARG}" ;;
+    y) yarnFlags="${OPTARG}" ;;
+    *) error "Unexpected option ${flag}" ;;
+  esac
+done
+
+yarn build $yarnFlags &&
 cd dist/ &&
-npm publish &&
+npm publish $npmFlags &&
 rm -rf dist/

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,6 +2,19 @@
 
 set -e # exit when error
 
+beta=false
+while test $# -gt 0; do
+  case "$1" in
+    -b|--beta)
+      printf "Publishing as a beta version\n"
+      beta=true
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
 # npm owner add and npm whoami cannot be moved to yarn yet
 if [[ -n $(cd packages/react-instantsearch && npm owner add "$(npm whoami)") ]]; then
   printf "Release: Not an owner of the npm repo, ask for it\n"
@@ -84,13 +97,19 @@ git push origin --tags
 
 printf "\n\nRelease: pushed to github, publish on npm"
 
+npmFlags=''
+yarnFlags=''
+if [[ beta ]]; then
+  npmFlags="--tag beta"
+fi
+
 (
-cd packages/react-instantsearch
-VERSION=$newVersion npm run build-and-publish
+cd packages/react-instantsearch 
+VERSION=$newVersion npm run build-and-publish -- -n "$npmFlags" -y "$yarnFlags"
 )
 
 (
-cd packages/react-instantsearch-theme-algolia
+cd packages/react-instantsearch-theme-algolia -- -n "$npmFlags" -y "$yarnFlags"
 npm run build-and-publish
 )
 


### PR DESCRIPTION
**What project are you opening a pull request for?**
- react-instantsearch (use v2 base)

**Summary**

partial fix for #2056 

add `-b` or `--beta` when releasing, which will then propagate the `--tag beta` to `npm publish`. With these changes it's also possible to set flags for the yarn commands run in the packages `build-and-publish.sh`