### PR TITLE
fix(es): wrong path to files

### DIFF
--- a/index.es6.js
+++ b/index.es6.js
@@ -2,8 +2,8 @@
 import algoliasearchHelper from 'algoliasearch-helper';
 import toFactory from 'to-factory';
 
-import InstantSearch from './dist-es6-module/lib/InstantSearch.js';
-import version from './dist-es6-module/lib/version.js';
+import InstantSearch from './lib/InstantSearch.js';
+import version from './lib/version.js';
 
 // import instantsearch from 'instantsearch.js';
 // -> provides instantsearch object without connectors and widgets


### PR DESCRIPTION
Fixes https://discourse.algolia.com/t/instantsearch-with-angular-1-5/2468

The path was the old one to the `dist-es6-module` folder that we renamed `es` after all.