### PR TITLE
[WIP] InstantSearch::removeWidget()

### DIFF
--- a/dev/app/index.js
+++ b/dev/app/index.js
@@ -4,6 +4,7 @@ import { registerDisposer, start } from 'dev-novel';
 import initBuiltInWidgets from './init-builtin-widgets.js';
 import initVanillaWidgets from './init-vanilla-widgets.js';
 import initJqueryWidgets from './init-jquery-widgets.js';
+import initUnmountWidgets from './init-unmount-widgets.js';
 
 import '../style.css';
 import '../../src/css/instantsearch.scss';
@@ -22,6 +23,9 @@ switch (true) {
     break;
   case q.includes('widgets=jquery'):
     initJqueryWidgets();
+    break;
+  case q.includes('widgets=unmount'):
+    initUnmountWidgets();
     break;
   default:
     initBuiltInWidgets();

--- a/dev/app/init-unmount-widgets.js
+++ b/dev/app/init-unmount-widgets.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/default */
-import { storiesOf } from 'dev-novel';
+import { action, storiesOf } from 'dev-novel';
 import instantsearch from '../../index.js';
 
 import wrapWithHits from './wrap-with-hits.js';
@@ -20,7 +20,7 @@ function wrapWithUnmount(getWidget, params) {
       </div>
     `;
 
-    const widget = getWidget('#widgetContainer');
+    const widget = getWidget(document.getElementById('widgetContainer'));
 
     window.search.addWidget(widget);
 
@@ -47,6 +47,25 @@ function wrapWithUnmount(getWidget, params) {
 }
 
 export default () => {
+  storiesOf('Analytics').add(
+    'default',
+    wrapWithUnmount(container => {
+      const description = document.createElement('p');
+      description.innerText = 'Search for something, look into Action Logger';
+      container.appendChild(description);
+
+      return instantsearch.widgets.analytics({
+        pushFunction(formattedParameters, state, results) {
+          action('pushFunction[formattedParameters]')(formattedParameters);
+          action('pushFunction[state]')(state);
+          action('pushFunction[results]')(results);
+        },
+        triggerOnUIInteraction: true,
+        pushInitialSearch: false,
+      });
+    })
+  );
+
   storiesOf('ClearAll').add(
     'default',
     wrapWithUnmount(

--- a/dev/app/init-unmount-widgets.js
+++ b/dev/app/init-unmount-widgets.js
@@ -1,0 +1,305 @@
+/* eslint-disable import/default */
+import { storiesOf } from 'dev-novel';
+import instantsearch from '../../index.js';
+
+import wrapWithHits from './wrap-with-hits.js';
+
+function wrapWithUnmount(getWidget, params) {
+  return wrapWithHits(container => {
+    container.innerHTML = `
+      <div>
+        <div id="widgetContainer"></div>
+        <div style="margin: 10px; border-top: solid 1px #E4E4E4;">
+          <button id="unmount" style="float: left; margin-right: 10px; margin-top: 10px">
+            Unmount widget
+          </div>
+          <button id="reload" style="float: left;">
+            Reload
+          </div>
+        </div>
+      </div>
+    `;
+
+    const widget = getWidget('#widgetContainer');
+
+    window.search.addWidget(widget);
+
+    function unmount() {
+      window.search.removeWidget(widget);
+      document
+        .getElementById('unmount')
+        .removeEventListener('click', unmount, false);
+    }
+
+    function reload() {
+      window.location.reload();
+      document
+        .getElementById('reload')
+        .removeEventListener('click', reload, false);
+    }
+
+    document
+      .getElementById('unmount')
+      .addEventListener('click', unmount, false);
+
+    document.getElementById('reload').addEventListener('click', reload, false);
+  }, params);
+}
+
+export default () => {
+  storiesOf('ClearAll').add(
+    'default',
+    wrapWithUnmount(
+      container => instantsearch.widgets.clearAll({ container }),
+      {
+        searchParameters: {
+          disjunctiveFacetsRefinements: { brand: ['Apple'] },
+          disjunctiveFacets: ['brand'],
+        },
+      }
+    )
+  );
+
+  storiesOf('CurrentRefinedValues').add(
+    'default',
+    wrapWithUnmount(
+      container => instantsearch.widgets.currentRefinedValues({ container }),
+      {
+        searchParameters: {
+          disjunctiveFacetsRefinements: { brand: ['Apple', 'Samsung'] },
+          disjunctiveFacets: ['brand'],
+        },
+      }
+    )
+  );
+
+  storiesOf('HierarchicalMenu').add(
+    'default',
+    wrapWithUnmount(
+      container =>
+        instantsearch.widgets.hierarchicalMenu({
+          container,
+          attributes: [
+            'hierarchicalCategories.lvl0',
+            'hierarchicalCategories.lvl1',
+            'hierarchicalCategories.lvl2',
+          ],
+          rootPath: 'Cameras & Camcorders',
+        }),
+      {
+        searchParameters: {
+          hierarchicalFacetsRefinements: {
+            'hierarchicalCategories.lvl0': [
+              'Cameras & Camcorders > Digital Cameras',
+            ],
+          },
+        },
+      }
+    )
+  );
+
+  storiesOf('Hits').add(
+    'default',
+    wrapWithUnmount(container => instantsearch.widgets.hits({ container }))
+  );
+
+  storiesOf('HitsPerPage').add(
+    'default',
+    wrapWithUnmount(container =>
+      instantsearch.widgets.hitsPerPageSelector({
+        container,
+        items: [
+          { value: 3, label: '3 per page' },
+          { value: 5, label: '5 per page' },
+          { value: 10, label: '10 per page' },
+        ],
+      })
+    )
+  );
+
+  storiesOf('InfiniteHits').add(
+    'default',
+    wrapWithUnmount(container =>
+      instantsearch.widgets.infiniteHits({
+        container,
+        showMoreLabel: 'Show more',
+        templates: {
+          item: '{{name}}',
+        },
+      })
+    )
+  );
+
+  storiesOf('Menu').add(
+    'default',
+    wrapWithUnmount(container =>
+      instantsearch.widgets.menu({
+        container,
+        attributeName: 'categories',
+      })
+    )
+  );
+
+  storiesOf('NumericRefinementList').add(
+    'default',
+    wrapWithUnmount(container =>
+      instantsearch.widgets.numericRefinementList({
+        container,
+        attributeName: 'price',
+        operator: 'or',
+        options: [
+          { name: 'All' },
+          { end: 4, name: 'less than 4' },
+          { start: 4, end: 4, name: '4' },
+          { start: 5, end: 10, name: 'between 5 and 10' },
+          { start: 10, name: 'more than 10' },
+        ],
+        cssClasses: {
+          header: 'facet-title',
+          link: 'facet-value',
+          count: 'facet-count pull-right',
+          active: 'facet-active',
+        },
+        templates: {
+          header: 'Numeric refinement list (price)',
+        },
+      })
+    )
+  );
+
+  storiesOf('NumericSelector').add(
+    'default',
+    wrapWithUnmount(container =>
+      instantsearch.widgets.numericSelector({
+        container,
+        operator: '>=',
+        attributeName: 'popularity',
+        options: [
+          { label: 'Default', value: 0 },
+          { label: 'Top 10', value: 9991 },
+          { label: 'Top 100', value: 9901 },
+          { label: 'Top 500', value: 9501 },
+        ],
+      })
+    )
+  );
+
+  storiesOf('Pagination').add(
+    'default',
+    wrapWithUnmount(container =>
+      instantsearch.widgets.pagination({
+        container,
+        maxPages: 20,
+      })
+    )
+  );
+
+  storiesOf('PriceRanges').add(
+    'default',
+    wrapWithUnmount(container =>
+      instantsearch.widgets.priceRanges({
+        container,
+        attributeName: 'price',
+        templates: {
+          header: 'Price ranges',
+        },
+      })
+    )
+  );
+
+  storiesOf('RefinementList').add(
+    'default',
+    wrapWithUnmount(container =>
+      instantsearch.widgets.refinementList({
+        container,
+        attributeName: 'brand',
+        operator: 'or',
+        limit: 10,
+        templates: {
+          header: 'Brands',
+        },
+      })
+    )
+  );
+
+  storiesOf('SearchBox').add(
+    'default',
+    wrapWithUnmount(container =>
+      instantsearch.widgets.searchBox({
+        container,
+        placeholder: 'Search for products',
+        poweredBy: true,
+      })
+    )
+  );
+
+  storiesOf('SortBySelector').add(
+    'default',
+    wrapWithUnmount(container =>
+      instantsearch.widgets.sortBySelector({
+        container,
+        indices: [
+          { name: 'instant_search', label: 'Most relevant' },
+          { name: 'instant_search_price_asc', label: 'Lowest price' },
+          { name: 'instant_search_price_desc', label: 'Highest price' },
+        ],
+      })
+    )
+  );
+
+  storiesOf('StarRating').add(
+    'default',
+    wrapWithUnmount(container =>
+      instantsearch.widgets.starRating({
+        container,
+        attributeName: 'rating',
+        max: 5,
+        labels: {
+          andUp: '& Up',
+        },
+        templates: {
+          header: 'Rating',
+        },
+      })
+    )
+  );
+
+  storiesOf('Stats').add(
+    'default',
+    wrapWithUnmount(container => instantsearch.widgets.stats({ container }))
+  );
+
+  storiesOf('Toggle').add(
+    'default',
+    wrapWithUnmount(container =>
+      instantsearch.widgets.toggle({
+        container,
+        attributeName: 'free_shipping',
+        label: 'Free Shipping (toggle single value)',
+        templates: {
+          header: 'Shipping',
+        },
+      })
+    )
+  );
+
+  storiesOf('rangeSlider').add(
+    'default',
+    wrapWithUnmount(container =>
+      instantsearch.widgets.rangeSlider({
+        container,
+        attributeName: 'price',
+        templates: {
+          header: 'Price',
+        },
+        max: 500,
+        step: 10,
+        tooltips: {
+          format(rawValue) {
+            return `$${Math.round(rawValue).toLocaleString()}`;
+          },
+        },
+      })
+    )
+  );
+};

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -97,7 +97,7 @@ Usage: instantsearch({
       this.widgets.splice(this.widgets.indexOf(widget), 1);
 
       // un-mount widget from DOM
-      widget.containerNode.innerHTML = '';
+      if (widget.containerNode) widget.containerNode.innerHTML = '';
 
       // remove configuration set by the widget
       const configuration =

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -361,4 +361,131 @@ describe('InstantSearch lifecycle', () => {
       expect(onRender.callCount).toEqual(1);
     });
   });
+
+  describe('When removing a widget', () => {
+    let widget;
+
+    function registerWidget(
+      widgetGetConfiguration = {
+        facets: ['categories'],
+        maxValuesPerFacet: 10,
+      }
+    ) {
+      widget = {
+        getConfiguration: sinon.stub().returns(widgetGetConfiguration),
+        init: sinon.spy(),
+        render: sinon.spy(),
+      };
+
+      search.addWidget(widget);
+
+      return widget;
+    }
+
+    beforeEach(() => {
+      search = new InstantSearch({
+        appId,
+        apiKey,
+        indexName,
+      });
+    });
+
+    it('should unmount a widget without configuration', () => {
+      const widget1 = registerWidget({});
+      const widget2 = registerWidget({});
+
+      expect(search.widgets.length).toBe(2);
+
+      search.start();
+      search.removeWidget(widget1);
+      search.removeWidget(widget2);
+
+      expect(search.widgets.length).toBe(0);
+    });
+
+    it('should unmount a widget with facets configuration', () => {
+      const widget1 = registerWidget({ facets: ['price'] });
+      search.start();
+
+      expect(search.widgets.length).toBe(1);
+      expect(search.searchParameters.facets).toEqual(['price']);
+
+      search.removeWidget(widget1);
+
+      expect(search.widgets.length).toBe(0);
+      expect(search.searchParameters.facets).toEqual([]);
+    });
+
+    it('should unmount a widget with hierarchicalFacets configuration', () => {
+      const widget1 = registerWidget({
+        hierarchicalFacets: [
+          {
+            name: 'price',
+            attributes: ['foo'],
+            separator: ' > ',
+            rootPath: 'lvl1',
+            showParentLevel: true,
+          },
+        ],
+      });
+      search.start();
+
+      expect(search.widgets.length).toBe(1);
+      expect(search.searchParameters.hierarchicalFacets).toEqual([
+        {
+          name: 'price',
+          attributes: ['foo'],
+          separator: ' > ',
+          rootPath: 'lvl1',
+          showParentLevel: true,
+        },
+      ]);
+
+      search.removeWidget(widget1);
+
+      expect(search.widgets.length).toBe(0);
+      expect(search.searchParameters.hierarchicalFacets).toEqual([]);
+    });
+
+    it('should unmount a widget with disjunctiveFacets configuration', () => {
+      const widget1 = registerWidget({ disjunctiveFacets: ['price'] });
+      search.start();
+
+      expect(search.widgets.length).toBe(1);
+      expect(search.searchParameters.disjunctiveFacets).toEqual(['price']);
+
+      search.removeWidget(widget1);
+
+      expect(search.widgets.length).toBe(0);
+      expect(search.searchParameters.disjunctiveFacets).toEqual([]);
+    });
+
+    it('should unmount a widget with numericRefinements configuration', () => {
+      const widget1 = registerWidget({ numericRefinements: { price: {} } });
+      search.start();
+
+      expect(search.widgets.length).toBe(1);
+      expect(search.searchParameters.numericRefinements).toEqual({ price: {} });
+
+      search.removeWidget(widget1);
+
+      expect(search.widgets.length).toBe(0);
+      expect(search.searchParameters.numericRefinements).toEqual({});
+    });
+
+    it('should unmount a widget with maxValuesPerFacet configuration', () => {
+      const widget1 = registerWidget();
+      search.start();
+
+      expect(search.widgets.length).toBe(1);
+      expect(search.searchParameters.facets).toEqual(['categories']);
+      expect(search.searchParameters.maxValuesPerFacet).toEqual(10);
+
+      search.removeWidget(widget1);
+
+      expect(search.widgets.length).toBe(0);
+      expect(search.searchParameters.facets).toEqual([]);
+      expect(search.searchParameters.maxValuesPerFacet).toBe(undefined);
+    });
+  });
 });

--- a/src/widgets/clear-all/clear-all.js
+++ b/src/widgets/clear-all/clear-all.js
@@ -144,7 +144,9 @@ export default function clearAll({
 
   try {
     const makeWidget = connectClearAll(specializedRenderer);
-    return makeWidget({ excludeAttributes, clearsQuery });
+    return Object.assign(makeWidget({ excludeAttributes, clearsQuery }), {
+      containerNode,
+    });
   } catch (e) {
     throw new Error(usage);
   }

--- a/src/widgets/current-refined-values/current-refined-values.js
+++ b/src/widgets/current-refined-values/current-refined-values.js
@@ -273,15 +273,13 @@ export default function currentRefinedValues({
       specializedRenderer
     );
     return Object.assign(
-      makeCurrentRefinedValues(
-        {
-          attributes,
-          onlyListedAttributes,
-          clearAll,
-          clearsQuery,
-        },
-        { containerNode }
-      )
+      makeCurrentRefinedValues({
+        attributes,
+        onlyListedAttributes,
+        clearAll,
+        clearsQuery,
+      }),
+      { containerNode }
     );
   } catch (e) {
     throw new Error(usage);

--- a/src/widgets/current-refined-values/current-refined-values.js
+++ b/src/widgets/current-refined-values/current-refined-values.js
@@ -272,12 +272,17 @@ export default function currentRefinedValues({
     const makeCurrentRefinedValues = connectCurrentRefinedValues(
       specializedRenderer
     );
-    return makeCurrentRefinedValues({
-      attributes,
-      onlyListedAttributes,
-      clearAll,
-      clearsQuery,
-    });
+    return Object.assign(
+      makeCurrentRefinedValues(
+        {
+          attributes,
+          onlyListedAttributes,
+          clearAll,
+          clearsQuery,
+        },
+        { containerNode }
+      )
+    );
   } catch (e) {
     throw new Error(usage);
   }

--- a/src/widgets/hierarchical-menu/hierarchical-menu.js
+++ b/src/widgets/hierarchical-menu/hierarchical-menu.js
@@ -213,14 +213,17 @@ export default function hierarchicalMenu(
 
   try {
     const makeHierarchicalMenu = connectHierarchicalMenu(specializedRenderer);
-    return makeHierarchicalMenu({
-      attributes,
-      separator,
-      rootPath,
-      showParentLevel,
-      limit,
-      sortBy,
-    });
+    return Object.assign(
+      makeHierarchicalMenu({
+        attributes,
+        separator,
+        rootPath,
+        showParentLevel,
+        limit,
+        sortBy,
+      }),
+      { containerNode }
+    );
   } catch (e) {
     throw new Error(usage);
   }

--- a/src/widgets/hits-per-page-selector/hits-per-page-selector.js
+++ b/src/widgets/hits-per-page-selector/hits-per-page-selector.js
@@ -106,7 +106,7 @@ export default function hitsPerPageSelector(
 
   try {
     const makeHitsPerPageSelector = connectHitsPerPage(specializedRenderer);
-    return makeHitsPerPageSelector({ items });
+    return Object.assign(makeHitsPerPageSelector({ items }), { containerNode });
   } catch (e) {
     throw new Error(usage);
   }

--- a/src/widgets/hits/hits.js
+++ b/src/widgets/hits/hits.js
@@ -137,7 +137,7 @@ export default function hits({
 
   try {
     const makeHits = connectHits(specializedRenderer);
-    return makeHits({ escapeHits });
+    return Object.assign(makeHits({ escapeHits }), { containerNode });
   } catch (e) {
     throw new Error(usage);
   }

--- a/src/widgets/infinite-hits/infinite-hits.js
+++ b/src/widgets/infinite-hits/infinite-hits.js
@@ -145,7 +145,7 @@ export default function infiniteHits(
 
   try {
     const makeInfiniteHits = connectInfiniteHits(specializedRenderer);
-    return makeInfiniteHits({ escapeHits });
+    return Object.assign(makeInfiniteHits({ escapeHits }), { containerNode });
   } catch (e) {
     throw new Error(usage);
   }

--- a/src/widgets/menu/menu.js
+++ b/src/widgets/menu/menu.js
@@ -218,7 +218,10 @@ export default function menu({
 
   try {
     const makeWidget = connectMenu(specializedRenderer);
-    return makeWidget({ attributeName, limit, sortBy, showMoreLimit });
+    return Object.assign(
+      makeWidget({ attributeName, limit, sortBy, showMoreLimit }),
+      { containerNode }
+    );
   } catch (e) {
     throw new Error(usage);
   }

--- a/src/widgets/numeric-refinement-list/numeric-refinement-list.js
+++ b/src/widgets/numeric-refinement-list/numeric-refinement-list.js
@@ -180,7 +180,10 @@ export default function numericRefinementList(
     const makeNumericRefinementList = connectNumericRefinementList(
       specializedRenderer
     );
-    return makeNumericRefinementList({ attributeName, options });
+    return Object.assign(
+      makeNumericRefinementList({ attributeName, options }),
+      { containerNode }
+    );
   } catch (e) {
     throw new Error(usage);
   }

--- a/src/widgets/numeric-selector/numeric-selector.js
+++ b/src/widgets/numeric-selector/numeric-selector.js
@@ -110,7 +110,10 @@ export default function numericSelector({
 
   try {
     const makeNumericSelector = connectNumericSelector(specializedRenderer);
-    return makeNumericSelector({ operator, attributeName, options });
+    return Object.assign(
+      makeNumericSelector({ operator, attributeName, options }),
+      { containerNode }
+    );
   } catch (e) {
     throw new Error(usage);
   }

--- a/src/widgets/pagination/pagination.js
+++ b/src/widgets/pagination/pagination.js
@@ -175,7 +175,7 @@ export default function pagination(
 
   try {
     const makeWidget = connectPagination(specializedRenderer);
-    return makeWidget({ maxPages });
+    return Object.assign(makeWidget({ maxPages }), { containerNode });
   } catch (e) {
     throw new Error(usage);
   }

--- a/src/widgets/price-ranges/price-ranges.js
+++ b/src/widgets/price-ranges/price-ranges.js
@@ -191,7 +191,7 @@ export default function priceRanges(
 
   try {
     const makeWidget = connectPriceRanges(specializedRenderer);
-    return makeWidget({ attributeName });
+    return Object.assign(makeWidget({ attributeName }), { containerNode });
   } catch (e) {
     throw new Error(usage);
   }

--- a/src/widgets/range-slider/range-slider.js
+++ b/src/widgets/range-slider/range-slider.js
@@ -196,7 +196,9 @@ export default function rangeSlider(
 
   try {
     const makeWidget = connectRangeSlider(specializedRenderer);
-    return makeWidget({ attributeName, min, max, precision });
+    return Object.assign(makeWidget({ attributeName, min, max, precision }), {
+      containerNode,
+    });
   } catch (e) {
     throw new Error(usage);
   }

--- a/src/widgets/refinement-list/refinement-list.js
+++ b/src/widgets/refinement-list/refinement-list.js
@@ -289,13 +289,16 @@ export default function refinementList(
 
   try {
     const makeWidget = connectRefinementList(specializedRenderer);
-    return makeWidget({
-      attributeName,
-      operator,
-      limit,
-      showMoreLimit,
-      sortBy,
-    });
+    return Object.assign(
+      makeWidget({
+        attributeName,
+        operator,
+        limit,
+        showMoreLimit,
+        sortBy,
+      }),
+      { containerNode }
+    );
   } catch (e) {
     throw new Error(e);
   }

--- a/src/widgets/search-box/search-box.js
+++ b/src/widgets/search-box/search-box.js
@@ -240,7 +240,7 @@ export default function searchBox(
 
   try {
     const makeWidget = connectSearchBox(specializedRenderer);
-    return makeWidget({ queryHook });
+    return Object.assign(makeWidget({ queryHook }), { containerNode });
   } catch (e) {
     throw new Error(usage);
   }

--- a/src/widgets/sort-by-selector/sort-by-selector.js
+++ b/src/widgets/sort-by-selector/sort-by-selector.js
@@ -104,7 +104,7 @@ export default function sortBySelector(
 
   try {
     const makeWidget = connectSortBySelector(specializedRenderer);
-    return makeWidget({ indices });
+    return Object.assign(makeWidget({ indices }), { containerNode });
   } catch (e) {
     throw new Error(usage);
   }

--- a/src/widgets/star-rating/star-rating.js
+++ b/src/widgets/star-rating/star-rating.js
@@ -193,7 +193,7 @@ export default function starRating(
 
   try {
     const makeWidget = connectStarRating(specializedRenderer);
-    return makeWidget({ attributeName, max });
+    return Object.assign(makeWidget({ attributeName, max }), { containerNode });
   } catch (e) {
     throw new Error(usage);
   }

--- a/src/widgets/stats/stats.js
+++ b/src/widgets/stats/stats.js
@@ -168,7 +168,7 @@ export default function stats(
 
   try {
     const makeWidget = connectStats(specializedRenderer);
-    return makeWidget();
+    return Object.assign(makeWidget(), { containerNode });
   } catch (e) {
     throw new Error(usage);
   }

--- a/src/widgets/toggle/toggle.js
+++ b/src/widgets/toggle/toggle.js
@@ -199,7 +199,10 @@ export default function toggle(
 
   try {
     const makeWidget = connectToggle(specializedRenderer);
-    return makeWidget({ attributeName, label, values: userValues });
+    return Object.assign(
+      makeWidget({ attributeName, label, values: userValues }),
+      { containerNode }
+    );
   } catch (e) {
     throw new Error(usage);
   }


### PR DESCRIPTION
**Summary**

The goal is to be able to mount and unmount widgets from the instantSearch instance dynamically. With such a feature we would be able to build "dynamic" search experiences.

I'm opening this PR to open the discussion around the subject and gather your feedback.

**How it works?**

InstantSearch object has now a new `removeWidgets()` method which takes as only parameter the reference to the widget you want to remove.

1. It removes it from `this.widgets[]` array
2. Call `widget.getConfiguration()` to figure out what parameters we need to remove from state of the helper.
3. Remove the refined facets from the removed widget (for example, if you have a menu and something is refined from the menu. When you unmount the menu widget, the refined value will be removed as well)
4. Re-compute all the configuration from the remaining widgets (for instance if two widgets uses the same facet and one remains)
5. Update the helper state with the new computed one and triggers a new search

**Result**

You can run the dev environment with `$ yarn dev` and go into in your browser to http://localhost:8080/?widgets=unmount where you will be able to unmount widgets via a button and see the behaviour.

**Todo**

* [x] Unmount widgets
* [x] Remove refinement from unmounted widgets
* [ ] Add widgets
* [ ] Documentation
* [ ] Tests