### PR TITLE
chore(doc): misc. issues in the doc

### DIFF
--- a/docgen/.babelrc
+++ b/docgen/.babelrc
@@ -1,7 +1,6 @@
 {
   "presets": [
     ["env", { "targets": { "browsers": ["last 2 versions", "ie >= 9"] } }],
-    "latest",
     "stage-2"
   ]
 }

--- a/docgen/layouts/archetypes/content-with-menu.pug
+++ b/docgen/layouts/archetypes/content-with-menu.pug
@@ -18,6 +18,7 @@ body.documentation
 
   include ../common/footer.pug
   script(src=webpack.assets['js/main.js'])
+  block footer_script
   script(type="text/javascript").
     var _kmq = _kmq || [];
     var _kmk = _kmk || 'cb5a3adb92e8915a37a36ba1a50f2ce4fae4a1b9';

--- a/docgen/layouts/widget-showcase.pug
+++ b/docgen/layouts/widget-showcase.pug
@@ -3,7 +3,7 @@ include mixins/nav.pug
 include mixins/documentationjs/widget-category-showcase.pug
 
 block head
-  script(src="https://cdn.jsdelivr.net/npm/instantsearch.js@2.0.2/dist/instantsearch.min.js")
+  script(src="https://cdn.jsdelivr.net/npm/instantsearch.js@2/dist/instantsearch.min.js")
 
 block navigation
   - let headings2 = headings || []

--- a/docgen/package.json
+++ b/docgen/package.json
@@ -13,7 +13,6 @@
     "babel-cli": "6.26.0",
     "babel-loader": "6.4.1",
     "babel-preset-env": "1.6.0",
-    "babel-preset-latest": "6.24.1",
     "babel-preset-stage-2": "6.24.1",
     "browser-sync": "2.18.13",
     "clipboard": "1.7.1",

--- a/docgen/yarn.lock
+++ b/docgen/yarn.lock
@@ -971,7 +971,7 @@ babel-preset-env@1.6.0, babel-preset-env@^1.1.9, babel-preset-env@^1.6.0:
     invariant "^2.2.2"
     semver "^5.3.0"
 
-babel-preset-es2015@^6.16.0, babel-preset-es2015@^6.22.0, babel-preset-es2015@^6.24.1:
+babel-preset-es2015@^6.16.0, babel-preset-es2015@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz#d44050d6bc2c9feea702aaf38d727a0210538939"
   dependencies:
@@ -1000,32 +1000,11 @@ babel-preset-es2015@^6.16.0, babel-preset-es2015@^6.22.0, babel-preset-es2015@^6
     babel-plugin-transform-es2015-unicode-regex "^6.24.1"
     babel-plugin-transform-regenerator "^6.24.1"
 
-babel-preset-es2016@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-preset-es2016/-/babel-preset-es2016-6.24.1.tgz#f900bf93e2ebc0d276df9b8ab59724ebfd959f8b"
-  dependencies:
-    babel-plugin-transform-exponentiation-operator "^6.24.1"
-
-babel-preset-es2017@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-preset-es2017/-/babel-preset-es2017-6.24.1.tgz#597beadfb9f7f208bcfd8a12e9b2b29b8b2f14d1"
-  dependencies:
-    babel-plugin-syntax-trailing-function-commas "^6.22.0"
-    babel-plugin-transform-async-to-generator "^6.24.1"
-
 babel-preset-flow@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz#e71218887085ae9a24b5be4169affb599816c49d"
   dependencies:
     babel-plugin-transform-flow-strip-types "^6.22.0"
-
-babel-preset-latest@6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-preset-latest/-/babel-preset-latest-6.24.1.tgz#677de069154a7485c2d25c577c02f624b85b85e8"
-  dependencies:
-    babel-preset-es2015 "^6.24.1"
-    babel-preset-es2016 "^6.24.1"
-    babel-preset-es2017 "^6.24.1"
 
 babel-preset-react@^6.16.0:
   version "6.24.1"

--- a/src/widgets/menu-select/menu-select.js
+++ b/src/widgets/menu-select/menu-select.js
@@ -63,7 +63,7 @@ menuSelect({
 })`;
 
 /**
- * @typedef {Object} MenuCSSClasses
+ * @typedef {Object} MenuSelectCSSClasses
  * @property {string|string[]} [root] CSS class to add to the root element.
  * @property {string|string[]} [header] CSS class to add to the header element.
  * @property {string|string[]} [select] CSS class to add to the select element.
@@ -73,10 +73,10 @@ menuSelect({
 
 /**
  * @typedef {Object} MenuSelectTemplates
- * @property {string|Function} [header] Header template.
- * @property {string|Function(name: string, count: number, isRefined: boolean)} [item] Item template, provided with `name`, `count`, `isRefined`, `url` data properties.
+ * @property {string|function} [header] Header template.
+ * @property {string|function(name: string, count: number, isRefined: boolean)} [item] Item template, provided with `name`, `count`, `isRefined`, `url` data properties.
  * @property {string} [seeAllOption='See all'] Label of the see all option in the select.
- * @property {string|Function} [footer] Footer template.
+ * @property {string|function} [footer] Footer template.
  */
 
 /**

--- a/src/widgets/menu-select/menu-select.js
+++ b/src/widgets/menu-select/menu-select.js
@@ -107,7 +107,7 @@ menuSelect({
  * @example
  * search.addWidget(
  *   instantsearch.widgets.menuSelect({
- *     container: '#categories',
+ *     container: '#categories-menuSelect',
  *     attributeName: 'hierarchicalCategories.lvl0',
  *     limit: 10,
  *     templates: {


### PR DESCRIPTION
After releasing the v2.2.0, I found several problems when building the docs: 
 - incorrect types
 - updated babel doesn't support some of the presets we were using
 - menuSelect wasn't displayed in the showcase (updated the instantsearch.js loaded to the latest but that should be fixed correctly #2446)