### PR TITLE
docs(org): ensure /v2/index.html still works while reorg

### DIFF
--- a/docgen/middlewares.js
+++ b/docgen/middlewares.js
@@ -114,8 +114,7 @@ const common = [
     pattern: 'v2/index.html',
     transform: path => {
       return 'index.html'
-    },
-    move: true
+    }
   }),
   // perfStop(),
 ];


### PR DESCRIPTION
Before this fix, when we would deploy the new org (v1, v2) to the live
website, link to /v2/ (homepage) could endup in a 404 (because the cloudflare redirect takes some time to be activated). With this fix it will not
and I will at the same time activate a rule to redirect /v2/ (homepage) to /.