### PR TITLE
Fix range slider boundaries

### DIFF
--- a/dev/app/init-builtin-widgets.js
+++ b/dev/app/init-builtin-widgets.js
@@ -548,7 +548,7 @@ export default () => {
           instantsearch.widgets.rangeSlider({
             container,
             attributeName: 'price',
-            step: 10,
+            step: 500,
             tooltips: {
               format(rawValue) {
                 return `$${Math.round(rawValue).toLocaleString()}`;

--- a/dev/app/init-builtin-widgets.js
+++ b/dev/app/init-builtin-widgets.js
@@ -541,6 +541,28 @@ export default () => {
           })
         );
       })
+    )
+    .add(
+      'with min / max boundaries',
+      wrapWithHits(container => {
+        window.search.addWidget(
+          instantsearch.widgets.rangeSlider({
+            container,
+            attributeName: 'price',
+            templates: {
+              header: 'Price',
+            },
+            min: 10,
+            max: 500,
+            step: 10,
+            tooltips: {
+              format(rawValue) {
+                return `$${Math.round(rawValue).toLocaleString()}`;
+              },
+            },
+          })
+        );
+      })
     );
 
   storiesOf('HierarchicalMenu')

--- a/dev/app/init-builtin-widgets.js
+++ b/dev/app/init-builtin-widgets.js
@@ -576,6 +576,46 @@ export default () => {
       })
     )
     .add(
+      'with min boundaries',
+      wrapWithHits(container => {
+        window.search.addWidget(
+          instantsearch.widgets.rangeSlider({
+            container,
+            attributeName: 'price',
+            templates: {
+              header: 'Price',
+            },
+            min: 10,
+            tooltips: {
+              format(rawValue) {
+                return `$${Math.round(rawValue).toLocaleString()}`;
+              },
+            },
+          })
+        );
+      })
+    )
+    .add(
+      'with max boundaries',
+      wrapWithHits(container => {
+        window.search.addWidget(
+          instantsearch.widgets.rangeSlider({
+            container,
+            attributeName: 'price',
+            templates: {
+              header: 'Price',
+            },
+            max: 500,
+            tooltips: {
+              format(rawValue) {
+                return `$${Math.round(rawValue).toLocaleString()}`;
+              },
+            },
+          })
+        );
+      })
+    )
+    .add(
       'with min / max boundaries',
       wrapWithHits(container => {
         window.search.addWidget(

--- a/dev/app/init-builtin-widgets.js
+++ b/dev/app/init-builtin-widgets.js
@@ -523,6 +523,28 @@ export default () => {
       })
     )
     .add(
+      'disabled',
+      wrapWithHits(container => {
+        window.search.addWidget(
+          instantsearch.widgets.rangeSlider({
+            container,
+            attributeName: 'price',
+            templates: {
+              header: 'Price',
+            },
+            min: 100,
+            max: 50,
+            step: 10,
+            tooltips: {
+              format(rawValue) {
+                return `$${Math.round(rawValue).toLocaleString()}`;
+              },
+            },
+          })
+        );
+      })
+    )
+    .add(
       'without pips',
       wrapWithHits(container => {
         window.search.addWidget(

--- a/dev/app/init-builtin-widgets.js
+++ b/dev/app/init-builtin-widgets.js
@@ -585,7 +585,7 @@ export default () => {
             templates: {
               header: 'Price',
             },
-            min: 10,
+            min: 36,
             tooltips: {
               format(rawValue) {
                 return `$${Math.round(rawValue).toLocaleString()}`;
@@ -605,7 +605,7 @@ export default () => {
             templates: {
               header: 'Price',
             },
-            max: 500,
+            max: 36,
             tooltips: {
               format(rawValue) {
                 return `$${Math.round(rawValue).toLocaleString()}`;

--- a/dev/app/init-builtin-widgets.js
+++ b/dev/app/init-builtin-widgets.js
@@ -511,8 +511,6 @@ export default () => {
             templates: {
               header: 'Price',
             },
-            max: 500,
-            step: 10,
             tooltips: {
               format(rawValue) {
                 return `$${Math.round(rawValue).toLocaleString()}`;
@@ -534,6 +532,22 @@ export default () => {
             },
             min: 100,
             max: 50,
+            tooltips: {
+              format(rawValue) {
+                return `$${Math.round(rawValue).toLocaleString()}`;
+              },
+            },
+          })
+        );
+      })
+    )
+    .add(
+      'with step',
+      wrapWithHits(container => {
+        window.search.addWidget(
+          instantsearch.widgets.rangeSlider({
+            container,
+            attributeName: 'price',
             step: 10,
             tooltips: {
               format(rawValue) {
@@ -551,10 +565,7 @@ export default () => {
           instantsearch.widgets.rangeSlider({
             container,
             attributeName: 'price',
-            min: 0,
-            max: 500,
             pips: false,
-            step: 10,
             tooltips: {
               format(rawValue) {
                 return `$${Math.round(rawValue).toLocaleString()}`;
@@ -576,7 +587,6 @@ export default () => {
             },
             min: 10,
             max: 500,
-            step: 10,
             tooltips: {
               format(rawValue) {
                 return `$${Math.round(rawValue).toLocaleString()}`;

--- a/src/components/Slider/Slider.js
+++ b/src/components/Slider/Slider.js
@@ -2,9 +2,8 @@ import times from 'lodash/times';
 import range from 'lodash/range';
 import has from 'lodash/has';
 
-import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Rheostat from 'rheostat';
 import cx from 'classnames';
 
@@ -13,7 +12,7 @@ import Pit from './Pit.js';
 import autoHideContainerHOC from '../../decorators/autoHideContainer.js';
 import headerFooterHOC from '../../decorators/headerFooter.js';
 
-class Slider extends Component {
+export class Slider extends Component {
   static propTypes = {
     refine: PropTypes.func.isRequired,
     min: PropTypes.number.isRequired,
@@ -31,17 +30,9 @@ class Slider extends Component {
     return this.props.min >= this.props.max;
   }
 
-  handleChange = ({ min, max, values }) => {
-    // when Slider is disabled, we alter `min, max` values
-    // in order to render a "disabled state" Slider. Since we alter
-    // theses values, Rheostat trigger a "change" event which trigger a new
-    // search to Algolia with wrong values.
+  handleChange = ({ values }) => {
     if (!this.isDisabled) {
-      const { refine } = this.props;
-      refine([
-        min === values[0] ? undefined : values[0],
-        max === values[1] ? undefined : values[1],
-      ]);
+      this.props.refine(values);
     }
   };
 

--- a/src/components/Slider/Slider.js
+++ b/src/components/Slider/Slider.js
@@ -12,7 +12,7 @@ import Pit from './Pit.js';
 import autoHideContainerHOC from '../../decorators/autoHideContainer.js';
 import headerFooterHOC from '../../decorators/headerFooter.js';
 
-export class Slider extends Component {
+export class RawSlider extends Component {
   static propTypes = {
     refine: PropTypes.func.isRequired,
     min: PropTypes.number.isRequired,
@@ -111,4 +111,4 @@ export class Slider extends Component {
   }
 }
 
-export default autoHideContainerHOC(headerFooterHOC(Slider));
+export default autoHideContainerHOC(headerFooterHOC(RawSlider));

--- a/src/components/Slider/__tests__/Slider-test.js
+++ b/src/components/Slider/__tests__/Slider-test.js
@@ -2,13 +2,13 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import { shallow } from 'enzyme';
 
-import Enhance, { Slider } from '../Slider';
+import Slider, { RawSlider } from '../Slider';
 
 describe('Slider', () => {
   it('expect to render correctly', () => {
     const tree = renderer
       .create(
-        <Enhance
+        <Slider
           refine={() => undefined}
           min={0}
           max={500}
@@ -26,7 +26,7 @@ describe('Slider', () => {
   it('expect to render without pips', () => {
     const tree = renderer
       .create(
-        <Enhance
+        <Slider
           refine={() => undefined}
           min={0}
           max={500}
@@ -53,7 +53,7 @@ describe('Slider', () => {
       shouldAutoHideContainer: false,
     };
 
-    shallow(<Slider {...props} />)
+    shallow(<RawSlider {...props} />)
       .find('Rheostat')
       .simulate('change', {
         values: [0, 100],

--- a/src/components/Slider/__tests__/Slider-test.js
+++ b/src/components/Slider/__tests__/Slider-test.js
@@ -5,7 +5,7 @@ import { shallow } from 'enzyme';
 import Enhance, { Slider } from '../Slider';
 
 describe('Slider', () => {
-  it('should render correctly', () => {
+  it('expect to render correctly', () => {
     const tree = renderer
       .create(
         <Enhance
@@ -23,7 +23,7 @@ describe('Slider', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('should render without pips', () => {
+  it('expect to render without pips', () => {
     const tree = renderer
       .create(
         <Enhance

--- a/src/components/Slider/__tests__/Slider-test.js
+++ b/src/components/Slider/__tests__/Slider-test.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { shallow } from 'enzyme';
 
-import Slider from '../Slider';
+import Enhance, { Slider } from '../Slider';
 
 describe('Slider', () => {
   it('should render correctly', () => {
     const tree = renderer
       .create(
-        <Slider
+        <Enhance
           refine={() => undefined}
           min={0}
           max={500}
@@ -25,7 +26,7 @@ describe('Slider', () => {
   it('should render without pips', () => {
     const tree = renderer
       .create(
-        <Slider
+        <Enhance
           refine={() => undefined}
           min={0}
           max={500}
@@ -38,5 +39,26 @@ describe('Slider', () => {
       )
       .toJSON();
     expect(tree).toMatchSnapshot();
+  });
+
+  it('expect to call handleChange on change', () => {
+    const props = {
+      refine: jest.fn(),
+      min: 0,
+      max: 500,
+      values: [0, 0],
+      pips: true,
+      step: 2,
+      tooltips: true,
+      shouldAutoHideContainer: false,
+    };
+
+    shallow(<Slider {...props} />)
+      .find('Rheostat')
+      .simulate('change', {
+        values: [0, 100],
+      });
+
+    expect(props.refine).toHaveBeenCalledWith([0, 100]);
   });
 });

--- a/src/components/Slider/__tests__/__snapshots__/Slider-test.js.snap
+++ b/src/components/Slider/__tests__/__snapshots__/Slider-test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Slider should render correctly 1`] = `
+exports[`Slider expect to render correctly 1`] = `
 <div
   style={
     Object {
@@ -465,7 +465,7 @@ exports[`Slider should render correctly 1`] = `
 </div>
 `;
 
-exports[`Slider should render without pips 1`] = `
+exports[`Slider expect to render without pips 1`] = `
 <div
   style={
     Object {

--- a/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
+++ b/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
@@ -482,4 +482,319 @@ describe('connectRangeSlider', () => {
       expect(actual).toEqual(expectation);
     });
   });
+
+  describe('_refine', () => {
+    const attributeName = 'price';
+    const rendering = () => {};
+
+    it('expect to refine min and max from empty state', () => {
+      const values = [0, 500];
+      const widget = connectRangeSlider(rendering)({ attributeName });
+      const helper = {
+        getNumericRefinement: jest.fn(() => []),
+        addNumericRefinement: jest.fn(),
+        clearRefinements: jest.fn(),
+        search: jest.fn(),
+      };
+
+      widget._refine(helper)(values);
+
+      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
+        attributeName,
+        '>=',
+        0
+      );
+
+      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
+        attributeName,
+        '<=',
+        500
+      );
+
+      expect(helper.clearRefinements).toHaveBeenCalled();
+      expect(helper.search).toHaveBeenCalled();
+    });
+
+    it('expect to refine min and max from non empty state', () => {
+      const values = [20, 480];
+      const widget = connectRangeSlider(rendering)({ attributeName });
+      const helper = {
+        getNumericRefinement: jest.fn(
+          (_, operation) => (operation === '>=' ? 0 : 500)
+        ),
+        addNumericRefinement: jest.fn(),
+        clearRefinements: jest.fn(),
+        search: jest.fn(),
+      };
+
+      widget._refine(helper)(values);
+
+      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
+        attributeName,
+        '>=',
+        20
+      );
+
+      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
+        attributeName,
+        '<=',
+        480
+      );
+
+      expect(helper.clearRefinements).toHaveBeenCalled();
+      expect(helper.search).toHaveBeenCalled();
+    });
+
+    it('expect to refine min from empty state', () => {
+      const values = [0, null];
+      const widget = connectRangeSlider(rendering)({ attributeName });
+      const helper = {
+        getNumericRefinement: jest.fn(() => []),
+        addNumericRefinement: jest.fn(),
+        clearRefinements: jest.fn(),
+        search: jest.fn(),
+      };
+
+      widget._refine(helper)(values);
+
+      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
+        attributeName,
+        '>=',
+        0
+      );
+
+      expect(helper.addNumericRefinement).not.toHaveBeenCalledWith(
+        attributeName,
+        '<=',
+        expect.any(Number)
+      );
+
+      expect(helper.clearRefinements).toHaveBeenCalled();
+      expect(helper.search).toHaveBeenCalled();
+    });
+
+    it('expect to refine min from non empty state', () => {
+      const values = [20, 500];
+      const widget = connectRangeSlider(rendering)({ attributeName });
+      const helper = {
+        getNumericRefinement: jest.fn(
+          (_, operation) => (operation === '>=' ? 0 : 500)
+        ),
+        addNumericRefinement: jest.fn(),
+        clearRefinements: jest.fn(),
+        search: jest.fn(),
+      };
+
+      widget._refine(helper)(values);
+
+      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
+        attributeName,
+        '>=',
+        20
+      );
+
+      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
+        attributeName,
+        '<=',
+        500
+      );
+
+      expect(helper.clearRefinements).toHaveBeenCalled();
+      expect(helper.search).toHaveBeenCalled();
+    });
+
+    it('expect to refine min when it is equal to bounds', () => {
+      const values = [20, 500];
+      const widget = connectRangeSlider(rendering)({
+        attributeName,
+        min: 20,
+      });
+
+      const helper = {
+        getNumericRefinement: jest.fn(
+          (_, operation) => (operation === '>=' ? 50 : 500)
+        ),
+        addNumericRefinement: jest.fn(),
+        clearRefinements: jest.fn(),
+        search: jest.fn(),
+      };
+
+      widget._refine(helper)(values);
+
+      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
+        attributeName,
+        '>=',
+        20
+      );
+
+      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
+        attributeName,
+        '<=',
+        500
+      );
+
+      expect(helper.clearRefinements).toHaveBeenCalled();
+      expect(helper.search).toHaveBeenCalled();
+    });
+
+    it('expect to refine max from empty state', () => {
+      const values = [null, 250];
+      const widget = connectRangeSlider(rendering)({ attributeName });
+      const helper = {
+        getNumericRefinement: jest.fn(() => []),
+        addNumericRefinement: jest.fn(),
+        clearRefinements: jest.fn(),
+        search: jest.fn(),
+      };
+
+      widget._refine(helper)(values);
+
+      expect(helper.addNumericRefinement).not.toHaveBeenCalledWith(
+        attributeName,
+        '>=',
+        expect.any(Number)
+      );
+
+      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
+        attributeName,
+        '<=',
+        250
+      );
+
+      expect(helper.clearRefinements).toHaveBeenCalled();
+      expect(helper.search).toHaveBeenCalled();
+    });
+
+    it('expect to refine max from non empty state', () => {
+      const values = [0, 250];
+      const widget = connectRangeSlider(rendering)({ attributeName });
+      const helper = {
+        getNumericRefinement: jest.fn(
+          (_, operation) => (operation === '>=' ? 0 : 500)
+        ),
+        addNumericRefinement: jest.fn(),
+        clearRefinements: jest.fn(),
+        search: jest.fn(),
+      };
+
+      widget._refine(helper)(values);
+
+      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
+        attributeName,
+        '>=',
+        0
+      );
+
+      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
+        attributeName,
+        '<=',
+        250
+      );
+
+      expect(helper.clearRefinements).toHaveBeenCalled();
+      expect(helper.search).toHaveBeenCalled();
+    });
+
+    it('expect to refine max when it is equal to bounds', () => {
+      const values = [20, 450];
+      const widget = connectRangeSlider(rendering)({
+        attributeName,
+        max: 450,
+      });
+
+      const helper = {
+        getNumericRefinement: jest.fn(
+          (_, operation) => (operation === '>=' ? 20 : 500)
+        ),
+        addNumericRefinement: jest.fn(),
+        clearRefinements: jest.fn(),
+        search: jest.fn(),
+      };
+
+      widget._refine(helper)(values);
+
+      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
+        attributeName,
+        '>=',
+        20
+      );
+
+      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
+        attributeName,
+        '<=',
+        450
+      );
+
+      expect(helper.clearRefinements).toHaveBeenCalled();
+      expect(helper.search).toHaveBeenCalled();
+    });
+
+    it("expect to not refine when both min and max aren't changed", () => {
+      const values = [0, 500];
+      const widget = connectRangeSlider(rendering)({ attributeName });
+      const helper = {
+        getNumericRefinement: jest.fn(
+          (_, operation) => (operation === '>=' ? 0 : 500)
+        ),
+        addNumericRefinement: jest.fn(),
+        clearRefinements: jest.fn(),
+        search: jest.fn(),
+      };
+
+      widget._refine(helper)(values);
+
+      expect(helper.addNumericRefinement).not.toHaveBeenCalledWith();
+      expect(helper.addNumericRefinement).not.toHaveBeenCalledWith();
+      expect(helper.clearRefinements).not.toHaveBeenCalled();
+      expect(helper.search).not.toHaveBeenCalled();
+    });
+
+    it("expect to not refine min when it's out of bounds", () => {
+      const values = [0, 500];
+      const widget = connectRangeSlider(rendering)({
+        attributeName,
+        min: 50,
+      });
+
+      const helper = {
+        getNumericRefinement: jest.fn(
+          (_, operation) => (operation === '>=' ? 50 : 500)
+        ),
+        addNumericRefinement: jest.fn(),
+        clearRefinements: jest.fn(),
+        search: jest.fn(),
+      };
+
+      widget._refine(helper)(values);
+
+      expect(helper.addNumericRefinement).not.toHaveBeenCalledWith();
+      expect(helper.addNumericRefinement).not.toHaveBeenCalledWith();
+      expect(helper.clearRefinements).toHaveBeenCalled();
+      expect(helper.search).toHaveBeenCalled();
+    });
+
+    it("expect to not refine max when it's out of bounds", () => {
+      const values = [0, 480];
+      const widget = connectRangeSlider(rendering)({
+        attributeName,
+        max: 450,
+      });
+
+      const helper = {
+        getNumericRefinement: jest.fn(
+          (_, operation) => (operation === '>=' ? 0 : 450)
+        ),
+        addNumericRefinement: jest.fn(),
+        clearRefinements: jest.fn(),
+        search: jest.fn(),
+      };
+
+      widget._refine(helper)(values);
+
+      expect(helper.addNumericRefinement).not.toHaveBeenCalledWith();
+      expect(helper.addNumericRefinement).not.toHaveBeenCalledWith();
+      expect(helper.clearRefinements).toHaveBeenCalled();
+      expect(helper.search).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
+++ b/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
@@ -339,6 +339,20 @@ describe('connectRangeSlider', () => {
       expect(actual).toEqual(expectation);
     });
 
+    it("expect to return default configuration if the given bounds aren't valid", () => {
+      const currentConfiguration = {};
+      const widget = connectRangeSlider(rendering)({
+        attributeName,
+        min: 1000,
+        max: 500,
+      });
+
+      const expectation = { disjunctiveFacets: ['price'] };
+      const actual = widget.getConfiguration(currentConfiguration);
+
+      expect(actual).toEqual(expectation);
+    });
+
     it('expect to return configuration with added numeric refinements', () => {
       const currentConfiguration = {};
       const widget = connectRangeSlider(rendering)({

--- a/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
+++ b/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
@@ -361,6 +361,73 @@ describe('connectRangeSlider', () => {
     });
   });
 
+  describe('_isAbleToRefine', () => {
+    const attributeName = 'price';
+    const rendering = () => {};
+
+    it('expect to return true when only min is provided', () => {
+      const widget = connectRangeSlider(rendering)({
+        attributeName,
+      });
+
+      const actual0 = widget._isAbleToRefine(10, null);
+      const actual1 = widget._isAbleToRefine(10, undefined);
+
+      expect(actual0).toBe(true);
+      expect(actual1).toBe(true);
+    });
+
+    it('expect to return true when only max is provided', () => {
+      const widget = connectRangeSlider(rendering)({
+        attributeName,
+      });
+
+      const actual0 = widget._isAbleToRefine(null, 10);
+      const actual1 = widget._isAbleToRefine(undefined, 10);
+
+      expect(actual0).toBe(true);
+      expect(actual1).toBe(true);
+    });
+
+    it('expect to return true when both are provided with min lower than max', () => {
+      const widget = connectRangeSlider(rendering)({
+        attributeName,
+      });
+
+      const actual = widget._isAbleToRefine(10, 20);
+
+      expect(actual).toBe(true);
+    });
+
+    it('expect to return false when both are provided with min greater or equal than max', () => {
+      const widget = connectRangeSlider(rendering)({
+        attributeName,
+      });
+
+      const actual0 = widget._isAbleToRefine(10, 10);
+      const actual1 = widget._isAbleToRefine(20, 10);
+
+      expect(actual0).toBe(false);
+      expect(actual1).toBe(false);
+    });
+
+    it('expect to return false when both are invalid', () => {
+      const widget = connectRangeSlider(rendering)({
+        attributeName,
+      });
+
+      const actual0 = widget._isAbleToRefine(null, null);
+      const actual1 = widget._isAbleToRefine(null, undefined);
+      const actual2 = widget._isAbleToRefine(undefined, null);
+      const actual3 = widget._isAbleToRefine(undefined, undefined);
+
+      expect(actual0).toBe(false);
+      expect(actual1).toBe(false);
+      expect(actual2).toBe(false);
+      expect(actual3).toBe(false);
+    });
+  });
+
   describe('_getCurrentRange', () => {
     const attributeName = 'price';
     const rendering = () => {};

--- a/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
+++ b/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
@@ -43,7 +43,7 @@ describe('connectRangeSlider', () => {
       // should provide good values for the first rendering
       const { range, start, widgetParams } = rendering.lastCall.args[0];
       expect(range).toEqual({ min: 0, max: 0 });
-      expect(start).toEqual([-Infinity, Infinity]);
+      expect(start).toEqual([0, 0]);
       expect(widgetParams).toEqual({
         attributeName,
       });
@@ -82,7 +82,7 @@ describe('connectRangeSlider', () => {
       // should provide good values for the first rendering
       const { range, start } = rendering.lastCall.args[0];
       expect(range).toEqual({ min: 10, max: 30 });
-      expect(start).toEqual([-Infinity, Infinity]);
+      expect(start).toEqual([10, 30]);
     }
   });
 
@@ -429,7 +429,7 @@ describe('connectRangeSlider', () => {
         },
       };
 
-      const expectation = { min: -Infinity, max: Infinity };
+      const expectation = { min: 0, max: 0 };
       const actual = widget._getCurrentRefinement(helper, stats);
 
       expect(actual).toEqual(expectation);

--- a/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
+++ b/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
@@ -520,7 +520,7 @@ describe('connectRangeSlider', () => {
       const widget = connectRangeSlider(rendering)({ attributeName });
       const helper = {
         getNumericRefinement: jest.fn(
-          (_, operation) => (operation === '>=' ? 0 : 500)
+          (_, operation) => (operation === '>=' ? [0] : [500])
         ),
         addNumericRefinement: jest.fn(),
         clearRefinements: jest.fn(),
@@ -578,7 +578,7 @@ describe('connectRangeSlider', () => {
       const widget = connectRangeSlider(rendering)({ attributeName });
       const helper = {
         getNumericRefinement: jest.fn(
-          (_, operation) => (operation === '>=' ? 0 : 500)
+          (_, operation) => (operation === '>=' ? [0] : [500])
         ),
         addNumericRefinement: jest.fn(),
         clearRefinements: jest.fn(),
@@ -612,7 +612,7 @@ describe('connectRangeSlider', () => {
 
       const helper = {
         getNumericRefinement: jest.fn(
-          (_, operation) => (operation === '>=' ? 50 : 500)
+          (_, operation) => (operation === '>=' ? [50] : [500])
         ),
         addNumericRefinement: jest.fn(),
         clearRefinements: jest.fn(),
@@ -670,7 +670,7 @@ describe('connectRangeSlider', () => {
       const widget = connectRangeSlider(rendering)({ attributeName });
       const helper = {
         getNumericRefinement: jest.fn(
-          (_, operation) => (operation === '>=' ? 0 : 500)
+          (_, operation) => (operation === '>=' ? [0] : [500])
         ),
         addNumericRefinement: jest.fn(),
         clearRefinements: jest.fn(),
@@ -704,7 +704,7 @@ describe('connectRangeSlider', () => {
 
       const helper = {
         getNumericRefinement: jest.fn(
-          (_, operation) => (operation === '>=' ? 20 : 500)
+          (_, operation) => (operation === '>=' ? [20] : [500])
         ),
         addNumericRefinement: jest.fn(),
         clearRefinements: jest.fn(),
@@ -734,7 +734,7 @@ describe('connectRangeSlider', () => {
       const widget = connectRangeSlider(rendering)({ attributeName });
       const helper = {
         getNumericRefinement: jest.fn(
-          (_, operation) => (operation === '>=' ? 0 : 500)
+          (_, operation) => (operation === '>=' ? [0] : [500])
         ),
         addNumericRefinement: jest.fn(),
         clearRefinements: jest.fn(),
@@ -757,9 +757,7 @@ describe('connectRangeSlider', () => {
       });
 
       const helper = {
-        getNumericRefinement: jest.fn(
-          (_, operation) => (operation === '>=' ? 50 : 500)
-        ),
+        getNumericRefinement: jest.fn(),
         addNumericRefinement: jest.fn(),
         clearRefinements: jest.fn(),
         search: jest.fn(),
@@ -781,9 +779,7 @@ describe('connectRangeSlider', () => {
       });
 
       const helper = {
-        getNumericRefinement: jest.fn(
-          (_, operation) => (operation === '>=' ? 0 : 450)
-        ),
+        getNumericRefinement: jest.fn(),
         addNumericRefinement: jest.fn(),
         clearRefinements: jest.fn(),
         search: jest.fn(),

--- a/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
+++ b/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
@@ -303,6 +303,64 @@ describe('connectRangeSlider', () => {
     }
   });
 
+  describe('getConfiguration', () => {
+    const attributeName = 'price';
+    const rendering = () => {};
+
+    it('expect to return default configuration', () => {
+      const currentConfiguration = {};
+      const widget = connectRangeSlider(rendering)({
+        attributeName,
+      });
+
+      const expectation = { disjunctiveFacets: ['price'] };
+      const actual = widget.getConfiguration(currentConfiguration);
+
+      expect(actual).toEqual(expectation);
+    });
+
+    it('expect to return default configuration if previous one has already numeric refinements', () => {
+      const currentConfiguration = {
+        numericRefinements: {
+          price: {
+            '<=': [500],
+          },
+        },
+      };
+
+      const widget = connectRangeSlider(rendering)({
+        attributeName,
+        max: 500,
+      });
+
+      const expectation = { disjunctiveFacets: ['price'] };
+      const actual = widget.getConfiguration(currentConfiguration);
+
+      expect(actual).toEqual(expectation);
+    });
+
+    it('expect to return configuration with added numeric refinements', () => {
+      const currentConfiguration = {};
+      const widget = connectRangeSlider(rendering)({
+        attributeName,
+        max: 500,
+      });
+
+      const expectation = {
+        disjunctiveFacets: ['price'],
+        numericRefinements: {
+          price: {
+            '<=': [500],
+          },
+        },
+      };
+
+      const actual = widget.getConfiguration(currentConfiguration);
+
+      expect(actual).toEqual(expectation);
+    });
+  });
+
   describe('_getCurrentRange', () => {
     const attributeName = 'price';
     const rendering = () => {};

--- a/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
+++ b/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
@@ -82,7 +82,7 @@ describe('connectRangeSlider', () => {
       // should provide good values for the first rendering
       const { range, start } = rendering.lastCall.args[0];
       expect(range).toEqual({ min: 10, max: 30 });
-      expect(start).toEqual([10, 30]);
+      expect(start).toEqual([-Infinity, Infinity]);
     }
   });
 
@@ -502,7 +502,6 @@ describe('connectRangeSlider', () => {
     const rendering = () => {};
 
     it('expect to return default refinement', () => {
-      const stats = {};
       const widget = connectRangeSlider(rendering)({ attributeName });
       const helper = {
         state: {
@@ -511,28 +510,12 @@ describe('connectRangeSlider', () => {
       };
 
       const expectation = { min: -Infinity, max: Infinity };
-      const actual = widget._getCurrentRefinement(helper, stats);
-
-      expect(actual).toEqual(expectation);
-    });
-
-    it('expect to return refinement from stats', () => {
-      const stats = { min: 10, max: 500 };
-      const widget = connectRangeSlider(rendering)({ attributeName });
-      const helper = {
-        state: {
-          getNumericRefinement: jest.fn(() => []),
-        },
-      };
-
-      const expectation = { min: 10, max: 500 };
-      const actual = widget._getCurrentRefinement(helper, stats);
+      const actual = widget._getCurrentRefinement(helper);
 
       expect(actual).toEqual(expectation);
     });
 
     it('expect to return refinement from helper', () => {
-      const stats = {};
       const widget = connectRangeSlider(rendering)({ attributeName });
       const helper = {
         state: {
@@ -543,22 +526,23 @@ describe('connectRangeSlider', () => {
       };
 
       const expectation = { min: 10, max: 100 };
-      const actual = widget._getCurrentRefinement(helper, stats);
+      const actual = widget._getCurrentRefinement(helper);
 
       expect(actual).toEqual(expectation);
     });
 
     it('expect to return rounded refinement values', () => {
-      const stats = { min: 1.79, max: 499.99 };
       const widget = connectRangeSlider(rendering)({ attributeName });
       const helper = {
         state: {
-          getNumericRefinement: jest.fn(() => []),
+          getNumericRefinement: jest.fn(
+            (_, operation) => (operation === '>=' ? [10.9] : [99.1])
+          ),
         },
       };
 
-      const expectation = { min: 1, max: 500 };
-      const actual = widget._getCurrentRefinement(helper, stats);
+      const expectation = { min: 10, max: 100 };
+      const actual = widget._getCurrentRefinement(helper);
 
       expect(actual).toEqual(expectation);
     });

--- a/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
+++ b/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
@@ -359,4 +359,71 @@ describe('connectRangeSlider', () => {
       expect(actual).toEqual(expectation);
     });
   });
+
+  describe('_getCurrentRefinement', () => {
+    const attributeName = 'price';
+    const rendering = () => {};
+
+    it('expect to return default refinement', () => {
+      const stats = {};
+      const widget = connectRangeSlider(rendering)({ attributeName });
+      const helper = {
+        state: {
+          getNumericRefinement: jest.fn(() => []),
+        },
+      };
+
+      const expectation = { min: -Infinity, max: Infinity };
+      const actual = widget._getCurrentRefinement(helper, stats);
+
+      expect(actual).toEqual(expectation);
+    });
+
+    it('expect to return refinement from stats', () => {
+      const stats = { min: 10, max: 500 };
+      const widget = connectRangeSlider(rendering)({ attributeName });
+      const helper = {
+        state: {
+          getNumericRefinement: jest.fn(() => []),
+        },
+      };
+
+      const expectation = { min: 10, max: 500 };
+      const actual = widget._getCurrentRefinement(helper, stats);
+
+      expect(actual).toEqual(expectation);
+    });
+
+    it('expect to return refinement from helper', () => {
+      const stats = {};
+      const widget = connectRangeSlider(rendering)({ attributeName });
+      const helper = {
+        state: {
+          getNumericRefinement: jest.fn(
+            (_, operation) => (operation === '>=' ? [10] : [100])
+          ),
+        },
+      };
+
+      const expectation = { min: 10, max: 100 };
+      const actual = widget._getCurrentRefinement(helper, stats);
+
+      expect(actual).toEqual(expectation);
+    });
+
+    it('expect to return rounded refinement values', () => {
+      const stats = { min: 1.79, max: 499.99 };
+      const widget = connectRangeSlider(rendering)({ attributeName });
+      const helper = {
+        state: {
+          getNumericRefinement: jest.fn(() => []),
+        },
+      };
+
+      const expectation = { min: 1, max: 500 };
+      const actual = widget._getCurrentRefinement(helper, stats);
+
+      expect(actual).toEqual(expectation);
+    });
+  });
 });

--- a/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
+++ b/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
@@ -291,13 +291,13 @@ describe('connectRangeSlider', () => {
       expect(helper.getNumericRefinement('price', '<=')).toEqual([100]);
       expect(helper.search.callCount).toBe(1);
 
-      refine([0, undefined]);
-      expect(helper.getNumericRefinement('price', '>=')).toEqual([0]);
+      refine([10, undefined]);
+      expect(helper.getNumericRefinement('price', '>=')).toEqual([10]);
       expect(helper.getNumericRefinement('price', '<=')).toEqual(undefined);
       expect(helper.search.callCount).toBe(2);
 
-      refine([0, 100]);
-      expect(helper.getNumericRefinement('price', '>=')).toEqual([0]);
+      refine([10, 100]);
+      expect(helper.getNumericRefinement('price', '>=')).toEqual([10]);
       expect(helper.getNumericRefinement('price', '<=')).toEqual([100]);
       expect(helper.search.callCount).toBe(3);
     }
@@ -723,6 +723,64 @@ describe('connectRangeSlider', () => {
         attributeName,
         '<=',
         450
+      );
+
+      expect(helper.clearRefinements).toHaveBeenCalled();
+      expect(helper.search).toHaveBeenCalled();
+    });
+
+    it('expect to not refine min when no bounds are set and the min range is equal to next min', () => {
+      const values = [0, 500];
+      const range = { min: 0, max: 750 };
+      const widget = connectRangeSlider(rendering)({ attributeName });
+      const helper = {
+        getNumericRefinement: jest.fn(),
+        addNumericRefinement: jest.fn(),
+        clearRefinements: jest.fn(),
+        search: jest.fn(),
+      };
+
+      widget._refine(helper, range)(values);
+
+      expect(helper.addNumericRefinement).not.toHaveBeenCalledWith(
+        attributeName,
+        '>=',
+        0
+      );
+
+      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
+        attributeName,
+        '<=',
+        500
+      );
+
+      expect(helper.clearRefinements).toHaveBeenCalled();
+      expect(helper.search).toHaveBeenCalled();
+    });
+
+    it('expect to not refine max when no bounds are set and the max range is equal to next max', () => {
+      const values = [10, 500];
+      const range = { min: 0, max: 500 };
+      const widget = connectRangeSlider(rendering)({ attributeName });
+      const helper = {
+        getNumericRefinement: jest.fn(),
+        addNumericRefinement: jest.fn(),
+        clearRefinements: jest.fn(),
+        search: jest.fn(),
+      };
+
+      widget._refine(helper, range)(values);
+
+      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
+        attributeName,
+        '>=',
+        10
+      );
+
+      expect(helper.addNumericRefinement).not.toHaveBeenCalledWith(
+        attributeName,
+        '<=',
+        500
       );
 
       expect(helper.clearRefinements).toHaveBeenCalled();

--- a/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
+++ b/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
@@ -339,7 +339,7 @@ describe('connectRangeSlider', () => {
       expect(actual).toEqual(expectation);
     });
 
-    it("expect to return default configuration if the given bounds aren't valid", () => {
+    it('expect to return default configuration if the given min bound are greater than max bound', () => {
       const currentConfiguration = {};
       const widget = connectRangeSlider(rendering)({
         attributeName,
@@ -353,18 +353,18 @@ describe('connectRangeSlider', () => {
       expect(actual).toEqual(expectation);
     });
 
-    it('expect to return configuration with added numeric refinements', () => {
+    it('expect to return configuration with min numeric refinement', () => {
       const currentConfiguration = {};
       const widget = connectRangeSlider(rendering)({
         attributeName,
-        max: 500,
+        min: 10,
       });
 
       const expectation = {
         disjunctiveFacets: ['price'],
         numericRefinements: {
           price: {
-            '<=': [500],
+            '>=': [10],
           },
         },
       };
@@ -373,72 +373,49 @@ describe('connectRangeSlider', () => {
 
       expect(actual).toEqual(expectation);
     });
-  });
 
-  describe('_isAbleToRefine', () => {
-    const attributeName = 'price';
-    const rendering = () => {};
-
-    it('expect to return true when only min is provided', () => {
+    it('expect to return configuration with max numeric refinement', () => {
+      const currentConfiguration = {};
       const widget = connectRangeSlider(rendering)({
         attributeName,
+        max: 10,
       });
 
-      const actual0 = widget._isAbleToRefine(10, null);
-      const actual1 = widget._isAbleToRefine(10, undefined);
+      const expectation = {
+        disjunctiveFacets: ['price'],
+        numericRefinements: {
+          price: {
+            '<=': [10],
+          },
+        },
+      };
 
-      expect(actual0).toBe(true);
-      expect(actual1).toBe(true);
+      const actual = widget.getConfiguration(currentConfiguration);
+
+      expect(actual).toEqual(expectation);
     });
 
-    it('expect to return true when only max is provided', () => {
+    it('expect to return configuration with both numeric refinements', () => {
+      const currentConfiguration = {};
       const widget = connectRangeSlider(rendering)({
         attributeName,
+        min: 10,
+        max: 500,
       });
 
-      const actual0 = widget._isAbleToRefine(null, 10);
-      const actual1 = widget._isAbleToRefine(undefined, 10);
+      const expectation = {
+        disjunctiveFacets: ['price'],
+        numericRefinements: {
+          price: {
+            '>=': [10],
+            '<=': [500],
+          },
+        },
+      };
 
-      expect(actual0).toBe(true);
-      expect(actual1).toBe(true);
-    });
+      const actual = widget.getConfiguration(currentConfiguration);
 
-    it('expect to return true when both are provided with min lower than max', () => {
-      const widget = connectRangeSlider(rendering)({
-        attributeName,
-      });
-
-      const actual = widget._isAbleToRefine(10, 20);
-
-      expect(actual).toBe(true);
-    });
-
-    it('expect to return false when both are provided with min greater or equal than max', () => {
-      const widget = connectRangeSlider(rendering)({
-        attributeName,
-      });
-
-      const actual0 = widget._isAbleToRefine(10, 10);
-      const actual1 = widget._isAbleToRefine(20, 10);
-
-      expect(actual0).toBe(false);
-      expect(actual1).toBe(false);
-    });
-
-    it('expect to return false when both are invalid', () => {
-      const widget = connectRangeSlider(rendering)({
-        attributeName,
-      });
-
-      const actual0 = widget._isAbleToRefine(null, null);
-      const actual1 = widget._isAbleToRefine(null, undefined);
-      const actual2 = widget._isAbleToRefine(undefined, null);
-      const actual3 = widget._isAbleToRefine(undefined, undefined);
-
-      expect(actual0).toBe(false);
-      expect(actual1).toBe(false);
-      expect(actual2).toBe(false);
-      expect(actual3).toBe(false);
+      expect(actual).toEqual(expectation);
     });
   });
 

--- a/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
+++ b/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
@@ -291,13 +291,13 @@ describe('connectRangeSlider', () => {
       expect(helper.getNumericRefinement('price', '<=')).toEqual([100]);
       expect(helper.search.callCount).toBe(1);
 
-      refine([10, undefined]);
-      expect(helper.getNumericRefinement('price', '>=')).toEqual([10]);
+      refine([0, undefined]);
+      expect(helper.getNumericRefinement('price', '>=')).toEqual([0]);
       expect(helper.getNumericRefinement('price', '<=')).toEqual(undefined);
       expect(helper.search.callCount).toBe(2);
 
-      refine([10, 100]);
-      expect(helper.getNumericRefinement('price', '>=')).toEqual([10]);
+      refine([0, 100]);
+      expect(helper.getNumericRefinement('price', '>=')).toEqual([0]);
       expect(helper.getNumericRefinement('price', '<=')).toEqual([100]);
       expect(helper.search.callCount).toBe(3);
     }
@@ -552,158 +552,41 @@ describe('connectRangeSlider', () => {
     const attributeName = 'price';
     const rendering = () => {};
 
-    it('expect to refine min and max from empty state', () => {
-      const values = [0, 500];
-      const widget = connectRangeSlider(rendering)({ attributeName });
-      const helper = {
-        getNumericRefinement: jest.fn(() => []),
-        addNumericRefinement: jest.fn(),
-        clearRefinements: jest.fn(),
-        search: jest.fn(),
-      };
-
-      widget._refine(helper)(values);
-
-      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
-        attributeName,
-        '>=',
-        0
-      );
-
-      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
-        attributeName,
-        '<=',
-        500
-      );
-
-      expect(helper.clearRefinements).toHaveBeenCalled();
-      expect(helper.search).toHaveBeenCalled();
-    });
-
-    it('expect to refine min and max from non empty state', () => {
-      const values = [20, 480];
-      const widget = connectRangeSlider(rendering)({ attributeName });
-      const helper = {
-        getNumericRefinement: jest.fn(
-          (_, operation) => (operation === '>=' ? [0] : [500])
-        ),
-        addNumericRefinement: jest.fn(),
-        clearRefinements: jest.fn(),
-        search: jest.fn(),
-      };
-
-      widget._refine(helper)(values);
-
-      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
-        attributeName,
-        '>=',
-        20
-      );
-
-      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
-        attributeName,
-        '<=',
-        480
-      );
-
-      expect(helper.clearRefinements).toHaveBeenCalled();
-      expect(helper.search).toHaveBeenCalled();
-    });
-
-    it('expect to refine min from empty state', () => {
-      const values = [0, null];
-      const widget = connectRangeSlider(rendering)({ attributeName });
-      const helper = {
-        getNumericRefinement: jest.fn(() => []),
-        addNumericRefinement: jest.fn(),
-        clearRefinements: jest.fn(),
-        search: jest.fn(),
-      };
-
-      widget._refine(helper)(values);
-
-      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
-        attributeName,
-        '>=',
-        0
-      );
-
-      expect(helper.addNumericRefinement).not.toHaveBeenCalledWith(
-        attributeName,
-        '<=',
-        expect.any(Number)
-      );
-
-      expect(helper.clearRefinements).toHaveBeenCalled();
-      expect(helper.search).toHaveBeenCalled();
-    });
-
-    it('expect to refine min from non empty state', () => {
-      const values = [20, 500];
-      const widget = connectRangeSlider(rendering)({ attributeName });
-      const helper = {
-        getNumericRefinement: jest.fn(
-          (_, operation) => (operation === '>=' ? [0] : [500])
-        ),
-        addNumericRefinement: jest.fn(),
-        clearRefinements: jest.fn(),
-        search: jest.fn(),
-      };
-
-      widget._refine(helper)(values);
-
-      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
-        attributeName,
-        '>=',
-        20
-      );
-
-      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
-        attributeName,
-        '<=',
-        500
-      );
-
-      expect(helper.clearRefinements).toHaveBeenCalled();
-      expect(helper.search).toHaveBeenCalled();
-    });
-
-    it('expect to refine min when it is equal to bounds', () => {
-      const values = [20, 500];
+    it('expect to refine when range are not set', () => {
+      const range = {};
+      const values = [10, 490];
       const widget = connectRangeSlider(rendering)({
         attributeName,
-        min: 20,
       });
 
       const helper = {
-        getNumericRefinement: jest.fn(
-          (_, operation) => (operation === '>=' ? [50] : [500])
-        ),
+        getNumericRefinement: jest.fn(() => []),
         addNumericRefinement: jest.fn(),
         clearRefinements: jest.fn(),
         search: jest.fn(),
       };
 
-      widget._refine(helper)(values);
+      widget._refine(helper, range)(values);
 
       expect(helper.addNumericRefinement).toHaveBeenCalledWith(
         attributeName,
         '>=',
-        20
+        10
       );
 
       expect(helper.addNumericRefinement).toHaveBeenCalledWith(
         attributeName,
         '<=',
-        500
+        490
       );
 
       expect(helper.clearRefinements).toHaveBeenCalled();
       expect(helper.search).toHaveBeenCalled();
     });
 
-    it('expect to refine max from empty state', () => {
-      const values = [null, 250];
+    it('expect to refine when values are in range', () => {
+      const range = { min: 0, max: 500 };
+      const values = [10, 490];
       const widget = connectRangeSlider(rendering)({ attributeName });
       const helper = {
         getNumericRefinement: jest.fn(() => []),
@@ -712,94 +595,96 @@ describe('connectRangeSlider', () => {
         search: jest.fn(),
       };
 
-      widget._refine(helper)(values);
+      widget._refine(helper, range)(values);
 
-      expect(helper.addNumericRefinement).not.toHaveBeenCalledWith(
+      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
         attributeName,
         '>=',
-        expect.any(Number)
+        10
       );
 
       expect(helper.addNumericRefinement).toHaveBeenCalledWith(
         attributeName,
         '<=',
-        250
+        490
       );
 
       expect(helper.clearRefinements).toHaveBeenCalled();
       expect(helper.search).toHaveBeenCalled();
     });
 
-    it('expect to refine max from non empty state', () => {
-      const values = [0, 250];
-      const widget = connectRangeSlider(rendering)({ attributeName });
-      const helper = {
-        getNumericRefinement: jest.fn(
-          (_, operation) => (operation === '>=' ? [0] : [500])
-        ),
-        addNumericRefinement: jest.fn(),
-        clearRefinements: jest.fn(),
-        search: jest.fn(),
-      };
-
-      widget._refine(helper)(values);
-
-      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
-        attributeName,
-        '>=',
-        0
-      );
-
-      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
-        attributeName,
-        '<=',
-        250
-      );
-
-      expect(helper.clearRefinements).toHaveBeenCalled();
-      expect(helper.search).toHaveBeenCalled();
-    });
-
-    it('expect to refine max when it is equal to bounds', () => {
-      const values = [20, 450];
+    it('expect to refine min when user bounds are set and value is at range bound', () => {
+      const range = { min: 10, max: 500 };
+      const values = [10, 490];
       const widget = connectRangeSlider(rendering)({
         attributeName,
-        max: 450,
+        min: 10,
       });
 
       const helper = {
-        getNumericRefinement: jest.fn(
-          (_, operation) => (operation === '>=' ? [20] : [500])
-        ),
+        getNumericRefinement: jest.fn(() => []),
         addNumericRefinement: jest.fn(),
         clearRefinements: jest.fn(),
         search: jest.fn(),
       };
 
-      widget._refine(helper)(values);
+      widget._refine(helper, range)(values);
 
       expect(helper.addNumericRefinement).toHaveBeenCalledWith(
         attributeName,
         '>=',
-        20
+        10
       );
 
       expect(helper.addNumericRefinement).toHaveBeenCalledWith(
         attributeName,
         '<=',
-        450
+        490
       );
 
       expect(helper.clearRefinements).toHaveBeenCalled();
       expect(helper.search).toHaveBeenCalled();
     });
 
-    it('expect to not refine min when no bounds are set and the min range is equal to next min', () => {
-      const values = [0, 500];
-      const range = { min: 0, max: 750 };
+    it('expect to refine max when user bounds are set and value is at range bound', () => {
+      const range = { min: 0, max: 490 };
+      const values = [10, 490];
+      const widget = connectRangeSlider(rendering)({
+        attributeName,
+        max: 490,
+      });
+
+      const helper = {
+        getNumericRefinement: jest.fn(() => []),
+        addNumericRefinement: jest.fn(),
+        clearRefinements: jest.fn(),
+        search: jest.fn(),
+      };
+
+      widget._refine(helper, range)(values);
+
+      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
+        attributeName,
+        '>=',
+        10
+      );
+
+      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
+        attributeName,
+        '<=',
+        490
+      );
+
+      expect(helper.clearRefinements).toHaveBeenCalled();
+      expect(helper.search).toHaveBeenCalled();
+    });
+
+    it('expect to not refine min when no user bounds are set and value is at range bound', () => {
+      const range = { min: 0, max: 500 };
+      const values = [0, 490];
       const widget = connectRangeSlider(rendering)({ attributeName });
       const helper = {
-        getNumericRefinement: jest.fn(),
+        getNumericRefinement: jest.fn(() => []),
         addNumericRefinement: jest.fn(),
         clearRefinements: jest.fn(),
         search: jest.fn(),
@@ -816,19 +701,19 @@ describe('connectRangeSlider', () => {
       expect(helper.addNumericRefinement).toHaveBeenCalledWith(
         attributeName,
         '<=',
-        500
+        490
       );
 
       expect(helper.clearRefinements).toHaveBeenCalled();
       expect(helper.search).toHaveBeenCalled();
     });
 
-    it('expect to not refine max when no bounds are set and the max range is equal to next max', () => {
-      const values = [10, 500];
+    it('expect to not refine max when no user bounds are set and value is at range bound', () => {
       const range = { min: 0, max: 500 };
+      const values = [10, 500];
       const widget = connectRangeSlider(rendering)({ attributeName });
       const helper = {
-        getNumericRefinement: jest.fn(),
+        getNumericRefinement: jest.fn(() => []),
         addNumericRefinement: jest.fn(),
         clearRefinements: jest.fn(),
         search: jest.fn(),
@@ -852,41 +737,18 @@ describe('connectRangeSlider', () => {
       expect(helper.search).toHaveBeenCalled();
     });
 
-    it("expect to not refine when both min and max aren't changed", () => {
-      const values = [0, 500];
+    it("expect to not refine min when it's out of range", () => {
+      const range = { min: 10, max: 500 };
+      const values = [0, 490];
       const widget = connectRangeSlider(rendering)({ attributeName });
       const helper = {
-        getNumericRefinement: jest.fn(
-          (_, operation) => (operation === '>=' ? [0] : [500])
-        ),
+        getNumericRefinement: jest.fn(() => []),
         addNumericRefinement: jest.fn(),
         clearRefinements: jest.fn(),
         search: jest.fn(),
       };
 
-      widget._refine(helper)(values);
-
-      expect(helper.addNumericRefinement).not.toHaveBeenCalled();
-      expect(helper.addNumericRefinement).not.toHaveBeenCalled();
-      expect(helper.clearRefinements).not.toHaveBeenCalled();
-      expect(helper.search).not.toHaveBeenCalled();
-    });
-
-    it("expect to not refine min when it's out of bounds", () => {
-      const values = [0, 500];
-      const widget = connectRangeSlider(rendering)({
-        attributeName,
-        min: 50,
-      });
-
-      const helper = {
-        getNumericRefinement: jest.fn(),
-        addNumericRefinement: jest.fn(),
-        clearRefinements: jest.fn(),
-        search: jest.fn(),
-      };
-
-      widget._refine(helper)(values);
+      widget._refine(helper, range)(values);
 
       expect(helper.addNumericRefinement).not.toHaveBeenCalledWith(
         attributeName,
@@ -895,6 +757,35 @@ describe('connectRangeSlider', () => {
       );
 
       expect(helper.addNumericRefinement).toHaveBeenCalledWith(
+        attributeName,
+        '<=',
+        490
+      );
+
+      expect(helper.clearRefinements).toHaveBeenCalled();
+      expect(helper.search).toHaveBeenCalled();
+    });
+
+    it("expect to not refine max when it's out of range", () => {
+      const range = { min: 0, max: 490 };
+      const values = [10, 500];
+      const widget = connectRangeSlider(rendering)({ attributeName });
+      const helper = {
+        getNumericRefinement: jest.fn(() => []),
+        addNumericRefinement: jest.fn(),
+        clearRefinements: jest.fn(),
+        search: jest.fn(),
+      };
+
+      widget._refine(helper, range)(values);
+
+      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
+        attributeName,
+        '>=',
+        10
+      );
+
+      expect(helper.addNumericRefinement).not.toHaveBeenCalledWith(
         attributeName,
         '<=',
         500
@@ -904,13 +795,41 @@ describe('connectRangeSlider', () => {
       expect(helper.search).toHaveBeenCalled();
     });
 
-    it("expect to not refine max when it's out of bounds", () => {
-      const values = [0, 480];
-      const widget = connectRangeSlider(rendering)({
-        attributeName,
-        max: 450,
-      });
+    it('expect to not refine when both values have not changed', () => {
+      const range = { min: 0, max: 500 };
+      const values = [10, 250];
+      const widget = connectRangeSlider(rendering)({ attributeName });
+      const helper = {
+        getNumericRefinement: jest.fn(
+          (_, operation) => (operation === '>=' ? [10] : [250])
+        ),
+        addNumericRefinement: jest.fn(),
+        clearRefinements: jest.fn(),
+        search: jest.fn(),
+      };
 
+      widget._refine(helper, range)(values);
+
+      expect(helper.addNumericRefinement).not.toHaveBeenCalledWith(
+        attributeName,
+        '>=',
+        10
+      );
+
+      expect(helper.addNumericRefinement).not.toHaveBeenCalledWith(
+        attributeName,
+        '<=',
+        250
+      );
+
+      expect(helper.clearRefinements).not.toHaveBeenCalled();
+      expect(helper.search).not.toHaveBeenCalled();
+    });
+
+    it('expect to not refine when values are invalid', () => {
+      const range = { min: 0, max: 500 };
+      const values = [null, null];
+      const widget = connectRangeSlider(rendering)({ attributeName });
       const helper = {
         getNumericRefinement: jest.fn(),
         addNumericRefinement: jest.fn(),
@@ -918,20 +837,9 @@ describe('connectRangeSlider', () => {
         search: jest.fn(),
       };
 
-      widget._refine(helper)(values);
+      widget._refine(helper, range)(values);
 
-      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
-        attributeName,
-        '>=',
-        0
-      );
-
-      expect(helper.addNumericRefinement).not.toHaveBeenCalledWith(
-        attributeName,
-        '<=',
-        480
-      );
-
+      expect(helper.addNumericRefinement).not.toHaveBeenCalledWith();
       expect(helper.clearRefinements).toHaveBeenCalled();
       expect(helper.search).toHaveBeenCalled();
     });

--- a/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
+++ b/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
@@ -54,7 +54,8 @@ describe('connectRangeSlider', () => {
         {
           hits: [{ test: 'oneTime' }],
           facets: { price: { 10: 1, 20: 1, 30: 1 } },
-        facets_stats: { // eslint-disable-line
+          // eslint-disable-next-line camelcase
+          facets_stats: {
             price: {
               avg: 20,
               max: 30,
@@ -153,7 +154,8 @@ describe('connectRangeSlider', () => {
         {
           hits: [{ test: 'oneTime' }],
           facets: { price: { 10: 1, 20: 1, 30: 1 } },
-        facets_stats: { // eslint-disable-line
+          // eslint-disable-next-line camelcase
+          facets_stats: {
             price: {
               avg: 20,
               max: 30,
@@ -299,5 +301,62 @@ describe('connectRangeSlider', () => {
       expect(helper.getNumericRefinement('price', '<=')).toEqual([100]);
       expect(helper.search.callCount).toBe(3);
     }
+  });
+
+  describe('_getCurrentRange', () => {
+    const attributeName = 'price';
+    const rendering = () => {};
+
+    it('expect to return default range', () => {
+      const bounds = {};
+      const stats = {};
+      const widget = connectRangeSlider(rendering)({
+        attributeName,
+      });
+
+      const expectation = { min: 0, max: 0 };
+      const actual = widget._getCurrentRange(bounds, stats);
+
+      expect(actual).toEqual(expectation);
+    });
+
+    it('expect to return range from stats', () => {
+      const bounds = {};
+      const stats = { min: 10, max: 500 };
+      const widget = connectRangeSlider(rendering)({
+        attributeName,
+      });
+
+      const expectation = { min: 10, max: 500 };
+      const actual = widget._getCurrentRange(bounds, stats);
+
+      expect(actual).toEqual(expectation);
+    });
+
+    it('expect to return range from bounds', () => {
+      const bounds = { min: 20, max: 250 };
+      const stats = { min: 10, max: 500 };
+      const widget = connectRangeSlider(rendering)({
+        attributeName,
+      });
+
+      const expectation = { min: 20, max: 250 };
+      const actual = widget._getCurrentRange(bounds, stats);
+
+      expect(actual).toEqual(expectation);
+    });
+
+    it('expect to return rounded range values', () => {
+      const bounds = {};
+      const stats = { min: 1.79, max: 499.99 };
+      const widget = connectRangeSlider(rendering)({
+        attributeName,
+      });
+
+      const expectation = { min: 1, max: 500 };
+      const actual = widget._getCurrentRange(bounds, stats);
+
+      expect(actual).toEqual(expectation);
+    });
   });
 });

--- a/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
+++ b/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
@@ -801,8 +801,8 @@ describe('connectRangeSlider', () => {
 
       widget._refine(helper)(values);
 
-      expect(helper.addNumericRefinement).not.toHaveBeenCalledWith();
-      expect(helper.addNumericRefinement).not.toHaveBeenCalledWith();
+      expect(helper.addNumericRefinement).not.toHaveBeenCalled();
+      expect(helper.addNumericRefinement).not.toHaveBeenCalled();
       expect(helper.clearRefinements).not.toHaveBeenCalled();
       expect(helper.search).not.toHaveBeenCalled();
     });
@@ -823,8 +823,18 @@ describe('connectRangeSlider', () => {
 
       widget._refine(helper)(values);
 
-      expect(helper.addNumericRefinement).not.toHaveBeenCalledWith();
-      expect(helper.addNumericRefinement).not.toHaveBeenCalledWith();
+      expect(helper.addNumericRefinement).not.toHaveBeenCalledWith(
+        attributeName,
+        '>=',
+        0
+      );
+
+      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
+        attributeName,
+        '<=',
+        500
+      );
+
       expect(helper.clearRefinements).toHaveBeenCalled();
       expect(helper.search).toHaveBeenCalled();
     });
@@ -845,8 +855,18 @@ describe('connectRangeSlider', () => {
 
       widget._refine(helper)(values);
 
-      expect(helper.addNumericRefinement).not.toHaveBeenCalledWith();
-      expect(helper.addNumericRefinement).not.toHaveBeenCalledWith();
+      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
+        attributeName,
+        '>=',
+        0
+      );
+
+      expect(helper.addNumericRefinement).not.toHaveBeenCalledWith(
+        attributeName,
+        '<=',
+        480
+      );
+
       expect(helper.clearRefinements).toHaveBeenCalled();
       expect(helper.search).toHaveBeenCalled();
     });

--- a/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
+++ b/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
@@ -502,14 +502,14 @@ describe('connectRangeSlider', () => {
       expect(actual).toEqual(expectation);
     });
 
-    it('expect to return rounded refinement values', () => {
+    it('expect to return float refinement values', () => {
       const widget = connectRangeSlider(rendering)({ attributeName });
       const helper = createHelper();
 
       helper.addNumericRefinement(attributeName, '>=', 10.9);
       helper.addNumericRefinement(attributeName, '<=', 99.1);
 
-      const expectation = [10, 100];
+      const expectation = [10.9, 99.1];
       const actual = widget._getCurrentRefinement(helper);
 
       expect(actual).toEqual(expectation);

--- a/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
+++ b/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
@@ -366,53 +366,51 @@ describe('connectRangeSlider', () => {
     const rendering = () => {};
 
     it('expect to return default range', () => {
-      const bounds = {};
       const stats = {};
       const widget = connectRangeSlider(rendering)({
         attributeName,
       });
 
       const expectation = { min: 0, max: 0 };
-      const actual = widget._getCurrentRange(bounds, stats);
+      const actual = widget._getCurrentRange(stats);
+
+      expect(actual).toEqual(expectation);
+    });
+
+    it('expect to return range from bounds', () => {
+      const stats = { min: 10, max: 500 };
+      const widget = connectRangeSlider(rendering)({
+        attributeName,
+        min: 20,
+        max: 250,
+      });
+
+      const expectation = { min: 20, max: 250 };
+      const actual = widget._getCurrentRange(stats);
 
       expect(actual).toEqual(expectation);
     });
 
     it('expect to return range from stats', () => {
-      const bounds = {};
       const stats = { min: 10, max: 500 };
       const widget = connectRangeSlider(rendering)({
         attributeName,
       });
 
       const expectation = { min: 10, max: 500 };
-      const actual = widget._getCurrentRange(bounds, stats);
-
-      expect(actual).toEqual(expectation);
-    });
-
-    it('expect to return range from bounds', () => {
-      const bounds = { min: 20, max: 250 };
-      const stats = { min: 10, max: 500 };
-      const widget = connectRangeSlider(rendering)({
-        attributeName,
-      });
-
-      const expectation = { min: 20, max: 250 };
-      const actual = widget._getCurrentRange(bounds, stats);
+      const actual = widget._getCurrentRange(stats);
 
       expect(actual).toEqual(expectation);
     });
 
     it('expect to return rounded range values', () => {
-      const bounds = {};
       const stats = { min: 1.79, max: 499.99 };
       const widget = connectRangeSlider(rendering)({
         attributeName,
       });
 
       const expectation = { min: 1, max: 500 };
-      const actual = widget._getCurrentRange(bounds, stats);
+      const actual = widget._getCurrentRange(stats);
 
       expect(actual).toEqual(expectation);
     });

--- a/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
+++ b/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
@@ -185,7 +185,7 @@ describe('connectRangeSlider', () => {
     }
   });
 
-  it('should add numeric refinement when refining min boundary', () => {
+  it('should add numeric refinement when refining min boundary without previous configuation', () => {
     const rendering = sinon.stub();
     const makeWidget = connectRangeSlider(rendering);
 
@@ -193,6 +193,45 @@ describe('connectRangeSlider', () => {
     const widget = makeWidget({ attributeName, min: 0, max: 500 });
 
     const helper = jsHelper(fakeClient, '', widget.getConfiguration());
+    helper.search = sinon.stub();
+
+    widget.init({
+      helper,
+      state: helper.state,
+      createURL: () => '#',
+      onHistoryChange: () => {},
+    });
+
+    {
+      // first rendering
+      expect(helper.getNumericRefinement('price', '>=')).toEqual([0]);
+      expect(helper.getNumericRefinement('price', '<=')).toEqual([500]);
+
+      const renderOptions = rendering.lastCall.args[0];
+      const { refine } = renderOptions;
+      refine([10, 30]);
+
+      expect(helper.getNumericRefinement('price', '>=')).toEqual([10]);
+      expect(helper.getNumericRefinement('price', '<=')).toEqual([30]);
+      expect(helper.search.callCount).toBe(1);
+
+      refine([0, undefined]);
+      expect(helper.getNumericRefinement('price', '>=')).toEqual([0]);
+      expect(helper.getNumericRefinement('price', '<=')).toEqual(undefined);
+    }
+  });
+
+  it('should add numeric refinement when refining min boundary with previous configuration', () => {
+    const rendering = sinon.stub();
+    const makeWidget = connectRangeSlider(rendering);
+
+    const attributeName = 'price';
+    const widget = makeWidget({ attributeName, min: 0, max: 500 });
+    const configuration = widget.getConfiguration({
+      indexName: 'movie',
+    });
+
+    const helper = jsHelper(fakeClient, '', configuration);
     helper.search = sinon.stub();
 
     widget.init({

--- a/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
+++ b/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
@@ -486,7 +486,7 @@ describe('connectRangeSlider', () => {
         },
       };
 
-      const expectation = { min: -Infinity, max: Infinity };
+      const expectation = [-Infinity, Infinity];
       const actual = widget._getCurrentRefinement(helper);
 
       expect(actual).toEqual(expectation);
@@ -502,7 +502,7 @@ describe('connectRangeSlider', () => {
         },
       };
 
-      const expectation = { min: 10, max: 100 };
+      const expectation = [10, 100];
       const actual = widget._getCurrentRefinement(helper);
 
       expect(actual).toEqual(expectation);
@@ -518,7 +518,7 @@ describe('connectRangeSlider', () => {
         },
       };
 
-      const expectation = { min: 10, max: 100 };
+      const expectation = [10, 100];
       const actual = widget._getCurrentRefinement(helper);
 
       expect(actual).toEqual(expectation);

--- a/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
+++ b/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
@@ -477,14 +477,11 @@ describe('connectRangeSlider', () => {
   describe('_getCurrentRefinement', () => {
     const attributeName = 'price';
     const rendering = () => {};
+    const createHelper = () => jsHelper(fakeClient);
 
     it('expect to return default refinement', () => {
       const widget = connectRangeSlider(rendering)({ attributeName });
-      const helper = {
-        state: {
-          getNumericRefinement: jest.fn(() => []),
-        },
-      };
+      const helper = createHelper();
 
       const expectation = [-Infinity, Infinity];
       const actual = widget._getCurrentRefinement(helper);
@@ -494,13 +491,10 @@ describe('connectRangeSlider', () => {
 
     it('expect to return refinement from helper', () => {
       const widget = connectRangeSlider(rendering)({ attributeName });
-      const helper = {
-        state: {
-          getNumericRefinement: jest.fn(
-            (_, operation) => (operation === '>=' ? [10] : [100])
-          ),
-        },
-      };
+      const helper = createHelper();
+
+      helper.addNumericRefinement(attributeName, '>=', 10);
+      helper.addNumericRefinement(attributeName, '<=', 100);
 
       const expectation = [10, 100];
       const actual = widget._getCurrentRefinement(helper);
@@ -510,13 +504,10 @@ describe('connectRangeSlider', () => {
 
     it('expect to return rounded refinement values', () => {
       const widget = connectRangeSlider(rendering)({ attributeName });
-      const helper = {
-        state: {
-          getNumericRefinement: jest.fn(
-            (_, operation) => (operation === '>=' ? [10.9] : [99.1])
-          ),
-        },
-      };
+      const helper = createHelper();
+
+      helper.addNumericRefinement(attributeName, '>=', 10.9);
+      helper.addNumericRefinement(attributeName, '<=', 99.1);
 
       const expectation = [10, 100];
       const actual = widget._getCurrentRefinement(helper);
@@ -528,35 +519,26 @@ describe('connectRangeSlider', () => {
   describe('_refine', () => {
     const attributeName = 'price';
     const rendering = () => {};
+    const createHelper = () => {
+      const helper = jsHelper(fakeClient);
+      helper.clearRefinements = jest.fn();
+      helper.search = jest.fn();
+
+      return helper;
+    };
 
     it('expect to refine when range are not set', () => {
       const range = {};
       const values = [10, 490];
+      const helper = createHelper();
       const widget = connectRangeSlider(rendering)({
         attributeName,
       });
 
-      const helper = {
-        getNumericRefinement: jest.fn(() => []),
-        addNumericRefinement: jest.fn(),
-        clearRefinements: jest.fn(),
-        search: jest.fn(),
-      };
-
       widget._refine(helper, range)(values);
 
-      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
-        attributeName,
-        '>=',
-        10
-      );
-
-      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
-        attributeName,
-        '<=',
-        490
-      );
-
+      expect(helper.getNumericRefinement(attributeName, '>=')).toEqual([10]);
+      expect(helper.getNumericRefinement(attributeName, '<=')).toEqual([490]);
       expect(helper.clearRefinements).toHaveBeenCalled();
       expect(helper.search).toHaveBeenCalled();
     });
@@ -564,28 +546,13 @@ describe('connectRangeSlider', () => {
     it('expect to refine when values are in range', () => {
       const range = { min: 0, max: 500 };
       const values = [10, 490];
+      const helper = createHelper();
       const widget = connectRangeSlider(rendering)({ attributeName });
-      const helper = {
-        getNumericRefinement: jest.fn(() => []),
-        addNumericRefinement: jest.fn(),
-        clearRefinements: jest.fn(),
-        search: jest.fn(),
-      };
 
       widget._refine(helper, range)(values);
 
-      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
-        attributeName,
-        '>=',
-        10
-      );
-
-      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
-        attributeName,
-        '<=',
-        490
-      );
-
+      expect(helper.getNumericRefinement(attributeName, '>=')).toEqual([10]);
+      expect(helper.getNumericRefinement(attributeName, '<=')).toEqual([490]);
       expect(helper.clearRefinements).toHaveBeenCalled();
       expect(helper.search).toHaveBeenCalled();
     });
@@ -593,32 +560,16 @@ describe('connectRangeSlider', () => {
     it('expect to refine min when user bounds are set and value is at range bound', () => {
       const range = { min: 10, max: 500 };
       const values = [10, 490];
+      const helper = createHelper();
       const widget = connectRangeSlider(rendering)({
         attributeName,
         min: 10,
       });
 
-      const helper = {
-        getNumericRefinement: jest.fn(() => []),
-        addNumericRefinement: jest.fn(),
-        clearRefinements: jest.fn(),
-        search: jest.fn(),
-      };
-
       widget._refine(helper, range)(values);
 
-      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
-        attributeName,
-        '>=',
-        10
-      );
-
-      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
-        attributeName,
-        '<=',
-        490
-      );
-
+      expect(helper.getNumericRefinement(attributeName, '>=')).toEqual([10]);
+      expect(helper.getNumericRefinement(attributeName, '<=')).toEqual([490]);
       expect(helper.clearRefinements).toHaveBeenCalled();
       expect(helper.search).toHaveBeenCalled();
     });
@@ -626,32 +577,16 @@ describe('connectRangeSlider', () => {
     it('expect to refine max when user bounds are set and value is at range bound', () => {
       const range = { min: 0, max: 490 };
       const values = [10, 490];
+      const helper = createHelper();
       const widget = connectRangeSlider(rendering)({
         attributeName,
         max: 490,
       });
 
-      const helper = {
-        getNumericRefinement: jest.fn(() => []),
-        addNumericRefinement: jest.fn(),
-        clearRefinements: jest.fn(),
-        search: jest.fn(),
-      };
-
       widget._refine(helper, range)(values);
 
-      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
-        attributeName,
-        '>=',
-        10
-      );
-
-      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
-        attributeName,
-        '<=',
-        490
-      );
-
+      expect(helper.getNumericRefinement(attributeName, '>=')).toEqual([10]);
+      expect(helper.getNumericRefinement(attributeName, '<=')).toEqual([490]);
       expect(helper.clearRefinements).toHaveBeenCalled();
       expect(helper.search).toHaveBeenCalled();
     });
@@ -659,28 +594,15 @@ describe('connectRangeSlider', () => {
     it('expect to not refine min when no user bounds are set and value is at range bound', () => {
       const range = { min: 0, max: 500 };
       const values = [0, 490];
+      const helper = createHelper();
       const widget = connectRangeSlider(rendering)({ attributeName });
-      const helper = {
-        getNumericRefinement: jest.fn(() => []),
-        addNumericRefinement: jest.fn(),
-        clearRefinements: jest.fn(),
-        search: jest.fn(),
-      };
 
       widget._refine(helper, range)(values);
 
-      expect(helper.addNumericRefinement).not.toHaveBeenCalledWith(
-        attributeName,
-        '>=',
-        0
+      expect(helper.getNumericRefinement(attributeName, '>=')).toEqual(
+        undefined
       );
-
-      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
-        attributeName,
-        '<=',
-        490
-      );
-
+      expect(helper.getNumericRefinement(attributeName, '<=')).toEqual([490]);
       expect(helper.clearRefinements).toHaveBeenCalled();
       expect(helper.search).toHaveBeenCalled();
     });
@@ -688,28 +610,15 @@ describe('connectRangeSlider', () => {
     it('expect to not refine max when no user bounds are set and value is at range bound', () => {
       const range = { min: 0, max: 500 };
       const values = [10, 500];
+      const helper = createHelper();
       const widget = connectRangeSlider(rendering)({ attributeName });
-      const helper = {
-        getNumericRefinement: jest.fn(() => []),
-        addNumericRefinement: jest.fn(),
-        clearRefinements: jest.fn(),
-        search: jest.fn(),
-      };
 
       widget._refine(helper, range)(values);
 
-      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
-        attributeName,
-        '>=',
-        10
+      expect(helper.getNumericRefinement(attributeName, '>=')).toEqual([10]);
+      expect(helper.getNumericRefinement(attributeName, '<=')).toEqual(
+        undefined
       );
-
-      expect(helper.addNumericRefinement).not.toHaveBeenCalledWith(
-        attributeName,
-        '<=',
-        500
-      );
-
       expect(helper.clearRefinements).toHaveBeenCalled();
       expect(helper.search).toHaveBeenCalled();
     });
@@ -717,28 +626,15 @@ describe('connectRangeSlider', () => {
     it("expect to not refine min when it's out of range", () => {
       const range = { min: 10, max: 500 };
       const values = [0, 490];
+      const helper = createHelper();
       const widget = connectRangeSlider(rendering)({ attributeName });
-      const helper = {
-        getNumericRefinement: jest.fn(() => []),
-        addNumericRefinement: jest.fn(),
-        clearRefinements: jest.fn(),
-        search: jest.fn(),
-      };
 
       widget._refine(helper, range)(values);
 
-      expect(helper.addNumericRefinement).not.toHaveBeenCalledWith(
-        attributeName,
-        '>=',
-        0
+      expect(helper.getNumericRefinement(attributeName, '>=')).toEqual(
+        undefined
       );
-
-      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
-        attributeName,
-        '<=',
-        490
-      );
-
+      expect(helper.getNumericRefinement(attributeName, '<=')).toEqual([490]);
       expect(helper.clearRefinements).toHaveBeenCalled();
       expect(helper.search).toHaveBeenCalled();
     });
@@ -746,28 +642,15 @@ describe('connectRangeSlider', () => {
     it("expect to not refine max when it's out of range", () => {
       const range = { min: 0, max: 490 };
       const values = [10, 500];
+      const helper = createHelper();
       const widget = connectRangeSlider(rendering)({ attributeName });
-      const helper = {
-        getNumericRefinement: jest.fn(() => []),
-        addNumericRefinement: jest.fn(),
-        clearRefinements: jest.fn(),
-        search: jest.fn(),
-      };
 
       widget._refine(helper, range)(values);
 
-      expect(helper.addNumericRefinement).toHaveBeenCalledWith(
-        attributeName,
-        '>=',
-        10
+      expect(helper.getNumericRefinement(attributeName, '>=')).toEqual([10]);
+      expect(helper.getNumericRefinement(attributeName, '<=')).toEqual(
+        undefined
       );
-
-      expect(helper.addNumericRefinement).not.toHaveBeenCalledWith(
-        attributeName,
-        '<=',
-        500
-      );
-
       expect(helper.clearRefinements).toHaveBeenCalled();
       expect(helper.search).toHaveBeenCalled();
     });
@@ -775,30 +658,16 @@ describe('connectRangeSlider', () => {
     it('expect to not refine when both values have not changed', () => {
       const range = { min: 0, max: 500 };
       const values = [10, 250];
+      const helper = createHelper();
       const widget = connectRangeSlider(rendering)({ attributeName });
-      const helper = {
-        getNumericRefinement: jest.fn(
-          (_, operation) => (operation === '>=' ? [10] : [250])
-        ),
-        addNumericRefinement: jest.fn(),
-        clearRefinements: jest.fn(),
-        search: jest.fn(),
-      };
+
+      helper.addNumericRefinement(attributeName, '>=', 10);
+      helper.addNumericRefinement(attributeName, '<=', 250);
 
       widget._refine(helper, range)(values);
 
-      expect(helper.addNumericRefinement).not.toHaveBeenCalledWith(
-        attributeName,
-        '>=',
-        10
-      );
-
-      expect(helper.addNumericRefinement).not.toHaveBeenCalledWith(
-        attributeName,
-        '<=',
-        250
-      );
-
+      expect(helper.getNumericRefinement(attributeName, '>=')).toEqual([10]);
+      expect(helper.getNumericRefinement(attributeName, '<=')).toEqual([250]);
       expect(helper.clearRefinements).not.toHaveBeenCalled();
       expect(helper.search).not.toHaveBeenCalled();
     });
@@ -806,17 +675,17 @@ describe('connectRangeSlider', () => {
     it('expect to not refine when values are invalid', () => {
       const range = { min: 0, max: 500 };
       const values = [null, null];
+      const helper = createHelper();
       const widget = connectRangeSlider(rendering)({ attributeName });
-      const helper = {
-        getNumericRefinement: jest.fn(),
-        addNumericRefinement: jest.fn(),
-        clearRefinements: jest.fn(),
-        search: jest.fn(),
-      };
 
       widget._refine(helper, range)(values);
 
-      expect(helper.addNumericRefinement).not.toHaveBeenCalledWith();
+      expect(helper.getNumericRefinement(attributeName, '>=')).toEqual(
+        undefined
+      );
+      expect(helper.getNumericRefinement(attributeName, '<=')).toEqual(
+        undefined
+      );
       expect(helper.clearRefinements).toHaveBeenCalled();
       expect(helper.search).toHaveBeenCalled();
     });

--- a/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
+++ b/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
@@ -43,7 +43,7 @@ describe('connectRangeSlider', () => {
       // should provide good values for the first rendering
       const { range, start, widgetParams } = rendering.lastCall.args[0];
       expect(range).toEqual({ min: 0, max: 0 });
-      expect(start).toEqual([0, 0]);
+      expect(start).toEqual([-Infinity, Infinity]);
       expect(widgetParams).toEqual({
         attributeName,
       });
@@ -429,7 +429,7 @@ describe('connectRangeSlider', () => {
         },
       };
 
-      const expectation = { min: 0, max: 0 };
+      const expectation = { min: -Infinity, max: Infinity };
       const actual = widget._getCurrentRefinement(helper, stats);
 
       expect(actual).toEqual(expectation);

--- a/src/connectors/range-slider/connectRangeSlider.js
+++ b/src/connectors/range-slider/connectRangeSlider.js
@@ -104,33 +104,6 @@ export default function connectRangeSlider(renderFn) {
         };
       },
 
-      getConfiguration: currentConfiguration => {
-        const configuration = {
-          disjunctiveFacets: [attributeName],
-        };
-
-        const boundsAlreadyDefined =
-          currentConfiguration &&
-          currentConfiguration.numericRefinements &&
-          currentConfiguration.numericRefinements[attributeName] !== undefined;
-
-        const isBoundsDefined = isMinBounds || isMaxBounds;
-
-        if (isBoundsDefined && !boundsAlreadyDefined) {
-          configuration.numericRefinements = { [attributeName]: {} };
-
-          if (isMinBounds) {
-            configuration.numericRefinements[attributeName]['>='] = [minBounds];
-          }
-
-          if (isMaxBounds) {
-            configuration.numericRefinements[attributeName]['<='] = [maxBounds];
-          }
-        }
-
-        return configuration;
-      },
-
       _getCurrentRefinement: (helper, stats = {}) => {
         const minValues = helper.state.getNumericRefinement(
           attributeName,
@@ -199,6 +172,33 @@ export default function connectRangeSlider(renderFn) {
 
           helper.search();
         }
+      },
+
+      getConfiguration: currentConfiguration => {
+        const configuration = {
+          disjunctiveFacets: [attributeName],
+        };
+
+        const boundsAlreadyDefined =
+          currentConfiguration &&
+          currentConfiguration.numericRefinements &&
+          currentConfiguration.numericRefinements[attributeName] !== undefined;
+
+        const isBoundsDefined = isMinBounds || isMaxBounds;
+
+        if (isBoundsDefined && !boundsAlreadyDefined) {
+          configuration.numericRefinements = { [attributeName]: {} };
+
+          if (isMinBounds) {
+            configuration.numericRefinements[attributeName]['>='] = [minBounds];
+          }
+
+          if (isMaxBounds) {
+            configuration.numericRefinements[attributeName]['<='] = [maxBounds];
+          }
+        }
+
+        return configuration;
       },
 
       init({ helper, instantSearchInstance }) {

--- a/src/connectors/range-slider/connectRangeSlider.js
+++ b/src/connectors/range-slider/connectRangeSlider.js
@@ -123,25 +123,38 @@ export default function connectRangeSlider(renderFn) {
         return conf;
       },
 
-      _getCurrentRefinement(helper) {
-        let min = helper.state.getNumericRefinement(attributeName, '>=');
-        let max = helper.state.getNumericRefinement(attributeName, '<=');
+      _getCurrentRefinement(helper, stats = {}) {
+        const minValues = helper.state.getNumericRefinement(
+          attributeName,
+          '>='
+        );
 
-        if (min && min.length) {
-          min = min[0];
+        const maxValues = helper.state.getNumericRefinement(
+          attributeName,
+          '<='
+        );
+
+        let min;
+        if (minValues && minValues.length) {
+          min = minValues[0];
+        } else if (stats.min !== undefined && stats.min !== null) {
+          min = stats.min;
         } else {
           min = -Infinity;
         }
 
-        if (max && max.length) {
-          max = max[0];
+        let max;
+        if (maxValues && maxValues.length) {
+          max = maxValues[0];
+        } else if (stats.max !== undefined && stats.max !== null) {
+          max = stats.max;
         } else {
           max = Infinity;
         }
 
         return {
-          min,
-          max,
+          min: Math.floor(min),
+          max: Math.ceil(max),
         };
       },
 
@@ -194,7 +207,7 @@ export default function connectRangeSlider(renderFn) {
         const bounds = { min: userMin, max: userMax };
         const stats = {};
         const currentRange = this._getCurrentRange(bounds, stats);
-        const currentRefinement = this._getCurrentRefinement(helper);
+        const currentRefinement = this._getCurrentRefinement(helper, stats);
 
         renderFn(
           {
@@ -216,7 +229,7 @@ export default function connectRangeSlider(renderFn) {
         const stats = facet && facet.stats;
 
         const currentRange = this._getCurrentRange(bounds, stats);
-        const currentRefinement = this._getCurrentRefinement(helper);
+        const currentRefinement = this._getCurrentRefinement(helper, stats);
 
         renderFn(
           {

--- a/src/connectors/range-slider/connectRangeSlider.js
+++ b/src/connectors/range-slider/connectRangeSlider.js
@@ -166,58 +166,58 @@ export default function connectRangeSlider(renderFn) {
         };
       },
 
-      init({ helper, instantSearchInstance }) {
-        this._refine = newValues => {
-          const currentValues = [
-            helper.getNumericRefinement(attributeName, '>='),
-            helper.getNumericRefinement(attributeName, '<='),
-          ];
+      _refine: helper => newValues => {
+        const currentValues = [
+          helper.getNumericRefinement(attributeName, '>='),
+          helper.getNumericRefinement(attributeName, '<='),
+        ];
+
+        if (
+          currentValues[0] !== newValues[0] ||
+          currentValues[1] !== newValues[1]
+        ) {
+          helper.clearRefinements();
+
+          const minValueChanged =
+            newValues[0] !== null && newValues[0] !== undefined;
 
           if (
-            currentValues[0] !== newValues[0] ||
-            currentValues[1] !== newValues[1]
+            (isMinBounds && minValueChanged && minBounds < newValues[0]) ||
+            (!isMinBounds && minValueChanged)
           ) {
-            helper.clearRefinements(attributeName);
-
-            const minValueChanged =
-              newValues[0] !== null && newValues[0] !== undefined;
-
-            if (
-              (isMinBounds && minValueChanged && minBounds < newValues[0]) ||
-              (!isMinBounds && minValueChanged)
-            ) {
-              helper.addNumericRefinement(
-                attributeName,
-                '>=',
-                formatToNumber(newValues[0])
-              );
-            }
-
-            const maxValueChanged =
-              newValues[1] !== null && newValues[1] !== undefined;
-
-            if (
-              (isMaxBounds && maxValueChanged && maxBounds > newValues[1]) ||
-              (!isMaxBounds && maxValueChanged)
-            ) {
-              helper.addNumericRefinement(
-                attributeName,
-                '<=',
-                formatToNumber(newValues[1])
-              );
-            }
-
-            helper.search();
+            helper.addNumericRefinement(
+              attributeName,
+              '>=',
+              formatToNumber(newValues[0])
+            );
           }
-        };
 
+          const maxValueChanged =
+            newValues[1] !== null && newValues[1] !== undefined;
+
+          if (
+            (isMaxBounds && maxValueChanged && maxBounds > newValues[1]) ||
+            (!isMaxBounds && maxValueChanged)
+          ) {
+            helper.addNumericRefinement(
+              attributeName,
+              '<=',
+              formatToNumber(newValues[1])
+            );
+          }
+
+          helper.search();
+        }
+      },
+
+      init({ helper, instantSearchInstance }) {
         const stats = {};
         const currentRange = this._getCurrentRange(stats);
         const currentRefinement = this._getCurrentRefinement(helper, stats);
 
         renderFn(
           {
-            refine: this._refine,
+            refine: this._refine(helper),
             range: currentRange,
             start: [currentRefinement.min, currentRefinement.max],
             format: sliderFormatter,
@@ -238,7 +238,7 @@ export default function connectRangeSlider(renderFn) {
 
         renderFn(
           {
-            refine: this._refine,
+            refine: this._refine(helper),
             range: currentRange,
             start: [currentRefinement.min, currentRefinement.max],
             format: sliderFormatter,

--- a/src/connectors/range-slider/connectRangeSlider.js
+++ b/src/connectors/range-slider/connectRangeSlider.js
@@ -139,32 +139,42 @@ export default function connectRangeSlider(renderFn) {
         };
       },
 
-      _refine: helper => ([nextMin, nextMax] = []) => {
+      _refine: (helper, range = {}) => ([nextMin, nextMax] = []) => {
+        const { min: rangeMin, max: rangeMax } = range;
+
         const [min] = helper.getNumericRefinement(attributeName, '>=') || [];
         const [max] = helper.getNumericRefinement(attributeName, '<=') || [];
 
-        if (min !== nextMin || max !== nextMax) {
+        const newNextMin =
+          !isMinBounds && rangeMin === nextMin ? undefined : nextMin;
+
+        const newNextMax =
+          !isMaxBounds && rangeMax === nextMax ? undefined : nextMax;
+
+        if (min !== newNextMin || max !== newNextMax) {
           helper.clearRefinements();
 
-          const isValidMinInput = nextMin !== null && nextMin !== undefined;
-          const isGreatherThanBounds = isMinBounds && minBounds <= nextMin;
+          const isValidMinInput =
+            newNextMin !== null && newNextMin !== undefined;
+          const isGreatherThanBounds = isMinBounds && minBounds <= newNextMin;
 
           if (isValidMinInput && (!isMinBounds || isGreatherThanBounds)) {
             helper.addNumericRefinement(
               attributeName,
               '>=',
-              formatToNumber(nextMin)
+              formatToNumber(newNextMin)
             );
           }
 
-          const isValidMaxInput = nextMax !== null && nextMax !== undefined;
-          const isLowerThanBounds = isMaxBounds && maxBounds >= nextMax;
+          const isValidMaxInput =
+            newNextMax !== null && newNextMax !== undefined;
+          const isLowerThanBounds = isMaxBounds && maxBounds >= newNextMax;
 
           if (isValidMaxInput && (!isMaxBounds || isLowerThanBounds)) {
             helper.addNumericRefinement(
               attributeName,
               '<=',
-              formatToNumber(nextMax)
+              formatToNumber(newNextMax)
             );
           }
 
@@ -206,7 +216,7 @@ export default function connectRangeSlider(renderFn) {
 
         renderFn(
           {
-            refine: this._refine(helper),
+            refine: this._refine(helper, currentRange),
             range: currentRange,
             start: [currentRefinement.min, currentRefinement.max],
             format: sliderFormatter,
@@ -227,7 +237,7 @@ export default function connectRangeSlider(renderFn) {
 
         renderFn(
           {
-            refine: this._refine(helper),
+            refine: this._refine(helper, currentRange),
             range: currentRange,
             start: [currentRefinement.min, currentRefinement.max],
             format: sliderFormatter,

--- a/src/connectors/range-slider/connectRangeSlider.js
+++ b/src/connectors/range-slider/connectRangeSlider.js
@@ -215,15 +215,15 @@ export default function connectRangeSlider(renderFn) {
 
       init({ helper, instantSearchInstance }) {
         const stats = {};
-        const currentRange = this._getCurrentRange(stats);
-        const currentRefinement = this._getCurrentRefinement(helper);
+        const range = this._getCurrentRange(stats);
+        const { min, max } = this._getCurrentRefinement(helper);
 
         renderFn(
           {
-            refine: this._refine(helper, currentRange),
-            range: currentRange,
-            start: [currentRefinement.min, currentRefinement.max],
+            refine: this._refine(helper, range),
+            start: [min, max],
             format: sliderFormatter,
+            range,
             widgetParams,
             instantSearchInstance,
           },
@@ -236,15 +236,15 @@ export default function connectRangeSlider(renderFn) {
         const facet = find(facetsFromResults, _ => _.name === attributeName);
         const stats = facet && facet.stats;
 
-        const currentRange = this._getCurrentRange(stats);
-        const currentRefinement = this._getCurrentRefinement(helper);
+        const range = this._getCurrentRange(stats);
+        const { min, max } = this._getCurrentRefinement(helper);
 
         renderFn(
           {
-            refine: this._refine(helper, currentRange),
-            range: currentRange,
-            start: [currentRefinement.min, currentRefinement.max],
+            refine: this._refine(helper, range),
+            start: [min, max],
             format: sliderFormatter,
+            range,
             widgetParams,
             instantSearchInstance,
           },

--- a/src/connectors/range-slider/connectRangeSlider.js
+++ b/src/connectors/range-slider/connectRangeSlider.js
@@ -60,8 +60,8 @@ export default function connectRangeSlider(renderFn) {
   return (widgetParams = {}) => {
     const {
       attributeName,
-      min: minBounds,
-      max: maxBounds,
+      min: minBound,
+      max: maxBound,
       precision = 2,
     } = widgetParams;
 
@@ -69,8 +69,8 @@ export default function connectRangeSlider(renderFn) {
       throw new Error(usage);
     }
 
-    const hasMinBound = _isFinite(minBounds);
-    const hasMaxBound = _isFinite(maxBounds);
+    const hasMinBound = _isFinite(minBound);
+    const hasMaxBound = _isFinite(maxBound);
 
     const formatToNumber = v => Number(Number(v).toFixed(precision));
 
@@ -94,7 +94,7 @@ export default function connectRangeSlider(renderFn) {
       _getCurrentRange(stats = {}) {
         let min;
         if (hasMinBound) {
-          min = minBounds;
+          min = minBound;
         } else if (_isFinite(stats.min)) {
           min = stats.min;
         } else {
@@ -103,7 +103,7 @@ export default function connectRangeSlider(renderFn) {
 
         let max;
         if (hasMaxBound) {
-          max = maxBounds;
+          max = maxBound;
         } else if (_isFinite(stats.max)) {
           max = stats.max;
         } else {
@@ -189,17 +189,17 @@ export default function connectRangeSlider(renderFn) {
           currentConfiguration.numericRefinements[attributeName] !== undefined;
 
         const isBoundsDefined = hasMinBound || hasMaxBound;
-        const isAbleToRefine = this._isAbleToRefine(minBounds, maxBounds);
+        const isAbleToRefine = this._isAbleToRefine(minBound, maxBound);
 
         if (isBoundsDefined && !boundsAlreadyDefined && isAbleToRefine) {
           configuration.numericRefinements = { [attributeName]: {} };
 
           if (hasMinBound) {
-            configuration.numericRefinements[attributeName]['>='] = [minBounds];
+            configuration.numericRefinements[attributeName]['>='] = [minBound];
           }
 
           if (hasMaxBound) {
-            configuration.numericRefinements[attributeName]['<='] = [maxBounds];
+            configuration.numericRefinements[attributeName]['<='] = [maxBound];
           }
         }
 

--- a/src/connectors/range-slider/connectRangeSlider.js
+++ b/src/connectors/range-slider/connectRangeSlider.js
@@ -105,19 +105,15 @@ export default function connectRangeSlider(renderFn) {
       },
 
       _getCurrentRefinement: (helper, stats = {}) => {
-        const minValues = helper.state.getNumericRefinement(
-          attributeName,
-          '>='
-        );
+        const [minValue] =
+          helper.state.getNumericRefinement(attributeName, '>=') || [];
 
-        const maxValues = helper.state.getNumericRefinement(
-          attributeName,
-          '<='
-        );
+        const [maxValue] =
+          helper.state.getNumericRefinement(attributeName, '<=') || [];
 
         let min;
-        if (minValues && minValues.length) {
-          min = minValues[0];
+        if (minValue !== undefined && minValue !== null) {
+          min = minValue;
         } else if (stats.min !== undefined && stats.min !== null) {
           min = stats.min;
         } else {
@@ -125,8 +121,8 @@ export default function connectRangeSlider(renderFn) {
         }
 
         let max;
-        if (maxValues && maxValues.length) {
-          max = maxValues[0];
+        if (maxValue !== undefined && maxValue !== null) {
+          max = maxValue;
         } else if (stats.max !== undefined && stats.max !== null) {
           max = stats.max;
         } else {

--- a/src/connectors/range-slider/connectRangeSlider.js
+++ b/src/connectors/range-slider/connectRangeSlider.js
@@ -1,4 +1,5 @@
 import find from 'lodash/find';
+import _isFinite from 'lodash/isFinite';
 
 import { checkRendering } from '../../lib/utils.js';
 
@@ -68,8 +69,8 @@ export default function connectRangeSlider(renderFn) {
       throw new Error(usage);
     }
 
-    const isMinBounds = minBounds !== undefined && minBounds !== null;
-    const isMaxBounds = maxBounds !== undefined && maxBounds !== null;
+    const isMinBounds = _isFinite(minBounds);
+    const isMaxBounds = _isFinite(maxBounds);
 
     const formatToNumber = v => Number(Number(v).toFixed(precision));
 
@@ -80,8 +81,8 @@ export default function connectRangeSlider(renderFn) {
 
     return {
       _isAbleToRefine(min, max) {
-        const isMinValid = min !== undefined && min !== null;
-        const isMaxValid = max !== undefined && max !== null;
+        const isMinValid = _isFinite(min);
+        const isMaxValid = _isFinite(max);
 
         if (isMinValid && isMaxValid && min >= max) {
           return false;
@@ -94,7 +95,7 @@ export default function connectRangeSlider(renderFn) {
         let min;
         if (isMinBounds) {
           min = minBounds;
-        } else if (stats.min !== undefined && stats.min !== null) {
+        } else if (_isFinite(stats.min)) {
           min = stats.min;
         } else {
           min = 0;
@@ -103,7 +104,7 @@ export default function connectRangeSlider(renderFn) {
         let max;
         if (isMaxBounds) {
           max = maxBounds;
-        } else if (stats.max !== undefined && stats.max !== null) {
+        } else if (_isFinite(stats.max)) {
           max = stats.max;
         } else {
           max = 0;
@@ -123,14 +124,14 @@ export default function connectRangeSlider(renderFn) {
           helper.state.getNumericRefinement(attributeName, '<=') || [];
 
         let min;
-        if (minValue !== undefined && minValue !== null) {
+        if (_isFinite(minValue)) {
           min = minValue;
         } else {
           min = -Infinity;
         }
 
         let max;
-        if (maxValue !== undefined && maxValue !== null) {
+        if (_isFinite(maxValue)) {
           max = maxValue;
         } else {
           max = Infinity;
@@ -158,11 +159,8 @@ export default function connectRangeSlider(renderFn) {
           if (min !== newNextMin || max !== newNextMax) {
             helper.clearRefinements();
 
-            const isValidMinInput =
-              newNextMin !== undefined && newNextMin !== null;
-
-            const isValidMinRange = rangeMin !== undefined && rangeMin !== null;
-
+            const isValidMinInput = _isFinite(newNextMin);
+            const isValidMinRange = _isFinite(rangeMin);
             const isGreatherThanRange =
               isValidMinRange && rangeMin <= newNextMin;
 
@@ -174,11 +172,8 @@ export default function connectRangeSlider(renderFn) {
               );
             }
 
-            const isValidMaxInput =
-              newNextMax !== undefined && newNextMax !== null;
-
-            const isValidMaxRange = rangeMax !== undefined && rangeMax !== null;
-
+            const isValidMaxInput = _isFinite(newNextMax);
+            const isValidMaxRange = _isFinite(rangeMax);
             const isLowerThanRange = isValidMaxRange && rangeMax >= newNextMax;
 
             if (isValidMaxInput && (!isValidMaxRange || isLowerThanRange)) {

--- a/src/connectors/range-slider/connectRangeSlider.js
+++ b/src/connectors/range-slider/connectRangeSlider.js
@@ -76,6 +76,31 @@ export default function connectRangeSlider(renderFn) {
     };
 
     return {
+      _getCurrentRange: (bounds = {}, stats = {}) => {
+        let min;
+        if (bounds.min !== undefined && bounds.min !== null) {
+          min = bounds.min;
+        } else if (stats.min !== undefined && stats.min !== null) {
+          min = stats.min;
+        } else {
+          min = 0;
+        }
+
+        let max;
+        if (bounds.max !== undefined && bounds.max !== null) {
+          max = bounds.max;
+        } else if (stats.max !== undefined && stats.max !== null) {
+          max = stats.max;
+        } else {
+          max = 0;
+        }
+
+        return {
+          min: Math.floor(min),
+          max: Math.ceil(max),
+        };
+      },
+
       getConfiguration: originalConf => {
         const conf = {
           disjunctiveFacets: [attributeName],
@@ -166,16 +191,15 @@ export default function connectRangeSlider(renderFn) {
           }
         };
 
-        const stats = {
-          min: userMin || null,
-          max: userMax || null,
-        };
+        const bounds = { min: userMin, max: userMax };
+        const stats = {};
+        const currentRange = this._getCurrentRange(bounds, stats);
         const currentRefinement = this._getCurrentRefinement(helper);
 
         renderFn(
           {
-            refine: this._refine(stats),
-            range: { min: Math.floor(stats.min), max: Math.ceil(stats.max) },
+            refine: this._refine(bounds),
+            range: currentRange,
             start: [currentRefinement.min, currentRefinement.max],
             format: sliderFormatter,
             widgetParams,
@@ -186,28 +210,18 @@ export default function connectRangeSlider(renderFn) {
       },
 
       render({ results, helper, instantSearchInstance }) {
+        const bounds = { min: userMin, max: userMax };
         const facetsFromResults = results.disjunctiveFacets || [];
-        const facet = find(
-          facetsFromResults,
-          ({ name }) => name === attributeName
-        );
-        const stats =
-          facet !== undefined && facet.stats !== undefined
-            ? facet.stats
-            : {
-                min: null,
-                max: null,
-              };
+        const facet = find(facetsFromResults, _ => _.name === attributeName);
+        const stats = facet && facet.stats;
 
-        if (userMin !== undefined) stats.min = userMin;
-        if (userMax !== undefined) stats.max = userMax;
-
+        const currentRange = this._getCurrentRange(bounds, stats);
         const currentRefinement = this._getCurrentRefinement(helper);
 
         renderFn(
           {
-            refine: this._refine(stats),
-            range: { min: Math.floor(stats.min), max: Math.ceil(stats.max) },
+            refine: this._refine(bounds),
+            range: currentRange,
             start: [currentRefinement.min, currentRefinement.max],
             format: sliderFormatter,
             widgetParams,

--- a/src/connectors/range-slider/connectRangeSlider.js
+++ b/src/connectors/range-slider/connectRangeSlider.js
@@ -69,8 +69,8 @@ export default function connectRangeSlider(renderFn) {
       throw new Error(usage);
     }
 
-    const isMinBounds = _isFinite(minBounds);
-    const isMaxBounds = _isFinite(maxBounds);
+    const hasMinBound = _isFinite(minBounds);
+    const hasMaxBound = _isFinite(maxBounds);
 
     const formatToNumber = v => Number(Number(v).toFixed(precision));
 
@@ -93,7 +93,7 @@ export default function connectRangeSlider(renderFn) {
 
       _getCurrentRange(stats = {}) {
         let min;
-        if (isMinBounds) {
+        if (hasMinBound) {
           min = minBounds;
         } else if (_isFinite(stats.min)) {
           min = stats.min;
@@ -102,7 +102,7 @@ export default function connectRangeSlider(renderFn) {
         }
 
         let max;
-        if (isMaxBounds) {
+        if (hasMaxBound) {
           max = maxBounds;
         } else if (_isFinite(stats.max)) {
           max = stats.max;
@@ -140,10 +140,10 @@ export default function connectRangeSlider(renderFn) {
           const [max] = helper.getNumericRefinement(attributeName, '<=') || [];
 
           const newNextMin =
-            !isMinBounds && rangeMin === nextMin ? undefined : nextMin;
+            !hasMinBound && rangeMin === nextMin ? undefined : nextMin;
 
           const newNextMax =
-            !isMaxBounds && rangeMax === nextMax ? undefined : nextMax;
+            !hasMaxBound && rangeMax === nextMax ? undefined : nextMax;
 
           if (min !== newNextMin || max !== newNextMax) {
             helper.clearRefinements();
@@ -188,17 +188,17 @@ export default function connectRangeSlider(renderFn) {
           currentConfiguration.numericRefinements &&
           currentConfiguration.numericRefinements[attributeName] !== undefined;
 
-        const isBoundsDefined = isMinBounds || isMaxBounds;
+        const isBoundsDefined = hasMinBound || hasMaxBound;
         const isAbleToRefine = this._isAbleToRefine(minBounds, maxBounds);
 
         if (isBoundsDefined && !boundsAlreadyDefined && isAbleToRefine) {
           configuration.numericRefinements = { [attributeName]: {} };
 
-          if (isMinBounds) {
+          if (hasMinBound) {
             configuration.numericRefinements[attributeName]['>='] = [minBounds];
           }
 
-          if (isMaxBounds) {
+          if (hasMaxBound) {
             configuration.numericRefinements[attributeName]['<='] = [maxBounds];
           }
         }

--- a/src/connectors/range-slider/connectRangeSlider.js
+++ b/src/connectors/range-slider/connectRangeSlider.js
@@ -115,7 +115,7 @@ export default function connectRangeSlider(renderFn) {
         const min = _isFinite(minValue) ? minValue : -Infinity;
         const max = _isFinite(maxValue) ? maxValue : Infinity;
 
-        return [Math.floor(min), Math.ceil(max)];
+        return [min, max];
       },
 
       _refine(helper, range = {}) {

--- a/src/connectors/range-slider/connectRangeSlider.js
+++ b/src/connectors/range-slider/connectRangeSlider.js
@@ -101,26 +101,33 @@ export default function connectRangeSlider(renderFn) {
         };
       },
 
-      getConfiguration: originalConf => {
-        const conf = {
+      getConfiguration: currentConfiguration => {
+        const configuration = {
           disjunctiveFacets: [attributeName],
         };
 
-        const hasUserBounds = userMin !== undefined || userMax !== undefined;
-        const boundsAlreadyDefined =
-          originalConf &&
-          originalConf.numericRefinements &&
-          originalConf.numericRefinements[attributeName] !== undefined;
+        const isMinBound = userMin !== undefined && userMin !== null;
+        const isMaxBound = userMax !== undefined && userMax !== null;
+        const boundsDefined = isMinBound || isMaxBound;
 
-        if (hasUserBounds && !boundsAlreadyDefined) {
-          conf.numericRefinements = { [attributeName]: {} };
-          if (userMin !== undefined)
-            conf.numericRefinements[attributeName]['>='] = [userMin];
-          if (userMax !== undefined)
-            conf.numericRefinements[attributeName]['<='] = [userMax];
+        const boundsAlreadyDefined =
+          currentConfiguration &&
+          currentConfiguration.numericRefinements &&
+          currentConfiguration.numericRefinements[attributeName] !== undefined;
+
+        if (boundsDefined && !boundsAlreadyDefined) {
+          configuration.numericRefinements = { [attributeName]: {} };
+
+          if (isMinBound) {
+            configuration.numericRefinements[attributeName]['>='] = [userMin];
+          }
+
+          if (isMaxBound) {
+            configuration.numericRefinements[attributeName]['<='] = [userMax];
+          }
         }
 
-        return conf;
+        return configuration;
       },
 
       _getCurrentRefinement(helper, stats = {}) {

--- a/src/connectors/range-slider/connectRangeSlider.js
+++ b/src/connectors/range-slider/connectRangeSlider.js
@@ -123,19 +123,8 @@ export default function connectRangeSlider(renderFn) {
         const [maxValue] =
           helper.state.getNumericRefinement(attributeName, '<=') || [];
 
-        let min;
-        if (_isFinite(minValue)) {
-          min = minValue;
-        } else {
-          min = -Infinity;
-        }
-
-        let max;
-        if (_isFinite(maxValue)) {
-          max = maxValue;
-        } else {
-          max = Infinity;
-        }
+        const min = _isFinite(minValue) ? minValue : -Infinity;
+        const max = _isFinite(maxValue) ? maxValue : Infinity;
 
         return {
           min: Math.floor(min),

--- a/src/connectors/range-slider/connectRangeSlider.js
+++ b/src/connectors/range-slider/connectRangeSlider.js
@@ -34,9 +34,9 @@ Full documentation available at https://community.algolia.com/instantsearch.js/c
 
 /**
  * @typedef {Object} RangeSliderRenderingOptions
- * @property {function({min: number, max: number})} refine Sets a range to filter the results on. Both values
+ * @property {function(Array<number, number>)} refine Sets a range to filter the results on. Both values
  * are optional, and will default to the higher and lower bounds.
- * @property {{min: number, max: number}} numeric Results bounds without the current range filter.
+ * @property {{min: number, max: number}} range Results bounds without the current range filter.
  * @property {Array<number, number>} start Current numeric bounds of the search.
  * @property {{from: function, to: function}} formatter Transform for the rendering `from` and/or `to` values.
  * Both functions take a `number` as input and should output a `string`.

--- a/src/connectors/range-slider/connectRangeSlider.js
+++ b/src/connectors/range-slider/connectRangeSlider.js
@@ -115,10 +115,7 @@ export default function connectRangeSlider(renderFn) {
         const min = _isFinite(minValue) ? minValue : -Infinity;
         const max = _isFinite(maxValue) ? maxValue : Infinity;
 
-        return {
-          min: Math.floor(min),
-          max: Math.ceil(max),
-        };
+        return [Math.floor(min), Math.ceil(max)];
       },
 
       _refine(helper, range = {}) {
@@ -204,7 +201,7 @@ export default function connectRangeSlider(renderFn) {
       init({ helper, instantSearchInstance }) {
         const stats = {};
         const range = this._getCurrentRange(stats);
-        const { min, max } = this._getCurrentRefinement(helper);
+        const start = this._getCurrentRefinement(helper);
 
         renderFn(
           {
@@ -212,9 +209,9 @@ export default function connectRangeSlider(renderFn) {
             // to be able to bypass the validation
             // related to it
             refine: this._refine(helper, {}),
-            start: [min, max],
             format: sliderFormatter,
             range,
+            start,
             widgetParams,
             instantSearchInstance,
           },
@@ -228,14 +225,14 @@ export default function connectRangeSlider(renderFn) {
         const stats = facet && facet.stats;
 
         const range = this._getCurrentRange(stats);
-        const { min, max } = this._getCurrentRefinement(helper);
+        const start = this._getCurrentRefinement(helper);
 
         renderFn(
           {
             refine: this._refine(helper, range),
-            start: [min, max],
             format: sliderFormatter,
             range,
+            start,
             widgetParams,
             instantSearchInstance,
           },

--- a/src/connectors/range-slider/connectRangeSlider.js
+++ b/src/connectors/range-slider/connectRangeSlider.js
@@ -233,7 +233,7 @@ export default function connectRangeSlider(renderFn) {
 
       render({ results, helper, instantSearchInstance }) {
         const facetsFromResults = results.disjunctiveFacets || [];
-        const facet = find(facetsFromResults, _ => _.name === attributeName);
+        const facet = find(facetsFromResults, { name: attributeName });
         const stats = facet && facet.stats;
 
         const range = this._getCurrentRange(stats);

--- a/src/connectors/range-slider/connectRangeSlider.js
+++ b/src/connectors/range-slider/connectRangeSlider.js
@@ -115,7 +115,7 @@ export default function connectRangeSlider(renderFn) {
         };
       },
 
-      _getCurrentRefinement: (helper, stats = {}) => {
+      _getCurrentRefinement: helper => {
         const [minValue] =
           helper.state.getNumericRefinement(attributeName, '>=') || [];
 
@@ -125,8 +125,6 @@ export default function connectRangeSlider(renderFn) {
         let min;
         if (minValue !== undefined && minValue !== null) {
           min = minValue;
-        } else if (stats.min !== undefined && stats.min !== null) {
-          min = stats.min;
         } else {
           min = -Infinity;
         }
@@ -134,8 +132,6 @@ export default function connectRangeSlider(renderFn) {
         let max;
         if (maxValue !== undefined && maxValue !== null) {
           max = maxValue;
-        } else if (stats.max !== undefined && stats.max !== null) {
-          max = stats.max;
         } else {
           max = Infinity;
         }
@@ -220,7 +216,7 @@ export default function connectRangeSlider(renderFn) {
       init({ helper, instantSearchInstance }) {
         const stats = {};
         const currentRange = this._getCurrentRange(stats);
-        const currentRefinement = this._getCurrentRefinement(helper, stats);
+        const currentRefinement = this._getCurrentRefinement(helper);
 
         renderFn(
           {
@@ -241,7 +237,7 @@ export default function connectRangeSlider(renderFn) {
         const stats = facet && facet.stats;
 
         const currentRange = this._getCurrentRange(stats);
-        const currentRefinement = this._getCurrentRefinement(helper, stats);
+        const currentRefinement = this._getCurrentRefinement(helper);
 
         renderFn(
           {

--- a/src/connectors/range-slider/connectRangeSlider.js
+++ b/src/connectors/range-slider/connectRangeSlider.js
@@ -140,10 +140,8 @@ export default function connectRangeSlider(renderFn) {
       },
 
       _refine: helper => ([nextMin, nextMax] = []) => {
-        const [min, max] = [
-          helper.getNumericRefinement(attributeName, '>='),
-          helper.getNumericRefinement(attributeName, '<='),
-        ];
+        const [min] = helper.getNumericRefinement(attributeName, '>=') || [];
+        const [max] = helper.getNumericRefinement(attributeName, '<=') || [];
 
         if (min !== nextMin || max !== nextMax) {
           helper.clearRefinements();

--- a/src/connectors/range-slider/connectRangeSlider.js
+++ b/src/connectors/range-slider/connectRangeSlider.js
@@ -131,7 +131,7 @@ export default function connectRangeSlider(renderFn) {
         return configuration;
       },
 
-      _getCurrentRefinement(helper, stats = {}) {
+      _getCurrentRefinement: (helper, stats = {}) => {
         const minValues = helper.state.getNumericRefinement(
           attributeName,
           '>='

--- a/src/connectors/range-slider/connectRangeSlider.js
+++ b/src/connectors/range-slider/connectRangeSlider.js
@@ -79,7 +79,7 @@ export default function connectRangeSlider(renderFn) {
     };
 
     return {
-      _isAbleToRefine: (min, max) => {
+      _isAbleToRefine(min, max) {
         const isMinValid = min !== undefined && min !== null;
         const isMaxValid = max !== undefined && max !== null;
 
@@ -90,7 +90,7 @@ export default function connectRangeSlider(renderFn) {
         return isMinValid || isMaxValid;
       },
 
-      _getCurrentRange: (stats = {}) => {
+      _getCurrentRange(stats = {}) {
         let min;
         if (isMinBounds) {
           min = minBounds;
@@ -115,7 +115,7 @@ export default function connectRangeSlider(renderFn) {
         };
       },
 
-      _getCurrentRefinement: helper => {
+      _getCurrentRefinement(helper) {
         const [minValue] =
           helper.state.getNumericRefinement(attributeName, '>=') || [];
 
@@ -142,47 +142,49 @@ export default function connectRangeSlider(renderFn) {
         };
       },
 
-      _refine: (helper, range = {}) => ([nextMin, nextMax] = []) => {
-        const { min: rangeMin, max: rangeMax } = range;
+      _refine(helper, range = {}) {
+        return ([nextMin, nextMax] = []) => {
+          const { min: rangeMin, max: rangeMax } = range;
 
-        const [min] = helper.getNumericRefinement(attributeName, '>=') || [];
-        const [max] = helper.getNumericRefinement(attributeName, '<=') || [];
+          const [min] = helper.getNumericRefinement(attributeName, '>=') || [];
+          const [max] = helper.getNumericRefinement(attributeName, '<=') || [];
 
-        const newNextMin =
-          !isMinBounds && rangeMin === nextMin ? undefined : nextMin;
+          const newNextMin =
+            !isMinBounds && rangeMin === nextMin ? undefined : nextMin;
 
-        const newNextMax =
-          !isMaxBounds && rangeMax === nextMax ? undefined : nextMax;
+          const newNextMax =
+            !isMaxBounds && rangeMax === nextMax ? undefined : nextMax;
 
-        if (min !== newNextMin || max !== newNextMax) {
-          helper.clearRefinements();
+          if (min !== newNextMin || max !== newNextMax) {
+            helper.clearRefinements();
 
-          const isValidMinInput =
-            newNextMin !== null && newNextMin !== undefined;
-          const isGreatherThanBounds = isMinBounds && minBounds <= newNextMin;
+            const isValidMinInput =
+              newNextMin !== null && newNextMin !== undefined;
+            const isGreatherThanBounds = isMinBounds && minBounds <= newNextMin;
 
-          if (isValidMinInput && (!isMinBounds || isGreatherThanBounds)) {
-            helper.addNumericRefinement(
-              attributeName,
-              '>=',
-              formatToNumber(newNextMin)
-            );
+            if (isValidMinInput && (!isMinBounds || isGreatherThanBounds)) {
+              helper.addNumericRefinement(
+                attributeName,
+                '>=',
+                formatToNumber(newNextMin)
+              );
+            }
+
+            const isValidMaxInput =
+              newNextMax !== null && newNextMax !== undefined;
+            const isLowerThanBounds = isMaxBounds && maxBounds >= newNextMax;
+
+            if (isValidMaxInput && (!isMaxBounds || isLowerThanBounds)) {
+              helper.addNumericRefinement(
+                attributeName,
+                '<=',
+                formatToNumber(newNextMax)
+              );
+            }
+
+            helper.search();
           }
-
-          const isValidMaxInput =
-            newNextMax !== null && newNextMax !== undefined;
-          const isLowerThanBounds = isMaxBounds && maxBounds >= newNextMax;
-
-          if (isValidMaxInput && (!isMaxBounds || isLowerThanBounds)) {
-            helper.addNumericRefinement(
-              attributeName,
-              '<=',
-              formatToNumber(newNextMax)
-            );
-          }
-
-          helper.search();
-        }
+        };
       },
 
       getConfiguration(currentConfiguration) {

--- a/src/connectors/range-slider/connectRangeSlider.js
+++ b/src/connectors/range-slider/connectRangeSlider.js
@@ -159,10 +159,14 @@ export default function connectRangeSlider(renderFn) {
             helper.clearRefinements();
 
             const isValidMinInput =
-              newNextMin !== null && newNextMin !== undefined;
-            const isGreatherThanBounds = isMinBounds && minBounds <= newNextMin;
+              newNextMin !== undefined && newNextMin !== null;
 
-            if (isValidMinInput && (!isMinBounds || isGreatherThanBounds)) {
+            const isValidMinRange = rangeMin !== undefined && rangeMin !== null;
+
+            const isGreatherThanRange =
+              isValidMinRange && rangeMin <= newNextMin;
+
+            if (isValidMinInput && (!isValidMinRange || isGreatherThanRange)) {
               helper.addNumericRefinement(
                 attributeName,
                 '>=',
@@ -171,10 +175,13 @@ export default function connectRangeSlider(renderFn) {
             }
 
             const isValidMaxInput =
-              newNextMax !== null && newNextMax !== undefined;
-            const isLowerThanBounds = isMaxBounds && maxBounds >= newNextMax;
+              newNextMax !== undefined && newNextMax !== null;
 
-            if (isValidMaxInput && (!isMaxBounds || isLowerThanBounds)) {
+            const isValidMaxRange = rangeMax !== undefined && rangeMax !== null;
+
+            const isLowerThanRange = isValidMaxRange && rangeMax >= newNextMax;
+
+            if (isValidMaxInput && (!isValidMaxRange || isLowerThanRange)) {
               helper.addNumericRefinement(
                 attributeName,
                 '<=',
@@ -222,7 +229,10 @@ export default function connectRangeSlider(renderFn) {
 
         renderFn(
           {
-            refine: this._refine(helper, range),
+            // On first render pass an empty range
+            // to be able to bypass the validation
+            // related to it
+            refine: this._refine(helper, {}),
             start: [min, max],
             format: sliderFormatter,
             range,

--- a/src/connectors/range-slider/connectRangeSlider.js
+++ b/src/connectors/range-slider/connectRangeSlider.js
@@ -80,17 +80,6 @@ export default function connectRangeSlider(renderFn) {
     };
 
     return {
-      _isAbleToRefine(min, max) {
-        const isMinValid = _isFinite(min);
-        const isMaxValid = _isFinite(max);
-
-        if (isMinValid && isMaxValid && min >= max) {
-          return false;
-        }
-
-        return isMinValid || isMaxValid;
-      },
-
       _getCurrentRange(stats = {}) {
         let min;
         if (hasMinBound) {
@@ -183,13 +172,19 @@ export default function connectRangeSlider(renderFn) {
           disjunctiveFacets: [attributeName],
         };
 
+        const isBoundsDefined = hasMinBound || hasMaxBound;
+
         const boundsAlreadyDefined =
           currentConfiguration &&
           currentConfiguration.numericRefinements &&
           currentConfiguration.numericRefinements[attributeName] !== undefined;
 
-        const isBoundsDefined = hasMinBound || hasMaxBound;
-        const isAbleToRefine = this._isAbleToRefine(minBound, maxBound);
+        const isMinBoundValid = _isFinite(minBound);
+        const isMaxBoundValid = _isFinite(maxBound);
+        const isAbleToRefine =
+          isMinBoundValid && isMaxBoundValid
+            ? minBound < maxBound
+            : isMinBoundValid || isMaxBoundValid;
 
         if (isBoundsDefined && !boundsAlreadyDefined && isAbleToRefine) {
           configuration.numericRefinements = { [attributeName]: {} };

--- a/src/connectors/range-slider/connectRangeSlider.js
+++ b/src/connectors/range-slider/connectRangeSlider.js
@@ -79,6 +79,17 @@ export default function connectRangeSlider(renderFn) {
     };
 
     return {
+      _isAbleToRefine: (min, max) => {
+        const isMinValid = min !== undefined && min !== null;
+        const isMaxValid = max !== undefined && max !== null;
+
+        if (isMinValid && isMaxValid && min >= max) {
+          return false;
+        }
+
+        return isMinValid || isMaxValid;
+      },
+
       _getCurrentRange: (stats = {}) => {
         let min;
         if (isMinBounds) {

--- a/src/connectors/range-slider/connectRangeSlider.js
+++ b/src/connectors/range-slider/connectRangeSlider.js
@@ -121,7 +121,7 @@ export default function connectRangeSlider(renderFn) {
         } else if (stats.min !== undefined && stats.min !== null) {
           min = stats.min;
         } else {
-          min = -Infinity;
+          min = 0;
         }
 
         let max;
@@ -130,7 +130,7 @@ export default function connectRangeSlider(renderFn) {
         } else if (stats.max !== undefined && stats.max !== null) {
           max = stats.max;
         } else {
-          max = Infinity;
+          max = 0;
         }
 
         return {

--- a/src/connectors/range-slider/connectRangeSlider.js
+++ b/src/connectors/range-slider/connectRangeSlider.js
@@ -82,12 +82,12 @@ export default function connectRangeSlider(renderFn) {
         };
 
         const hasUserBounds = userMin !== undefined || userMax !== undefined;
-        const boundsNotAlreadyDefined =
-          !originalConf ||
-          (originalConf.numericRefinements &&
-            originalConf.numericRefinements[attributeName] === undefined);
+        const boundsAlreadyDefined =
+          originalConf &&
+          originalConf.numericRefinements &&
+          originalConf.numericRefinements[attributeName] !== undefined;
 
-        if (hasUserBounds && boundsNotAlreadyDefined) {
+        if (hasUserBounds && !boundsAlreadyDefined) {
           conf.numericRefinements = { [attributeName]: {} };
           if (userMin !== undefined)
             conf.numericRefinements[attributeName]['>='] = [userMin];

--- a/src/connectors/range-slider/connectRangeSlider.js
+++ b/src/connectors/range-slider/connectRangeSlider.js
@@ -121,7 +121,7 @@ export default function connectRangeSlider(renderFn) {
         } else if (stats.min !== undefined && stats.min !== null) {
           min = stats.min;
         } else {
-          min = 0;
+          min = -Infinity;
         }
 
         let max;
@@ -130,7 +130,7 @@ export default function connectRangeSlider(renderFn) {
         } else if (stats.max !== undefined && stats.max !== null) {
           max = stats.max;
         } else {
-          max = 0;
+          max = Infinity;
         }
 
         return {

--- a/src/connectors/range-slider/connectRangeSlider.js
+++ b/src/connectors/range-slider/connectRangeSlider.js
@@ -182,7 +182,7 @@ export default function connectRangeSlider(renderFn) {
             newValues[0] !== null && newValues[0] !== undefined;
 
           if (
-            (isMinBounds && minValueChanged && minBounds < newValues[0]) ||
+            (isMinBounds && minValueChanged && minBounds <= newValues[0]) ||
             (!isMinBounds && minValueChanged)
           ) {
             helper.addNumericRefinement(
@@ -196,7 +196,7 @@ export default function connectRangeSlider(renderFn) {
             newValues[1] !== null && newValues[1] !== undefined;
 
           if (
-            (isMaxBounds && maxValueChanged && maxBounds > newValues[1]) ||
+            (isMaxBounds && maxValueChanged && maxBounds >= newValues[1]) ||
             (!isMaxBounds && maxValueChanged)
           ) {
             helper.addNumericRefinement(

--- a/src/connectors/range-slider/connectRangeSlider.js
+++ b/src/connectors/range-slider/connectRangeSlider.js
@@ -189,7 +189,7 @@ export default function connectRangeSlider(renderFn) {
         }
       },
 
-      getConfiguration: currentConfiguration => {
+      getConfiguration(currentConfiguration) {
         const configuration = {
           disjunctiveFacets: [attributeName],
         };
@@ -200,8 +200,9 @@ export default function connectRangeSlider(renderFn) {
           currentConfiguration.numericRefinements[attributeName] !== undefined;
 
         const isBoundsDefined = isMinBounds || isMaxBounds;
+        const isAbleToRefine = this._isAbleToRefine(minBounds, maxBounds);
 
-        if (isBoundsDefined && !boundsAlreadyDefined) {
+        if (isBoundsDefined && !boundsAlreadyDefined && isAbleToRefine) {
           configuration.numericRefinements = { [attributeName]: {} };
 
           if (isMinBounds) {

--- a/src/connectors/range-slider/connectRangeSlider.js
+++ b/src/connectors/range-slider/connectRangeSlider.js
@@ -166,43 +166,34 @@ export default function connectRangeSlider(renderFn) {
         };
       },
 
-      _refine: helper => newValues => {
-        const currentValues = [
+      _refine: helper => ([nextMin, nextMax] = []) => {
+        const [min, max] = [
           helper.getNumericRefinement(attributeName, '>='),
           helper.getNumericRefinement(attributeName, '<='),
         ];
 
-        if (
-          currentValues[0] !== newValues[0] ||
-          currentValues[1] !== newValues[1]
-        ) {
+        if (min !== nextMin || max !== nextMax) {
           helper.clearRefinements();
 
-          const minValueChanged =
-            newValues[0] !== null && newValues[0] !== undefined;
+          const isValidMinInput = nextMin !== null && nextMin !== undefined;
+          const isGreatherThanBounds = isMinBounds && minBounds <= nextMin;
 
-          if (
-            (isMinBounds && minValueChanged && minBounds <= newValues[0]) ||
-            (!isMinBounds && minValueChanged)
-          ) {
+          if (isValidMinInput && (!isMinBounds || isGreatherThanBounds)) {
             helper.addNumericRefinement(
               attributeName,
               '>=',
-              formatToNumber(newValues[0])
+              formatToNumber(nextMin)
             );
           }
 
-          const maxValueChanged =
-            newValues[1] !== null && newValues[1] !== undefined;
+          const isValidMaxInput = nextMax !== null && nextMax !== undefined;
+          const isLowerThanBounds = isMaxBounds && maxBounds >= nextMax;
 
-          if (
-            (isMaxBounds && maxValueChanged && maxBounds >= newValues[1]) ||
-            (!isMaxBounds && maxValueChanged)
-          ) {
+          if (isValidMaxInput && (!isMaxBounds || isLowerThanBounds)) {
             helper.addNumericRefinement(
               attributeName,
               '<=',
-              formatToNumber(newValues[1])
+              formatToNumber(nextMax)
             );
           }
 

--- a/src/widgets/range-slider/__tests__/__snapshots__/range-slider-test.js.snap
+++ b/src/widgets/range-slider/__tests__/__snapshots__/range-slider-test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`rangeSlider widget usage max option render will use the results min when only max is passed 1`] = `
+exports[`rangeSlider widget usage max option will use the results min when only max is passed 1`] = `
 <HeaderFooter-AutoHide
   collapsible={undefined}
   cssClasses={

--- a/src/widgets/range-slider/__tests__/range-slider-test.js
+++ b/src/widgets/range-slider/__tests__/range-slider-test.js
@@ -257,12 +257,14 @@ describe('rangeSlider', () => {
         const targetValue = stats.min + 1;
 
         const state0 = helper.state;
-        widget._refine(stats)([targetValue, stats.max]);
+        widget._refine(helper)([targetValue, stats.max]);
         const state1 = helper.state;
 
         expect(helper.search).toHaveBeenCalledTimes(1);
         expect(state1).toEqual(
-          state0.addNumericRefinement(attributeName, '>=', targetValue)
+          state0
+            .addNumericRefinement(attributeName, '>=', targetValue)
+            .addNumericRefinement(attributeName, '<=', stats.max)
         );
       });
 
@@ -271,12 +273,14 @@ describe('rangeSlider', () => {
         const targetValue = stats.max - 1;
 
         const state0 = helper.state;
-        widget._refine(stats)([stats.min, targetValue]);
+        widget._refine(helper)([stats.min, targetValue]);
         const state1 = helper.state;
 
         expect(helper.search).toHaveBeenCalledTimes(1);
         expect(state1).toEqual(
-          state0.addNumericRefinement(attributeName, '<=', targetValue)
+          state0
+            .addNumericRefinement(attributeName, '>=', stats.min)
+            .addNumericRefinement(attributeName, '<=', targetValue)
         );
       });
 
@@ -285,7 +289,7 @@ describe('rangeSlider', () => {
         const targetValue = [stats.min + 1, stats.max - 1];
 
         const state0 = helper.state;
-        widget._refine(stats)(targetValue);
+        widget._refine(helper)(targetValue);
         const state1 = helper.state;
 
         expect(helper.search).toHaveBeenCalledTimes(1);

--- a/src/widgets/range-slider/__tests__/range-slider-test.js
+++ b/src/widgets/range-slider/__tests__/range-slider-test.js
@@ -297,6 +297,38 @@ describe('rangeSlider', () => {
             .addNumericRefinement(attributeName, '<=', targetValue[1])
         );
       });
+
+      it("expect to clamp the min value to the max range when it's greater than range", () => {
+        widget = rangeSlider({
+          container,
+          attributeName,
+        });
+
+        widget.init({ helper, instantSearchInstance });
+
+        helper.addNumericRefinement(attributeName, '>=', 5550);
+        helper.addNumericRefinement(attributeName, '<=', 6000);
+
+        widget.render({ results, helper });
+
+        expect(ReactDOM.render.mock.calls[0][0].props.values[0]).toBe(5000);
+      });
+
+      it("expect to clamp the max value to the min range when it's lower than range", () => {
+        widget = rangeSlider({
+          container,
+          attributeName,
+        });
+
+        widget.init({ helper, instantSearchInstance });
+
+        helper.addNumericRefinement(attributeName, '>=', -50);
+        helper.addNumericRefinement(attributeName, '<=', 0);
+
+        widget.render({ results, helper });
+
+        expect(ReactDOM.render.mock.calls[0][0].props.values[1]).toBe(1);
+      });
     });
   });
 });

--- a/src/widgets/range-slider/__tests__/range-slider-test.js
+++ b/src/widgets/range-slider/__tests__/range-slider-test.js
@@ -46,6 +46,49 @@ describe('rangeSlider', () => {
       rangeSlider.__ResetDependency__('headerFooterHOC');
     });
 
+    it('should render without results', () => {
+      widget = rangeSlider({
+        container,
+        attributeName,
+        cssClasses: { root: ['root', 'cx'] },
+      });
+
+      widget.init({ helper, instantSearchInstance });
+      widget.render({ results: [], helper });
+
+      expect(ReactDOM.render).toHaveBeenCalledTimes(1);
+      expect(ReactDOM.render.mock.calls[0][0]).toMatchSnapshot();
+    });
+
+    it('should `shouldAutoHideContainer` when range min === max', () => {
+      const results = {
+        disjunctiveFacets: [
+          {
+            name: attributeName,
+            stats: {
+              min: 65,
+              max: 65,
+            },
+          },
+        ],
+      };
+
+      widget = rangeSlider({
+        container,
+        attributeName,
+        cssClasses: { root: ['root', 'cx'] },
+      });
+
+      widget.init({ helper, instantSearchInstance });
+      widget.render({ results, helper });
+
+      expect(ReactDOM.render).toHaveBeenCalledTimes(1);
+      expect(
+        ReactDOM.render.mock.calls[0][0].props.shouldAutoHideContainer
+      ).toEqual(true);
+      expect(ReactDOM.render.mock.calls[0][0]).toMatchSnapshot();
+    });
+
     describe('min option', () => {
       it('refines when no previous configuration', () => {
         widget = rangeSlider({ container, attributeName, min: 100 });
@@ -137,73 +180,28 @@ describe('rangeSlider', () => {
         });
       });
 
-      describe('render', () => {
-        it('will use the results min when only max is passed', () => {
-          const results = {
-            disjunctiveFacets: [
-              {
-                name: attributeName,
-                stats: {
-                  min: 1.99,
-                  max: 4999.98,
-                },
+      it('will use the results min when only max is passed', () => {
+        const results = {
+          disjunctiveFacets: [
+            {
+              name: attributeName,
+              stats: {
+                min: 1.99,
+                max: 4999.98,
               },
-            ],
-          };
-
-          widget = rangeSlider({ container, attributeName, max: 100 });
-          helper.setState(widget.getConfiguration());
-          widget.init({ helper, instantSearchInstance });
-          widget.render({ results, helper });
-
-          expect(ReactDOM.render).toHaveBeenCalledTimes(1);
-          expect(ReactDOM.render.mock.calls[0][0].props.min).toEqual(1);
-          expect(ReactDOM.render.mock.calls[0][0]).toMatchSnapshot();
-        });
-      });
-    });
-
-    it('should render without results', () => {
-      widget = rangeSlider({
-        container,
-        attributeName,
-        cssClasses: { root: ['root', 'cx'] },
-      });
-
-      widget.init({ helper, instantSearchInstance });
-      widget.render({ results: [], helper });
-
-      expect(ReactDOM.render).toHaveBeenCalledTimes(1);
-      expect(ReactDOM.render.mock.calls[0][0]).toMatchSnapshot();
-    });
-
-    it('should `shouldAutoHideContainer` when range min === max', () => {
-      const results = {
-        disjunctiveFacets: [
-          {
-            name: attributeName,
-            stats: {
-              min: 65,
-              max: 65,
             },
-          },
-        ],
-      };
+          ],
+        };
 
-      widget = rangeSlider({
-        container,
-        attributeName,
-        cssClasses: { root: ['root', 'cx'] },
+        widget = rangeSlider({ container, attributeName, max: 100 });
+        helper.setState(widget.getConfiguration());
+        widget.init({ helper, instantSearchInstance });
+        widget.render({ results, helper });
+
+        expect(ReactDOM.render).toHaveBeenCalledTimes(1);
+        expect(ReactDOM.render.mock.calls[0][0].props.min).toEqual(1);
+        expect(ReactDOM.render.mock.calls[0][0]).toMatchSnapshot();
       });
-
-      widget.init({ helper, instantSearchInstance });
-      widget.render({ results, helper });
-
-      expect(ReactDOM.render).toHaveBeenCalledTimes(1);
-      expect(
-        ReactDOM.render.mock.calls[0][0].props.shouldAutoHideContainer
-      ).toEqual(true);
-      expect(ReactDOM.render.mock.calls[0][0]).toMatchSnapshot();
     });
 
     describe('with results', () => {

--- a/src/widgets/range-slider/range-slider.js
+++ b/src/widgets/range-slider/range-slider.js
@@ -38,16 +38,22 @@ const renderer = ({
     return;
   }
 
-  const { min, max } = range;
-  const shouldAutoHideContainer = autoHideContainer && min === max;
+  const { min: minRange, max: maxRange } = range;
+  const shouldAutoHideContainer = autoHideContainer && minRange === maxRange;
+
+  const [minStart, maxStart] = start;
+  const values = [
+    minStart === -Infinity ? 0 : minStart,
+    maxStart === Infinity ? 0 : maxStart,
+  ];
 
   ReactDOM.render(
     <Slider
       cssClasses={cssClasses}
       refine={refine}
-      min={min}
-      max={max}
-      values={start}
+      min={minRange}
+      max={maxRange}
+      values={values}
       tooltips={tooltips}
       step={step}
       pips={pips}

--- a/src/widgets/range-slider/range-slider.js
+++ b/src/widgets/range-slider/range-slider.js
@@ -42,9 +42,15 @@ const renderer = ({
   const shouldAutoHideContainer = autoHideContainer && minRange === maxRange;
 
   const [minStart, maxStart] = start;
+  const minFinite = minStart === -Infinity ? minRange : minStart;
+  const maxFinite = maxStart === Infinity ? maxRange : maxStart;
+
+  // Clamp values to the range for avoid extra rendering & refinement
+  // Should probably be done on the connector side, but we need to stay
+  // backward compatible so we still need to pass [-Infinity, Infinity]
   const values = [
-    minStart === -Infinity ? minRange : minStart,
-    maxStart === Infinity ? maxRange : maxStart,
+    minFinite > maxRange ? maxRange : minFinite,
+    maxFinite < minRange ? minRange : maxFinite,
   ];
 
   ReactDOM.render(

--- a/src/widgets/range-slider/range-slider.js
+++ b/src/widgets/range-slider/range-slider.js
@@ -43,8 +43,8 @@ const renderer = ({
 
   const [minStart, maxStart] = start;
   const values = [
-    minStart === -Infinity ? 0 : minStart,
-    maxStart === Infinity ? 0 : maxStart,
+    minStart === -Infinity ? minRange : minStart,
+    maxStart === Infinity ? maxRange : maxStart,
   ];
 
   ReactDOM.render(

--- a/src/widgets/range-slider/range-slider.js
+++ b/src/widgets/range-slider/range-slider.js
@@ -28,10 +28,7 @@ const renderer = ({
   collapsible,
   renderState,
   templates,
-}) => (
-  { refine, range: { min, max }, start, instantSearchInstance },
-  isFirstRendering
-) => {
+}) => ({ refine, range, start, instantSearchInstance }, isFirstRendering) => {
   if (isFirstRendering) {
     renderState.templateProps = prepareTemplateProps({
       defaultTemplates,
@@ -41,10 +38,8 @@ const renderer = ({
     return;
   }
 
+  const { min, max } = range;
   const shouldAutoHideContainer = autoHideContainer && min === max;
-
-  const minValue = start[0] === -Infinity ? min : start[0];
-  const maxValue = start[1] === Infinity ? max : start[1];
 
   ReactDOM.render(
     <Slider
@@ -52,7 +47,7 @@ const renderer = ({
       refine={refine}
       min={min}
       max={max}
-      values={[minValue, maxValue]}
+      values={start}
       tooltips={tooltips}
       step={step}
       pips={pips}


### PR DESCRIPTION
**Summary**

Fix #2386 

- The boundaries were ignored in `getConfiguration` for the first render
- They were ignored when a refinement was triggered and reset

**Result**

You can play with the `RangeSlider` on `dev-novel` (some stories added)