### PR TITLE
chore(packaging): do not add engine instruction to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,6 @@
     "dist",
     "dist-es5-module"
   ],
-  "engines": {
-    "node": "7.10.0"
-  },
   "devDependencies": {
     "argos-cli": "^0.0.8",
     "autoprefixer": "^6.7.7",


### PR DESCRIPTION
This then warns user installing via npm about their engine not being compatible.