### PR TITLE
docs(react-instantsearch): remove mentions of ris

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,7 +3,7 @@
   Thanks for participating in this project!
 
   This form is to report issues or new features.
-  As for general questions like "How to do routing using React InstantSearch",
+  As for general questions like "How to hide results when the query is empty?",
   please search or post a question to our discourse forum: https://discourse.algolia.com/.
 
   In any case,

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,16 +1,44 @@
 <!--
+  ***************************
   Thanks for participating in this project!
-  Please:
-    - make sure you are using the latest version of the library.
-    - do at least one GitHub search in current issues, maybe your question is already here
+
+  This form is to report issues or new features.
+  As for general questions like "How to do routing using React InstantSearch",
+  please search or post a question to our discourse forum: https://discourse.algolia.com/.
+
+  In any case,
+    - make sure you are using the latest version of the library;
+    - do at least one search in current issues or questions, your question might already be answered;
+    - do include details, screenshots when it's a visual issue, console errors otherwise;
+  ***************************
 -->
 
 **Do you want to request a *feature* or report a *bug*?**
 
-**What is the current behavior?**
+<!--
+  ***************************
+  If the current behavior is a bug, please provide all the steps to reproduce and a minimal
+  [JSFiddle](https://jsfiddle.net/) example or a repository on GitHub that we can `npm install`
+  and `npm start`.
 
-**If the current behavior is a bug, please provide all the steps to reproduce and a minimal
-[JSFiddle](https://jsfiddle.net/) example or a repository on GitHub that we can `npm install`
-and `npm start`.**
+  We have a simple online template for you to use as a base to explain your bug or issue:
+  https://jsfiddle.net/vvoyer/0wm3donb/4/
 
-**What is the expected behavior?**
+  If you are requesting a new feature, we need to understand WHY would you
+  need this feature (your use case) or how you are limited with the current API.
+  ***************************
+-->
+
+**Bug: What is the current behavior?**
+
+**Bug: What is the expected behavior?**
+
+**Bug: What browsers are impacted? Which versions?**
+
+**Feature: What is your use case for such a feature?**
+
+**Feature: What is your proposed API entry? The new option to add? What is the behavior?**
+
+**What is the version you are using? Always use the latest one before opening a bug issue.**
+
+<!-- Delete any HTML comment and non relevant questions -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,225 +1,56 @@
-Hi (future) collaborator!
+[![InstantSearch.js logo][logo]][website]
 
-**tl;dr;**
-- submit pull requests to develop branch
-- use conventional changelog commit style messages
-- squash your commits
-- have fun
-
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**
-
-- [Where to start?](#where-to-start)
-- [New API proposal](#new-api-proposal)
-- [How to write issues](#how-to-write-issues)
-- [Development workflow](#development-workflow)
-- [Serving the build](#serving-the-build)
-- [Commit message guidelines](#commit-message-guidelines)
-  - [Revert](#revert)
-  - [Type](#type)
-  - [Scope](#scope)
-  - [Subject](#subject)
-  - [Body](#body)
-  - [Footer](#footer)
-- [Squash your commits](#squash-your-commits)
-- [When are issues closed?](#when-are-issues-closed)
-- [Milestones](#milestones)
-- [Releasing](#releasing)
-- [Hotfixes](#hotfixes)
-  - [Releasing hotfixes](#releasing-hotfixes)
-  - [Documentation updates](#documentation-updates)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
-# Where to start?
-
-Have a fix or a new feature? [Search for corresponding issues](https://github.com/algolia/instantsearch.js/issues) first then create a new one.
-
-Always check the status of the [develop branch](https://github.com/algolia/instantsearch.js/tree/develop) for the freshest code.
-
-Always submit pull requests to the develop branch.
-
-**Wanna help us?** All issues belonging to the [`next` milestone](https://github.com/algolia/instantsearch.js/milestones/next) can be worked on.
-
-# New API proposal
-
-If you have a new **API proposal** or change, create an issue describing it precisely:
-- JavaScript API example
-- Resulting DOM/effect
-
-Here's an example: [New widget: hitsPerPageSelector (#331)](https://github.com/algolia/instantsearch.js/issues/331).
-
-# How to write issues
-
-Start with some context, when and/or where you encountered the issue.
-
-Since instantsearch.js is a UI library, if your issue is UI related then adding a screenshot or (better) a GIF will make your issue a lot easier to understand.
-
-# Development workflow
-
-Requirements:
-- [Node.js](https://nodejs.org/)
-- [yarn](https://yarnpkg.com/en/docs/install)
-- [Ruby](https://www.ruby-lang.org/en/)
-- [Bundler](http://bundler.io/)
-
-Run the local example:
+## Development
 
 ```sh
-npm run dev
-# open http://localhost:8080
-# make changes in your widgets, or in example/app.js
+yarn
+yarn dev:docs
 ```
 
-Run local example and docs:
+Go to <http://localhost:8080> for the example playground.
+
+Go to <http://localhost:4000> for the documentation website.
+
+## Code
+
+The code for InstantSearch.js is located in [src](src).
+
+## Test
+
+We have unit tests written with [Jest](https://facebook.github.io/jest/):
+
+Single run and linting:
+```sh
+yarn test
+```
+
+Watch mode:
+```sh
+yarn test:watch # unit tests watch mode, no lint
+```
+
+## Lint
 
 ```sh
-npm run dev:docs
-# open http://localhost:4000/
+yarn lint
 ```
 
-Run tests and lint:
+Files are automatically formatted with prettier.
 
-```sh
-npm test
-```
-
-# Serving the build
-
-For some use cases like building a demo, you may want to serve the current build
-on an http endpoint.
-
-To do so:
-
-```sh
-npm run serve
-```
-
-Will build, watch for changes and serve instantsearch.css and instantsearch.js on http://localhost:8080.
-
-# Commit message guidelines
-
-We use [conventional changelog](https://github.com/ajoslin/conventional-changelog) to generate our changelog from our git commit messages.
-
-**Some examples**:
-- feat(rangeSlider): add new range option to the rangeSlider
-- fix(refinementList): send the full algolia result to the noResults template
-
-Here are the rules to write commit messages, they are the same than [angular/angular.js](https://github.com/angular/angular.js/blob/7c792f4cc99515ac27ed317e0e35e40940b3a400/CONTRIBUTING.md#commit-message-format).
-
-Each commit message consists of a **header**, a **body** and a **footer**.  The header has a special
-format that includes a **type**, a **scope** and a **subject**:
-
-```text
-<type>(<scope>): <subject>
-<BLANK LINE>
-<body>
-<BLANK LINE>
-<footer>
-```
-
-The **header** is mandatory and the **scope** of the header is optional.
-
-Any line of the commit message cannot be longer 100 characters! This allows the message to be easier
-to read on GitHub as well as in various git tools.
-
-## Revert
-If the commit reverts a previous commit, it should begin with `revert: `, followed by the header of the reverted commit. In the body it should say: `This reverts commit <hash>.`, where the hash is the SHA of the commit being reverted.
-
-## Type
-Must be one of the following:
-
-* **feat**: A new feature
-* **fix**: A bug fix
-* **docs**: Documentation only changes
-* **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing
-  semi-colons, etc)
-* **refactor**: A code change that neither fixes a bug nor adds a feature
-* **perf**: A code change that improves performance
-* **test**: Adding missing tests
-* **chore**: Changes to the build process or auxiliary tools and libraries such as documentation
-  generation
-
-## Scope
-The scope could be anything specifying place of the commit change. For example `RefinementList`,
-`refinementList`, `rangeSlider`, `CI`, `url`, `build` etc...
-
-## Subject
-The subject contains succinct description of the change:
-
-* use the imperative, present tense: "change" not "changed" nor "changes"
-* don't capitalize first letter
-* no dot (.) at the end
-
-## Body
-Just as in the **subject**, use the imperative, present tense: "change" not "changed" nor "changes".
-The body should include the motivation for the change and contrast this with previous behavior.
-
-## Footer
-The footer should contain any information about **Breaking Changes** and is also the place to
-reference GitHub issues that this commit **Closes**.
-
-**Breaking Changes** should start with the word `BREAKING CHANGE:` with a space or two newlines. The rest of the commit message is then used for this.
-
-# Squash your commits
-
-Once you are done with a fix or feature and the review was done, [squash](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html) your commits to avoid things like "fix dangling comma in bro.js", "fix after review".
-
-The goal is to have meaningful, feature based commits instead of a lot of small commits.
-
-Example:
-    - `feat(widget): new feature blabla..`
-    - `refactor new feature blablabla...`
-    - `fix after review ...`
-  - **both commits should be squashed* in a single commit: `feat(widget) ..`
-
-# When are issues closed?
-
-Once the a fix is done, having the fix in the `develop` branch is not sufficient, it needs to be part of a release for us to close the issue.
-
-So that you never ask yourself "Is this released?".
-
-Instead of closing the issue, we will add a ` ✔ to be released` label.
-
-# Milestones
-
-- `next` => Ideas, questions, refactors, bugs that were discuseed, turned into clear actions by the maintainers. You can work on this.
-- `x.x.x` => selected `next` actions to be done in a release. You can work on this.
-- no milestone => Still need investigation / discussion
-
-# Releasing
-
-If you are a maintainer, you can release.
-
-We use [semver](http://semver-ftw.org/).
-
-This task will merge develop into master.
+## Release
 
 ```sh
 npm run release
 ```
 
-# Hotfixes
-
-All our work is done on the develop branch but it could be necessary to push a hotfix to the master
-branch and do a patch release. To fix a very important bug.
-
-For this, you should:
-- add `HOTFIX` to the commit message **body**
-- submit your pull request to the master branch
-
-## Releasing hotfixes
-
-You must be on the master branch.
+### Beta release
 
 ```sh
-HOTFIX=1 npm run release
+npm run release -- -b # or --beta
 ```
 
-## Documentation updates
+Append `-beta.x` where x is a number to the version for beta, so 4.0.0-beta.2 for example.
 
-If you have important documentation update to release without wanting to release
-a new version of instantsearch.js, you can do a documentation hotfix.
+## Update docs
 
-Then once the hotfix is merged into master, the documentation will be updated automatically.
+Documentation website is automatically updated by Travis when master is merged.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Algolia
+Copyright (c) 2015-present Algolia, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,4 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![InstantSearch.js logo][logo]][website]
 
-InstantSearch projects: **InstantSearch.js** [React InstantSearch][react-instantsearch-github], [InstantSearch Android](instantsearch-android-github).
+InstantSearch projects: **InstantSearch.js** | [React InstantSearch][react-instantsearch-github] | [InstantSearch Android](instantsearch-android-github).
 
 ## InstantSearch.js
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![InstantSearch.js logo][readme-logo]][website]
+[![InstantSearch.js logo][logo]][website]
 
 InstantSearch projects: **InstantSearch.js** [React InstantSearch][react-instantsearch-github], [InstantSearch Android](instantsearch-android-github).
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ There's a dedicated documentation available at <https://community.algolia.com/in
 We welcome all contributors, from casual to regular. You are only
 one command away to start the developer environment, [read our CONTRIBUTING guide](CONTRIBUTING.md).
 
-[logo]: ./docgen/readme-logo.png
+[logo]: ./docs/readme-logo.png
 [website]: https://community.algolia.com/instantsearch.js
 [algolia-website]: https://www.algolia.com/
 [react-instantsearch-github]: https://github.com/algolia/react-instantsearch/

--- a/README.md
+++ b/README.md
@@ -1,209 +1,26 @@
-[![instantsearch.js logo][readme-logo]][website-url]
+[![InstantSearch.js logo][readme-logo]][website]
 
-[![Version][version-svg]][package-url] [![Build Status][travis-svg]][travis-url] [![License][license-image]][license-url] [![Downloads][downloads-image]][downloads-url]
+InstantSearch projects: **InstantSearch.js** [React InstantSearch][react-instantsearch-github], [InstantSearch Android](instantsearch-android-github).
 
-**instantsearch.js** is a library of UI widgets to help you build the best instant-search experience with [Algolia's Hosted Search API](https://www.algolia.com/?utm_medium=social-owned&utm_source=GitHub&utm_campaign=InstantSearch%20repository).
+## InstantSearch.js
 
-Have a look at the website: [https://community.algolia.com/instantsearch.js/][instantsearch-website].
+> ⚡ Lightning-fast search for websites
 
-## Demo
+Built by [Algolia][algolia-website].
 
-Here is an example of what you could easily build with `instantsearch.js` and
-Algolia:
+This repository holds the code for the InstantSearch.js project.
 
-[![instantsearch.js animated demo][readme-animated]][website-url]
+## Documentation
 
-You can find the complete [tutorial on how it was done](https://www.algolia.com/doc/search/instant-search) on our website.
+There's a dedicated documentation available at <https://community.algolia.com/instantsearch.js>.
 
-[travis-svg]: https://img.shields.io/travis/algolia/instantsearch.js/master.svg?style=flat-square
-[travis-url]: https://travis-ci.org/algolia/instantsearch.js
-[license-image]: http://img.shields.io/badge/license-MIT-green.svg?style=flat-square
-[license-url]: LICENSE
-[downloads-image]: https://img.shields.io/npm/dm/instantsearch.js.svg?style=flat-square
-[downloads-url]: http://npm-stat.com/charts.html?package=instantsearch.js
-[version-svg]: https://img.shields.io/npm/v/instantsearch.js.svg?style=flat-square
-[package-url]: https://npmjs.org/package/instantsearch.js
-[readme-logo]: ./docs/readme-logo.png
-[readme-animated]: ./docs/readme-animated.gif
-[website-url]: https://community.algolia.com/instantsearch.js/
-[instantsearch-website]: https://community.algolia.com/instantsearch.js/?utm_medium=social-owned&utm_source=GitHub&utm_campaign=InstantSearch%20repository
-[instantsearch-website-docs]: https://community.algolia.com/instantsearch.js/documentation/?utm_medium=social-owned&utm_source=GitHub&utm_campaign=InstantSearch%20repository
+## Contributing, dev, release
 
-## Table of contents
+We welcome all contributors, from casual to regular. You are only
+one command away to start the developer environment, [read our CONTRIBUTING guide](CONTRIBUTING.md).
 
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
-
-- [Setup](#setup)
-  - [With the jsDelivr CDN](#with-the-jsdelivr-cdn)
-  - [With npm, browserify, webpack](#with-npm-browserify-webpack)
-- [Quick Start](#quick-start)
-- [Browser support](#browser-support)
-- [Development workflow](#development-workflow)
-- [Test](#test)
-- [Functional tests](#functional-tests)
-  - [It's not working!](#its-not-working)
-- [License](#license)
-- [Contributing](#contributing)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
-## Setup
-
-### With the jsDelivr CDN
-
-instantsearch.js is available on [jsDelivr](https://www.jsdelivr.com/):
-
-```html
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/instantsearch.js/1/instantsearch.min.css" />
-<script src="https://cdn.jsdelivr.net/instantsearch.js/1/instantsearch.min.js"></script>
-```
-
-#### Other CDNS
-
-We recommend using jsDelivr, but algoliasearch is also available at:
-
-- CDNJS: https://cdnjs.com/libraries/instantsearch.js
-- npmcdn:
-  - https://npmcdn.com/instantsearch.js@1/dist/instantsearch.min.js
-  - https://npmcdn.com/instantsearch.js@1/dist/instantsearch.min.css
-
-Using jsDelivr you will get auto updates for all the 1.x.x versions without any breaking change.
-
-### With npm, browserify, webpack
-
-```sh
-npm install instantsearch.js --save
-```
-
-## Quick Start
-
-See our [documentation website][instantsearch-website-docs] for complete docs.
-
-```js
-let instantsearch = require('instantsearch.js');
-// or use the 'instantsearch' global (window) variable when using the jsDelivr build
-
-let search = instantsearch({
-  appId: appId,
-  apiKey: apiKey,
-  indexName: indexName
-});
-
-// add a searchBox widget
-search.addWidget(
-  instantsearch.widgets.searchBox({
-    container: '#search-box',
-    placeholder: 'Search for libraries in France...'
-  })
-);
-
-// add a hits widget
-search.addWidget(
-  instantsearch.widgets.hits({
-    container: '#hits-container',
-    hitsPerPage: 10
-  })
-);
-
-// start
-search.start();
-```
-## Browser support
-
-We natively support IE10+ and all other modern browsers without any dependency need
-on your side.
-
-To get < IE10 support, please insert this code in the `<head>`:
-
-```html
-<meta http-equiv="X-UA-Compatible" content="IE=Edge">
-<!--[if lte IE 9]>
-  <script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
-<![endif]-->
-```
-
-We use the [polyfill.io](https://cdn.polyfill.io/v2/docs/).
-
-## Development workflow
-
-Requirements:
-- [Node.js](https://nodejs.org/)
-- [yarn](https://yarnpkg.com/en/docs/install)
-- [Ruby](https://www.ruby-lang.org/en/)
-- [Bundler](http://bundler.io/)
-
-Run the local example:
-
-```sh
-npm run dev
-# open http://localhost:8080
-# make changes in your widgets, or in example/app.js
-```
-
-Run local example and docs:
-
-```sh
-npm run dev:docs
-# open http://localhost:4000/
-```
-
-Run tests and lint:
-
-```sh
-npm test
-```
-
-## Test
-
-```sh
-npm test # unit tests, jsdom + lint
-npm run test:watch # unit tests, jsdom, watch
-```
-
-Most of the time `npm run test:watch` is sufficient.
-
-## Functional tests
-
-You need [docker](https://docs.docker.com/engine/installation/).
-
-Run it like so:
-
-```sh
-docker pull elgalu/selenium
-docker run --name=grid --net=host --pid=host --privileged=true \
-    -e VNC_PASSWORD=realtime \
-    -e NOVNC=true \
-    -v /dev/shm:/dev/shm elgalu/selenium
-```
-
-Then run functional tests dev command with auto reload:
-
-```sh
-npm run test:functional:dev
-```
-
-You can see the live browser at http://localhost:26080/vnc.html (password: fun).
-
-You can use the full webdriverio API: http://webdriver.io/api.html.
-
-You can run the underlying web server for debugging purposes:
-
-```sh
-npm run test:functional:dev:debug-server
-```
-
-Useful when you want to modify the functional test app.
-
-### It's not working!
-
-Your docker installation must be compatible and ready to make the [--net="host"](https://docs.docker.com/engine/reference/run/#network-host) works.
-
-## License
-
-instantsearch.js is [MIT licensed](./LICENSE).
-
-## Contributing
-
-We have a [contributing guide](CONTRIBUTING.md), join us!
+[logo]: ./docgen/readme-logo.png
+[website]: https://community.algolia.com/instantsearch.js
+[algolia-website]: https://www.algolia.com/
+[react-instantsearch-github]: https://github.com/algolia/react-instantsearch/
+[instantsearch-android-github]: https://github.com/algolia/instantsearch-android

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -15,7 +15,7 @@ navigation:
  - text: About
    url: /about/
  - text: React InstantSearch
-   url: /react/
+   url: /react-instantsearch/
 # Build settings
 markdown: kramdown
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -131,7 +131,7 @@ To use it, require this file:
 
 ### React InstantSearch
 
-We also have a dedicated React library if you are already using React: [React InstantSearch](https://community.algolia.com/instantsearch.js/react/).
+We also have a dedicated React library if you are already using React: [React InstantSearch](https://community.algolia.com/react-instantsearch/).
 
 ### Initialization
 

--- a/docs/index.haml
+++ b/docs/index.haml
@@ -4,7 +4,7 @@ layout: default
 .marketing-banner
   %a{:href => "#closeBanner", :class => "banner-close"} &#10005;
   .banner__description
-    %a{:href => "https://community.algolia.com/instantsearch.js/react/"}
+    %a{:href => "https://community.algolia.com/instantsearch.js/react-instantsearch/"}
       %p <span>Looking for a React version of instantsearch.js?</span> Have a look at React InstantSearch!
 
       %img{:src => "http://res.cloudinary.com/hilnmyskv/image/upload/v1481540222/react-favicon_y43wx4.svg", :alt => "React-instantsearch icon"}/

--- a/scripts/docs/gh-pages.js
+++ b/scripts/docs/gh-pages.js
@@ -7,8 +7,7 @@ ghpages.clean();
 
 let config = {
   silent: true,
-  logger: msg => console.log(msg),
-  only: ['**/*', '!react/**/*', '!react']
+  logger: msg => console.log(msg)
 };
 
 if (process.env.CI === 'true') {


### PR DESCRIPTION
Since we moved react-instantsearch to
https://github.com/algolia/react-instantsearch/ and
https://community.algolia.com/react-instantsearch/

We can now remove mentions of the old repo organisation