### PR TITLE
[v1 Docs] Absolute URLs for meta images

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -12,14 +12,14 @@
     <meta content="@algolia" name="twitter:site">
     <meta content="instantsearch.js" name="twitter:title">
     <meta content="Check out instantsearch.js—the new JS library of UI widgets to help you build the best instant-search experience with Algolia" name="twitter:description">
-    <meta content="{% asset_path instantsearch-cover.png %}" name="twitter:image:src">
+    <meta content="{% asset_url instantsearch-cover.png %}" name="twitter:image:src">
     <meta content="www.algolia.com" name="twitter:domain">
     <!-- /facebook -->
     <meta content="https://www.algolia.com/" property="og:url">
     <meta content="Algolia" property="og:site_name">
     <meta content="instantsearch.js" property="og:title">
     <meta content="Check out instantsearch.js—the new JS library of UI widgets to help you build the best instant-search experience with Algolia" property="og:description">
-    <meta content="{% asset_path instantsearch-cover.png %}" property="og:image">
+    <meta content="{% asset_url instantsearch-cover.png %}" property="og:image">
     <meta content="1200" property="og:image:width">
     <meta content="500" property="og:image:height">
 

--- a/docs/_plugins/asset_url_tag.rb
+++ b/docs/_plugins/asset_url_tag.rb
@@ -1,0 +1,21 @@
+module Jekyll
+  class AssetUrlTag < Liquid::Tag
+    PARAMS_RE  = / ^
+                     \s*
+                     (?: "(?<path>[^"]+)" | '(?<path>[^']+)' | (?<path>[^ ]+) )
+                     (?<attrs>.*?)
+                     (?: \[(?<options>.*)\] )?
+                     \s*
+                     $
+                   /x
+
+    def render(context)
+      site = context.registers[:site]
+      match = @markup.strip.match(PARAMS_RE)
+
+      File.join(site.config['host'], site.asset_path(match['path']))
+    end
+  end
+end
+
+Liquid::Template.register_tag('asset_url', Jekyll::AssetUrlTag)

--- a/docs/_preview.yml
+++ b/docs/_preview.yml
@@ -2,3 +2,4 @@
 baseurl: "/instantsearch.js"
 instantsearch_css: "/instantsearch.js/instantsearch.min.css"
 instantsearch_js: "/instantsearch.js/instantsearch.min.js"
+host: https://community.algolia.com

--- a/docs/_production.yml
+++ b/docs/_production.yml
@@ -2,3 +2,4 @@
 baseurl: "/instantsearch.js"
 instantsearch_css: "https://cdn.jsdelivr.net/npm/instantsearch.js@1/dist/instantsearch.min.css"
 instantsearch_js: "https://cdn.jsdelivr.net/npm/instantsearch.js@1/dist/instantsearch.min.js"
+host: https://community.algolia.com


### PR DESCRIPTION
**Summary**
The `og:image` and `twitter:image:src` meta tags need to provide an absolute URL to be usable from external websites linking to the page.
Today, `asset_path` is used and returns a relative path, making the thumbnail broken on some websites such as our Discourse forum.

**Result**
Using `asset_url` instead of `asset_path` for `og:image` and `twitter:image:src` meta tags will output an absolute URL instead of a relative path.

Fixes #2238 
