### PR TITLE
docs(getting-started): make sure that the template doesn't get replaced

### DIFF
--- a/docgen/src/getting-started.md.hbs
+++ b/docgen/src/getting-started.md.hbs
@@ -155,7 +155,7 @@ In order to customize the view for each product, we can use a special option of 
       container: '#hits',
       templates: {
         empty: 'No results',
-        item: '<em>Hit {{objectID}}</em>: {{{_highlightResult.name.value}}}'
+        item: '<em>Hit \{{objectID}}</em>: \{{{_highlightResult.name.value}}}'
       }
     })
   );


### PR DESCRIPTION
The `in-place` plugin replaced these tags by their value (undefined), so they didn't show up.

Thanks @ronanlevesque for noticing this!
