### PR TITLE
fix(urlSync): remove is_v parameter

### DIFF
--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -32,8 +32,6 @@ import * as widgets from '../widgets/index.js';
  * can track only some of them by using [..., 'attribute:color', 'attribute:categories']. All other possible
  * values are all the [attributes of the Helper SearchParameters](https://community.algolia.com/algoliasearch-helper-js/reference.html#searchparameters).
  *
- * There's a special `is_v` parameter that will get added everytime, it tracks the version of instantsearch.js
- * linked to the url.
  * @property {boolean} [useHash] If set to true, the url will be
  * hash based. Otherwise, it'll use the query parameters using the modern
  * history API.

--- a/src/lib/url-sync.js
+++ b/src/lib/url-sync.js
@@ -1,11 +1,9 @@
 import algoliasearchHelper from 'algoliasearch-helper';
-import version from '../lib/version.js';
 import urlHelper from 'algoliasearch-helper/src/url';
 import isEqual from 'lodash/isEqual';
 import assign from 'lodash/assign';
 
 const AlgoliaSearchHelper = algoliasearchHelper.AlgoliaSearchHelper;
-const majorVersionNumber = version.split('.')[0];
 
 function timerMaker(t0) {
   let t = t0;
@@ -145,8 +143,6 @@ class URLSync {
     const currentQueryString = this.urlUtils.readUrl();
     const foreignConfig = AlgoliaSearchHelper
       .getForeignConfigurationInQueryString(currentQueryString, {mapping: this.mapping});
-    // eslint-disable-next-line camelcase
-    foreignConfig.is_v = majorVersionNumber;
 
     const qs = urlHelper.getQueryStringFromState(
       state.filter(this.trackedParameters),
@@ -171,9 +167,6 @@ class URLSync {
     const foreignConfig = algoliasearchHelper
       .url
       .getUnrecognizedParametersInQueryString(currentQueryString, {mapping: this.mapping});
-    // Add instantsearch version to reconciliate old url with newer versions
-    // eslint-disable-next-line camelcase
-    foreignConfig.is_v = majorVersionNumber;
     const relative = this
       .urlUtils
       .createURL(algoliasearchHelper.url.getQueryStringFromState(filteredState, {mapping: this.mapping}));


### PR DESCRIPTION
**Summary**

Remove `is_v` from urls because it's not needed

**Result**

This is not a breaking change, since superfluous parameters are simply ignored by the urlSync

fixes #2233