### PR TITLE
fix(CONTRIBUTING): remove section about beta releases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,14 +43,6 @@ Files are automatically formatted with prettier.
 npm run release
 ```
 
-### Beta release
-
-```sh
-npm run release -- -b # or --beta
-```
-
-Append `-beta.x` where x is a number to the version for beta, so 4.0.0-beta.2 for example.
-
 ## Update docs
 
 Documentation website is automatically updated by Travis when master is merged.


### PR DESCRIPTION
**Summary**

We don't have beta releases yet (see the [script](https://github.com/algolia/instantsearch.js/blob/develop/scripts/release.sh#L85-L92) and https://github.com/algolia/instantsearch.js/issues/2056), so the contributing section shouldn't be added yet.

We will put this back when `-b` works, and we've found a strategy for making it work with jsDeliver

**Result**

Remove the beta section in CONTRIBUTING for now