### PR TITLE
Pass facetsCount to header template of refinementList

### DIFF
--- a/src/widgets/refinement-list/refinement-list.js
+++ b/src/widgets/refinement-list/refinement-list.js
@@ -34,7 +34,7 @@ const bem = bemHelper('ais-refinement-list');
  * @param  {object} [options.showMore.templates.inactive] Template used when showMore not clicked
  * @param  {object} [options.showMore.limit] Max number of facets values to display when showMore is clicked
  * @param  {Object} [options.templates] Templates to use for the widget
- * @param  {string|Function} [options.templates.header] Header template, provided with `refinedFacetsCount` data property
+ * @param  {string|Function} [options.templates.header] Header template, provided with `facetsCount`, `refinedFacetsCount` data properties
  * @param  {string|Function} [options.templates.item] Item template, provided with `name`, `count`, `isRefined`, `url` data properties
  * @param  {string|Function} [options.templates.footer] Footer template
  * @param  {Function} [options.transformData.item] Function to change the object passed to the `item` template
@@ -134,10 +134,11 @@ function refinementList({
       return createURL(state.toggleRefinement(attributeName, facetValue));
     }
 
-    // Pass count of currently selected items to the header template
+    // Pass count of total and currently selected items to the header template
+    const facetsCount = facetValues.length;
     const refinedFacetsCount = filter(facetValues, {isRefined: true}).length;
     const headerFooterData = {
-      header: {refinedFacetsCount},
+      header: {facetsCount, refinedFacetsCount},
     };
 
     // Do not mistake searchForFacetValues and searchFacetValues which is the actual search


### PR DESCRIPTION
**Summary**

I needed to display my refinementList header like so (showing the total selected out of total options):
**My Attribute Label** (3/20)

**Result**

I simply also passed a `facetsCount` prop to the `header` template.

Ideally I could have used `transformData`, but `transformData.header` doesn't exist.
Plus, I think this is sensible default data to pass along. 