### PR TITLE
Fix for url sync issue in SPA

### DIFF
--- a/src/lib/url-sync.js
+++ b/src/lib/url-sync.js
@@ -6,7 +6,6 @@ import assign from 'lodash/assign';
 
 const AlgoliaSearchHelper = algoliasearchHelper.AlgoliaSearchHelper;
 const majorVersionNumber = version.split('.')[0];
-let firstRender = true;
 
 function timerMaker(t0) {
   let t = t0;
@@ -102,6 +101,7 @@ class URLSync {
     this.getHistoryState = options.getHistoryState || (() => null);
     this.threshold = options.threshold || 700;
     this.trackedParameters = options.trackedParameters || ['query', 'attribute:*', 'index', 'page', 'hitsPerPage'];
+    this.firstRender = true;
 
     this.searchParametersFromUrl = AlgoliaSearchHelper
       .getConfigurationFromQueryString(
@@ -123,8 +123,8 @@ class URLSync {
   }
 
   render({helper}) {
-    if (firstRender) {
-      firstRender = false;
+    if (this.firstRender) {
+      this.firstRender = false;
       this.onHistoryChange(this.onPopState.bind(this, helper));
       helper.on('search', state => this.renderURLFromState(state));
     }


### PR DESCRIPTION
I'm using Instantsearch in the context of a single page application.  Each time the user hits the page with the search field, a new instance of Instantsearch is created, and whenever they navigate away all handlers are destroyed.  

This generally works, with the exception of the urlSync feature.  Since the `firstRender` variable is defined outside of the URLSync class, once it is set to false the code in lines 127 - 129 never executes again, even when I spin up a new Instantsearch instance.  As a result that the `onHistoryChange` handler is never attached, and the url does not update when the query is changed.  This pr sets the `firstRender` instead to be an attribute on the `URLSync` class, so that it will be reset every time the class is re-instantiated.  This revision is one resolution to the problem, but I'd be interested to hear if you all have other suggestions.  Thanks!

