### PR TITLE
chore(travis): don’t build the docs when it’s a test

### DIFF
--- a/scripts/test-ci.sh
+++ b/scripts/test-ci.sh
@@ -4,16 +4,14 @@ set -ev # exit when error
 
 ./scripts/validate-pr-done-on-develop.sh
 npm test
+
 # we need to build to run functional tests
 NODE_ENV=production npm run build
 INDEX_PAGE=index npm run test:functional
 ./scripts/validate-commit-msgs.sh
-npm run docs:jsdoc # check we are able to generate docs
 
-# test the website can be built without errors
-cd docs
-bundle install
-JEKYLL_ENV=production VERSION=${VERSION} bundle exec jekyll build --config _config.yml,_production.yml
+# check we are able to generate docs
+npm run docs:jsdoc
 
 if [ $TRAVIS_PULL_REQUEST == 'false' ] && [ $TRAVIS_BRANCH == 'master' ]; then
   npm run finish-release


### PR DESCRIPTION
The Jekyll build is slowing down the travis build, but Netlify already does this build on another machine, and also gives a status when the build fails. 

If it’s a release the build would even run twice, so there’s no need to run it at all in test (see [update-website.sh#L25](https://github.com/algolia/instantsearch.js/blob/feat/instantsearch.js/v2/scripts/docs/update-website.sh#L25))

fixes #2110 

Should I also do this PR on the develop branch for v1?