### PR TITLE
Feature: RangeInput without validation in component

### DIFF
--- a/src/components/RangeInput/RangeInput.js
+++ b/src/components/RangeInput/RangeInput.js
@@ -47,8 +47,6 @@ export class RawRangeInput extends Component {
             <input
               className={cssClasses.inputMin}
               type="number"
-              min={min}
-              max={max}
               step={step}
               value={minValue}
               onChange={this.onChange('min')}
@@ -61,8 +59,6 @@ export class RawRangeInput extends Component {
             <input
               className={cssClasses.inputMax}
               type="number"
-              min={min}
-              max={max}
               step={step}
               value={maxValue}
               onChange={this.onChange('max')}

--- a/src/components/RangeInput/__tests__/__snapshots__/RangeInput-test.js.snap
+++ b/src/components/RangeInput/__tests__/__snapshots__/RangeInput-test.js.snap
@@ -14,8 +14,6 @@ exports[`RawRangeInput expect to render 1`] = `
       <input
         className="inputMin"
         disabled={false}
-        max={500}
-        min={0}
         onChange={[Function]}
         placeholder={0}
         step={1}
@@ -33,8 +31,6 @@ exports[`RawRangeInput expect to render 1`] = `
       <input
         className="inputMax"
         disabled={false}
-        max={500}
-        min={0}
         onChange={[Function]}
         placeholder={500}
         step={1}
@@ -66,8 +62,6 @@ exports[`RawRangeInput expect to render with disabled state 1`] = `
       <input
         className="inputMin"
         disabled={true}
-        max={20}
-        min={480}
         onChange={[Function]}
         placeholder={480}
         step={1}
@@ -85,8 +79,6 @@ exports[`RawRangeInput expect to render with disabled state 1`] = `
       <input
         className="inputMax"
         disabled={true}
-        max={20}
-        min={480}
         onChange={[Function]}
         placeholder={20}
         step={1}
@@ -118,8 +110,6 @@ exports[`RawRangeInput expect to render with values 1`] = `
       <input
         className="inputMin"
         disabled={false}
-        max={500}
-        min={0}
         onChange={[Function]}
         placeholder={0}
         step={1}
@@ -138,8 +128,6 @@ exports[`RawRangeInput expect to render with values 1`] = `
       <input
         className="inputMax"
         disabled={false}
-        max={500}
-        min={0}
         onChange={[Function]}
         placeholder={500}
         step={1}
@@ -172,8 +160,6 @@ exports[`RawRangeInput onChange expect to update the state when max change 1`] =
       <input
         className="inputMin"
         disabled={false}
-        max={500}
-        min={0}
         onChange={[Function]}
         placeholder={0}
         step={1}
@@ -191,8 +177,6 @@ exports[`RawRangeInput onChange expect to update the state when max change 1`] =
       <input
         className="inputMax"
         disabled={false}
-        max={500}
-        min={0}
         onChange={[Function]}
         placeholder={500}
         step={1}
@@ -225,8 +209,6 @@ exports[`RawRangeInput onChange expect to update the state when min change 1`] =
       <input
         className="inputMin"
         disabled={false}
-        max={500}
-        min={0}
         onChange={[Function]}
         placeholder={0}
         step={1}
@@ -245,8 +227,6 @@ exports[`RawRangeInput onChange expect to update the state when min change 1`] =
       <input
         className="inputMax"
         disabled={false}
-        max={500}
-        min={0}
         onChange={[Function]}
         placeholder={500}
         step={1}
@@ -278,8 +258,6 @@ exports[`RawRangeInput willReceiveProps expect to update the empty state from gi
       <input
         className="inputMin"
         disabled={false}
-        max={500}
-        min={0}
         onChange={[Function]}
         placeholder={0}
         step={1}
@@ -297,8 +275,6 @@ exports[`RawRangeInput willReceiveProps expect to update the empty state from gi
       <input
         className="inputMax"
         disabled={false}
-        max={500}
-        min={0}
         onChange={[Function]}
         placeholder={500}
         step={1}
@@ -330,8 +306,6 @@ exports[`RawRangeInput willReceiveProps expect to update the empty state from gi
       <input
         className="inputMin"
         disabled={false}
-        max={500}
-        min={0}
         onChange={[Function]}
         placeholder={0}
         step={1}
@@ -350,8 +324,6 @@ exports[`RawRangeInput willReceiveProps expect to update the empty state from gi
       <input
         className="inputMax"
         disabled={false}
-        max={500}
-        min={0}
         onChange={[Function]}
         placeholder={500}
         step={1}
@@ -384,8 +356,6 @@ exports[`RawRangeInput willReceiveProps expect to update the state from given pr
       <input
         className="inputMin"
         disabled={false}
-        max={500}
-        min={0}
         onChange={[Function]}
         placeholder={0}
         step={1}
@@ -404,8 +374,6 @@ exports[`RawRangeInput willReceiveProps expect to update the state from given pr
       <input
         className="inputMax"
         disabled={false}
-        max={500}
-        min={0}
         onChange={[Function]}
         placeholder={500}
         step={1}
@@ -438,8 +406,6 @@ exports[`RawRangeInput willReceiveProps expect to update the state from given pr
       <input
         className="inputMin"
         disabled={false}
-        max={500}
-        min={0}
         onChange={[Function]}
         placeholder={0}
         step={1}
@@ -458,8 +424,6 @@ exports[`RawRangeInput willReceiveProps expect to update the state from given pr
       <input
         className="inputMax"
         disabled={false}
-        max={500}
-        min={0}
         onChange={[Function]}
         placeholder={500}
         step={1}

--- a/src/connectors/range/__tests__/connectRange-test.js
+++ b/src/connectors/range/__tests__/connectRange-test.js
@@ -692,6 +692,40 @@ describe('connectRange', () => {
       expect(helper.search).toHaveBeenCalled();
     });
 
+    it('expect to refine min when user bounds are set and value is not valid', () => {
+      const range = { min: 10, max: 500 };
+      const values = [null, 490];
+      const helper = createHelper();
+      const widget = connectRangeSlider(rendering)({
+        attributeName,
+        min: 10,
+      });
+
+      widget._refine(helper, range)(values);
+
+      expect(helper.getNumericRefinement(attributeName, '>=')).toEqual([10]);
+      expect(helper.getNumericRefinement(attributeName, '<=')).toEqual([490]);
+      expect(helper.clearRefinements).toHaveBeenCalled();
+      expect(helper.search).toHaveBeenCalled();
+    });
+
+    it('expect to refine max when user bounds are set and value is not valid', () => {
+      const range = { min: 10, max: 500 };
+      const values = [20, null];
+      const helper = createHelper();
+      const widget = connectRangeSlider(rendering)({
+        attributeName,
+        max: 500,
+      });
+
+      widget._refine(helper, range)(values);
+
+      expect(helper.getNumericRefinement(attributeName, '>=')).toEqual([20]);
+      expect(helper.getNumericRefinement(attributeName, '<=')).toEqual([500]);
+      expect(helper.clearRefinements).toHaveBeenCalled();
+      expect(helper.search).toHaveBeenCalled();
+    });
+
     it('expect to not refine min when no user bounds are set and value is at range bound', () => {
       const range = { min: 0, max: 500 };
       const values = [0, 490];

--- a/src/connectors/range/__tests__/connectRange-test.js
+++ b/src/connectors/range/__tests__/connectRange-test.js
@@ -593,40 +593,6 @@ describe('connectRange', () => {
       expect(helper.search).toHaveBeenCalled();
     });
 
-    it('expect to refine to given min when user bounds are set and value is a parsable number', () => {
-      const range = { min: 10, max: 500 };
-      const values = ['20', 490];
-      const helper = createHelper();
-      const widget = connectRange(rendering)({
-        attributeName,
-        min: 10,
-      });
-
-      widget._refine(helper, range)(values);
-
-      expect(helper.getNumericRefinement(attributeName, '>=')).toEqual([20]);
-      expect(helper.getNumericRefinement(attributeName, '<=')).toEqual([490]);
-      expect(helper.clearRefinements).toHaveBeenCalled();
-      expect(helper.search).toHaveBeenCalled();
-    });
-
-    it('expect to refine to given max when user bounds are set and value is a parsable number', () => {
-      const range = { min: 10, max: 500 };
-      const values = [20, '490'];
-      const helper = createHelper();
-      const widget = connectRange(rendering)({
-        attributeName,
-        max: 500,
-      });
-
-      widget._refine(helper, range)(values);
-
-      expect(helper.getNumericRefinement(attributeName, '>=')).toEqual([20]);
-      expect(helper.getNumericRefinement(attributeName, '<=')).toEqual([490]);
-      expect(helper.clearRefinements).toHaveBeenCalled();
-      expect(helper.search).toHaveBeenCalled();
-    });
-
     it('expect to refine min when user bounds are set and value is at range bound', () => {
       const range = { min: 10, max: 500 };
       const values = [10, 490];
@@ -640,7 +606,7 @@ describe('connectRange', () => {
 
       expect(helper.getNumericRefinement(attributeName, '>=')).toEqual([10]);
       expect(helper.getNumericRefinement(attributeName, '<=')).toEqual([490]);
-      expect(helper.clearRefinements).toHaveBeenCalledWith(attributeName);
+      expect(helper.clearRefinements).toHaveBeenCalled();
       expect(helper.search).toHaveBeenCalled();
     });
 
@@ -657,83 +623,18 @@ describe('connectRange', () => {
 
       expect(helper.getNumericRefinement(attributeName, '>=')).toEqual([10]);
       expect(helper.getNumericRefinement(attributeName, '<=')).toEqual([490]);
-      expect(helper.clearRefinements).toHaveBeenCalledWith(attributeName);
-      expect(helper.search).toHaveBeenCalled();
-    });
-
-    it('expect to refine min when user bounds are set and value is not a parsable number', () => {
-      const range = { min: 10, max: 500 };
-      const values = [null, 490];
-      const helper = createHelper();
-      const widget = connectRange(rendering)({
-        attributeName,
-        min: 10,
-      });
-
-      widget._refine(helper, range)(values);
-
-      expect(helper.getNumericRefinement(attributeName, '>=')).toEqual([10]);
-      expect(helper.getNumericRefinement(attributeName, '<=')).toEqual([490]);
-      expect(helper.clearRefinements).toHaveBeenCalledWith(attributeName);
-      expect(helper.search).toHaveBeenCalled();
-    });
-
-    it('expect to refine max when user bounds are set and value is not a parsable number', () => {
-      const range = { min: 10, max: 500 };
-      const values = [20, null];
-      const helper = createHelper();
-      const widget = connectRange(rendering)({
-        attributeName,
-        max: 500,
-      });
-
-      widget._refine(helper, range)(values);
-
-      expect(helper.getNumericRefinement(attributeName, '>=')).toEqual([20]);
-      expect(helper.getNumericRefinement(attributeName, '<=')).toEqual([500]);
-      expect(helper.clearRefinements).toHaveBeenCalledWith(attributeName);
-      expect(helper.search).toHaveBeenCalled();
-    });
-
-    it('expect to refine min when user bounds are set and value is not valid', () => {
-      const range = { min: 10, max: 500 };
-      const values = [null, 490];
-      const helper = createHelper();
-      const widget = connectRange(rendering)({
-        attributeName,
-        min: 10,
-      });
-
-      widget._refine(helper, range)(values);
-
-      expect(helper.getNumericRefinement(attributeName, '>=')).toEqual([10]);
-      expect(helper.getNumericRefinement(attributeName, '<=')).toEqual([490]);
       expect(helper.clearRefinements).toHaveBeenCalled();
       expect(helper.search).toHaveBeenCalled();
     });
 
-    it('expect to refine max when user bounds are set and value is not valid', () => {
-      const range = { min: 10, max: 500 };
-      const values = [20, null];
-      const helper = createHelper();
-      const widget = connectRange(rendering)({
-        attributeName,
-        max: 500,
-      });
-
-      widget._refine(helper, range)(values);
-
-      expect(helper.getNumericRefinement(attributeName, '>=')).toEqual([20]);
-      expect(helper.getNumericRefinement(attributeName, '<=')).toEqual([500]);
-      expect(helper.clearRefinements).toHaveBeenCalled();
-      expect(helper.search).toHaveBeenCalled();
-    });
-
-    it('expect to not refine min when no user bounds are set and value is at range bound', () => {
+    it('expect to reset min refinenement when value is undefined', () => {
       const range = { min: 0, max: 500 };
-      const values = [0, 490];
+      const values = [undefined, 490];
       const helper = createHelper();
       const widget = connectRange(rendering)({ attributeName });
+
+      helper.addNumericRefinement(attributeName, '>=', 10);
+      helper.addNumericRefinement(attributeName, '<=', 490);
 
       widget._refine(helper, range)(values);
 
@@ -745,11 +646,14 @@ describe('connectRange', () => {
       expect(helper.search).toHaveBeenCalled();
     });
 
-    it('expect to not refine max when no user bounds are set and value is at range bound', () => {
+    it('expect to reset max refinenement when value is undefined', () => {
       const range = { min: 0, max: 500 };
-      const values = [10, 500];
+      const values = [10, undefined];
       const helper = createHelper();
       const widget = connectRange(rendering)({ attributeName });
+
+      helper.addNumericRefinement(attributeName, '>=', 10);
+      helper.addNumericRefinement(attributeName, '<=', 490);
 
       widget._refine(helper, range)(values);
 
@@ -761,11 +665,14 @@ describe('connectRange', () => {
       expect(helper.search).toHaveBeenCalled();
     });
 
-    it("expect to not refine min when it's out of range", () => {
-      const range = { min: 10, max: 500 };
-      const values = [0, 490];
+    it('expect to reset min refinenement when value is empty string', () => {
+      const range = { min: 0, max: 500 };
+      const values = ['', 490];
       const helper = createHelper();
       const widget = connectRange(rendering)({ attributeName });
+
+      helper.addNumericRefinement(attributeName, '>=', 10);
+      helper.addNumericRefinement(attributeName, '<=', 490);
 
       widget._refine(helper, range)(values);
 
@@ -777,7 +684,118 @@ describe('connectRange', () => {
       expect(helper.search).toHaveBeenCalled();
     });
 
-    it("expect to not refine max when it's out of range", () => {
+    it('expect to reset max refinenement when value is empty string', () => {
+      const range = { min: 0, max: 500 };
+      const values = [10, ''];
+      const helper = createHelper();
+      const widget = connectRange(rendering)({ attributeName });
+
+      helper.addNumericRefinement(attributeName, '>=', 10);
+      helper.addNumericRefinement(attributeName, '<=', 490);
+
+      widget._refine(helper, range)(values);
+
+      expect(helper.getNumericRefinement(attributeName, '>=')).toEqual([10]);
+      expect(helper.getNumericRefinement(attributeName, '<=')).toEqual(
+        undefined
+      );
+      expect(helper.clearRefinements).toHaveBeenCalledWith(attributeName);
+      expect(helper.search).toHaveBeenCalled();
+    });
+
+    it('expect to reset min refinenement when user bounds are not set and value is at bounds', () => {
+      const range = { min: 0, max: 500 };
+      const values = [0, 490];
+      const helper = createHelper();
+      const widget = connectRange(rendering)({ attributeName });
+
+      helper.addNumericRefinement(attributeName, '>=', 10);
+
+      widget._refine(helper, range)(values);
+
+      expect(helper.getNumericRefinement(attributeName, '>=')).toEqual(
+        undefined
+      );
+      expect(helper.getNumericRefinement(attributeName, '<=')).toEqual([490]);
+      expect(helper.clearRefinements).toHaveBeenCalledWith(attributeName);
+      expect(helper.search).toHaveBeenCalled();
+    });
+
+    it('expect to reset max refinenement when user bounds are not set and value is at bounds', () => {
+      const range = { min: 0, max: 500 };
+      const values = [10, 500];
+      const helper = createHelper();
+      const widget = connectRange(rendering)({ attributeName });
+
+      helper.addNumericRefinement(attributeName, '<=', 490);
+
+      widget._refine(helper, range)(values);
+
+      expect(helper.getNumericRefinement(attributeName, '>=')).toEqual([10]);
+      expect(helper.getNumericRefinement(attributeName, '<=')).toEqual(
+        undefined
+      );
+      expect(helper.clearRefinements).toHaveBeenCalledWith(attributeName);
+      expect(helper.search).toHaveBeenCalled();
+    });
+
+    it('expect to reset min refinenement when user bounds are set and value is nullable', () => {
+      const range = { min: 0, max: 500 };
+      const values = [undefined, 490];
+      const helper = createHelper();
+      const widget = connectRange(rendering)({
+        attributeName,
+        min: 10,
+      });
+
+      helper.addNumericRefinement(attributeName, '>=', 20);
+
+      widget._refine(helper, range)(values);
+
+      expect(helper.getNumericRefinement(attributeName, '>=')).toEqual([10]);
+      expect(helper.getNumericRefinement(attributeName, '<=')).toEqual([490]);
+      expect(helper.clearRefinements).toHaveBeenCalled();
+      expect(helper.search).toHaveBeenCalled();
+    });
+
+    it('expect to reset max refinenement when user bounds are set and value is nullable', () => {
+      const range = { min: 0, max: 500 };
+      const values = [10, undefined];
+      const helper = createHelper();
+      const widget = connectRange(rendering)({
+        attributeName,
+        max: 250,
+      });
+
+      helper.addNumericRefinement(attributeName, '>=', 240);
+
+      widget._refine(helper, range)(values);
+
+      expect(helper.getNumericRefinement(attributeName, '>=')).toEqual([10]);
+      expect(helper.getNumericRefinement(attributeName, '<=')).toEqual([250]);
+      expect(helper.clearRefinements).toHaveBeenCalled();
+      expect(helper.search).toHaveBeenCalled();
+    });
+
+    it("expect to not refine when min it's out of range", () => {
+      const range = { min: 10, max: 500 };
+      const values = [0, 490];
+      const helper = createHelper();
+      const widget = connectRange(rendering)({ attributeName });
+
+      widget._refine(helper, range)(values);
+
+      expect(helper.getNumericRefinement(attributeName, '>=')).toEqual(
+        undefined
+      );
+      expect(helper.getNumericRefinement(attributeName, '<=')).toEqual(
+        undefined
+      );
+      expect(helper.clearRefinements).not.toHaveBeenCalled();
+      expect(helper.search).not.toHaveBeenCalled();
+    });
+
+    it("expect to not refine when max it's out of range", () => {
       const range = { min: 0, max: 490 };
       const values = [10, 500];
       const helper = createHelper();
@@ -785,34 +803,19 @@ describe('connectRange', () => {
 
       widget._refine(helper, range)(values);
 
-      expect(helper.getNumericRefinement(attributeName, '>=')).toEqual([10]);
+      expect(helper.getNumericRefinement(attributeName, '>=')).toEqual(
+        undefined
+      );
       expect(helper.getNumericRefinement(attributeName, '<=')).toEqual(
         undefined
       );
-      expect(helper.clearRefinements).toHaveBeenCalledWith(attributeName);
-      expect(helper.search).toHaveBeenCalled();
-    });
-
-    it('expect to not refine when both values have not changed', () => {
-      const range = { min: 0, max: 500 };
-      const values = [10, 250];
-      const helper = createHelper();
-      const widget = connectRange(rendering)({ attributeName });
-
-      helper.addNumericRefinement(attributeName, '>=', 10);
-      helper.addNumericRefinement(attributeName, '<=', 250);
-
-      widget._refine(helper, range)(values);
-
-      expect(helper.getNumericRefinement(attributeName, '>=')).toEqual([10]);
-      expect(helper.getNumericRefinement(attributeName, '<=')).toEqual([250]);
       expect(helper.clearRefinements).not.toHaveBeenCalled();
       expect(helper.search).not.toHaveBeenCalled();
     });
 
-    it('expect to not refine when values are invalid', () => {
+    it("expect to not refine when values don't have changed from empty state", () => {
       const range = { min: 0, max: 500 };
-      const values = [null, null];
+      const values = [undefined, undefined];
       const helper = createHelper();
       const widget = connectRange(rendering)({ attributeName });
 
@@ -824,8 +827,43 @@ describe('connectRange', () => {
       expect(helper.getNumericRefinement(attributeName, '<=')).toEqual(
         undefined
       );
-      expect(helper.clearRefinements).toHaveBeenCalledWith(attributeName);
-      expect(helper.search).toHaveBeenCalled();
+      expect(helper.clearRefinements).not.toHaveBeenCalled();
+      expect(helper.search).not.toHaveBeenCalled();
+    });
+
+    it("expect to not refine when values don't have changed from non empty state", () => {
+      const range = { min: 0, max: 500 };
+      const values = [10, 490];
+      const helper = createHelper();
+      const widget = connectRange(rendering)({ attributeName });
+
+      helper.addNumericRefinement(attributeName, '>=', 10);
+      helper.addNumericRefinement(attributeName, '<=', 490);
+
+      widget._refine(helper, range)(values);
+
+      expect(helper.getNumericRefinement(attributeName, '>=')).toEqual([10]);
+      expect(helper.getNumericRefinement(attributeName, '<=')).toEqual([490]);
+      expect(helper.clearRefinements).not.toHaveBeenCalled();
+      expect(helper.search).not.toHaveBeenCalled();
+    });
+
+    it('expect to not refine when values are invalid', () => {
+      const range = { min: 0, max: 500 };
+      const values = ['ADASA', 'FFDSFQS'];
+      const helper = createHelper();
+      const widget = connectRange(rendering)({ attributeName });
+
+      widget._refine(helper, range)(values);
+
+      expect(helper.getNumericRefinement(attributeName, '>=')).toEqual(
+        undefined
+      );
+      expect(helper.getNumericRefinement(attributeName, '<=')).toEqual(
+        undefined
+      );
+      expect(helper.clearRefinements).not.toHaveBeenCalled();
+      expect(helper.search).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/connectors/range/__tests__/connectRange-test.js
+++ b/src/connectors/range/__tests__/connectRange-test.js
@@ -696,7 +696,7 @@ describe('connectRange', () => {
       const range = { min: 10, max: 500 };
       const values = [null, 490];
       const helper = createHelper();
-      const widget = connectRangeSlider(rendering)({
+      const widget = connectRange(rendering)({
         attributeName,
         min: 10,
       });
@@ -713,7 +713,7 @@ describe('connectRange', () => {
       const range = { min: 10, max: 500 };
       const values = [20, null];
       const helper = createHelper();
-      const widget = connectRangeSlider(rendering)({
+      const widget = connectRange(rendering)({
         attributeName,
         max: 500,
       });

--- a/src/connectors/range/__tests__/connectRange-test.js
+++ b/src/connectors/range/__tests__/connectRange-test.js
@@ -526,8 +526,11 @@ describe('connectRange', () => {
     const rendering = () => {};
     const createHelper = () => {
       const helper = jsHelper(fakeClient);
-      helper.clearRefinements = jest.fn();
       helper.search = jest.fn();
+      const initalClearRefinements = helper.clearRefinements;
+      helper.clearRefinements = jest.fn((...args) =>
+        initalClearRefinements.apply(helper, args)
+      );
 
       return helper;
     };

--- a/src/connectors/range/connectRange.js
+++ b/src/connectors/range/connectRange.js
@@ -107,10 +107,10 @@ export default function connectRange(renderFn) {
 
       _getCurrentRefinement(helper) {
         const [minValue] =
-          helper.state.getNumericRefinement(attributeName, '>=') || [];
+          helper.getNumericRefinement(attributeName, '>=') || [];
 
         const [maxValue] =
-          helper.state.getNumericRefinement(attributeName, '<=') || [];
+          helper.getNumericRefinement(attributeName, '<=') || [];
 
         const min = _isFinite(minValue) ? minValue : -Infinity;
         const max = _isFinite(maxValue) ? maxValue : Infinity;

--- a/src/widgets/range-input/__tests__/__snapshots__/range-input-test.js.snap
+++ b/src/widgets/range-input/__tests__/__snapshots__/range-input-test.js.snap
@@ -46,8 +46,8 @@ exports[`rangeInput expect to render with custom classNames 1`] = `
   }
   values={
     Object {
-      "max": null,
-      "min": null,
+      "max": undefined,
+      "min": undefined,
     }
   }
 />
@@ -99,8 +99,8 @@ exports[`rangeInput expect to render with custom labels 1`] = `
   }
   values={
     Object {
-      "max": null,
-      "min": null,
+      "max": undefined,
+      "min": undefined,
     }
   }
 />
@@ -205,8 +205,8 @@ exports[`rangeInput expect to render with refinement at boundaries 1`] = `
   }
   values={
     Object {
-      "max": null,
-      "min": null,
+      "max": undefined,
+      "min": undefined,
     }
   }
 />
@@ -258,8 +258,8 @@ exports[`rangeInput expect to render with results 1`] = `
   }
   values={
     Object {
-      "max": null,
-      "min": null,
+      "max": undefined,
+      "min": undefined,
     }
   }
 />
@@ -311,8 +311,8 @@ exports[`rangeInput expect to render without results 1`] = `
   }
   values={
     Object {
-      "max": null,
-      "min": null,
+      "max": undefined,
+      "min": undefined,
     }
   }
 />

--- a/src/widgets/range-input/__tests__/range-input-test.js
+++ b/src/widgets/range-input/__tests__/range-input-test.js
@@ -215,8 +215,8 @@ describe('rangeInput', () => {
     expect(ReactDOM.render).toHaveBeenCalledTimes(1);
     expect(ReactDOM.render.mock.calls[0][0]).toMatchSnapshot();
     expect(ReactDOM.render.mock.calls[0][0].props.values).toEqual({
-      min: null,
-      max: null,
+      min: undefined,
+      max: undefined,
     });
   });
 

--- a/src/widgets/range-input/range-input.js
+++ b/src/widgets/range-input/range-input.js
@@ -41,8 +41,8 @@ const renderer = ({
   const shouldAutoHideContainer = autoHideContainer && rangeMin === rangeMax;
 
   const values = {
-    min: minValue !== -Infinity && minValue !== rangeMin ? minValue : null,
-    max: maxValue !== Infinity && maxValue !== rangeMax ? maxValue : null,
+    min: minValue !== -Infinity && minValue !== rangeMin ? minValue : undefined,
+    max: maxValue !== Infinity && maxValue !== rangeMax ? maxValue : undefined,
   };
 
   ReactDOM.render(


### PR DESCRIPTION
**Summary**

As we discuss [here](https://github.com/algolia/instantsearch.js/pull/2440#discussion_r143139279), this PR remove the validations on the inputs inside the component. All the logic is purely handled by the connector. The most significant change is that now **both** inputs must be valid to trigger a search.

The logic for the connector is less permissive for the validation part than the other one. It's a good point, specially for the user using the connector API. But IMO we still need to validate the inputs from the component (via the HTML5 validation) because when the user trigger a search out of range nothing happen. The user as no clue on why the search is invalid.

**Example:**

- use `RangeInput` on `default`
- set `min` input to `10` & `max` input to `35000` (value out of range)
- submit the form

Nothing happen, because the search is out of range. But the user don't have feedbacks of the state of his search. With the HTML5 validation we should see an error that display `Value must be less or equal than {MAX}`.
