### PR TITLE
fix(argos-ci): blur the active element

### DIFF
--- a/functional-tests/test.js
+++ b/functional-tests/test.js
@@ -1,5 +1,5 @@
 import expect from 'expect';
-import {searchBox} from './utils.js';
+import {searchBox, prepareScreenshot} from './utils.js';
 
 describe('searchBox', () => {
   describe('when there is no query', () => {
@@ -9,6 +9,7 @@ describe('searchBox', () => {
 
     it('triggers an empty search', () => {
       expect(browser.getText('#hits')).toNotContain('MP3');
+      prepareScreenshot();
       browser.checkDocument({
         hide: ['.ais-stats--body'], // Flaky X ms information.
       });
@@ -22,6 +23,7 @@ describe('searchBox', () => {
 
     it('triggers a new search', () => {
       expect(browser.getText('#hits')).toContain('MP3');
+      prepareScreenshot();
       browser.checkDocument({
         hide: ['.ais-stats--body'], // Flaky X ms information.
       });

--- a/functional-tests/utils.js
+++ b/functional-tests/utils.js
@@ -16,3 +16,14 @@ export const searchBox = {
     return browser.getValue('#search-box');
   },
 };
+
+function blurAll() {
+  if ('activeElement' in document) {
+    document.activeElement.blur();
+  }
+}
+
+export function prepareScreenshot() {
+  // The focus bar visibility is flaky.
+  return browser.execute(blurAll);
+}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

The focus bar visibility is flaky, we cant take screenshots with it.
<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

Fix that build https://www.argos-ci.com/algolia/instantsearch.js/builds/4431.
For reference, here are some of [the tweaks](https://github.com/argos-ci/argos/blob/master/examples/with-rails/test/ui_tweak_helper.rb) we use at Doctolib to make it work at scale (for a lot of e2e tests).