### PR TITLE
chore(doc): update link to v2 in v1

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -16,7 +16,7 @@ navigation:
  - text: About
    url: /about/
  - text: InstantSearch.js V2
-   url: ../v2/
+   url: /../v2/
 # Build settings
 markdown: kramdown
 


### PR DESCRIPTION
https://community.algolia.com/instantsearch.js/v1/documentation/

If you go to this page you can see the broken link :)