### PR TITLE
Feat/2.1 namespace es6 build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,4 @@ dev/dist/*
 functional-tests/screenshots/
 
 # Ignore ES6 build files
-dist-es6-module/
-instantsearch.js
-connectors.js
-widgets.js
+es/

--- a/docgen/src/guides/usage.md
+++ b/docgen/src/guides/usage.md
@@ -69,13 +69,13 @@ With InstantSearch.js it's really simple to use, the example speaks for itself:
 
 ```javascript
 // instantsearch() function without reference to the widgets or connectors
-import instantsearch from 'instantsearch.js/instantsearch';
+import instantsearch from 'instantsearch.js/es';
 
 // import connectors individually
-import {connectSearchBox} from 'instantsearch.js/connectors';
+import {connectSearchBox} from 'instantsearch.js/es/connectors';
 
 // import widgets individually
-import {searchBox} from 'instantsearch.js/widgets';
+import {searchBox} from 'instantsearch.js/es/widgets';
 
 const search = instantsearch({ ... });
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "homepage": "https://community.algolia.com/instantsearch.js/",
   "main": "dist-es5-module/index.js",
   "author": "Algolia <support@algolia.com>",
+  "module": "./es/index.js",
   "scripts": {
     "build": "./scripts/build.sh",
     "dev": "./scripts/dev.sh",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,8 +2,8 @@
 
 set -e # exit when error
 
-rm -rf dist dist-es5-module dist-es6-module connectors.js instantsearch.js widgets.js
-mkdir -p dist dist-es5-module dist-es6-module
+rm -rf dist dist-es5-module es connectors.js instantsearch.js widgets.js
+mkdir -p dist dist-es5-module es
 
 echo "➡️  Bundle instantsearch.js to UMD build './dist' via webpack"
 NODE_ENV=production BABEL_ENV=production webpack --config scripts/webpack.config.js --hide-modules
@@ -16,13 +16,8 @@ BABEL_ENV=production babel src -d dist-es5-module/src --ignore *-test.js --quiet
 
 wait
 
-echo "➡️  Bundle instantsearch.js to ES6 build './dist-es6-module' via babel-cli"
-BABEL_ENV="production-es6" babel -q index.es6.js -o instantsearch.js &
-BABEL_ENV="production-es6" babel src -d dist-es6-module --ignore *-test.js --quiet &
-
-# * allow `import {connectXXX} from 'instantsearch.js/connectors'`
-# * allow `import {searchBox} from 'instantsearch.js/widgets'`
-echo "export * from './dist-es6-module/connectors/index';" >> ./connectors.js &
-echo "export * from './dist-es6-module/widgets/index';" >> ./widgets.js
+echo "➡️  Bundle instantsearch.js to ES6 build './es' via babel-cli"
+BABEL_ENV="production-es6" babel -q index.es6.js -o es/index.js &
+BABEL_ENV="production-es6" babel src -d es --ignore *-test.js --quiet &
 
 wait


### PR DESCRIPTION
As we discussed on Slack, we will namespace the whole ES6 modules build like some popular libraries does (lodash-es, redux/es, ...)

I've updated the usage guide to fix the example:

```js
// instantsearch() function without reference to the widgets or connectors
import instantsearch from 'instantsearch.js/es';

// import connectors individually
import {connectSearchBox} from 'instantsearch.js/es/connectors';

// import widgets individually
import {searchBox} from 'instantsearch.js/es/widgets';

const search = instantsearch({ ... });

search.addWidget(searchBox({ ... }));
search.addWidget(connectSearchBox(function() { ... })({ ... }))
```