### PR TITLE
docs(connectHits): make a custom hits example using bel

### DIFF
--- a/dev/app/custom-widgets/vanilla/hits.js
+++ b/dev/app/custom-widgets/vanilla/hits.js
@@ -1,0 +1,37 @@
+/* eslint-disable import/default */
+import instantsearch from '../../../../index.js';
+import bel from 'bel';
+
+function render({hits, widgetParams: {containerNode}}) {
+  const content = bel`<div>
+    ${hits.map(hit => {
+      const title = bel`<h4></h4>`;
+      title.innerHTML = hit._highlightResult.name.value;
+      const description = bel`<p></p>`;
+      description.innerHTML = hit._highlightResult.description.value;
+
+      return bel`
+        <div class="ais-hits--item">
+          <div class="hit" id="hit-bel-${hit.objectID}">
+            <div class="media">
+              <a class="pull-left" href="${hit.url}">
+                <img class="media-object" src="${hit.image}">
+              </a>
+              <div class="media-body">
+                <h3 class="pull-right text-right text-info">$${hit.price}</h3>
+                <h4>${title}</h4>
+                <p>${description}</p>
+                ${hit.free_shipping ? bel`<span class="badge pull-right">Free Shipping</span>` : ''}
+              </div>
+            </div>
+            <a href="#">Go back to top</a>
+          </div>
+        </div>`;
+    })}
+  </div>`;
+
+  containerNode.innerText = '';
+  containerNode.appendChild(content);
+}
+
+export default instantsearch.connectors.connectHits(render);

--- a/dev/app/custom-widgets/vanilla/index.js
+++ b/dev/app/custom-widgets/vanilla/index.js
@@ -1,1 +1,2 @@
 export {default as clearAll} from './clearAll';
+export {default as hits} from './hits';

--- a/dev/app/init-vanilla-widgets.js
+++ b/dev/app/init-vanilla-widgets.js
@@ -7,4 +7,10 @@ export default search => {
       containerNode: document.getElementById('clear-all'),
     })
   );
+
+  search.addWidget(
+    vanillaWidgets.hits({
+      containerNode: document.getElementById('hits'),
+    })
+  );
 };

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "babel-register": "^6.24.0",
     "babel-template": "^6.23.0",
     "babel-types": "^6.23.0",
+    "bel": "^4.6.0",
     "cheerio": "^0.22.0",
     "collect-json": "^1.0.8",
     "compression": "^1.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1170,6 +1170,14 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+bel@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/bel/-/bel-4.6.0.tgz#3ade16e236ab2204d8d1c66eac4bd573793ac999"
+  dependencies:
+    global "^4.3.0"
+    hyperx "^2.3.0"
+    on-load "^3.2.0"
+
 big.js@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.1.3.tgz#4cada2193652eb3ca9ec8e55c9015669c9806978"
@@ -3867,6 +3875,16 @@ https-proxy-agent@~1.0.0:
     debug "2"
     extend "3"
 
+hyperscript-attribute-to-property@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/hyperscript-attribute-to-property/-/hyperscript-attribute-to-property-1.0.0.tgz#825308d49bb8e2957923f731981bcc811cad7aff"
+
+hyperx@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/hyperx/-/hyperx-2.3.0.tgz#70f473d66d4ad550ddd1c83e4be2651276bbf1e2"
+  dependencies:
+    hyperscript-attribute-to-property "^1.0.0"
+
 i@0.3.x:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/i/-/i-0.3.5.tgz#1d2b854158ec8169113c6cb7f6b6801e99e211d5"
@@ -5665,6 +5683,12 @@ on-finished@~2.3.0:
 on-headers@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.1.tgz#928f5d0f470d49342651ea6794b0857c100693f7"
+
+on-load@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/on-load/-/on-load-3.2.0.tgz#dd3145d3a5c2faa5666920d1df674b69f0c2f66f"
+  dependencies:
+    global "^4.3.0"
 
 once@^1.3.0, once@^1.3.3, once@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
**Summary**

[Bel](https://github.com/shama/bel) is an easy 'vanilla'-ish element create thingy, and it's nice to try if we play nice with it for hits. It turns out we do!

Theres's a way to transform these into real `document.createElement` calls with [yo-yoify](https://github.com/shama/yo-yoify#how-this-works), but that's browserify specific, and for production.

It's possible to switch this to [yo-yo](https://github.com/maxogden/yo-yo#dynamic-updates) which is does DOM diffing etc, but that seemed superfluous for this.

**Result**

A custom hits via a connector made with bel