### PR TITLE
chore(pkg) fix Algolia name

### DIFF
--- a/packages/react-instantsearch/package.json
+++ b/packages/react-instantsearch/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-instantsearch",
   "author": {
-    "name": "Algolia, Inc.",
+    "name": "Algolia SAS",
     "url": "https://www.algolia.com"
   },
   "description": "⚡ Lightning-fast search for React and React Native apps",


### PR DESCRIPTION
**What project are you opening a pull request for?**
- react-instantsearch (use v2 base)

**Summary**

As far as I know we always use Algolia SAS, since that's our actual financial "title", or do we have an Inc. too?

**Result**

package.json now contains Algolia SAS as the author name