### PR TITLE
fix(build): minify css with `csso` instead of unminify css

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "compression": "1.7.0",
     "conventional-changelog-cli": "1.3.3",
     "css-loader": "0.28.7",
-    "cssunminifier": "0.0.2",
+    "csso-cli": "^1.1.0",
     "dev-novel": "0.0.4",
     "doctoc": "1.3.0",
     "enzyme": "2.9.1",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,8 +7,8 @@ mkdir -p dist dist-es5-module es
 
 echo "➡️  Bundle instantsearch.js to UMD build './dist' via webpack"
 NODE_ENV=production BABEL_ENV=production webpack --config scripts/webpack.config.js --hide-modules
-cssunminifier dist/instantsearch.min.css dist/instantsearch.css &
-cssunminifier dist/instantsearch-theme-algolia.min.css dist/instantsearch-theme-algolia.css
+csso dist/instantsearch.css dist/instantsearch.min.css --map file &
+csso dist/instantsearch-theme-algolia.css dist/instantsearch-theme-algolia.min.css --map file
 
 wait
 

--- a/scripts/webpack.config.js
+++ b/scripts/webpack.config.js
@@ -8,10 +8,8 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const HappyPack = require('happypack');
 const UnminifiedWebpackPlugin = require('unminified-webpack-plugin');
 
-const extractCSS = new ExtractTextPlugin('instantsearch.min.css');
-const extractTheme = new ExtractTextPlugin(
-  'instantsearch-theme-algolia.min.css'
-);
+const extractCSS = new ExtractTextPlugin('instantsearch.css');
+const extractTheme = new ExtractTextPlugin('instantsearch-theme-algolia.css');
 
 const { NODE_ENV = 'development', VERSION = 'UNRELEASED' } = process.env;
 
@@ -104,7 +102,7 @@ module.exports = {
 
     new HappyPack({
       loaders: [
-        { loader: 'css-loader', options: { minimize: true, sourceMap: true } },
+        { loader: 'css-loader', options: { minimize: false, sourceMap: true } },
         { loader: 'postcss-loader', options: { sourceMap: true } },
         { loader: 'sass-loader', options: { sourceMap: true } },
       ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2560,6 +2560,13 @@ css-to-react-native@^2.0.3:
     fbjs "^0.8.5"
     postcss-value-parser "^3.3.0"
 
+css-tree@1.0.0-alpha23:
+  version "1.0.0-alpha23"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.0.0-alpha23.tgz#5129518def61e99931d9a3397c3d6758af2ff0c5"
+  dependencies:
+    mdn-data "^1.0.0"
+    source-map "^0.5.3"
+
 css-value@~0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/css-value/-/css-value-0.0.1.tgz#5efd6c2eea5ea1fd6b6ac57ec0427b18452424ea"
@@ -2622,6 +2629,21 @@ cssmin@0.3.x:
     postcss-value-parser "^3.2.3"
     postcss-zindex "^2.0.1"
 
+csso-cli@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/csso-cli/-/csso-cli-1.1.0.tgz#c787557612fae522875788bfb6e69594fe79b3c7"
+  dependencies:
+    chokidar "^1.6.1"
+    clap "^1.0.9"
+    csso "^3.2.0"
+    source-map "^0.5.3"
+
+csso@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/csso/-/csso-3.2.0.tgz#b290b9581551904aad45bca8988af17ca0711235"
+  dependencies:
+    css-tree "1.0.0-alpha23"
+
 csso@~2.3.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/csso/-/csso-2.3.2.tgz#ddd52c587033f49e94b71fc55569f252e8ff5f85"
@@ -2638,10 +2660,6 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-0.2.37.tgz#541097234cb2513c83ceed3acddc27ff27987d54"
   dependencies:
     cssom "0.3.x"
-
-cssunminifier@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/cssunminifier/-/cssunminifier-0.0.2.tgz#96e8708e8fa79fa05ffa8db8984a299220e49abc"
 
 ctype@0.5.3:
   version "0.5.3"
@@ -6142,6 +6160,10 @@ md5.js@^1.3.4:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
+
+mdn-data@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-1.0.0.tgz#a69d9da76847b4d5834c1465ea25c0653a1fbf66"
 
 media-typer@0.3.0:
   version "0.3.0"


### PR DESCRIPTION
Now webpack build output un-minified CSS and we process the CSS into https://github.com/css/csso after.

Fixes #2375 