### PR TITLE
docs(getting-started): use `instant_search` as indexName

### DIFF
--- a/docgen/src/getting-started.md.hbs
+++ b/docgen/src/getting-started.md.hbs
@@ -87,8 +87,8 @@ To initialize with the credentials proposed at the beginning:
 ```javascript
 const search = instantsearch({
   appId: 'latency',
-  apiKey: '3d9875e51fbd20c7754e65422f7ce5e1',
-  indexName: 'bestbuy',
+  apiKey: '6be0576ff61c053d5f9a3225e2a90f76',
+  indexName: 'instant_search',
   urlSync: true
 });
 


### PR DESCRIPTION
This is the one used in the examples of the widgets, which is almost the same as bestbuy, but slightly different.

As noticed by @ronanlevesque, there are a few widgets (range, rangeSlider, hierarchicalMenu and menu) that didn't work with the attribute names in `latency`, but that does work with the ones in `instant_search`.

The API key here is search-only