### PR TITLE
fix(sffv): no error when not providing noResults and no results

### DIFF
--- a/dev/app/init-builtin-widgets.js
+++ b/dev/app/init-builtin-widgets.js
@@ -294,6 +294,25 @@ export default () => {
       })
     )
     .add(
+      'with search inside items (using the default noResults template)',
+      wrapWithHits(container => {
+        window.search.addWidget(
+          instantsearch.widgets.refinementList({
+            container,
+            attributeName: 'brand',
+            operator: 'or',
+            limit: 10,
+            templates: {
+              header: 'Searchable brands',
+            },
+            searchForFacetValues: {
+              placeholder: 'Find other brands...',
+            },
+          })
+        );
+      })
+    )
+    .add(
       'with operator `and`',
       wrapWithHits(container => {
         window.search.addWidget(

--- a/src/widgets/refinement-list/defaultTemplates.searchForFacetValue.js
+++ b/src/widgets/refinement-list/defaultTemplates.searchForFacetValue.js
@@ -1,0 +1,3 @@
+export default {
+  noResults: 'No results',
+};

--- a/src/widgets/refinement-list/refinement-list.js
+++ b/src/widgets/refinement-list/refinement-list.js
@@ -6,6 +6,7 @@ import filter from 'lodash/filter';
 import RefinementList from '../../components/RefinementList/RefinementList.js';
 import connectRefinementList from '../../connectors/refinement-list/connectRefinementList.js';
 import defaultTemplates from './defaultTemplates.js';
+import sffvDefaultTemplates from './defaultTemplates.searchForFacetValue.js';
 import getShowMoreConfig from '../../lib/show-more/getShowMoreConfig.js';
 
 import {
@@ -253,7 +254,7 @@ export default function refinementList(
     ? prefixKeys('show-more-', showMoreConfig.templates)
     : {};
   const searchForValuesTemplates = searchForFacetValues
-    ? searchForFacetValues.templates
+    ? searchForFacetValues.templates || sffvDefaultTemplates
     : {};
   const allTemplates = {
     ...templates,


### PR DESCRIPTION
When there was no results and the template is not provided, is.js would trigger an error.

Fix #2087