### PR TITLE
Remove React occurrences in the codebase

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,7 +6,14 @@
         "react",
         "stage-2"
       ],
-      "plugins": ["babel-plugin-rewire"]
+      "plugins": [
+        "babel-plugin-rewire",
+        ["module-resolver", {
+          "alias": {
+            "preact-compat": "react"
+          }
+        }]
+      ]
     },
     "development": {
       "presets": [

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "babel-core": "6.26.0",
     "babel-eslint": "8.0.0",
     "babel-loader": "7.1.2",
+    "babel-plugin-module-resolver": "^2.7.1",
     "babel-plugin-rewire": "1.1.0",
     "babel-plugin-syntax-jsx": "6.18.0",
     "babel-plugin-transform-react-constant-elements": "6.23.0",
@@ -126,7 +127,7 @@
     "preact": "^8.1.0",
     "preact-compat": "^3.16.0",
     "prop-types": "^15.5.10",
-    "rheostat": "algolia/rheostat#dist",
+    "rheostat": "algolia/rheostat#dist-preact",
     "to-factory": "^1.0.0"
   },
   "license": "MIT"

--- a/src/components/ClearAll/ClearAll.js
+++ b/src/components/ClearAll/ClearAll.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React from 'preact-compat';
 import Template from '../Template.js';
 import { isSpecialClick } from '../../lib/utils.js';
 

--- a/src/components/CurrentRefinedValues/CurrentRefinedValues.js
+++ b/src/components/CurrentRefinedValues/CurrentRefinedValues.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React from 'preact-compat';
 
 import Template from '../Template.js';
 

--- a/src/components/Hits.js
+++ b/src/components/Hits.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React from 'preact-compat';
 import map from 'lodash/map';
 import Template from './Template.js';
 import hasKey from 'lodash/has';
@@ -23,11 +23,7 @@ class Hits extends React.Component {
       );
     });
 
