### PR TITLE
chore: whitelist only `dist` && `dist-es5-modules`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
     "serve": "./scripts/serve.sh"
   },
   "repository": "algolia/instantsearch.js",
+  "files": [
+    "dist",
+    "dist-es5-modules"
+  ],
   "devDependencies": {
     "autoprefixer": "^6.7.6",
     "babel-cli": "^6.23.0",


### PR DESCRIPTION
Only upload `/dist` and `/dist-es5-modules` to npm, should fix the issue with jsdelivr size limit 👍 