### PR TITLE
fix deploy of 1.11.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "repository": "algolia/instantsearch.js",
   "files": [
     "dist",
-    "dist-es5-modules"
+    "dist-es5-module"
   ],
   "devDependencies": {
     "autoprefixer": "^6.7.6",


### PR DESCRIPTION
fixes #2150

was `dist-es5-modules` but should be `dist-es5-module` @iam4x 