### PR TITLE
fix(menuSelect): select in userCssClasses

### DIFF
--- a/src/widgets/menu-select/__tests__/__snapshots__/menu-select-test.js.snap
+++ b/src/widgets/menu-select/__tests__/__snapshots__/menu-select-test.js.snap
@@ -9,7 +9,7 @@ exports[`menuSelect render correctly 1`] = `
       "header": "ais-menu-select--header",
       "option": "ais-menu-select--option",
       "root": "ais-menu-select",
-      "select": "ais-menu-select--footer",
+      "select": "ais-menu-select--select",
     }
   }
   items={

--- a/src/widgets/menu-select/menu-select.js
+++ b/src/widgets/menu-select/menu-select.js
@@ -135,7 +135,7 @@ export default function menuSelect({
     root: cx(bem(null), userCssClasses.root),
     header: cx(bem('header'), userCssClasses.header),
     footer: cx(bem('footer'), userCssClasses.footer),
-    select: cx(bem('footer'), userCssClasses.footer),
+    select: cx(bem('select'), userCssClasses.select),
     option: cx(bem('option'), userCssClasses.option),
   };
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

Bug fix: `select` in `cssClasses` are currently applied to `footer` element.