### PR TITLE
Hits xss

### DIFF
--- a/src/connectors/hits/__tests__/connectHits-test.js
+++ b/src/connectors/hits/__tests__/connectHits-test.js
@@ -88,4 +88,56 @@ describe('connectHits', () => {
     expect(secondRenderingOptions.hits).toEqual(hits);
     expect(secondRenderingOptions.results).toEqual(results);
   });
+
+  it('escape highlight properties if requested', () => {
+    const rendering = sinon.stub();
+    const makeWidget = connectHits(rendering);
+    const widget = makeWidget({escapeHits: true});
+
+    const helper = jsHelper(fakeClient, '', {});
+    helper.search = sinon.stub();
+
+    widget.init({
+      helper,
+      state: helper.state,
+      createURL: () => '#',
+      onHistoryChange: () => {},
+    });
+
+    const firstRenderingOptions = rendering.lastCall.args[0];
+    expect(firstRenderingOptions.hits).toEqual([]);
+    expect(firstRenderingOptions.results).toBe(undefined);
+
+    const hits = [
+      {
+        _highlightResult: {
+          foobar: {
+            value: '<script>__ais-highlight__foobar__/ais-highlight__</script>',
+          },
+        },
+      },
+    ];
+
+    const results = new SearchResults(helper.state, [{hits}]);
+    widget.render({
+      results,
+      state: helper.state,
+      helper,
+      createURL: () => '#',
+    });
+
+    const escapedHits = [
+      {
+        _highlightResult: {
+          foobar: {
+            value: '&lt;script&gt;<em>foobar</em>&lt;/script&gt;',
+          },
+        },
+      },
+    ];
+
+    const secondRenderingOptions = rendering.lastCall.args[0];
+    expect(secondRenderingOptions.hits).toEqual(escapedHits);
+    expect(secondRenderingOptions.results).toEqual(results);
+  });
 });

