### PR TITLE
feat(Highlight): allow a custom tag

### DIFF
--- a/packages/react-instantsearch/src/components/Highlight.js
+++ b/packages/react-instantsearch/src/components/Highlight.js
@@ -9,5 +9,6 @@ Highlight.propTypes = {
   hit: React.PropTypes.object.isRequired,
   attributeName: React.PropTypes.string.isRequired,
   highlight: React.PropTypes.func.isRequired,
+  TagName: React.PropTypes.string,
 };
 

--- a/packages/react-instantsearch/src/components/Highlighter.js
+++ b/packages/react-instantsearch/src/components/Highlighter.js
@@ -1,13 +1,14 @@
 import React from 'react';
 
-export default function Highlighter({hit, attributeName, highlight, highlightProperty}) {
+export default function Highlighter({hit, attributeName, highlight, highlightProperty, TagName}) {
   const parsedHighlightedValue = highlight({hit, attributeName, highlightProperty});
   const reactHighlighted = parsedHighlightedValue.map((v, i) => {
     const key = `split-${i}-${v.value}`;
     if (!v.isHighlighted) {
       return <span key={key} className="ais-Highlight__nonHighlighted">{v.value}</span>;
     }
-    return <em key={key} className="ais-Highlight__highlighted">{v.value}</em>;
+    const HighlightedTag = TagName ? TagName : 'em';
+    return <HighlightedTag key={key} className="ais-Highlight__highlighted">{v.value}</HighlightedTag>;
   });
   return <span className="ais-Highlight">{reactHighlighted}</span>;
 }
@@ -17,4 +18,5 @@ Highlighter.propTypes = {
   attributeName: React.PropTypes.string.isRequired,
   highlight: React.PropTypes.func.isRequired,
   highlightProperty: React.PropTypes.string.isRequired,
+  TagName: React.PropTypes.string,
 };

--- a/packages/react-instantsearch/src/components/Highlighter.test.js
+++ b/packages/react-instantsearch/src/components/Highlighter.test.js
@@ -41,4 +41,40 @@ describe('Highlighter', () => {
     );
     expect(tree.toJSON()).toMatchSnapshot();
   });
+
+  it('renders a hit with a custom tag correctly', () => {
+    const hitFromAPI = {
+      objectID: 0,
+      deep: {attribute: {value: 'awesome highlighted hit!'}},
+      _highlightProperty: {
+        deep: {
+          attribute: {
+            value: {
+              value: 'awesome <ais-highlight>hi</ais-highlight>ghlighted <ais-highlight>hi</ais-highlight>t!',
+              fullyHighlighted: true,
+              matchLevel: 'full',
+              matchedWords: [''],
+            },
+          },
+        },
+      },
+    };
+
+    const highlight = ({hit, attributeName, highlightProperty}) => parseAlgoliaHit({
+      preTag: '<ais-highlight>',
+      postTag: '</ais-highlight>',
+      attributeName,
+      hit,
+      highlightProperty,
+    });
+
+    const tree = renderer.create(
+      <Highlighter attributeName="deep.attribute.value"
+                   hit={hitFromAPI}
+                   highlight={highlight}
+                   highlightProperty="_highlightProperty"
+                   TagName="mark"/>
+    );
+    expect(tree.toJSON()).toMatchSnapshot();
+  });
 });

--- a/packages/react-instantsearch/src/components/Snippet.js
+++ b/packages/react-instantsearch/src/components/Snippet.js
@@ -10,4 +10,5 @@ Snippet.propTypes = {
   hit: React.PropTypes.object.isRequired,
   attributeName: React.PropTypes.string.isRequired,
   highlight: React.PropTypes.func.isRequired,
+  TagName: React.PropTypes.string,
 };

--- a/packages/react-instantsearch/src/components/__snapshots__/Highlighter.test.js.snap
+++ b/packages/react-instantsearch/src/components/__snapshots__/Highlighter.test.js.snap
@@ -31,3 +31,35 @@ exports[`Highlighter parses an highlighted attribute of hit object 1`] = `
   </span>
 </span>
 `;
