### PR TITLE
fix minor spelling errors

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -5,14 +5,14 @@ permalink: /about/
 ---
 **instantsearch.js** is an open source project developed and maintained by [Algolia](https://www.algolia.com) [on GitHub](https://github.com/algolia/instantsearch.js) and released under MIT license. Our mission has always been to help developers implement great search experiences in no time. We started by focusing our efforts on the speed and relevance of the search engine itself, and we quickly discovered that querying the engine from the frontend was important–end users crave Google-and-Amazon-like experiences: fast and relevant search results pages that don't require page reloads.
 
-We dedicated all our energy to developing a product that could be used directly from the frontend, without compromising on required security features. For example [secured API Keys](https://www.algolia.com/doc/ruby#secured-api-keys) allow us to replicate on the frontend all the restriction enforcements we take for granted on the backend. Unfortunately, we also discovered that implementing the UI itself is complex and time consuming because of tricky issues such as handling refinement states, updating the URL, etc...
+We dedicated all our energy to developing a product that could be used directly from the frontend, without compromising on required security features. For example, [secured API Keys](https://www.algolia.com/doc/ruby#secured-api-keys) allow us to replicate on the frontend all the restriction enforcements we take for granted on the backend. Unfortunately, we also discovered that implementing the UI itself is complex and time-consuming because of tricky issues such as handling refinement states, updating the URL, etc...
 
 We started developing **instantsearch.js** in early 2015. Our initial idea was inspired by [Stripe Checkout](https://stripe.com/docs/checkout), a great payment UI/UX packaged as a JS library that anyone can easily use. The main difference between Stripe Checkout and **instantsearch.js** is that it is close to impossible to package all search use-cases in one monolithic script. This is why we chose a different approach—a UI library containing different widgets that you can assemble and customize to build great search experiences.
 
 <div class="spacer100"></div>
 
 # About Algolia
-Founded in 2012, Algolia is a privately held company created by developers, veterans in the fields of algorithms, search engines and text mining. We develop a search-as-a-service API to help developers deliver an intuitive search-as-you-type experience in their applications and websites.
+Founded in 2012, Algolia is a privately held company created by developers, veterans in the fields of algorithms, search engines, and text mining. We develop a search-as-a-service API to help developers deliver an intuitive search-as-you-type experience in their applications and websites.
 
 We enable super fast and relevant search experiences in no time with our worldwide infrastructure deployed in 14 different regions (28 different datacenters). In one click, you can distribute your search on several regions with our [Distributed Search Network](https://www.algolia.com/dsn) infrastructure.
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -185,7 +185,7 @@ The `urlSync` option has more parameters, see the `instantsearch` function docum
 
 <div class="codebox-combo">
 
-To build your search results page, you need to combine several widgets. Start by adding a `searchBox` widget, a `hits` widget and a `pagination` widget to build a basic results page.
+To build your search results page, you need to combine several widgets. Start by adding a `searchBox` widget, a `hits` widget, and a `pagination` widget to build a basic results page.
 
 <div class="code-box">
   <div class="code-sample-snippet js-toggle-snippet ignore">
@@ -1264,7 +1264,7 @@ This method takes only one argument, `helper`, on which you can call `.search()`
 to actually start the search.  `helper.state` also contains information about
 the current state of your search.
 
-You can for example check for `helper.state.query` to see if the query is empty
+You can, for example, check for `helper.state.query` to see if the query is empty
 or not, and act accordingly. You might also have to handle the case when users
 start typing, then delete their query and hide the results when that happens.
 
@@ -1352,7 +1352,7 @@ In order to help you use templates, **instantsearch.js** exposes a few helpers.
 
 All helpers are accessible in the Mustache templating through `{% raw %}{{#helpers.nameOfTheHelper}}{{valueToFormat}}{{/helpers.nameOfTheHelper}}{% endraw %}`. To use them in the function templates, you'll have to call `search.templatesConfig.helpers.nameOfTheHelper` where `search` is your current **instantsearch.js** instance.
 
-Currently we have one helper:
+Currently, we have one helper:
 
 `formatNumber`: Will accept a number as input and return the formatted version of the number in the locale defined with the `numberLocale` config option (defaults to `en-EN`). eg. `100000` will be formatted as `100 000` with `en-EN`
 
@@ -1427,7 +1427,7 @@ The widget may implement some of the following methods (depending on the need of
     - results: the [results](https://community.algolia.com/algoliasearch-helper-js/reference.html#searchresults) of the query
     - state: the [search state](https://community.algolia.com/algoliasearch-helper-js/reference.html#searchparameters).
     - helper: the [helper](https://community.algolia.com/algoliasearch-helper-js/reference.html#algoliasearchhelper) used to create a new search query
-    - createURL: function provided to create urls
+    - createURL: function provided to create URLs
 
   </div>
 </div>
@@ -1470,7 +1470,7 @@ Or you can wrap an existing React component, see our [<i class='fa fa-github'></
 
 All widgets have been designed to be heavily stylable with CSS rules. **instantsearch.js** ships with a default CSS theme that only includes the necessary CSS classes.
 
-You can see all the existing customizable CSS classes in the [non minified CSS](https://cdn.jsdelivr.net/instantsearch.js/1/instantsearch.css).
+You can see all the existing customizable CSS classes in the [non-minified CSS](https://cdn.jsdelivr.net/instantsearch.js/1/instantsearch.css).
 
 We use [Sass](http://sass-lang.com/) to build the CSS.
 


### PR DESCRIPTION
**Summary**
This PR fixes a couple of comma errors in the `/documentation/` and `/about/` docs pages.
There are no linked issues to my knowledge.

**Result**
For some reason, the GitHub highlighter does not show the exact changes on `line 8` in the `docs/about.md`. To speed-up the check, here is what was changed:

```
For example [secured API Keys]
->
For example, [secured API Keys]`
```
```
the UI itself is complex and time consuming because
->
the UI itself is complex and time-consuming because
```