### PR TITLE
fix(infinite-hits): Remove hitsPerPage option

### DIFF
--- a/dev/app/init-builtin-widgets.js
+++ b/dev/app/init-builtin-widgets.js
@@ -94,7 +94,6 @@ export default search => {
         empty,
         allItems,
       },
-      hitsPerPage: 24,
     })
   );
 
@@ -105,7 +104,6 @@ export default search => {
         empty,
         item,
       },
-      hitsPerPage: 24,
     })
   );
 
@@ -116,7 +114,6 @@ export default search => {
         empty,
         item,
       },
-      hitsPerPage: 3,
       showMoreLabel: 'Show more',
     })
   );

--- a/dev/app/init-jquery-widgets.js
+++ b/dev/app/init-jquery-widgets.js
@@ -54,7 +54,6 @@ export default search => {
   search.addWidget(
     jqueryWidgets.hits({
       containerNode: window.$('#hits'),
-      hitsPerPage: 3,
     })
   );
 
@@ -147,7 +146,6 @@ export default search => {
   search.addWidget(
     jqueryWidgets.infiniteHits({
       containerNode: window.$('#infinite-hits'),
-      hitsPerPage: 3,
     })
   );
 

--- a/docgen/src/guides/migration.md
+++ b/docgen/src/guides/migration.md
@@ -7,3 +7,22 @@ withHeadings: true
 navWeight: 0
 ---
 
+## No more `hitsPerPage` in `hits` and `infiniteHits`
+
+This option has been removed from those two widgets. To configure
+this option of the engine, there are still three ways:
+
+ - use the [dashboard](https://www.algolia.com/explorer/display/) or
+   the [client](https://www.algolia.com/doc/api-client/default/settings/#set-settings),
+   to change the setting at the index level.
+ - use the [hitsPerPageSelector](../widgets/hitsPerPageSelector.html) widget.
+ - use the configuration option of instantsearch:
+
+```javascript
+var search = instantsearch({
+  // ... do not forget the credentials
+  searchParameters: {
+    hitsPerPage: 42,
+  }
+});
+```

--- a/src/connectors/hits/__tests__/connectHits-test.js
+++ b/src/connectors/hits/__tests__/connectHits-test.js
@@ -15,6 +15,8 @@ describe('connectHits', () => {
     const makeWidget = connectHits(rendering);
     const widget = makeWidget();
 
+    expect(widget.getConfiguration).toEqual(undefined);
+
     // test if widget is not rendered yet at this point
     expect(rendering.callCount).toBe(0);
 

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.js
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.js
@@ -17,13 +17,12 @@ describe('connectInfiniteHits', () => {
       hitsPerPage: 10,
     });
 
-    const config = widget.getConfiguration({});
-    expect(config).toEqual({hitsPerPage: 10});
+    expect(widget.getConfiguration).toEqual(undefined);
 
     // test if widget is not rendered yet at this point
     expect(rendering.callCount).toBe(0);
 
-    const helper = jsHelper(fakeClient, '', config);
+    const helper = jsHelper(fakeClient, '');
     helper.search = sinon.stub();
 
     widget.init({

--- a/src/connectors/infinite-hits/connectInfiniteHits.js
+++ b/src/connectors/infinite-hits/connectInfiniteHits.js
@@ -12,17 +12,10 @@ var customInfiniteHits = connectInfiniteHits(function render(params, isFirstRend
   // }
 });
 search.addWidget(
-  customInfiniteHits({
-    [ hitsPerPage = 20 ]
-  })
+  customInfiniteHits()
 );
 Full documentation available at https://community.algolia.com/instantsearch.js/connectors/connectInfiniteHits.html
 `;
-
-/**
- * @typedef {Object} CustomInfiniteHitsWidgetOptions
- * @property {number} [hitsPerPage = 20] The number of hits to display per page
- */
 
 /**
  * @typedef {Object} InfiniteHitsRenderingOptions
@@ -38,21 +31,16 @@ Full documentation available at https://community.algolia.com/instantsearch.js/c
  * Connects a rendering function with the infinite hits business logic.
  * @type {Connector}
  * @param {function(InfiniteHitsRenderingOptions, boolean)} renderFn function that renders the infinite hits widget
- * @return {function(CustomInfiniteHitsWidgetOptions)} a widget factory for infinite hits widget
+ * @return {function(object)} a widget factory for infinite hits widget
  */
 export default function connectInfiniteHits(renderFn) {
   checkRendering(renderFn, usage);
 
   return (widgetParams = {}) => {
-    const {hitsPerPage = 20} = widgetParams;
     let hitsCache = [];
     const getShowMore = helper => () => helper.nextPage().search();
 
     return {
-      getConfiguration() {
-        return {hitsPerPage};
-      },
-
       init({instantSearchInstance, helper}) {
         this.showMore = getShowMore(helper);
 

--- a/src/widgets/infinite-hits/__tests__/infinite-hits-test.js
+++ b/src/widgets/infinite-hits/__tests__/infinite-hits-test.js
@@ -42,8 +42,8 @@ describe('infiniteHits()', () => {
     results = {hits: [{first: 'hit', second: 'hit'}]};
   });
 
-  it('configures hitsPerPage', () => {
-    expect(widget.getConfiguration()).toEqual({hitsPerPage: 20});
+  it('Does not have a specific configuration', () => {
+    expect(widget.getConfiguration).toBe(undefined);
   });
 
   it('calls twice ReactDOM.render(<Hits props />, container)', () => {

--- a/src/widgets/infinite-hits/infinite-hits.js
+++ b/src/widgets/infinite-hits/infinite-hits.js
@@ -60,7 +60,6 @@ infiniteHits({
   [ cssClasses.{root,empty,item}={} ],
   [ templates.{empty,item} | templates.{empty} ],
   [ transformData.{empty,item} | transformData.{empty} ],
-  [ hitsPerPage=20 ]
 })`;
 
 /**
@@ -85,7 +84,6 @@ infiniteHits({
 /**
  * @typedef {Object} InfiniteHitsWidgetOptions
  * @property  {string|DOMElement} container CSS Selector or DOMElement to insert the widget
- * @property  {number} [hitsPerPage=20] The number of hits to display per page
  * @property  {InfiniteHitsTemplates} [templates] Templates to use for the widget
  * @property  {string} [showMoreLabel="Show more results"] label used on the show more button
  * @property  {InfiniteHitsTransforms} [transformData] Method to change the object passed to the templates
@@ -104,7 +102,6 @@ export default function infiniteHits({
   showMoreLabel = 'Show more results',
   templates = defaultTemplates,
   transformData,
-  hitsPerPage = 20,
 } = {}) {
   if (!container) {
     throw new Error(`Must provide a container.${usage}`);
@@ -129,7 +126,7 @@ export default function infiniteHits({
 
   try {
     const makeInfiniteHits = connectInfiniteHits(specializedRenderer);
-    return makeInfiniteHits({hitsPerPage});
+    return makeInfiniteHits();
   } catch (e) {
     throw new Error(usage);
   }


### PR DESCRIPTION
hitsPerPage is an option of the `hits` and `infiniteHits` that we decided we should move away from. The reason is that there are already many ways to define it, and it's not always clear why it should be on those widgets.

The migration guide and examples have been updated accordingly.