### PR TITLE
fix(url-sync): sync url on search

### DIFF
--- a/dev/app.js
+++ b/dev/app.js
@@ -29,6 +29,15 @@ search.addWidget(
 );
 
 search.addWidget(
+  instantsearch.widgets.searchBox({
+    container: '#search-box-keypress',
+    placeholder: 'Search for products (keypress)',
+    poweredBy: true,
+    searchOnEnterKeyPressOnly: true,
+  })
+);
+
+search.addWidget(
   instantsearch.widgets.analytics({
     pushFunction(/* formattedParameters, state, results*/) {
       // Google Analytics

--- a/dev/index.html
+++ b/dev/index.html
@@ -38,6 +38,9 @@
         <div class="form-group">
           <input id="search-box" class="form-control" />
         </div>
+        <div class="form-group">
+          <input id="search-box-keypress" class="form-control" />
+        </div>
         <div class="smooth-search smooth-search--hidden">
           <div class="row">
             <div class="col-md-3">

--- a/src/lib/url-sync.js
+++ b/src/lib/url-sync.js
@@ -126,7 +126,7 @@ class URLSync {
     if (firstRender) {
       firstRender = false;
       this.onHistoryChange(this.onPopState.bind(this, helper));
-      helper.on('change', state => this.renderURLFromState(state));
+      helper.on('search', state => this.renderURLFromState(state));
     }
   }
 


### PR DESCRIPTION
This fixes an issue when setting searchOnEnterKeyPressOnly to true on
searchbox. Before it would update the URL even though the search was
not triggered (on enter key press).

This also adds a new searchbox that uses the searchOnEnterKeyPressOnly
on the searchbox in the kitchen sink.

Fixes #2105 