### PR TITLE
Documentation: remove hitsPerPage from hits & infiniteHits examples

### DIFF
--- a/src/widgets/hits/hits.js
+++ b/src/widgets/hits/hits.js
@@ -102,7 +102,6 @@ hits({
  *       empty: 'No results',
  *       item: '<strong>Hit {{objectID}}</strong>: {{{_highlightResult.name.value}}}'
  *     },
- *     hitsPerPage: 6,
  *     escapeHits: true,
  *   })
  * );

--- a/src/widgets/infinite-hits/infinite-hits.js
+++ b/src/widgets/infinite-hits/infinite-hits.js
@@ -109,7 +109,6 @@ infiniteHits({
  *       empty: 'No results',
  *       item: '<strong>Hit {{objectID}}</strong>: {{{_highlightResult.name.value}}}'
  *     },
- *     hitsPerPage: 3,
  *     escapeHits: true,
  *   })
  * );


### PR DESCRIPTION
**Summary**

As `hitsPerPage` is no longer supported as an argument in `hits` & `infiniteHits` widgets, I removed it from the examples.