### PR TITLE
fix(url-sync): reverting back to using `change` event

### DIFF
--- a/src/lib/url-sync.js
+++ b/src/lib/url-sync.js
@@ -126,7 +126,7 @@ class URLSync {
     if (this.firstRender) {
       this.firstRender = false;
       this.onHistoryChange(this.onPopState.bind(this, helper));
-      helper.on('search', state => this.renderURLFromState(state));
+      helper.on('change', state => this.renderURLFromState(state));
     }
   }
 


### PR DESCRIPTION
This reverts the behaviour of the URL sync to using the `change` event.
Unfortunately it reverts back the state prior to fixing #2105. However
this behaviour was introduced on purpose with #1015

Fixes #2173 #2171

http://aromatic-card.surge.sh/