### PR TITLE
chore(doc): Fix side navigation for integrate angular guide

### DIFF
--- a/docgen/src/guides/angular-integration.md
+++ b/docgen/src/guides/angular-integration.md
@@ -2,9 +2,10 @@
 title: Integrate with Angular (2+)
 mainTitle: Guides
 layout: main.pug
+category: guides
 name: integrate-angular
 withHeadings: true
-navHeight: 20
+navWeight: 9
 editable: true
 githubSource: docgen/src/guides/angular-integration.md
 ---


### PR DESCRIPTION
Fix sidebar navigation for the integrate angular guide. Was displaying the examples.

Was:
![screen shot 2017-08-29 at 1 49 12 pm](https://user-images.githubusercontent.com/393765/29819395-e91e59fe-8cc0-11e7-9780-c01be12a3ed4.png)

Now:
![screen shot 2017-08-29 at 1 49 55 pm](https://user-images.githubusercontent.com/393765/29819453-225dd8ac-8cc1-11e7-860e-e2047f91062f.png)
