### PR TITLE
chore(doc): publish doc during the build process

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -210,6 +210,7 @@ inquirer
               shell.exec('git push origin master');
               shell.exec('git push origin --tags');
               shell.exec('npm publish');
+              shell.exec(`VERSION=${newVersion} npm run docs:publish`);
               shell.exec('git checkout develop');
               shell.exec('git pull origin develop');
               shell.exec('git merge master');
@@ -219,13 +220,6 @@ inquirer
               shell.exec('git push origin --tags');
               shell.exec('npm publish --tag beta');
             }
-
-            shell.echo(
-              colors.green(`
-              Package was published to npm.
-              A job on travis-ci will be automatically launched to finalize the release.
-              `)
-            );
 
             return process.exit(0);
           });


### PR DESCRIPTION
The doc is not auto updated anymore using TravisCI because we don't have to wait for
jsDeliver to publish the packages anymore. This PR makes the release script to publish
the doc just after we've pushed to NPM.