### PR TITLE
docs(v1): add v1 link

### DIFF
--- a/docgen/src/data/communityHeader.json
+++ b/docgen/src/data/communityHeader.json
@@ -108,7 +108,10 @@
   {
     "name": "<span class='hidden-sm'>Demos</span>",
     "url": "examples.html"
-  },{
+  },  {
+    "name": "v1 docs",
+    "url": "https://community.algolia.com/instantsearch.js/v1/"
+  }, {
     "name": "Github",
     "image": "<img src='assets/img/github-icon.svg'/>",
     "url": "https://github.com/algolia/instantsearch.js/"
@@ -148,6 +151,10 @@
   {
     "name": "Demos",
     "url": "examples.html"
+  },
+  {
+    "name": "v1 docs",
+    "url": "https://community.algolia.com/instantsearch.js/v1/"
   }],
   "docSearch": {
     "input_selector": "searchbox",


### PR DESCRIPTION
This add a link back to v1 docs

![image](https://user-images.githubusercontent.com/123822/31127869-62ac5104-a850-11e7-8b3b-c12230e1d53e.png)