### PR TITLE
fix(searchFunction): implement another way to express #1924 API

### DIFF
--- a/dev/app/index.js
+++ b/dev/app/index.js
@@ -17,6 +17,9 @@ const search = instantsearch({
       hFR: 'hierarchical',
     },
   },
+  searchFunction: h => {
+    h.search();
+  },
 });
 
 const q = window.location.search;
@@ -35,6 +38,20 @@ default:
 search.once('render', () => {
   [...document.querySelectorAll('.smooth-search--hidden')]
     .forEach(element => element.classList.remove('smooth-search--hidden'));
+});
+
+search.addWidget({
+  init: ({helper}) => {
+    helper.on('change', () => {
+      console.log('change event');
+    });
+    helper.on('search', () => {
+      console.log('search event');
+    });
+    helper.on('result', () => {
+      console.log('result event');
+    });
+  },
 });
 
 search.start();

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -120,19 +120,19 @@ Usage: instantsearch({
       this.searchParameters
     );
 
+    this.helper = helper;
     if (this._searchFunction) {
-      this.helper = Object.create(helper);
+      this._originalSearchMethod = this.helper.search;
       this.helper.search = () => {
-        helper.setState(this.helper.state);
+        const proxySearch = this.helper.search;
+        this.helper.search = this._originalSearchMethod;
         this._searchFunction(helper);
+        this.helper.search = proxySearch;
       };
-      this._init(helper.state, this.helper);
-      helper.on('result', this._render.bind(this, this.helper));
-    } else {
-      this.helper = helper;
-      this._init(helper.state, this.helper);
-      this.helper.on('result', this._render.bind(this, this.helper));
     }
+
+    this._init(helper.state, this.helper);
+    this.helper.on('result', this._render.bind(this, this.helper));
 
     this.helper.search();
   }

--- a/src/lib/url-sync.js
+++ b/src/lib/url-sync.js
@@ -88,7 +88,8 @@ function getFullURL(relative) {
 // IE <= 11 has no location.origin or buggy
 function getLocationOrigin() {
   // eslint-disable-next-line max-len
-  return `${window.location.protocol}//${window.location.hostname}${window.location.port ? `:${window.location.port}` : ''}`;
+  const port = window.location.port ? `:${window.location.port}` : '';
+  return `${window.location.protocol}//${window.location.hostname}${port}`;
 }
 
 // see InstantSearch.js file for urlSync options
@@ -126,7 +127,10 @@ class URLSync {
     if (this.firstRender) {
       this.firstRender = false;
       this.onHistoryChange(this.onPopState.bind(this, helper));
-      helper.on('search', state => this.renderURLFromState(state));
+      helper.on('change', state => {
+        console.log('updating url');
+        this.renderURLFromState(state);
+      });
     }
   }
 


### PR DESCRIPTION
The new approach is less subtle than the previous one: instead of
overloading the search method using the helper as a prototype, we change
the implementation of the search on the fly.

Fixes #2176

**Summary**

We couldn't bind the events `search` and `result` in the previous implementation

**Result**

 - go to http://debonair-current.surge.sh/
 - open the console and see the different log message created by event listeners :)