### PR TITLE
fix(webpack.dev): sourcemaps in dev

### DIFF
--- a/dev/webpack.config.js
+++ b/dev/webpack.config.js
@@ -13,7 +13,7 @@ const __DEV__ = process.env.NODE_ENV === 'development';
 const clean = arr => arr.filter(item => item !== false);
 
 module.exports = {
-  devtool: __DEV__ ? 'cheap-eval-source-map' : 'source-map',
+  devtool: __DEV__ ? 'cheap-module-source-map' : 'source-map',
 
   entry: __DEV__
     ? {


### PR DESCRIPTION
Sourcemaps are buggy in chrome, let's use a less aggressive option in webpack to restore them until it's fixed in webpack.

-> Impacts a slower re-build time