### PR TITLE
test(visual): hide flaky jpg issue

### DIFF
--- a/functional-tests/test.js
+++ b/functional-tests/test.js
@@ -1,6 +1,11 @@
 import expect from 'expect';
 import {searchBox, prepareScreenshot} from './utils.js';
 
+const hide = [
+  '.ais-stats--body', // Flaky X ms information.
+  '.media-object', // Flaky jpg rendering
+];
+
 describe('searchBox', () => {
   describe('when there is no query', () => {
     beforeEach(() => searchBox.clear());
@@ -10,9 +15,7 @@ describe('searchBox', () => {
     it('triggers an empty search', () => {
       expect(browser.getText('#hits')).toNotContain('MP3');
       prepareScreenshot();
-      browser.checkDocument({
-        hide: ['.ais-stats--body'], // Flaky X ms information.
-      });
+      browser.checkDocument({ hide });
     });
   });
 
@@ -24,9 +27,7 @@ describe('searchBox', () => {
     it('triggers a new search', () => {
       expect(browser.getText('#hits')).toContain('MP3');
       prepareScreenshot();
-      browser.checkDocument({
-        hide: ['.ais-stats--body'], // Flaky X ms information.
-      });
+      browser.checkDocument({ hide });
     });
   });
 });


### PR DESCRIPTION
This is the temporary fix [I have been referring to](https://github.com/algolia/instantsearch.js/pull/2234#issuecomment-315109588). I need to better handle imperceptible color changes.