### PR TITLE
fix(sffv): disable sffv input when few facet values FIX #2111

### DIFF
--- a/src/components/RefinementList/RefinementList.js
+++ b/src/components/RefinementList/RefinementList.js
@@ -165,7 +165,7 @@ class RefinementList extends React.Component {
         placeholder={this.props.searchPlaceholder}
         onChange={this.props.searchFacetValues}
         onValidate={() => this.refineFirstValue()}
-        disabled={displayedFacetValues.length < limit}/> :
+        disabled={!this.props.isFromSearch && displayedFacetValues.length < limit}/> :
       null;
 
     const noResults = this.props.searchFacetValues && this.props.isFromSearch && this.props.facetValues.length === 0 ?

--- a/src/components/RefinementList/RefinementList.js
+++ b/src/components/RefinementList/RefinementList.js
@@ -164,7 +164,8 @@ class RefinementList extends React.Component {
       <SearchBox ref={i => { this.searchbox = i; }}
         placeholder={this.props.searchPlaceholder}
         onChange={this.props.searchFacetValues}
-        onValidate={() => this.refineFirstValue()}/> :
+        onValidate={() => this.refineFirstValue()}
+        disabled={displayedFacetValues.length < limit}/> :
       null;
 
     const noResults = this.props.searchFacetValues && this.props.isFromSearch && this.props.facetValues.length === 0 ?

--- a/src/components/SearchBox/index.js
+++ b/src/components/SearchBox/index.js
@@ -25,9 +25,7 @@ export default class SearchBox extends React.Component {
 
   render() {
     const {placeholder, onChange} = this.props;
-    const searchInput = this.props.disabled ?
-      <input type="search" name="search" placeholder={placeholder} autoComplete="off" required="required" className="sbx-sffv__input sbx-sffv__input-disabled" onChange={e => onChange(e.target.value)} ref={i => { this.input = i; }} disabled/> :
-      <input type="search" name="search" placeholder={placeholder} autoComplete="off" required="required" className="sbx-sffv__input" onChange={e => onChange(e.target.value)} ref={i => { this.input = i; }}/>;
+    const inputCssClasses = this.props.disabled ? 'sbx-sffv__input sbx-sffv__input-disabled' : 'sbx-sffv__input';
 
     return (
       <form noValidate="novalidate"
@@ -46,7 +44,7 @@ export default class SearchBox extends React.Component {
         </svg>
 
         <div role="search" className="sbx-sffv__wrapper">
-          {searchInput}
+          <input type="search" name="search" placeholder={placeholder} autoComplete="off" required="required" className={inputCssClasses} onChange={e => onChange(e.target.value)} ref={i => { this.input = i; }} disabled={this.props.disabled}/> :
           <button type="submit" title="Submit your search query." className="sbx-sffv__submit">
             <svg role="img" aria-label="Search">
               <use xlinkHref="#sbx-icon-search-12"></use>

--- a/src/components/SearchBox/index.js
+++ b/src/components/SearchBox/index.js
@@ -6,6 +6,7 @@ export default class SearchBox extends React.Component {
     placeholder: React.PropTypes.string.isRequired,
     onChange: React.PropTypes.func.isRequired,
     onValidate: React.PropTypes.func.isRequired,
+    disabled: React.PropTypes.bool,
   }
 
   clearInput() {
@@ -24,6 +25,9 @@ export default class SearchBox extends React.Component {
 
   render() {
     const {placeholder, onChange} = this.props;
+    const searchInput = this.props.disabled ?
+      <input type="search" name="search" placeholder={placeholder} autoComplete="off" required="required" className="sbx-sffv__input sbx-sffv__input-disabled" onChange={e => onChange(e.target.value)} ref={i => { this.input = i; }} disabled/> :
+      <input type="search" name="search" placeholder={placeholder} autoComplete="off" required="required" className="sbx-sffv__input" onChange={e => onChange(e.target.value)} ref={i => { this.input = i; }}/>;
 
     return (
       <form noValidate="novalidate"
@@ -42,7 +46,7 @@ export default class SearchBox extends React.Component {
         </svg>
 
         <div role="search" className="sbx-sffv__wrapper">
-          <input type="search" name="search" placeholder={placeholder} autoComplete="off" required="required" className="sbx-sffv__input" onChange={e => onChange(e.target.value)} ref={i => { this.input = i; }} />
+          {searchInput}
           <button type="submit" title="Submit your search query." className="sbx-sffv__submit">
             <svg role="img" aria-label="Search">
               <use xlinkHref="#sbx-icon-search-12"></use>


### PR DESCRIPTION
When the number of items displayed in a refinement list is lower than
the max number of facet displayed, the search for facet input should be
disabled.

This fix disables the input and adds a new classname to identify the
state of the input.

**Result**

[staging default](http://capricious-song.surge.sh/): the search input is not disabled.

fixes #2111 

[staging with a query that limits the items](http://capricious-song.surge.sh/?query=SanDisk%20-%20Ultra%20Plus%2032GB%20microSDHC%20Class%2010%20UHS-1%20Memory%20Card%20-%20Gray%2FRed&hits=3&idx=instant_search&p=0&hierarchical%5BhierarchicalCategories.lvl0%5D%5B0%5D=Cameras%20%26%20Camcorders&nR%5Bpopularity%5D%5B%3E%3D%5D%5B0%5D=0&is_v=1): the input is disabled.