### PR TITLE
fix(build): provide unminified css as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "compression": "^1.6.2",
     "conventional-changelog-cli": "^1.3.1",
     "css-loader": "^0.28.4",
+    "cssunminifier": "^0.0.2",
     "dev-novel": "^0.0.3",
     "doctoc": "^1.3.0",
     "enzyme": "^2.7.1",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,6 +7,10 @@ mkdir -p dist dist-es5-module es
 
 echo "➡️  Bundle instantsearch.js to UMD build './dist' via webpack"
 NODE_ENV=production BABEL_ENV=production webpack --config scripts/webpack.config.js --hide-modules
+cssunminifier dist/instantsearch.min.css dist/instantsearch.css &
+cssunminifier dist/instantsearch-theme-algolia.min.css dist/instantsearch-theme-algolia.css
+
+wait
 
 printf "dist/instantsearch.min.js gzipped will weight `cat dist/instantsearch.min.js | gzip -9 | wc -c | pretty-bytes`\n\n"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2450,6 +2450,10 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   dependencies:
     cssom "0.3.x"
 
+cssunminifier@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/cssunminifier/-/cssunminifier-0.0.2.tgz#96e8708e8fa79fa05ffa8db8984a299220e49abc"
+
 ctype@0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/ctype/-/ctype-0.5.3.tgz#82c18c2461f74114ef16c135224ad0b9144ca12f"


### PR DESCRIPTION
The v2.1.0 was not providing an unminified css build used by the examples.
