### PR TITLE
fix(url): link relatively to react-instantsearch

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -15,7 +15,7 @@ navigation:
  - text: About
    url: /about/
  - text: React InstantSearch
-   url: /react-instantsearch/
+   url: /../react-instantsearch/
 # Build settings
 markdown: kramdown
 


### PR DESCRIPTION
since the header adds `/instantsearch.js` to all urls in the nav (with `{{site.baseurl}}`), this is needed to be able to link to `/react-instantsearch` instead of `/instantsearch.js/react-instantsearch`.

reported by @seafoox

fixes #2119 