--- a/src/connectors/hits/__tests__/connectHits-test.js
+++ b/src/connectors/hits/__tests__/connectHits-test.js
@@ -92,7 +92,7 @@ describe('connectHits', () => {
   it('escape highlight properties if requested', () => {
     const rendering = sinon.stub();
     const makeWidget = connectHits(rendering);
-    const widget = makeWidget({escapeHits: true});
+    const widget = makeWidget();
 
     const helper = jsHelper(fakeClient, '', {});
     helper.search = sinon.stub();

--- a/src/connectors/hits/__tests__/connectHits-test.js
+++ b/src/connectors/hits/__tests__/connectHits-test.js
@@ -87,6 +87,18 @@ describe('connectHits', () => {
         },
       },
       {
+        toEscapeAlso: '<a href="#top">Go to top</a>',
+        _highlightResult: {
+          toEscape: {
+            wontEscape: '<h1>Not escaped</h1>',
+            value: {
+              foo: '<a href="#top">__ais-highlight__Go to top__/ais-highlight__</a>',
+              bar: '<a href="#top">__ais-highlight__Go to top__/ais-highlight__</a>',
+            },
+          },
+        },
+      },
+      {
         whitelisted: '<a href="#top">Go to top</a>',
         _highlightResult: {
           whitelisted: {
@@ -114,6 +126,18 @@ describe('connectHits', () => {
           toEscape: {
             wontEscape: '<h1>Not escaped</h1>',
             value: '&lt;a href=&quot;#top&quot;&gt;<em>Go to top</em>&lt;/a&gt;',
+          },
+        },
+      },
+      {
+        toEscapeAlso: '&lt;a href=&quot;#top&quot;&gt;Go to top&lt;/a&gt;',
+        _highlightResult: {
+          toEscape: {
+            wontEscape: '<h1>Not escaped</h1>',
+            value: {
+              foo: '&lt;a href=&quot;#top&quot;&gt;<em>Go to top</em>&lt;/a&gt;',
+              bar: '&lt;a href=&quot;#top&quot;&gt;<em>Go to top</em>&lt;/a&gt;',
+            },
           },
         },
       },

--- a/src/connectors/hits/__tests__/connectHits-test.js
+++ b/src/connectors/hits/__tests__/connectHits-test.js
@@ -15,7 +15,10 @@ describe('connectHits', () => {
     const makeWidget = connectHits(rendering);
     const widget = makeWidget();
 
-    expect(widget.getConfiguration).toEqual(undefined);
+    expect(widget.getConfiguration()).toEqual({
+      highlightPreTag: '__ais-highlight__',
+      highlightPostTag: '__/ais-highlight__',
+    });
 
     // test if widget is not rendered yet at this point
     expect(rendering.callCount).toBe(0);
@@ -71,7 +74,17 @@ describe('connectHits', () => {
     const hits = [
       {fake: 'data'},
       {sample: 'infos'},
+      {
+        toEscape: '<a href="#top">Go to top</a>',
+        _highlightResult: {
+          toEscape: {
+            wontEscape: '<h1>Not escaped</h1>',
+            value: '<a href="#top">__ais-highlight__Go to top__/ais-highlight__</a>',
+          },
+        },
+      },
     ];
+
     const results = new SearchResults(helper.state, [{hits}]);
     widget.render({
       results,
@@ -80,8 +93,22 @@ describe('connectHits', () => {
       createURL: () => '#',
     });
 
+    const processedHits = [
+      {fake: 'data'},
+      {sample: 'infos'},
+      {
+        toEscape: '&lt;a href=&quot;#top&quot;&gt;Go to top&lt;/a&gt;',
+        _highlightResult: {
+          toEscape: {
+            wontEscape: '<h1>Not escaped</h1>',
+            value: '&lt;a href=&quot;#top&quot;&gt;<em>Go to top</em>&lt;/a&gt;',
+          },
+        },
+      },
+    ];
+
     const secondRenderingOptions = rendering.lastCall.args[0];
-    expect(secondRenderingOptions.hits).toEqual(hits);
+    expect(secondRenderingOptions.hits).toEqual(processedHits);
     expect(secondRenderingOptions.results).toEqual(results);
   });
 });

--- a/src/connectors/hits/__tests__/connectHits-test.js
+++ b/src/connectors/hits/__tests__/connectHits-test.js
@@ -55,7 +55,10 @@ describe('connectHits', () => {
   it('Provides the hits and the whole results', () => {
     const rendering = sinon.stub();
     const makeWidget = connectHits(rendering);
-    const widget = makeWidget();
+    const widget = makeWidget({
+      escapeHits: true,
+      escapeHitsWhitelist: ['whitelisted'],
+    });
 
     const helper = jsHelper(fakeClient, '', {});
     helper.search = sinon.stub();
@@ -83,6 +86,15 @@ describe('connectHits', () => {
           },
         },
       },
+      {
+        whitelisted: '<a href="#top">Go to top</a>',
+        _highlightResult: {
+          whitelisted: {
+            wontEscape: '<h1>Not escaped</h1>',
+            value: '<a href="#top">__ais-highlight__Go to top__/ais-highlight__</a>',
+          },
+        },
+      },
     ];
 
     const results = new SearchResults(helper.state, [{hits}]);
@@ -102,6 +114,15 @@ describe('connectHits', () => {
           toEscape: {
             wontEscape: '<h1>Not escaped</h1>',
             value: '&lt;a href=&quot;#top&quot;&gt;<em>Go to top</em>&lt;/a&gt;',
+          },
+        },
+      },
+      {
+        whitelisted: '<a href="#top">Go to top</a>',
+        _highlightResult: {
+          whitelisted: {
+            wontEscape: '<h1>Not escaped</h1>',
+            value: '<a href="#top"><em>Go to top</em></a>',
           },
         },
       },

--- a/src/connectors/hits/__tests__/connectHits-test.js
+++ b/src/connectors/hits/__tests__/connectHits-test.js
@@ -76,7 +76,7 @@ describe('connectHits', () => {
       {sample: 'infos'},
     ];
 
-    const results = new SearchResults(helper.state, [{hits}]);
+    const results = new SearchResults(helper.state, [{hits: [].concat(hits)}]);
     widget.render({
       results,
       state: helper.state,

--- a/src/connectors/hits/__tests__/connectHits-test.js
+++ b/src/connectors/hits/__tests__/connectHits-test.js
@@ -55,10 +55,7 @@ describe('connectHits', () => {
   it('Provides the hits and the whole results', () => {
     const rendering = sinon.stub();
     const makeWidget = connectHits(rendering);
-    const widget = makeWidget({
-      escapeHits: true,
-      escapeHitsWhitelist: ['whitelisted'],
-    });
+    const widget = makeWidget({});
 
     const helper = jsHelper(fakeClient, '', {});
     helper.search = sinon.stub();
@@ -77,36 +74,6 @@ describe('connectHits', () => {
     const hits = [
       {fake: 'data'},
       {sample: 'infos'},
-      {
-        toEscape: '<a href="#top">Go to top</a>',
-        _highlightResult: {
-          toEscape: {
-            wontEscape: '<h1>Not escaped</h1>',
-            value: '<a href="#top">__ais-highlight__Go to top__/ais-highlight__</a>',
-          },
-        },
-      },
-      {
-        toEscapeAlso: '<a href="#top">Go to top</a>',
-        _highlightResult: {
-          toEscape: {
-            wontEscape: '<h1>Not escaped</h1>',
-            value: {
-              foo: '<a href="#top">__ais-highlight__Go to top__/ais-highlight__</a>',
-              bar: '<a href="#top">__ais-highlight__Go to top__/ais-highlight__</a>',
-            },
-          },
-        },
-      },
-      {
-        whitelisted: '<a href="#top">Go to top</a>',
-        _highlightResult: {
-          whitelisted: {
-            wontEscape: '<h1>Not escaped</h1>',
-            value: '<a href="#top">__ais-highlight__Go to top__/ais-highlight__</a>',
-          },
-        },
-      },
     ];
 
     const results = new SearchResults(helper.state, [{hits}]);
@@ -117,43 +84,8 @@ describe('connectHits', () => {
       createURL: () => '#',
     });
 
-    const processedHits = [
-      {fake: 'data'},
-      {sample: 'infos'},
-      {
-        toEscape: '&lt;a href=&quot;#top&quot;&gt;Go to top&lt;/a&gt;',
-        _highlightResult: {
-          toEscape: {
-            wontEscape: '<h1>Not escaped</h1>',
-            value: '&lt;a href=&quot;#top&quot;&gt;<em>Go to top</em>&lt;/a&gt;',
-          },
-        },
-      },
-      {
-        toEscapeAlso: '&lt;a href=&quot;#top&quot;&gt;Go to top&lt;/a&gt;',
-        _highlightResult: {
-          toEscape: {
-            wontEscape: '<h1>Not escaped</h1>',
-            value: {
-              foo: '&lt;a href=&quot;#top&quot;&gt;<em>Go to top</em>&lt;/a&gt;',
-              bar: '&lt;a href=&quot;#top&quot;&gt;<em>Go to top</em>&lt;/a&gt;',
-            },
-          },
-        },
-      },
-      {
-        whitelisted: '<a href="#top">Go to top</a>',
-        _highlightResult: {
-          whitelisted: {
-            wontEscape: '<h1>Not escaped</h1>',
-            value: '<a href="#top"><em>Go to top</em></a>',
-          },
-        },
-      },
-    ];
-
     const secondRenderingOptions = rendering.lastCall.args[0];
-    expect(secondRenderingOptions.hits).toEqual(processedHits);
+    expect(secondRenderingOptions.hits).toEqual(hits);
     expect(secondRenderingOptions.results).toEqual(results);
   });
 });

--- a/src/connectors/hits/__tests__/connectHits-test.js
+++ b/src/connectors/hits/__tests__/connectHits-test.js
@@ -92,7 +92,7 @@ describe('connectHits', () => {
   it('escape highlight properties if requested', () => {
     const rendering = sinon.stub();
     const makeWidget = connectHits(rendering);
-    const widget = makeWidget();
+    const widget = makeWidget({escapeHits: true});
 
     const helper = jsHelper(fakeClient, '', {});
     helper.search = sinon.stub();

--- a/src/connectors/hits/connectHits.js
+++ b/src/connectors/hits/connectHits.js
@@ -140,7 +140,7 @@ function escapeHighlightProperty(highlightResult, whitelist) {
     highlightResult,
     (result, value, key) => {
       // Stop here don't escape this key, it's whitelisted.
-      if (whitelist.includes(key)) {
+      if (whitelist.indexOf(key) !== -1) {
         if (isPlainObject(value)) value.value = replaceWithEm(value.value);
         result[key] = value;
         return result;
@@ -170,7 +170,7 @@ function recursiveEscape(val, whitelist) {
       val,
       (result, value, key) => {
         // dont escape theses values, they are whitelisted
-        if (whitelist.includes(key)) {
+        if (whitelist.indexOf(key) !== -1) {
           result[key] = value;
         } else {
           result[key] = key === '_highlightResult' || key === '_snippetResult'

--- a/src/connectors/hits/connectHits.js
+++ b/src/connectors/hits/connectHits.js
@@ -74,7 +74,7 @@ export default function connectHits(renderFn) {
     },
 
     render({results, instantSearchInstance}) {
-      results.hits = escapeAll(results.hits);
+      results.hits = recursiveEscape(results.hits);
 
       renderFn({
         hits: results.hits,
@@ -84,15 +84,6 @@ export default function connectHits(renderFn) {
       }, false);
     },
   });
-}
-
-function escapeAll(hits) {
-  if (hits && hits.__hitsEscaped !== true && hits.length > 0) {
-    hits.__hitsEscaped = true;
-    return recursiveEscape(hits);
-  }
-
-  return hits;
 }
 
 function replaceWithEm(val) {

--- a/src/connectors/hits/connectHits.js
+++ b/src/connectors/hits/connectHits.js
@@ -19,11 +19,6 @@ Full documentation available at https://community.algolia.com/instantsearch.js/c
 `;
 
 /**
- * @typedef {Object} CustomHitsWidgetOptions
- * @property {boolean} [escapeHits = false] Escape HTML entities from hits string values.
- */
-
-/**
  * @typedef {Object} HitsRenderingOptions
  * @property {Object[]} hits The matched hits from Algolia API.
  * @property {Object} results The complete results response from Algolia API.
@@ -34,7 +29,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/c
  * **Hits** connector provides the logic to create custom widgets that will render the results retrieved from Algolia.
  * @type {Connector}
  * @param {function(HitsRenderingOptions, boolean)} renderFn Rendering function for the custom **Hits** widget.
- * @return {function(CustomHitsWidgetOptions)} Re-usable widget factory for a custom **Hits** widget.
+ * @return {function()} Re-usable widget factory for a custom **Hits** widget.
  * @example
  * // custom `renderFn` to render the custom Hits widget
  * function renderFn(HitsRenderingOptions) {
@@ -58,35 +53,31 @@ Full documentation available at https://community.algolia.com/instantsearch.js/c
 export default function connectHits(renderFn) {
   checkRendering(renderFn, usage);
 
-  return (widgetParams = {}) => {
-    const {escapeHits = false} = widgetParams;
+  return (widgetParams = {}) => ({
+    getConfiguration() {
+      return tagConfig;
+    },
 
-    return {
-      getConfiguration() {
-        return tagConfig;
-      },
+    init({instantSearchInstance}) {
+      renderFn({
+        hits: [],
+        results: undefined,
+        instantSearchInstance,
+        widgetParams,
+      }, true);
+    },
 
-      init({instantSearchInstance}) {
-        renderFn({
-          hits: [],
-          results: undefined,
-          instantSearchInstance,
-          widgetParams,
-        }, true);
-      },
+    render({results, instantSearchInstance}) {
+      if (results.hits && results.hits.length > 0) {
+        results.hits = results.hits.map(escapeHighlight);
+      }
 
-      render({results, instantSearchInstance}) {
-        if (escapeHits === true) {
-          results.hits = results.hits.map(escapeHighlight);
-        }
-
-        renderFn({
-          hits: results.hits,
-          results,
-          instantSearchInstance,
-          widgetParams,
-        }, false);
-      },
-    };
-  };
+      renderFn({
+        hits: results.hits,
+        results,
+        instantSearchInstance,
+        widgetParams,
+      }, false);
+    },
+  });
 }

--- a/src/connectors/hits/connectHits.js
+++ b/src/connectors/hits/connectHits.js
@@ -1,4 +1,4 @@
-import escapeHighlight, {tagConfig} from '../../lib/escape-highlight.js';
+import escapeHits, {tagConfig} from '../../lib/escape-highlight.js';
 import {checkRendering} from '../../lib/utils.js';
 
 const usage = `Usage:
@@ -69,7 +69,7 @@ export default function connectHits(renderFn) {
 
     render({results, instantSearchInstance}) {
       if (results.hits && results.hits.length > 0) {
-        results.hits = results.hits.map(escapeHighlight);
+        results.hits = escapeHits(results.hits);
       }
 
       renderFn({

--- a/src/connectors/hits/connectHits.js
+++ b/src/connectors/hits/connectHits.js
@@ -1,4 +1,4 @@
-import escapeHighlight from '../../lib/escape-highlight.js';
+import escapeHighlight, {tagConfig} from '../../lib/escape-highlight.js';
 import {checkRendering} from '../../lib/utils.js';
 
 const usage = `Usage:
@@ -17,11 +17,6 @@ search.addWidget(
 );
 Full documentation available at https://community.algolia.com/instantsearch.js/connectors/connectHits.html
 `;
-
-const config = {
-  highlightPreTag: '__ais-highlight__',
-  highlightPostTag: '__/ais-highlight__',
-};
 
 /**
  * @typedef {Object} CustomHitsWidgetOptions
@@ -68,7 +63,7 @@ export default function connectHits(renderFn) {
 
     return {
       getConfiguration() {
-        return config;
+        return tagConfig;
       },
 
       init({instantSearchInstance}) {

--- a/src/connectors/hits/connectHits.js
+++ b/src/connectors/hits/connectHits.js
@@ -26,10 +26,15 @@ Full documentation available at https://community.algolia.com/instantsearch.js/c
  */
 
 /**
+ * @typedef {Object} CustomHitsWidgetOptions
+ * @property {boolean} [escapeHits = false] If true, escape HTML tags from `hits[i]._highlightResult`.
+ */
+
+/**
  * **Hits** connector provides the logic to create custom widgets that will render the results retrieved from Algolia.
  * @type {Connector}
  * @param {function(HitsRenderingOptions, boolean)} renderFn Rendering function for the custom **Hits** widget.
- * @return {function()} Re-usable widget factory for a custom **Hits** widget.
+ * @return {function(CustomHitsWidgetOptions)} Re-usable widget factory for a custom **Hits** widget.
  * @example
  * // custom `renderFn` to render the custom Hits widget
  * function renderFn(HitsRenderingOptions) {
@@ -68,7 +73,7 @@ export default function connectHits(renderFn) {
     },
 
     render({results, instantSearchInstance}) {
-      if (results.hits && results.hits.length > 0) {
+      if (widgetParams.escapeHits && results.hits && results.hits.length > 0) {
         results.hits = escapeHits(results.hits);
       }
 

--- a/src/connectors/hits/connectHits.js
+++ b/src/connectors/hits/connectHits.js
@@ -116,7 +116,7 @@ function replaceWithEm(val) {
       val,
       (result, value, key) => {
         result[key] = replaceWithEm(value);
-        return {};
+        return result;
       },
       {}
     );

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.js
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.js
@@ -17,7 +17,10 @@ describe('connectInfiniteHits', () => {
       hitsPerPage: 10,
     });
 
-    expect(widget.getConfiguration).toEqual(undefined);
+    expect(widget.getConfiguration()).toEqual({
+      highlightPostTag: '__/ais-highlight__',
+      highlightPreTag: '__ais-highlight__',
+    });
 
     // test if widget is not rendered yet at this point
     expect(rendering.callCount).toBe(0);

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.js
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.js
@@ -83,7 +83,7 @@ describe('connectInfiniteHits', () => {
       {fake: 'data'},
       {sample: 'infos'},
     ];
-    const results = new SearchResults(helper.state, [{hits}]);
+    const results = new SearchResults(helper.state, [{hits: [].concat(hits)}]);
     widget.render({
       results,
       state: helper.state,
@@ -104,7 +104,7 @@ describe('connectInfiniteHits', () => {
       {sample: 'infos 2'},
     ];
     const otherResults = new SearchResults(helper.state, [{
-      hits: otherHits,
+      hits: [].concat(otherHits),
     }]);
     widget.render({
       results: otherResults,
@@ -126,7 +126,7 @@ describe('connectInfiniteHits', () => {
       {sample: 'infos 3'},
     ];
     const thirdResults = new SearchResults(helper.state, [{
-      hits: thirdHits,
+      hits: [].concat(thirdHits),
     }]);
     widget.render({
       results: thirdResults,

--- a/src/connectors/infinite-hits/connectInfiniteHits.js
+++ b/src/connectors/infinite-hits/connectInfiniteHits.js
@@ -1,4 +1,4 @@
-import escapeHighlight, {tagConfig} from '../../lib/escape-highlight.js';
+import escapeHits, {tagConfig} from '../../lib/escape-highlight.js';
 import {checkRendering} from '../../lib/utils.js';
 
 const usage = `Usage:
@@ -97,7 +97,7 @@ export default function connectInfiniteHits(renderFn) {
         }
 
         if (results.hits && results.hits.length > 0) {
-          results.hits = results.hits.map(escapeHighlight);
+          results.hits = escapeHits(results.hits);
         }
 
         hitsCache = [...hitsCache, ...results.hits];

--- a/src/connectors/infinite-hits/connectInfiniteHits.js
+++ b/src/connectors/infinite-hits/connectInfiniteHits.js
@@ -13,7 +13,9 @@ var customInfiniteHits = connectInfiniteHits(function render(params, isFirstRend
   // }
 });
 search.addWidget(
-  customInfiniteHits()
+  customInfiniteHits({
+    escapeHits: true,
+  })
 );
 Full documentation available at https://community.algolia.com/instantsearch.js/connectors/connectInfiniteHits.html
 `;
@@ -28,12 +30,17 @@ Full documentation available at https://community.algolia.com/instantsearch.js/c
  */
 
 /**
+ * @typedef {Object} CustomInfiniteHitsWidgetOptions
+ * @property {boolean} [escapeHits = false] If true, escape HTML tags from `hits[i]._highlightResult`.
+ */
+
+/**
  * **InfiniteHits** connector provides the logic to create custom widgets that will render an continuous list of results retrieved from Algolia.
  *
  * This connector provides a `InfiniteHitsRenderingOptions.showMore()` function to load next page of matched results.
  * @type {Connector}
  * @param {function(InfiniteHitsRenderingOptions, boolean)} renderFn Rendering function for the custom **InfiniteHits** widget.
- * @return {function(object)} Re-usable widget factory for a custom **InfiniteHits** widget.
+ * @return {function(CustomInfiniteHitsWidgetOptions)} Re-usable widget factory for a custom **InfiniteHits** widget.
  * @example
  * // custom `renderFn` to render the custom InfiniteHits widget
  * function renderFn(InfiniteHitsRenderingOptions, isFirstRendering) {
@@ -96,7 +103,7 @@ export default function connectInfiniteHits(renderFn) {
           hitsCache = [];
         }
 
-        if (results.hits && results.hits.length > 0) {
+        if (widgetParams.escapeHits && results.hits && results.hits.length > 0) {
           results.hits = escapeHits(results.hits);
         }
 

--- a/src/connectors/infinite-hits/connectInfiniteHits.js
+++ b/src/connectors/infinite-hits/connectInfiniteHits.js
@@ -1,3 +1,4 @@
+import escapeHighlight, {tagConfig} from '../../lib/escape-highlight.js';
 import {checkRendering} from '../../lib/utils.js';
 
 const usage = `Usage:
@@ -73,6 +74,10 @@ export default function connectInfiniteHits(renderFn) {
     const getShowMore = helper => () => helper.nextPage().search();
 
     return {
+      getConfiguration() {
+        return tagConfig;
+      },
+
       init({instantSearchInstance, helper}) {
         this.showMore = getShowMore(helper);
 
@@ -89,6 +94,10 @@ export default function connectInfiniteHits(renderFn) {
       render({results, state, instantSearchInstance}) {
         if (state.page === 0) {
           hitsCache = [];
+        }
+
+        if (results.hits && results.hits.length > 0) {
+          results.hits = results.hits.map(escapeHighlight);
         }
 
         hitsCache = [...hitsCache, ...results.hits];

--- a/src/lib/__tests__/escape-highlight-test.js
+++ b/src/lib/__tests__/escape-highlight-test.js
@@ -1,0 +1,111 @@
+import escapeHighlight from '../escape-highlight';
+
+describe('escapeHighlight()', () => {
+  it('should escape highlighProperty simple text value', () => {
+    const input = {
+      _snippetResult: {
+        foobar: {
+          value: '<script>__ais-highlight__foobar__/ais-highlight__</script>',
+        },
+      },
+      _highlightResult: {
+        foobar: {
+          value: '<script>__ais-highlight__foobar__/ais-highlight__</script>',
+        },
+      },
+    };
+
+    expect(escapeHighlight(input)).toEqual({
+      _highlightResult: {
+        foobar: {
+          value: '&lt;script&gt;<em>foobar</em>&lt;/script&gt;',
+        },
+      },
+      _snippetResult: {
+        foobar: {
+          value: '&lt;script&gt;<em>foobar</em>&lt;/script&gt;',
+        },
+      },
+    });
+  });
+
+  it('should escape highlighProperty nested object value', () => {
+    const input = {
+      _highlightResult: {
+        foobar: {
+          value: {
+            foo: '<script>__ais-highlight__bar__/ais-highlight__</script>',
+            bar: '<script>__ais-highlight__foo__/ais-highlight__</script>',
+          },
+        },
+      },
+      _snippetResult: {
+        foobar: {
+          value: {
+            foo: '<script>__ais-highlight__bar__/ais-highlight__</script>',
+            bar: '<script>__ais-highlight__foo__/ais-highlight__</script>',
+          },
+        },
+      },
+    };
+
+    expect(escapeHighlight(input)).toEqual({
+      _highlightResult: {
+        foobar: {
+          value: {
+            foo: '&lt;script&gt;<em>bar</em>&lt;/script&gt;',
+            bar: '&lt;script&gt;<em>foo</em>&lt;/script&gt;',
+          },
+        },
+      },
+      _snippetResult: {
+        foobar: {
+          value: {
+            foo: '&lt;script&gt;<em>bar</em>&lt;/script&gt;',
+            bar: '&lt;script&gt;<em>foo</em>&lt;/script&gt;',
+          },
+        },
+      },
+    });
+  });
+
+  it('should escape highlighProperty array of string as value', () => {
+    const input = {
+      _highlightResult: {
+        foobar: {
+          value: [
+            '<script>__ais-highlight__bar__/ais-highlight__</script>',
+            '<script>__ais-highlight__foo__/ais-highlight__</script>',
+          ],
+        },
+      },
+      _snippetResult: {
+        foobar: {
+          value: [
+            '<script>__ais-highlight__bar__/ais-highlight__</script>',
+            '<script>__ais-highlight__foo__/ais-highlight__</script>',
+          ],
+        },
+      },
+    };
+
+    expect(escapeHighlight(input)).toEqual({
+      _highlightResult: {
+        foobar: {
+          value: [
+            '&lt;script&gt;<em>bar</em>&lt;/script&gt;',
+            '&lt;script&gt;<em>foo</em>&lt;/script&gt;',
+          ],
+        },
+      },
+      _snippetResult: {
+        foobar: {
+          value: [
+            '&lt;script&gt;<em>bar</em>&lt;/script&gt;',
+            '&lt;script&gt;<em>foo</em>&lt;/script&gt;',
+          ],
+        },
+      },
+    });
+  });
+});

--- a/src/lib/__tests__/escape-highlight-test.js
+++ b/src/lib/__tests__/escape-highlight-test.js
@@ -1,8 +1,8 @@
-import escapeHighlight from '../escape-highlight';
+import escapeHits from '../escape-highlight';
 
-describe('escapeHighlight()', () => {
+describe('escapeHits()', () => {
   it('should escape highlighProperty simple text value', () => {
-    const input = {
+    const hits = [{
       _snippetResult: {
         foobar: {
           value: '<script>__ais-highlight__foobar__/ais-highlight__</script>',
@@ -13,9 +13,9 @@ describe('escapeHighlight()', () => {
           value: '<script>__ais-highlight__foobar__/ais-highlight__</script>',
         },
       },
-    };
+    }];
 
-    expect(escapeHighlight(input)).toEqual({
+    expect(escapeHits(hits)).toEqual([{
       _highlightResult: {
         foobar: {
           value: '&lt;script&gt;<em>foobar</em>&lt;/script&gt;',
@@ -26,11 +26,11 @@ describe('escapeHighlight()', () => {
           value: '&lt;script&gt;<em>foobar</em>&lt;/script&gt;',
         },
       },
-    });
+    }]);
   });
 
   it('should escape highlighProperty nested object value', () => {
-    const input = {
+    const hits = [{
       _highlightResult: {
         foobar: {
           value: {
@@ -47,9 +47,9 @@ describe('escapeHighlight()', () => {
           },
         },
       },
-    };
+    }];
 
-    expect(escapeHighlight(input)).toEqual({
+    expect(escapeHits(hits)).toEqual([{
       _highlightResult: {
         foobar: {
           value: {
@@ -66,11 +66,11 @@ describe('escapeHighlight()', () => {
           },
         },
       },
-    });
+    }]);
   });
 
   it('should escape highlighProperty array of string as value', () => {
-    const input = {
+    const hits = [{
       _highlightResult: {
         foobar: {
           value: [
@@ -87,9 +87,9 @@ describe('escapeHighlight()', () => {
           ],
         },
       },
-    };
+    }];
 
-    expect(escapeHighlight(input)).toEqual({
+    expect(escapeHits(hits)).toEqual([{
       _highlightResult: {
         foobar: {
           value: [
@@ -106,6 +106,31 @@ describe('escapeHighlight()', () => {
           ],
         },
       },
-    });
+    }]);
+  });
+
+  it('should not escape twice the same results', () => {
+    const hits = [{
+      _highlightResult: {
+        foobar: {
+          value: '<script>__ais-highlight__foo__/ais-highlight__</script>',
+        },
+      },
+    }];
+
+    escapeHits(hits);
+    escapeHits(hits);
+
+    const output = [{
+      _highlightResult: {
+        foobar: {
+          value: '&lt;script&gt;<em>foo</em>&lt;/script&gt;',
+        },
+      },
+    }];
+
+    output.__escaped = true;
+
+    expect(hits).toEqual(output);
   });
 });

--- a/src/lib/escape-highlight.js
+++ b/src/lib/escape-highlight.js
@@ -4,10 +4,15 @@ import isPlainObject from 'lodash/isPlainObject';
 import isArray from 'lodash/isArray';
 import mapValues from 'lodash/mapValues';
 
+export const tagConfig = {
+  highlightPreTag: '__ais-highlight__',
+  highlightPostTag: '__/ais-highlight__',
+};
+
 function replaceWithEmAndEscape(value) {
   return escape(value)
-    .replace(/__ais-highlight__/g, '<em>')
-    .replace(/__\/ais-highlight__/g, '</em>');
+    .replace(new RegExp(tagConfig.highlightPreTag, 'g'), '<em>')
+    .replace(new RegExp(tagConfig.highlightPostTag, 'g'), '</em>');
 }
 
 function recursiveEscape(input) {

--- a/src/lib/escape-highlight.js
+++ b/src/lib/escape-highlight.js
@@ -33,14 +33,22 @@ function recursiveEscape(input) {
   }, {});
 }
 
-export default function escapeHighlight(input) {
-  if (input._highlightResult) {
-    input._highlightResult = recursiveEscape(input._highlightResult);
+export default function escapeHits(hits) {
+  if (hits.__escaped === undefined) {
+    hits.__escaped = true;
+
+    return hits.map(hit => {
+      if (hit._highlightResult) {
+        hit._highlightResult = recursiveEscape(hit._highlightResult);
+      }
+
+      if (hit._snippetResult) {
+        hit._snippetResult = recursiveEscape(hit._snippetResult);
+      }
+
+      return hit;
+    });
   }
 
-  if (input._snippetResult) {
-    input._snippetResult = recursiveEscape(input._snippetResult);
-  }
-
-  return input;
+  return hits;
 }

--- a/src/lib/escape-highlight.js
+++ b/src/lib/escape-highlight.js
@@ -1,0 +1,41 @@
+import reduce from 'lodash/reduce';
+import escape from 'lodash/escape';
+import isPlainObject from 'lodash/isPlainObject';
+import isArray from 'lodash/isArray';
+import mapValues from 'lodash/mapValues';
+
+function replaceWithEmAndEscape(value) {
+  return escape(value)
+    .replace(/__ais-highlight__/g, '<em>')
+    .replace(/__\/ais-highlight__/g, '</em>');
+}
+
+function recursiveEscape(input) {
+  return reduce(input, (output, value, key) => {
+    if (typeof value.value === 'string') {
+      value.value = replaceWithEmAndEscape(value.value);
+    }
+
+    if (isPlainObject(value.value)) {
+      value.value = mapValues(value.value, replaceWithEmAndEscape);
+    }
+
+    if (isArray(value.value)) {
+      value.value = value.value.map(replaceWithEmAndEscape);
+    }
+
+    return {...output, [key]: value};
+  }, {});
+}
+
+export default function escapeHighlight(input) {
+  if (input._highlightResult) {
+    input._highlightResult = recursiveEscape(input._highlightResult);
+  }
+
+  if (input._snippetResult) {
+    input._snippetResult = recursiveEscape(input._snippetResult);
+  }
+
+  return input;
+}

--- a/src/widgets/hits/__tests__/hits-test.js
+++ b/src/widgets/hits/__tests__/hits-test.js
@@ -11,6 +11,10 @@ describe('hits call', () => {
   it('throws an exception when no container', () => {
     expect(hits).toThrow();
   });
+
+  it('throws an execption when `escapeHitsWhitelist` is wrong format', () => {
+    expect(() => hits({escapeHitsWhitelist: /foobar/})).toThrow();
+  });
 });
 
 describe('hits()', () => {

--- a/src/widgets/hits/__tests__/hits-test.js
+++ b/src/widgets/hits/__tests__/hits-test.js
@@ -11,10 +11,6 @@ describe('hits call', () => {
   it('throws an exception when no container', () => {
     expect(hits).toThrow();
   });
-
-  it('throws an execption when `escapeHitsWhitelist` is wrong format', () => {
-    expect(() => hits({escapeHitsWhitelist: /foobar/})).toThrow();
-  });
 });
 
 describe('hits()', () => {

--- a/src/widgets/hits/hits.js
+++ b/src/widgets/hits/hits.js
@@ -82,6 +82,8 @@ hits({
  * @property {HitsTemplates} [templates] Templates to use for the widget.
  * @property {HitsTransforms} [transformData] Method to change the object passed to the templates.
  * @property {HitsCSSClasses} [cssClasses] CSS classes to add.
+ * @property {boolean} [escapeHits = false] Escape HTML entities from hits string values.
+ * @property {string[]} [escapeHitsWhitelist = []] Dont escape theses fields from hits.
  */
 
 /**
@@ -110,6 +112,8 @@ export default function hits({
   cssClasses: userCssClasses = {},
   templates = defaultTemplates,
   transformData,
+  escapeHits = false,
+  escapeHitsWhitelist = [],
 }) {
   if (!container) {
     throw new Error(`Must provide a container.${usage}`);
@@ -136,7 +140,7 @@ export default function hits({
 
   try {
     const makeHits = connectHits(specializedRenderer);
-    return makeHits();
+    return makeHits({escapeHits, escapeHitsWhitelist});
   } catch (e) {
     throw new Error(usage);
   }

--- a/src/widgets/hits/hits.js
+++ b/src/widgets/hits/hits.js
@@ -83,7 +83,6 @@ hits({
  * @property {HitsTransforms} [transformData] Method to change the object passed to the templates.
  * @property {HitsCSSClasses} [cssClasses] CSS classes to add.
  * @property {boolean} [escapeHits = false] Escape HTML entities from hits string values.
- * @property {string[]} [escapeHitsWhitelist = []] Dont escape theses fields from hits.
  */
 
 /**
@@ -103,7 +102,8 @@ hits({
  *       empty: 'No results',
  *       item: '<strong>Hit {{objectID}}</strong>: {{{_highlightResult.name.value}}}'
  *     },
- *     hitsPerPage: 6
+ *     hitsPerPage: 6,
+ *     escapeHits: true,
  *   })
  * );
  */
@@ -113,7 +113,6 @@ export default function hits({
   templates = defaultTemplates,
   transformData,
   escapeHits = false,
-  escapeHitsWhitelist = [],
 }) {
   if (!container) {
     throw new Error(`Must provide a container.${usage}`);
@@ -140,7 +139,7 @@ export default function hits({
 
   try {
     const makeHits = connectHits(specializedRenderer);
-    return makeHits({escapeHits, escapeHitsWhitelist});
+    return makeHits({escapeHits});
   } catch (e) {
     throw new Error(usage);
   }

--- a/src/widgets/infinite-hits/__tests__/infinite-hits-test.js
+++ b/src/widgets/infinite-hits/__tests__/infinite-hits-test.js
@@ -42,8 +42,11 @@ describe('infiniteHits()', () => {
     results = {hits: [{first: 'hit', second: 'hit'}]};
   });
 
-  it('Does not have a specific configuration', () => {
-    expect(widget.getConfiguration).toBe(undefined);
+  it('It does have a specific configuration', () => {
+    expect(widget.getConfiguration()).toEqual({
+      highlightPostTag: '__/ais-highlight__',
+      highlightPreTag: '__ais-highlight__',
+    });
   });
 
   it('calls twice ReactDOM.render(<Hits props />, container)', () => {
@@ -72,10 +75,10 @@ describe('infiniteHits()', () => {
     });
 
     expect(ReactDOM.render.calledTwice).toBe(true, 'ReactDOM.render called twice');
-    const propsWithIsLastPageFalse = {...(getProps({...results, page: 0, nbPages: 2})), isLastPage: false};
+    const propsWithIsLastPageFalse = {...getProps({...results, page: 0, nbPages: 2}), isLastPage: false};
     expect(ReactDOM.render.firstCall.args[0]).toEqualJSX(<InfiniteHits {...propsWithIsLastPageFalse} />);
     expect(ReactDOM.render.firstCall.args[1]).toEqual(container);
-    const propsWithIsLastPageTrue = {...(getProps({...results, page: 1, nbPages: 2})), isLastPage: true};
+    const propsWithIsLastPageTrue = {...getProps({...results, page: 1, nbPages: 2}), isLastPage: true};
     expect(ReactDOM.render.secondCall.args[0]).toEqualJSX(<InfiniteHits {...propsWithIsLastPageTrue} />);
     expect(ReactDOM.render.secondCall.args[1]).toEqual(container);
   });

--- a/src/widgets/infinite-hits/infinite-hits.js
+++ b/src/widgets/infinite-hits/infinite-hits.js
@@ -56,6 +56,7 @@ const usage = `
 Usage:
 infiniteHits({
   container,
+  [ escapeHits = false ],
   [ showMoreLabel ],
   [ cssClasses.{root,empty,item}={} ],
   [ templates.{empty,item} | templates.{empty} ],
@@ -88,6 +89,7 @@ infiniteHits({
  * @property  {string} [showMoreLabel="Show more results"] label used on the show more button.
  * @property  {InfiniteHitsTransforms} [transformData] Method to change the object passed to the templates.
  * @property  {InfiniteHitsCSSClasses} [cssClasses] CSS classes to add.
+ * @property {boolean} [escapeHits = false] Escape HTML entities from hits string values.
  */
 
 /**
@@ -107,7 +109,8 @@ infiniteHits({
  *       empty: 'No results',
  *       item: '<strong>Hit {{objectID}}</strong>: {{{_highlightResult.name.value}}}'
  *     },
- *     hitsPerPage: 3
+ *     hitsPerPage: 3,
+ *     escapeHits: true,
  *   })
  * );
  */
@@ -117,6 +120,7 @@ export default function infiniteHits({
   showMoreLabel = 'Show more results',
   templates = defaultTemplates,
   transformData,
+  escapeHits = false,
 } = {}) {
   if (!container) {
     throw new Error(`Must provide a container.${usage}`);
@@ -141,7 +145,7 @@ export default function infiniteHits({
 
   try {
     const makeInfiniteHits = connectInfiniteHits(specializedRenderer);
-    return makeInfiniteHits();
+    return makeInfiniteHits({escapeHits});
   } catch (e) {
     throw new Error(usage);
   }


### PR DESCRIPTION
* [x] escape HTML entities only from `value` field of an `_highlightResult` or `_snippetResult`
* [x] replace from highlighted result `__ais-highlight__` with `<em>` tags
* [x] opt-in to enable escape of HTML

fix for https://github.com/algolia/instantsearch.js/issues/2138