### PR TITLE
chore(packaging): do not add engine instruction to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,6 @@
     "dist",
     "dist-es5-module"
   ],
-  "engines": {
-    "node": "7.10.0"
-  },
   "devDependencies": {
     "autoprefixer": "^6.7.6",
     "babel-cli": "^6.23.0",


### PR DESCRIPTION
This then warns user installing via npm about their engine not being compatible.