### PR TITLE
fix(sffv): add class for disabled state at the form level

### DIFF
--- a/src/components/SearchBox/index.js
+++ b/src/components/SearchBox/index.js
@@ -26,10 +26,11 @@ export default class SearchBox extends React.Component {
   render() {
     const {placeholder, onChange} = this.props;
     const inputCssClasses = this.props.disabled ? 'sbx-sffv__input sbx-sffv__input-disabled' : 'sbx-sffv__input';
+    const formCssClasses = this.props.disabled ? 'searchbox sbx-sffv sbx-sffv-disabled' : 'searchbox sbx-sffv';
 
     return (
       <form noValidate="novalidate"
-        className="searchbox sbx-sffv"
+        className={formCssClasses}
         onReset={() => { onChange(''); }}
         onSubmit={e => this.validateSearch(e) }
       >


### PR DESCRIPTION
The original fix for #2111 didn't add a class name at the form level, which prevents the user from completely hiding the form part of the refinement list when using search for facet values.

This patch adds that class.