### PR TITLE
Fix the connector-docs link + typo

### DIFF
--- a/docgen/src/guides/customization.md
+++ b/docgen/src/guides/customization.md
@@ -261,6 +261,8 @@ With this steps we introduced a way to provide custom parameters:
 
 And voilà, we have covered how to write a simple custom widget using connectors 🎉 !
 
-Now you can [read more about connectors](/connectors.html) in the docs and create more advance usages with the same simplicity.
+Now you can [read more about connectors](https://community.algolia.com/instantsearch.js/v2/connectors.html) in the docs and create more advanced usages with the same simplicity.  
+
+
 
 Feel free to share with the [community](https://discourse.algolia.com) your custom widgets 🙏


### PR DESCRIPTION
Previously the link for more info on connectors led to a 404.