-    return (
-      <div className={this.props.cssClasses.root}>
-        {renderedHits}
-      </div>
-    );
+    return <div className={this.props.cssClasses.root}>{renderedHits}</div>;
   }
 
   renderAllResults() {

--- a/src/components/InfiniteHits.js
+++ b/src/components/InfiniteHits.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React from 'preact-compat';
 import Hits from './Hits.js';
 
 class InfiniteHits extends React.Component {
@@ -12,13 +12,11 @@ class InfiniteHits extends React.Component {
       showMoreLabel,
       templateProps,
     } = this.props;
-    const btn = this.props.isLastPage
-      ? <button disabled>
-          {showMoreLabel}
-        </button>
-      : <button onClick={showMore}>
-          {showMoreLabel}
-        </button>;
+    const btn = this.props.isLastPage ? (
+      <button disabled>{showMoreLabel}</button>
+    ) : (
+      <button onClick={showMore}>{showMoreLabel}</button>
+    );
 
     return (
       <div>
@@ -28,9 +26,7 @@ class InfiniteHits extends React.Component {
           results={results}
           templateProps={templateProps}
         />
-        <div className={cssClasses.showmore}>
-          {btn}
-        </div>
+        <div className={cssClasses.showmore}>{btn}</div>
       </div>
     );
   }

--- a/src/components/Pagination/Pagination.js
+++ b/src/components/Pagination/Pagination.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React from 'preact-compat';
 import forEach from 'lodash/forEach';
 import defaultsDeep from 'lodash/defaultsDeep';
 import { isSpecialClick } from '../../lib/utils.js';

--- a/src/components/Pagination/PaginationLink.js
+++ b/src/components/Pagination/PaginationLink.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React from 'preact-compat';
 
 import isEqual from 'lodash/isEqual';
 
@@ -40,11 +40,7 @@ class PaginationLink extends React.Component {
 
     const element = React.createElement(tagName, attributes);
 
-    return (
-      <li className={cssClasses.item}>
-        {element}
-      </li>
-    );
+    return <li className={cssClasses.item}>{element}</li>;
   }
 }
 

--- a/src/components/PriceRanges/PriceRanges.js
+++ b/src/components/PriceRanges/PriceRanges.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React from 'preact-compat';
 
 import Template from '../Template.js';
 import PriceRangesForm from './PriceRangesForm.js';

--- a/src/components/PriceRanges/PriceRangesForm.js
+++ b/src/components/PriceRanges/PriceRangesForm.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React from 'preact-compat';
 
 class PriceRangesForm extends React.Component {
   constructor(props) {
@@ -61,7 +61,8 @@ class PriceRangesForm extends React.Component {
       >
         {fromInput}
         <span className={this.props.cssClasses.separator}>
-          {' '}{this.props.labels.separator}{' '}
+          {' '}
+          {this.props.labels.separator}{' '}
         </span>
         {toInput}
         <button className={this.props.cssClasses.button} type="submit">

--- a/src/components/RefinementList/RefinementList.js
+++ b/src/components/RefinementList/RefinementList.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React from 'preact-compat';
 import cx from 'classnames';
 import { isSpecialClick } from '../../lib/utils.js';
 
@@ -152,37 +152,39 @@ export class RawRefinementList extends React.Component {
     }
 
     const showMoreBtn =
-      this.props.showMore === true && this.props.canToggleShowMore
-        ? <Template
-            rootProps={{ onClick: this.props.toggleShowMore }}
-            templateKey={`show-more-${this.props.isShowingMore
-              ? 'active'
-              : 'inactive'}`}
-            {...this.props.templateProps}
-          />
-        : undefined;
+      this.props.showMore === true && this.props.canToggleShowMore ? (
+        <Template
+          rootProps={{ onClick: this.props.toggleShowMore }}
+          templateKey={`show-more-${this.props.isShowingMore
+            ? 'active'
+            : 'inactive'}`}
+          {...this.props.templateProps}
+        />
+      ) : (
+        undefined
+      );
 
     const shouldDisableSearchInput =
       this.props.searchIsAlwaysActive !== true &&
       !(this.props.isFromSearch || !this.props.hasExhaustiveItems);
-    const searchInput = this.props.searchFacetValues
-      ? <SearchBox
-          ref={i => {
-            this.searchbox = i;
-          }}
-          placeholder={this.props.searchPlaceholder}
-          onChange={this.props.searchFacetValues}
-          onValidate={() => this.refineFirstValue()}
-          disabled={shouldDisableSearchInput}
-        />
-      : null;
+    const searchInput = this.props.searchFacetValues ? (
+      <SearchBox
+        ref={i => {
+          this.searchbox = i;
+        }}
+        placeholder={this.props.searchPlaceholder}
+        onChange={this.props.searchFacetValues}
+        onValidate={() => this.refineFirstValue()}
+        disabled={shouldDisableSearchInput}
+      />
+    ) : null;
 
     const noResults =
       this.props.searchFacetValues &&
       this.props.isFromSearch &&
-      this.props.facetValues.length === 0
-        ? <Template templateKey={'noResults'} {...this.props.templateProps} />
-        : null;
+      this.props.facetValues.length === 0 ? (
+        <Template templateKey={'noResults'} {...this.props.templateProps} />
+      ) : null;
 
     return (
       <div className={cx(cssClassList)}>

--- a/src/components/RefinementList/RefinementListItem.js
+++ b/src/components/RefinementList/RefinementListItem.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React from 'preact-compat';
 
 import Template from '../Template.js';
 import isEqual from 'lodash/isEqual';

--- a/src/components/SearchBox/index.js
+++ b/src/components/SearchBox/index.js
@@ -1,6 +1,6 @@
 /* eslint-disable max-len, no-extra-parens */
 import PropTypes from 'prop-types';
-import React from 'react';
+import React from 'preact-compat';
 
 export default class SearchBox extends React.Component {
   static propTypes = {

--- a/src/components/Selector.js
+++ b/src/components/Selector.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React from 'preact-compat';
 
 import autoHideContainer from '../decorators/autoHideContainer.js';
 import headerFooter from '../decorators/headerFooter.js';
@@ -22,7 +22,7 @@ export class RawSelector extends React.Component {
         onChange={this.handleChange}
         value={currentValue}
       >
-        {options.map(option =>
+        {options.map(option => (
           <option
             className={this.props.cssClasses.item}
             key={option.label + option.value}
@@ -30,7 +30,7 @@ export class RawSelector extends React.Component {
           >
             {option.label}
           </option>
-        )}
+        ))}
       </select>
     );
   }

--- a/src/components/Slider/Pit.js
+++ b/src/components/Slider/Pit.js
@@ -4,10 +4,13 @@ import cx from 'classnames';
 
 import includes from 'lodash/includes';
 
-const Pit = ({ style, children }) => {
+const Pit = ({ key, style, children }) => {
   // first, end & middle
   const positionValue = Math.round(parseFloat(style.left));
   const shouldDisplayValue = includes([0, 50, 100], positionValue);
+
+  const value = children ? children : key.replace('pit-', '');
+  const pitValue = Math.round(parseFloat(value, 10) * 100) / 100;
 
   return (
     <div
@@ -20,19 +23,15 @@ const Pit = ({ style, children }) => {
       )}
     >
       {shouldDisplayValue ? (
-        <div className="ais-range-slider--value">
-          {Math.round(children * 100) / 100}
-        </div>
+        <div className="ais-range-slider--value">{pitValue}</div>
       ) : null}
     </div>
   );
 };
 
 Pit.propTypes = {
-  children: PropTypes.oneOfType([
-    PropTypes.number.isRequired,
-    PropTypes.string.isRequired,
-  ]),
+  key: PropTypes.string,
+  children: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   style: PropTypes.shape({
     position: PropTypes.string.isRequired,
     left: PropTypes.string.isRequired,

--- a/src/components/Slider/Pit.js
+++ b/src/components/Slider/Pit.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React from 'preact-compat';
 import cx from 'classnames';
 
 import includes from 'lodash/includes';
@@ -19,11 +19,11 @@ const Pit = ({ style, children }) => {
         }
       )}
     >
-      {shouldDisplayValue
-        ? <div className="ais-range-slider--value">
-            {Math.round(children * 100) / 100}
-          </div>
-        : null}
+      {shouldDisplayValue ? (
+        <div className="ais-range-slider--value">
+          {Math.round(children * 100) / 100}
+        </div>
+      ) : null}
     </div>
   );
 };

--- a/src/components/Slider/Slider.js
+++ b/src/components/Slider/Slider.js
@@ -4,7 +4,7 @@ import has from 'lodash/has';
 
 import PropTypes from 'prop-types';
 
-import React, { Component } from 'react';
+import React, { Component } from 'preact-compat';
 import Rheostat from 'rheostat';
 import cx from 'classnames';
 

--- a/src/components/Stats/Stats.js
+++ b/src/components/Stats/Stats.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React from 'preact-compat';
 
 import Template from '../Template.js';
 import autoHideContainerHOC from '../../decorators/autoHideContainer.js';

--- a/src/components/Template.js
+++ b/src/components/Template.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React from 'preact-compat';
 import hogan from 'hogan.js';
 
 import curry from 'lodash/curry';

--- a/src/decorators/autoHideContainer.js
+++ b/src/decorators/autoHideContainer.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component } from 'preact-compat';
 
 export default function(ComposedComponent) {
   return class AutoHide extends Component {

--- a/src/decorators/headerFooter.js
+++ b/src/decorators/headerFooter.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 // Issue with eslint + high-order components like decorators
 /* eslint react/prop-types: 0 */
 
-import React from 'react';
+import React from 'preact-compat';
 
 import cx from 'classnames';
 import getKey from 'lodash/get';

--- a/src/widgets/clear-all/__tests__/clear-all-test.js
+++ b/src/widgets/clear-all/__tests__/clear-all-test.js
@@ -20,7 +20,7 @@ describe('clearAll()', () => {
     ReactDOM = { render: sinon.spy() };
     createURL = sinon.stub().returns('#all-cleared');
 
-    clearAll.__Rewire__('ReactDOM', ReactDOM);
+    clearAll.__Rewire__('render', ReactDOM.render);
 
     container = document.createElement('div');
     widget = clearAll({

--- a/src/widgets/clear-all/clear-all.js
+++ b/src/widgets/clear-all/clear-all.js
@@ -1,5 +1,4 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
+import React, { render } from 'preact-compat';
 import ClearAllWithHOCs from '../../components/ClearAll/ClearAll.js';
 import cx from 'classnames';
 
@@ -37,7 +36,7 @@ const renderer = ({
 
   const shouldAutoHideContainer = autoHideContainer && !hasRefinements;
 
-  ReactDOM.render(
+  render(
     <ClearAllWithHOCs
       refine={refine}
       collapsible={collapsible}

--- a/src/widgets/current-refined-values/__tests__/current-refined-values-test.js
+++ b/src/widgets/current-refined-values/__tests__/current-refined-values-test.js
@@ -365,7 +365,7 @@ describe('currentRefinedValues()', () => {
 
     beforeEach(() => {
       ReactDOM = { render: sinon.spy() };
-      currentRefinedValues.__Rewire__('ReactDOM', ReactDOM);
+      currentRefinedValues.__Rewire__('render', ReactDOM.render);
 
       parameters = {
         container: document.createElement('div'),

--- a/src/widgets/current-refined-values/current-refined-values.js
+++ b/src/widgets/current-refined-values/current-refined-values.js
@@ -1,5 +1,4 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
+import React, { render } from 'preact-compat';
 import cx from 'classnames';
 
 import isUndefined from 'lodash/isUndefined';
@@ -64,7 +63,7 @@ const renderer = ({
     createURL(refinement)
   );
 
-  ReactDOM.render(
+  render(
     <CurrentRefinedValuesWithHOCs
       attributes={attributes}
       clearAllClick={clearAllClick}

--- a/src/widgets/hierarchical-menu/__tests__/hierarchical-menu-test.js
+++ b/src/widgets/hierarchical-menu/__tests__/hierarchical-menu-test.js
@@ -13,7 +13,7 @@ describe('hierarchicalMenu()', () => {
     attributes = ['hello', 'world'];
     options = {};
     ReactDOM = { render: sinon.spy() };
-    hierarchicalMenu.__Rewire__('ReactDOM', ReactDOM);
+    hierarchicalMenu.__Rewire__('render', ReactDOM.render);
   });
 
   describe('instantiated with wrong parameters', () => {

--- a/src/widgets/hierarchical-menu/hierarchical-menu.js
+++ b/src/widgets/hierarchical-menu/hierarchical-menu.js
@@ -1,5 +1,4 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
+import React, { render } from 'preact-compat';
 import cx from 'classnames';
 
 import connectHierarchicalMenu from '../../connectors/hierarchical-menu/connectHierarchicalMenu';
@@ -38,7 +37,7 @@ const renderer = ({
 
   const shouldAutoHideContainer = autoHideContainer && items.length === 0;
 
-  ReactDOM.render(
+  render(
     <RefinementList
       collapsible={collapsible}
       createURL={createURL}

--- a/src/widgets/hits-per-page-selector/__tests__/hits-per-page-selector-test.js
+++ b/src/widgets/hits-per-page-selector/__tests__/hits-per-page-selector-test.js
@@ -27,7 +27,7 @@ describe('hitsPerPageSelector()', () => {
   beforeEach(() => {
     ReactDOM = { render: sinon.spy() };
 
-    hitsPerPageSelector.__Rewire__('ReactDOM', ReactDOM);
+    hitsPerPageSelector.__Rewire__('render', ReactDOM.render);
     consoleWarn = sinon.stub(window.console, 'warn');
 
     container = document.createElement('div');

--- a/src/widgets/hits-per-page-selector/hits-per-page-selector.js
+++ b/src/widgets/hits-per-page-selector/hits-per-page-selector.js
@@ -1,5 +1,4 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
+import React, { render } from 'preact-compat';
 import cx from 'classnames';
 
 import find from 'lodash/find';
@@ -20,7 +19,7 @@ const renderer = ({ containerNode, cssClasses, autoHideContainer }) => (
   const { value: currentValue } =
     find(items, ({ isRefined }) => isRefined) || {};
 
-  ReactDOM.render(
+  render(
     <Selector
       cssClasses={cssClasses}
       currentValue={currentValue}

--- a/src/widgets/hits/__tests__/hits-test.js
+++ b/src/widgets/hits/__tests__/hits-test.js
@@ -23,7 +23,7 @@ describe('hits()', () => {
 
   beforeEach(() => {
     ReactDOM = { render: sinon.spy() };
-    hits.__Rewire__('ReactDOM', ReactDOM);
+    hits.__Rewire__('render', ReactDOM.render);
 
     container = document.createElement('div');
     templateProps = {

--- a/src/widgets/hits/hits.js
+++ b/src/widgets/hits/hits.js
@@ -1,5 +1,4 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
+import React, { render } from 'preact-compat';
 import cx from 'classnames';
 
 import Hits from '../../components/Hits.js';
@@ -34,7 +33,7 @@ const renderer = ({
     return;
   }
 
-  ReactDOM.render(
+  render(
     <Hits
       cssClasses={cssClasses}
       hits={receivedHits}

--- a/src/widgets/infinite-hits/__tests__/infinite-hits-test.js
+++ b/src/widgets/infinite-hits/__tests__/infinite-hits-test.js
@@ -28,7 +28,7 @@ describe('infiniteHits()', () => {
     helper.search = sinon.spy();
 
     ReactDOM = { render: sinon.spy() };
-    infiniteHits.__Rewire__('ReactDOM', ReactDOM);
+    infiniteHits.__Rewire__('render', ReactDOM.render);
 
     container = document.createElement('div');
     templateProps = {

--- a/src/widgets/infinite-hits/infinite-hits.js
+++ b/src/widgets/infinite-hits/infinite-hits.js
@@ -1,5 +1,4 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
+import React, { render } from 'preact-compat';
 import cx from 'classnames';
 
 import InfiniteHits from '../../components/InfiniteHits.js';
@@ -35,7 +34,7 @@ const renderer = ({
     return;
   }
 
-  ReactDOM.render(
+  render(
     <InfiniteHits
       cssClasses={cssClasses}
       hits={hits}

--- a/src/widgets/menu/__tests__/menu-test.js
+++ b/src/widgets/menu/__tests__/menu-test.js
@@ -24,7 +24,7 @@ describe('menu', () => {
     };
     const createURL = () => '#';
     const ReactDOM = { render: sinon.spy() };
-    menu.__Rewire__('ReactDOM', ReactDOM);
+    menu.__Rewire__('render', ReactDOM.render);
     const widget = menu({
       container: document.createElement('div'),
       attributeName: 'test',

--- a/src/widgets/menu/menu.js
+++ b/src/widgets/menu/menu.js
@@ -1,5 +1,4 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
+import React, { render } from 'preact-compat';
 import cx from 'classnames';
 
 import defaultTemplates from './defaultTemplates.js';
@@ -54,7 +53,7 @@ const renderer = ({
   }));
   const shouldAutoHideContainer = autoHideContainer && !canRefine;
 
-  ReactDOM.render(
+  render(
     <RefinementList
       collapsible={collapsible}
       createURL={createURL}

--- a/src/widgets/numeric-refinement-list/__tests__/numeric-refinement-list-test.js
+++ b/src/widgets/numeric-refinement-list/__tests__/numeric-refinement-list-test.js
@@ -49,7 +49,7 @@ describe('numericRefinementList()', () => {
 
   beforeEach(() => {
     ReactDOM = { render: sinon.spy() };
-    numericRefinementList.__Rewire__('ReactDOM', ReactDOM);
+    numericRefinementList.__Rewire__('render', ReactDOM.render);
 
     options = [
       { name: 'All' },

--- a/src/widgets/numeric-refinement-list/numeric-refinement-list.js
+++ b/src/widgets/numeric-refinement-list/numeric-refinement-list.js
@@ -1,5 +1,4 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
+import React, { render } from 'preact-compat';
 import cx from 'classnames';
 
 import RefinementList from '../../components/RefinementList/RefinementList.js';
@@ -36,7 +35,7 @@ const renderer = ({
     return;
   }
 
-  ReactDOM.render(
+  render(
     <RefinementList
       collapsible={collapsible}
       createURL={createURL}

--- a/src/widgets/numeric-selector/__tests__/numeric-selector-test.js
+++ b/src/widgets/numeric-selector/__tests__/numeric-selector-test.js
@@ -19,7 +19,7 @@ describe('numericSelector()', () => {
   beforeEach(() => {
     ReactDOM = { render: sinon.spy() };
 
-    numericSelector.__Rewire__('ReactDOM', ReactDOM);
+    numericSelector.__Rewire__('render', ReactDOM.render);
 
     container = document.createElement('div');
     options = [{ value: 1, label: 'first' }, { value: 2, label: 'second' }];

--- a/src/widgets/numeric-selector/numeric-selector.js
+++ b/src/widgets/numeric-selector/numeric-selector.js
@@ -1,5 +1,4 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
+import React, { render } from 'preact-compat';
 import cx from 'classnames';
 
 import Selector from '../../components/Selector.js';
@@ -15,7 +14,7 @@ const renderer = ({ containerNode, autoHideContainer, cssClasses }) => (
 ) => {
   if (isFirstRendering) return;
 
-  ReactDOM.render(
+  render(
     <Selector
       cssClasses={cssClasses}
       currentValue={currentRefinement}

--- a/src/widgets/pagination/__tests__/pagination-test.js
+++ b/src/widgets/pagination/__tests__/pagination-test.js
@@ -21,7 +21,7 @@ describe('pagination()', () => {
 
   beforeEach(() => {
     ReactDOM = { render: sinon.spy() };
-    pagination.__Rewire__('ReactDOM', ReactDOM);
+    pagination.__Rewire__('render', ReactDOM.render);
 
     container = document.createElement('div');
     cssClasses = {
@@ -159,7 +159,7 @@ describe('pagination MaxPage', () => {
 
   beforeEach(() => {
     ReactDOM = { render: sinon.spy() };
-    pagination.__Rewire__('ReactDOM', ReactDOM);
+    pagination.__Rewire__('render', ReactDOM.render);
 
     container = document.createElement('div');
     cssClasses = {

--- a/src/widgets/pagination/pagination.js
+++ b/src/widgets/pagination/pagination.js
@@ -1,7 +1,6 @@
 import defaults from 'lodash/defaults';
 
-import React from 'react';
-import ReactDOM from 'react-dom';
+import React, { render } from 'preact-compat';
 import cx from 'classnames';
 
 import Pagination from '../../components/Pagination/Pagination.js';
@@ -42,7 +41,7 @@ const renderer = ({
 
   const shouldAutoHideContainer = autoHideContainer && nbHits === 0;
 
-  ReactDOM.render(
+  render(
     <Pagination
       createURL={createURL}
       cssClasses={cssClasses}

--- a/src/widgets/price-ranges/__tests__/price-ranges-test.js
+++ b/src/widgets/price-ranges/__tests__/price-ranges-test.js
@@ -34,7 +34,7 @@ describe('priceRanges()', () => {
   beforeEach(() => {
     ReactDOM = { render: sinon.spy() };
 
-    priceRanges.__Rewire__('ReactDOM', ReactDOM);
+    priceRanges.__Rewire__('render', ReactDOM.render);
 
     container = document.createElement('div');
     widget = priceRanges({

--- a/src/widgets/price-ranges/price-ranges.js
+++ b/src/widgets/price-ranges/price-ranges.js
@@ -1,5 +1,4 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
+import React, { render } from 'preact-compat';
 import cx from 'classnames';
 
 import PriceRanges from '../../components/PriceRanges/PriceRanges.js';
@@ -35,7 +34,7 @@ const renderer = ({
 
   const shouldAutoHideContainer = autoHideContainer && items.length === 0;
 
-  ReactDOM.render(
+  render(
     <PriceRanges
       collapsible={collapsible}
       cssClasses={cssClasses}

--- a/src/widgets/range-slider/__tests__/range-slider-test.js
+++ b/src/widgets/range-slider/__tests__/range-slider-test.js
@@ -25,7 +25,7 @@ describe('rangeSlider', () => {
 
     beforeEach(() => {
       ReactDOM = { render: jest.fn() };
-      rangeSlider.__Rewire__('ReactDOM', ReactDOM);
+      rangeSlider.__Rewire__('render', ReactDOM.render);
 
       container = document.createElement('div');
       helper = new AlgoliasearchHelper(

--- a/src/widgets/range-slider/range-slider.js
+++ b/src/widgets/range-slider/range-slider.js
@@ -1,5 +1,4 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
+import React, { render } from 'preact-compat';
 import cx from 'classnames';
 
 import Slider from '../../components/Slider/Slider.js';
@@ -46,7 +45,7 @@ const renderer = ({
   const minValue = start[0] === -Infinity ? min : start[0];
   const maxValue = start[1] === Infinity ? max : start[1];
 
-  ReactDOM.render(
+  render(
     <Slider
       cssClasses={cssClasses}
       refine={refine}

--- a/src/widgets/refinement-list/__tests__/refinement-list-test.js
+++ b/src/widgets/refinement-list/__tests__/refinement-list-test.js
@@ -18,7 +18,7 @@ describe('refinementList()', () => {
     container = document.createElement('div');
 
     ReactDOM = { render: sinon.spy() };
-    refinementList.__Rewire__('ReactDOM', ReactDOM);
+    refinementList.__Rewire__('render', ReactDOM.render);
     autoHideContainer = sinon.stub().returnsArg(0);
     refinementList.__Rewire__('autoHideContainerHOC', autoHideContainer);
     headerFooter = sinon.stub().returnsArg(0);

--- a/src/widgets/refinement-list/refinement-list.js
+++ b/src/widgets/refinement-list/refinement-list.js
@@ -1,5 +1,4 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
+import React, { render } from 'preact-compat';
 import cx from 'classnames';
 import filter from 'lodash/filter';
 
@@ -59,7 +58,7 @@ const renderer = ({
     header: { refinedFacetsCount: filter(items, { isRefined: true }).length },
   };
 
-  ReactDOM.render(
+  render(
     <RefinementList
       collapsible={collapsible}
       createURL={createURL}

--- a/src/widgets/sort-by-selector/__tests__/sort-by-selector-test.js
+++ b/src/widgets/sort-by-selector/__tests__/sort-by-selector-test.js
@@ -33,7 +33,7 @@ describe('sortBySelector()', () => {
     autoHideContainer = sinon.stub().returns(Selector);
     ReactDOM = { render: sinon.spy() };
 
-    sortBySelector.__Rewire__('ReactDOM', ReactDOM);
+    sortBySelector.__Rewire__('render', ReactDOM.render);
     sortBySelector.__Rewire__('autoHideContainerHOC', autoHideContainer);
 
     container = document.createElement('div');

--- a/src/widgets/sort-by-selector/sort-by-selector.js
+++ b/src/widgets/sort-by-selector/sort-by-selector.js
@@ -1,5 +1,4 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
+import React, { render } from 'preact-compat';
 import cx from 'classnames';
 
 import Selector from '../../components/Selector.js';
@@ -16,7 +15,7 @@ const renderer = ({ containerNode, cssClasses, autoHideContainer }) => (
 
   const shouldAutoHideContainer = autoHideContainer && hasNoResults;
 
-  ReactDOM.render(
+  render(
     <Selector
       cssClasses={cssClasses}
       currentValue={currentRefinement}

--- a/src/widgets/star-rating/__tests__/star-rating-test.js
+++ b/src/widgets/star-rating/__tests__/star-rating-test.js
@@ -26,7 +26,7 @@ describe('starRating()', () => {
 
   beforeEach(() => {
     ReactDOM = { render: sinon.spy() };
-    starRating.__Rewire__('ReactDOM', ReactDOM);
+    starRating.__Rewire__('render', ReactDOM.render);
 
     container = document.createElement('div');
     widget = starRating({

--- a/src/widgets/star-rating/star-rating.js
+++ b/src/widgets/star-rating/star-rating.js
@@ -1,5 +1,4 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
+import React, { render } from 'preact-compat';
 import cx from 'classnames';
 
 import RefinementList from '../../components/RefinementList/RefinementList.js';
@@ -40,7 +39,7 @@ const renderer = ({
 
   const shouldAutoHideContainer = autoHideContainer && hasNoResults;
 
-  ReactDOM.render(
+  render(
     <RefinementList
       collapsible={collapsible}
       createURL={createURL}

--- a/src/widgets/stats/__tests__/stats-test.js
+++ b/src/widgets/stats/__tests__/stats-test.js
@@ -22,7 +22,7 @@ describe('stats()', () => {
 
   beforeEach(() => {
     ReactDOM = { render: sinon.spy() };
-    stats.__Rewire__('ReactDOM', ReactDOM);
+    stats.__Rewire__('render', ReactDOM.render);
 
     container = document.createElement('div');
     widget = stats({ container, cssClasses: { body: ['body', 'cx'] } });

--- a/src/widgets/stats/stats.js
+++ b/src/widgets/stats/stats.js
@@ -1,5 +1,4 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
+import React, { render } from 'preact-compat';
 import cx from 'classnames';
 
 import Stats from '../../components/Stats/Stats.js';
@@ -46,7 +45,7 @@ const renderer = ({
 
   const shouldAutoHideContainer = autoHideContainer && nbHits === 0;
 
-  ReactDOM.render(
+  render(
     <Stats
       collapsible={collapsible}
       cssClasses={cssClasses}

--- a/src/widgets/toggle/__tests__/currentToggle-test.js
+++ b/src/widgets/toggle/__tests__/currentToggle-test.js
@@ -22,7 +22,7 @@ describe('currentToggle()', () => {
     beforeEach(() => {
       ReactDOM = { render: sinon.spy() };
 
-      currentToggle.__Rewire__('ReactDOM', ReactDOM);
+      currentToggle.__Rewire__('render', ReactDOM.render);
 
       containerNode = document.createElement('div');
       label = 'Hello, ';

--- a/src/widgets/toggle/toggle.js
+++ b/src/widgets/toggle/toggle.js
@@ -1,5 +1,4 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
+import React, { render } from 'preact-compat';
 import cx from 'classnames';
 
 import defaultTemplates from './defaultTemplates.js';
@@ -39,7 +38,7 @@ const renderer = ({
   const shouldAutoHideContainer =
     autoHideContainer && (value.count === 0 || value.count === null);
 
-  ReactDOM.render(
+  render(
     <RefinementList
       collapsible={collapsible}
       createURL={createURL}

--- a/yarn.lock
+++ b/yarn.lock
@@ -810,6 +810,14 @@ babel-plugin-jest-hoist@^21.0.2:
   version "21.0.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.0.2.tgz#cfdce5bca40d772a056cb8528ad159c7bb4bb03d"
 
+babel-plugin-module-resolver@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-module-resolver/-/babel-plugin-module-resolver-2.7.1.tgz#18be3c42ddf59f7a456c9e0512cd91394f6e4be1"
+  dependencies:
+    find-babel-config "^1.0.1"
+    glob "^7.1.1"
+    resolve "^1.2.0"
+
 babel-plugin-rewire@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-rewire/-/babel-plugin-rewire-1.1.0.tgz#a6b966d9d8c06c03d95dcda2eec4e2521519549b"
@@ -3749,6 +3757,13 @@ finalhandler@~1.0.4, finalhandler@~1.0.6:
     parseurl "~1.3.2"
     statuses "~1.3.1"
     unpipe "~1.0.0"
+
+find-babel-config@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-babel-config/-/find-babel-config-1.1.0.tgz#acc01043a6749fec34429be6b64f542ebb5d6355"
+  dependencies:
+    json5 "^0.5.1"
+    path-exists "^3.0.0"
 
 find-cache-dir@^1.0.0:
   version "1.0.0"
@@ -7480,7 +7495,7 @@ postcss@^6.0.1, postcss@^6.0.11, postcss@^6.0.2:
     source-map "^0.5.7"
     supports-color "^4.4.0"
 
-preact-compat@^3.16.0:
+preact-compat@^3.16.0, preact-compat@^3.17.0:
   version "3.17.0"
   resolved "https://registry.yarnpkg.com/preact-compat/-/preact-compat-3.17.0.tgz#528cfdfc301190c1a0f47567336be1f4be0266b3"
   dependencies:
@@ -7500,7 +7515,7 @@ preact-transition-group@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/preact-transition-group/-/preact-transition-group-1.1.1.tgz#f0a49327ea515ece34ea2be864c4a7d29e5d6e10"
 
-preact@^8.1.0:
+preact@^8.1.0, preact@^8.2.5:
   version "8.2.5"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.2.5.tgz#cbfa3962a8012768159f6d01d46f9c1eb3213c0a"
 
@@ -8283,11 +8298,13 @@ rgb2hex@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/rgb2hex/-/rgb2hex-0.1.0.tgz#ccd55f860ae0c5c4ea37504b958e442d8d12325b"
 
-rheostat@algolia/rheostat#dist:
+rheostat@algolia/rheostat#dist-preact:
   version "2.1.1"
-  resolved "https://codeload.github.com/algolia/rheostat/tar.gz/00fa03bc93efe0fee4257efc7403360001038a71"
+  resolved "https://codeload.github.com/algolia/rheostat/tar.gz/1327d77e45fb8417589a76af00c4413bca7f6aee"
   dependencies:
     object.assign "^4.0.4"
+    preact "^8.2.5"
+    preact-compat "^3.17.0"
     prop-types "^15.5.10"
 
 right-align@^0.1.1:


### PR DESCRIPTION
Attempt to fix #2279 #2388

I replace `React` and `ReactDOM` by `preact-compat` and fixed the tests which were failing because of the update.

I've also replaced Rheostat `React` with `preact-compat` in the fork.