### PR TITLE
chore(eslint): ignore the correct files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,8 +4,4 @@ docs/
 docs.old/
 docgen/
 node_modules/
-
-dist-es6-module/
-instantsearch.js
-connectors.js
-widgets.js
+es/


### PR DESCRIPTION
Leftover from the back and forth about the naming of the exported files.