### PR TITLE
docs(clipboard): put outside of pre

### DIFF
--- a/docgen/assets/js/activateClipboard.js
+++ b/docgen/assets/js/activateClipboard.js
@@ -28,7 +28,7 @@ export default function activateClipboard(codeSamples) {
     heading.className = 'heading';
     heading.innerHTML = 'Code';
     heading.appendChild(copyToClipboard);
-    codeSample.insertBefore(heading, codeSample.firstChild);
+    codeSample.parentNode.insertBefore(heading, codeSample);
 
     copyToClipboard.addEventListener('mouseleave', setup, true);
     clipboard.on('success', () => {

--- a/docgen/src/stylesheets/components/_documentation.scss
+++ b/docgen/src/stylesheets/components/_documentation.scss
@@ -127,16 +127,36 @@
       }
     }
 
+    .heading {
+      background: #eee;
+      border: 1px solid #d8d8d8;
+      border-bottom: none;
+      border-radius: 2px 2px 0 0;
+      margin: -8px 0 0;
+      padding: 4px 8px;
+      font-family: $font-stack;
+
+      button {
+        float: right;
+        cursor: copy;
+        background: #ddd;
+        border: none;
+        padding: 0px 8px;
+        font-size: 90%;
+      }
+    }
+
     pre {
-      margin: .5em 0px .5em 0px;
+      margin: 0 0 .5em 0;
       line-height: 23px;
       white-space: pre;
       overflow-x: auto;
       word-break: inherit;
       word-wrap: inherit;
       border: 1px solid #d8d8d8;
-      border-radius: 2px;
-      padding: 0.5em 0;
+      border-top: none;
+      border-radius: 0 0 2px 2px;
+      padding: .5em 0;
       position: relative;
       z-index: 1; // avoid scroll bar being unusable because <code></code><h2></h2> used and headers have :content that will be over
 
@@ -144,22 +164,6 @@
         display: block;
         width: calc(100% - 4em);
         margin: auto;
-      }
-
-      .heading {
-        background: #eee;
-        margin: -8px 0 0;
-        padding: 4px 8px;
-        font-family: $font-stack;
-
-        button {
-          float: right;
-          cursor: copy;
-          background: #ddd;
-          border: none;
-          padding: 0px 8px;
-          font-size: 90%;
-        }
       }
     }
 


### PR DESCRIPTION
**Summary**

The “clipboard” header would scroll with the code, as seen in 

<img width="883" alt="screen shot 2017-05-17 at 11 18 56" src="https://cloud.githubusercontent.com/assets/6270048/26147997/8bad797a-3af5-11e7-9bb2-18f370388cd3.png">

**Result**

1. put clipboard above pre
2. update styles to look seamless

<img width="853" alt="screen shot 2017-05-17 at 13 15 21" src="https://cloud.githubusercontent.com/assets/6270048/26151384/ebd4b784-3b02-11e7-8da5-e617c23e1c3a.png">

