### PR TITLE
doc(searchState): don't wrap example in object

### DIFF
--- a/docgen/src/guide/Search_state.md
+++ b/docgen/src/guide/Search_state.md
@@ -11,38 +11,36 @@ If a widget uses an attribute, we store it under its widget category to prevent 
 
 Here's the `searchState` shape for all the connectors or widgets that we provide:
 
-```jsx
-{
-  const searchState = {
-    range: {
-      price: {
-        min: 20,
-        max: 3000
-      }
-    },
-    configure: {
-      aroundLatLng: true,
-    },
-    refinementList: {
-      fruits: ['lemon', 'orange']
-    },
-    hierarchicalMenu: {
-      products: 'Laptops > Surface'
-    },
-    menu: {
-      brands: 'Sony'
-    },
-    multiRange: {
-      rank: '2:5'
-    },
-    toggle: {
-      freeShipping: true
-    },
-    hitsPerPage: 10,
-    sortBy: 'mostPopular',
-    query: 'ora',
-    page: 2
-  }
+```js
+const searchState = {
+  range: {
+    price: {
+      min: 20,
+      max: 3000
+    }
+  },
+  configure: {
+    aroundLatLng: true,
+  },
+  refinementList: {
+    fruits: ['lemon', 'orange']
+  },
+  hierarchicalMenu: {
+    products: 'Laptops > Surface'
+  },
+  menu: {
+    brands: 'Sony'
+  },
+  multiRange: {
+    rank: '2:5'
+  },
+  toggle: {
+    freeShipping: true
+  },
+  hitsPerPage: 10,
+  sortBy: 'mostPopular',
+  query: 'ora',
+  page: 2
 }
 ```
 
@@ -50,21 +48,19 @@ If you are performing a search on multiple indices using the [Index](widgets/<In
 component, you'll get the following shape:
 
 
-```jsx
-{
-  const searchState = {
-    query: 'ora', //shared state between all indices
-    page: 2, //shared state between all indices 
-    indices: {
-      index1: {
-        configure: {
-          hitsPerPage: 3,
-        },
+```js
+const searchState = {
+  query: 'ora', //shared state between all indices
+  page: 2, //shared state between all indices 
+  indices: {
+    index1: {
+      configure: {
+        hitsPerPage: 3,
       },
-      index2: {
-        configure: {
-          hitsPerPage: 10,
-        },
+    },
+    index2: {
+      configure: {
+        hitsPerPage: 10,
       },
     },
   },


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**What project are you opening a pull request for?**
- react-instantsearch (use v2 base)

**Summary**

The syntax right now is confusing, because it's actually a block and not an object. 

It might be an option to just write the object without `const searchState =`



<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->