### PR TITLE
docs(menu): add a connectMenu as a select

### DIFF
--- a/dev/app/custom-widgets/vanilla/index.js
+++ b/dev/app/custom-widgets/vanilla/index.js
@@ -3,3 +3,4 @@ export {default as hits} from './hits';
 export {default as searchBox} from './searchBox';
 export {default as searchBoxReturn} from './searchBoxReturn';
 export {default as refinementList} from './refinementList';
+export {default as selectMenu} from './selectMenu';

--- a/dev/app/custom-widgets/vanilla/selectMenu.js
+++ b/dev/app/custom-widgets/vanilla/selectMenu.js
@@ -1,0 +1,36 @@
+/* eslint-disable import/default */
+import instantsearch from '../../../../index.js';
+
+function render(
+  {items, refine, widgetParams: {containerNode, title}},
+  isFirstRendering
+) {
+  let select;
+  if (isFirstRendering) {
+    const header = document.createElement('div');
+    header.innerText = title;
+    containerNode.appendChild(header);
+    select = document.createElement('select');
+
+    select.addEventListener('change', e => refine(e.target.value));
+
+    containerNode.appendChild(select);
+  } else {
+    select = containerNode.querySelector('select');
+  }
+
+  const options = items.map(item => {
+    const option = document.createElement('option');
+
+    option.innerText = `${item.label} ${item.count}`;
+    option.value = item.value;
+    option.selected = item.isRefined;
+
+    return option;
+  });
+
+  select.textContent = '';
+  options.forEach(el => select.appendChild(el));
+}
+
+export default instantsearch.connectors.connectMenu(render);

--- a/dev/app/init-vanilla-widgets.js
+++ b/dev/app/init-vanilla-widgets.js
@@ -37,6 +37,15 @@ export default () => {
     window.search.addWidget(vanillaWidgets.hits({containerNode}));
   }));
 
+  storiesOf('Menu').add('select', wrapWithHits(containerNode => {
+    window.search.addWidget(vanillaWidgets.selectMenu({
+      containerNode,
+      attributeName: 'brand',
+      limit: 10,
+      title: 'Brands',
+    }));
+  }));
+
   storiesOf('RefinementList').add('default', wrapWithHits(containerNode => {
     window.search.addWidget(
       vanillaWidgets.refinementList({


### PR DESCRIPTION
**Summary**

A menu definitely works as a `<select>` too! Someone asked on [Stack Overflow](https://stackoverflow.com/questions/37033654/create-a-select-dropdown-with-algolia-instantsearch-js/45169476#45169476), so I made it general-purpose

**Result**

A selectMenu vanilla custom widget in the dev novel