### PR TITLE
docs(header): fix link to GitHub source code

### DIFF
--- a/docgen/src/data/communityHeader.json
+++ b/docgen/src/data/communityHeader.json
@@ -95,7 +95,7 @@
   },{
     "name": "Github",
     "image": "<img src='assets/img/github-icon.svg'/>",
-    "url": "https://github.com/algolia/instantsearch.js/v2/"
+    "url": "https://github.com/algolia/instantsearch.js/"
   }],
   "mobileMenu": [{
     "name": "Getting Started",


### PR DESCRIPTION
Link in top right header was not to the good repository url