+
+exports[`Highlighter renders a hit with a custom tag correctly 1`] = `
+<span
+  className="ais-Highlight"
+>
+  <span
+    className="ais-Highlight__nonHighlighted"
+  >
+    awesome 
+  </span>
+  <mark
+    className="ais-Highlight__highlighted"
+  >
+    hi
+  </mark>
+  <span
+    className="ais-Highlight__nonHighlighted"
+  >
+    ghlighted 
+  </span>
+  <mark
+    className="ais-Highlight__highlighted"
+  >
+    hi
+  </mark>
+  <span
+    className="ais-Highlight__nonHighlighted"
+  >
+    t!
+  </span>
+</span>
+`;

--- a/stories/Highlight.stories.js
+++ b/stories/Highlight.stories.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import {storiesOf} from '@kadira/storybook';
+import {Highlight, Hits} from '../packages/react-instantsearch/dom';
+import {withKnobs, text} from '@kadira/storybook-addon-knobs';
+import {WrapWithHits} from './util';
+
+const stories = storiesOf('Highlight', module);
+
+stories.addDecorator(withKnobs);
+
+const Default = ({hit}) =>
+  <p>
+    <Highlight attributeName="name" hit={hit}/>
+  </p>;
+
+Default.propTypes = {
+  hit: React.PropTypes.object.isRequired,
+};
+
+const StrongHits = ({hit}) =>
+  <p>
+    <Highlight attributeName="name" TagName={text('tag name', 'strong')} hit={hit}/>
+  </p>;
+
+StrongHits.propTypes = {
+  hit: React.PropTypes.object.isRequired,
+};
+
+stories.add('default', () =>
+  <WrapWithHits hasPlayground={false} linkedStoryGroup="Highlight" >
+    <Hits hitComponent={Default} />
+  </WrapWithHits>
+).add('custom tag', () =>
+  <WrapWithHits hasPlayground={true} linkedStoryGroup="Highlight" >
+    <Hits hitComponent={StrongHits} />
+  </WrapWithHits>
+);

--- a/stories/Snippet.stories.js
+++ b/stories/Snippet.stories.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import {storiesOf} from '@kadira/storybook';
+import {Snippet, Hits} from '../packages/react-instantsearch/dom';
+import {withKnobs, text} from '@kadira/storybook-addon-knobs';
+import {WrapWithHits} from './util';
+
+const stories = storiesOf('Snippet', module);
+
+stories.addDecorator(withKnobs);
+
+const Default = ({hit}) =>
+  <p>
+    <Snippet attributeName="description" hit={hit}/>
+  </p>;
+
+Default.propTypes = {
+  hit: React.PropTypes.object.isRequired,
+};
+
+const StrongHits = ({hit}) =>
+  <p>
+    <Snippet attributeName="description" TagName={text('tag name', 'strong')} hit={hit}/>
+  </p>;
+
+StrongHits.propTypes = {
+  hit: React.PropTypes.object.isRequired,
+};
+
+stories.add('default', () =>
+  <WrapWithHits hasPlayground={false} linkedStoryGroup="Snippet" >
+    <Hits hitComponent={Default} />
+  </WrapWithHits>
+).add('custom tag', () =>
+  <WrapWithHits hasPlayground={true} linkedStoryGroup="Snippet" >
+    <Hits hitComponent={StrongHits} />
+  </WrapWithHits>
+);


### PR DESCRIPTION
**What project are you opening a pull request for?**
- react-instantsearch (use v2 base)

**Summary**

`<em>` isn't actually very suited for highlighting, a `<mark>` tag is way better, because it brings its own accessibility, default style etc. with it. 

To allow this, a new prop (`HighlightTagName`) was added to Highlight and Highlighter. 

**Result**

I added stories for `Highlight` to make this clear.

![2017-04-04 08_16_58](https://cloud.githubusercontent.com/assets/6270048/24643576/2c14c520-190f-11e7-92f6-dd84bac587a6.gif)
