### PR TITLE
default hits per page

### DIFF
--- a/dev/app/init-builtin-widgets.js
+++ b/dev/app/init-builtin-widgets.js
@@ -76,21 +76,37 @@ export default () => {
     })
   );
 
-  storiesOf('HitsPerPageSelector').add(
-    'default',
-    wrapWithHits(container => {
-      window.search.addWidget(
-        instantsearch.widgets.hitsPerPageSelector({
-          container,
-          items: [
-            { value: 3, label: '3 per page' },
-            { value: 5, label: '5 per page' },
-            { value: 10, label: '10 per page' },
-          ],
-        })
-      );
-    })
-  );
+  storiesOf('HitsPerPageSelector')
+    .add(
+      'default',
+      wrapWithHits(container => {
+        window.search.addWidget(
+          instantsearch.widgets.hitsPerPageSelector({
+            container,
+            items: [
+              { value: 3, label: '3 per page' },
+              { value: 5, label: '5 per page' },
+              { value: 10, label: '10 per page' },
+            ],
+          })
+        );
+      })
+    )
+    .add(
+      'With default hitPerPage to 5',
+      wrapWithHits(container => {
+        window.search.addWidget(
+          instantsearch.widgets.hitsPerPageSelector({
+            container,
+            items: [
+              { value: 3, label: '3 per page' },
+              { value: 5, label: '5 per page', default: true },
+              { value: 10, label: '10 per page' },
+            ],
+          })
+        );
+      })
+    );
 
   storiesOf('Hits').add(
     'default',

--- a/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
+++ b/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
@@ -7,6 +7,17 @@ import connectHitsPerPage from '../connectHitsPerPage.js';
 const fakeClient = { addAlgoliaAgent: () => {} };
 
 describe('connectHitsPerPage', () => {
+  it('should throw when there is two default items defined', () => {
+    expect(() => {
+      connectHitsPerPage(() => {})({
+        items: [
+          { value: 3, label: '3 items per page', default: true },
+          { value: 10, label: '10 items per page', default: true },
+        ],
+      });
+    }).toThrow(/^\[Error\]/);
+  });
+
   it('Renders during init and render', () => {
     // test that the dummyRendering is called with the isFirstRendering
     // flag set accordingly

--- a/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
+++ b/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
@@ -20,6 +20,7 @@ describe('connectHitsPerPage', () => {
     });
 
     expect(typeof widget.getConfiguration).toEqual('function');
+    expect(widget.getConfiguration()).toEqual({});
 
     // test if widget is not rendered yet at this point
     expect(rendering.callCount).toBe(0);
@@ -80,7 +81,7 @@ describe('connectHitsPerPage', () => {
     });
   });
 
-  it('Configures the search with the first item value provided', () => {
+  it('Does not configures the search when there is no default value', () => {
     const rendering = sinon.stub();
     const makeWidget = connectHitsPerPage(rendering);
     const widget = makeWidget({
@@ -90,9 +91,7 @@ describe('connectHitsPerPage', () => {
       ],
     });
 
-    expect(widget.getConfiguration()).toEqual({
-      hitsPerPage: 3,
-    });
+    expect(widget.getConfiguration()).toEqual({});
   });
 
   it('Provide a function to change the current hits per page, and provide the current value', () => {

--- a/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
+++ b/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
@@ -19,7 +19,7 @@ describe('connectHitsPerPage', () => {
       ],
     });
 
-    expect(widget.getConfiguration).toEqual(undefined);
+    expect(typeof widget.getConfiguration).toEqual('function');
 
     // test if widget is not rendered yet at this point
     expect(rendering.callCount).toBe(0);
@@ -62,6 +62,36 @@ describe('connectHitsPerPage', () => {
         { value: 3, label: '3 items per page' },
         { value: 10, label: '10 items per page' },
       ],
+    });
+  });
+
+  it('Configures the search with the default hitsPerPage provided', () => {
+    const rendering = sinon.stub();
+    const makeWidget = connectHitsPerPage(rendering);
+    const widget = makeWidget({
+      items: [
+        { value: 3, label: '3 items per page' },
+        { value: 10, label: '10 items per page', default: true },
+      ],
+    });
+
+    expect(widget.getConfiguration()).toEqual({
+      hitsPerPage: 10,
+    });
+  });
+
+  it('Configures the search with the first item value provided', () => {
+    const rendering = sinon.stub();
+    const makeWidget = connectHitsPerPage(rendering);
+    const widget = makeWidget({
+      items: [
+        { value: 3, label: '3 items per page' },
+        { value: 10, label: '10 items per page' },
+      ],
+    });
+
+    expect(widget.getConfiguration()).toEqual({
+      hitsPerPage: 3,
     });
   });
 

--- a/src/connectors/hits-per-page/connectHitsPerPage.js
+++ b/src/connectors/hits-per-page/connectHitsPerPage.js
@@ -118,16 +118,16 @@ export default function connectHitsPerPage(renderFn) {
 
     return {
       getConfiguration() {
-        if (items.filter(item => item.default).length > 1 && window.console) {
+        const defaultValues = items.filter(item => item.default);
+        if (defaultValues.length > 1 && window.console) {
           window.console.warn(
             `[Warning][hitsPerPageSelector] more than one default value is specified in \`items[]\`
   The first one will be picked, you should probably set only one default value`
           );
         }
 
-        const defaultHitsPerPage = items.find(item => item.default);
-        return defaultHitsPerPage
-          ? { hitsPerPage: defaultHitsPerPage.value }
+        return defaultValues.length > 0
+          ? { hitsPerPage: defaultValues[0].value }
           : {};
       },
 

--- a/src/connectors/hits-per-page/connectHitsPerPage.js
+++ b/src/connectors/hits-per-page/connectHitsPerPage.js
@@ -118,6 +118,13 @@ export default function connectHitsPerPage(renderFn) {
 
     return {
       getConfiguration() {
+        if (items.filter(item => item.default).length > 1 && window.console) {
+          window.console.warn(
+            `[Warning][hitsPerPageSelector] more than one default value is specified in \`items[]\`
+  The first one will be picked, you should probably set only one default value`
+          );
+        }
+
         const defaultHitsPerPage = items.find(item => item.default);
         return defaultHitsPerPage
           ? { hitsPerPage: defaultHitsPerPage.value }

--- a/src/connectors/hits-per-page/connectHitsPerPage.js
+++ b/src/connectors/hits-per-page/connectHitsPerPage.js
@@ -15,6 +15,7 @@ var customHitsPerPage = connectHitsPerPage(function render(params, isFirstRender
 search.addWidget(
   customHitsPerPage({
     items: [
+      {value: 5, label: '5 results per page', default: true},
       {value: 10, label: '10 results per page'},
       {value: 42, label: '42 results per page'},
     ],
@@ -34,6 +35,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/c
 * @typedef {Object} HitsPerPageWidgetOptionsItem
 * @property {number} value Number of hits to display per page.
 * @property {string} label Label to display in the option.
+* @property {boolean} default The default hits per page on first search.
 */
 
 /**
@@ -96,7 +98,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/c
  *   customHitsPerPage({
  *     containerNode: $('#custom-hits-per-page-container'),
  *     items: [
- *       {value: 6, label: '6 per page'},
+ *       {value: 6, label: '6 per page', default: true},
  *       {value: 12, label: '12 per page'},
  *       {value: 24, label: '24 per page'},
  *     ],
@@ -115,6 +117,13 @@ export default function connectHitsPerPage(renderFn) {
     }
 
     return {
+      getConfiguration() {
+        const { value: defaultHitsPerPage } =
+          items.find(item => item.default) || items[0];
+
+        return { hitsPerPage: defaultHitsPerPage };
+      },
+
       init({ helper, state, instantSearchInstance }) {
         const isCurrentInOptions = some(
           items,

--- a/src/connectors/hits-per-page/connectHitsPerPage.js
+++ b/src/connectors/hits-per-page/connectHitsPerPage.js
@@ -116,16 +116,16 @@ export default function connectHitsPerPage(renderFn) {
       throw new Error(usage);
     }
 
+    const defaultValues = items.filter(item => item.default);
+    if (defaultValues.length > 1) {
+      throw new Error(
+        `[Error][hitsPerPageSelector] more than one default value is specified in \`items[]\`
+The first one will be picked, you should probably set only one default value`
+      );
+    }
+
     return {
       getConfiguration() {
-        const defaultValues = items.filter(item => item.default);
-        if (defaultValues.length > 1) {
-          throw new Error(
-            `[Error][hitsPerPageSelector] more than one default value is specified in \`items[]\`
-  The first one will be picked, you should probably set only one default value`
-          );
-        }
-
         return defaultValues.length > 0
           ? { hitsPerPage: defaultValues[0].value }
           : {};

--- a/src/connectors/hits-per-page/connectHitsPerPage.js
+++ b/src/connectors/hits-per-page/connectHitsPerPage.js
@@ -119,9 +119,9 @@ export default function connectHitsPerPage(renderFn) {
     return {
       getConfiguration() {
         const defaultValues = items.filter(item => item.default);
-        if (defaultValues.length > 1 && window.console) {
-          window.console.warn(
-            `[Warning][hitsPerPageSelector] more than one default value is specified in \`items[]\`
+        if (defaultValues.length > 1) {
+          throw new Error(
+            `[Error][hitsPerPageSelector] more than one default value is specified in \`items[]\`
   The first one will be picked, you should probably set only one default value`
           );
         }

--- a/src/connectors/hits-per-page/connectHitsPerPage.js
+++ b/src/connectors/hits-per-page/connectHitsPerPage.js
@@ -118,10 +118,10 @@ export default function connectHitsPerPage(renderFn) {
 
     return {
       getConfiguration() {
-        const { value: defaultHitsPerPage } =
-          items.find(item => item.default) || items[0];
-
-        return { hitsPerPage: defaultHitsPerPage };
+        const defaultHitsPerPage = items.find(item => item.default);
+        return defaultHitsPerPage
+          ? { hitsPerPage: defaultHitsPerPage.value }
+          : {};
       },
 
       init({ helper, state, instantSearchInstance }) {

--- a/src/widgets/hits-per-page-selector/__tests__/hits-per-page-selector-test.js
+++ b/src/widgets/hits-per-page-selector/__tests__/hits-per-page-selector-test.js
@@ -56,8 +56,9 @@ describe('hitsPerPageSelector()', () => {
     };
   });
 
-  it("doesn't configure anything", () => {
-    expect(widget.getConfiguration).toEqual(undefined);
+  it('does configure the default hits per page if specified', () => {
+    expect(typeof widget.getConfiguration).toEqual('function');
+    expect(widget.getConfiguration()).toEqual({});
   });
 
   it('calls twice ReactDOM.render(<Selector props />, container)', () => {

--- a/src/widgets/hits-per-page-selector/__tests__/hits-per-page-selector-test.js
+++ b/src/widgets/hits-per-page-selector/__tests__/hits-per-page-selector-test.js
@@ -56,9 +56,23 @@ describe('hitsPerPageSelector()', () => {
     };
   });
 
-  it('does configure the default hits per page if specified', () => {
+  it('does not configure the default hits per page if not specified', () => {
     expect(typeof widget.getConfiguration).toEqual('function');
     expect(widget.getConfiguration()).toEqual({});
+  });
+
+  it('does configures the default hits per page if specified', () => {
+    const widgetWithDefaults = hitsPerPageSelector({
+      container: document.createElement('div'),
+      items: [
+        { value: 10, label: '10 results' },
+        { value: 20, label: '20 results', default: true },
+      ],
+    });
+
+    expect(widgetWithDefaults.getConfiguration()).toEqual({
+      hitsPerPage: 20,
+    });
   });
 
   it('calls twice ReactDOM.render(<Selector props />, container)', () => {

--- a/src/widgets/hits-per-page-selector/hits-per-page-selector.js
+++ b/src/widgets/hits-per-page-selector/hits-per-page-selector.js
@@ -50,6 +50,7 @@ hitsPerPageSelector({
  * @typedef {Object} HitsPerPageSelectorItems
  * @property {number} value number of hits to display per page.
  * @property {string} label Label to display in the option.
+ * @property {boolean} default The default hits per page on first search.
  */
 
 /**
@@ -63,6 +64,8 @@ hitsPerPageSelector({
 /**
  * The hitsPerPageSelector widget gives the user the ability to change the number of results
  * displayed in the hits widget.
+ *
+ * You can specify the default hits per page using a boolean in the items[] array. If none is specified, this first hits per page option will be picked.
  * @type {WidgetFactory}
  * @category basic
  * @param {HitsPerPageSelectorWidgetOptions} $0 The options of the HitPerPageSelector widget.
@@ -72,7 +75,7 @@ hitsPerPageSelector({
  *   instantsearch.widgets.hitsPerPageSelector({
  *     container: '#hits-per-page-selector',
  *     items: [
- *       {value: 3, label: '3 per page'},
+ *       {value: 3, label: '3 per page', default: true},
  *       {value: 6, label: '6 per page'},
  *       {value: 12, label: '12 per page'},
  *     ]


### PR DESCRIPTION
**Summary**

Actually, there is no options to set a default hitsPerPage appart from using the `searchParameters` object when you instantiate `instantsearch`.

My proposal, is to add a key `default: true` into the items[] of the hitsPerPageSelector options to specify on which value you want to start.

```js
instantsearch.widgets.hitsPerPageSelector({
  container,
  items: [
    { value: 3, label: '3 per page' },
    { value: 5, label: '5 per page', default: true },
    { value: 10, label: '10 per page' },
  ],
});
```

In this example the default value will be "5 per page" hits on the first search.

Fixes #2288 
