### PR TITLE
fix: avoid connectRangeSlider to clear all refinements

### DIFF
--- a/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
+++ b/src/connectors/range-slider/__tests__/connectRangeSlider-test.js
@@ -539,7 +539,7 @@ describe('connectRangeSlider', () => {
 
       expect(helper.getNumericRefinement(attributeName, '>=')).toEqual([10]);
       expect(helper.getNumericRefinement(attributeName, '<=')).toEqual([490]);
-      expect(helper.clearRefinements).toHaveBeenCalled();
+      expect(helper.clearRefinements).toHaveBeenCalledWith(attributeName);
       expect(helper.search).toHaveBeenCalled();
     });
 
@@ -553,7 +553,7 @@ describe('connectRangeSlider', () => {
 
       expect(helper.getNumericRefinement(attributeName, '>=')).toEqual([10]);
       expect(helper.getNumericRefinement(attributeName, '<=')).toEqual([490]);
-      expect(helper.clearRefinements).toHaveBeenCalled();
+      expect(helper.clearRefinements).toHaveBeenCalledWith(attributeName);
       expect(helper.search).toHaveBeenCalled();
     });
 
@@ -570,7 +570,7 @@ describe('connectRangeSlider', () => {
 
       expect(helper.getNumericRefinement(attributeName, '>=')).toEqual([10]);
       expect(helper.getNumericRefinement(attributeName, '<=')).toEqual([490]);
-      expect(helper.clearRefinements).toHaveBeenCalled();
+      expect(helper.clearRefinements).toHaveBeenCalledWith(attributeName);
       expect(helper.search).toHaveBeenCalled();
     });
 
@@ -587,7 +587,7 @@ describe('connectRangeSlider', () => {
 
       expect(helper.getNumericRefinement(attributeName, '>=')).toEqual([10]);
       expect(helper.getNumericRefinement(attributeName, '<=')).toEqual([490]);
-      expect(helper.clearRefinements).toHaveBeenCalled();
+      expect(helper.clearRefinements).toHaveBeenCalledWith(attributeName);
       expect(helper.search).toHaveBeenCalled();
     });
 
@@ -603,7 +603,7 @@ describe('connectRangeSlider', () => {
         undefined
       );
       expect(helper.getNumericRefinement(attributeName, '<=')).toEqual([490]);
-      expect(helper.clearRefinements).toHaveBeenCalled();
+      expect(helper.clearRefinements).toHaveBeenCalledWith(attributeName);
       expect(helper.search).toHaveBeenCalled();
     });
 
@@ -619,7 +619,7 @@ describe('connectRangeSlider', () => {
       expect(helper.getNumericRefinement(attributeName, '<=')).toEqual(
         undefined
       );
-      expect(helper.clearRefinements).toHaveBeenCalled();
+      expect(helper.clearRefinements).toHaveBeenCalledWith(attributeName);
       expect(helper.search).toHaveBeenCalled();
     });
 
@@ -635,7 +635,7 @@ describe('connectRangeSlider', () => {
         undefined
       );
       expect(helper.getNumericRefinement(attributeName, '<=')).toEqual([490]);
-      expect(helper.clearRefinements).toHaveBeenCalled();
+      expect(helper.clearRefinements).toHaveBeenCalledWith(attributeName);
       expect(helper.search).toHaveBeenCalled();
     });
 
@@ -651,7 +651,7 @@ describe('connectRangeSlider', () => {
       expect(helper.getNumericRefinement(attributeName, '<=')).toEqual(
         undefined
       );
-      expect(helper.clearRefinements).toHaveBeenCalled();
+      expect(helper.clearRefinements).toHaveBeenCalledWith(attributeName);
       expect(helper.search).toHaveBeenCalled();
     });
 
@@ -686,7 +686,7 @@ describe('connectRangeSlider', () => {
       expect(helper.getNumericRefinement(attributeName, '<=')).toEqual(
         undefined
       );
-      expect(helper.clearRefinements).toHaveBeenCalled();
+      expect(helper.clearRefinements).toHaveBeenCalledWith(attributeName);
       expect(helper.search).toHaveBeenCalled();
     });
   });

--- a/src/connectors/range-slider/connectRangeSlider.js
+++ b/src/connectors/range-slider/connectRangeSlider.js
@@ -132,7 +132,7 @@ export default function connectRangeSlider(renderFn) {
             !hasMaxBound && rangeMax === nextMax ? undefined : nextMax;
 
           if (min !== newNextMin || max !== newNextMax) {
-            helper.clearRefinements();
+            helper.clearRefinements(attributeName);
 
             const isValidMinInput = _isFinite(newNextMin);
             const isValidMinRange = _isFinite(rangeMin);


### PR DESCRIPTION
**Summary**

The `connectRangeSlider` clear all the refinements when refinement change.

This fix restrict the `clearRefinements` only on the current attribute.
