### PR TITLE
chore(website): Fix corrupted assets during build

### DIFF
--- a/docgen/middlewares.js
+++ b/docgen/middlewares.js
@@ -63,7 +63,9 @@ const common = [
     return false;
   }),
   documentationjs({rootJSFile: rootPath('src/lib/main.js')}),
-  inPlace(),
+  inPlace({
+    pattern: "**/*.hbs"
+  }),
   markdown,
   headings('h2'),
   nav(),

--- a/scripts/docs/publish.sh
+++ b/scripts/docs/publish.sh
@@ -1,16 +1,24 @@
 #! /usr/bin/env bash
 
-set -ev # exit when error
+set -e # exit when error
 
-if [ -z $TRAVIS_BRANCH ]; then
-  currentBranch=`git rev-parse --abbrev-ref HEAD`
+echo Publishing InstantSearch.js website...
+
+if [ -z "$TRAVIS_BRANCH" ]; then
+  currentBranch=$(git rev-parse --abbrev-ref HEAD)
 else
   currentBranch=$TRAVIS_BRANCH
 fi
 
-if [ $currentBranch != 'master' ]; then
-  printf "update-website: You must be on master"
-  exit 1
+if [ "$currentBranch" != 'master' ]; then
+  echo "You are not running this script from master."
+  echo -n "Are you sure you want to proceed (y/n)? "
+  read -r answer
+  if echo "$answer" | grep -iq "^y" ;then
+    echo As you wish...
+  else
+    exit 1
+  fi
 fi
 
 set -e # exit when error


### PR DESCRIPTION
The in-place plugin seems to tamper all the files, even
though it does not transform them >> Scoping this plugin to
only relevant extensions.

Also in this PR: we let the user publish the doc from any branch but we ask for confirmation if not on master.