### PR TITLE
fix(ie11): preact-compat algolia fork with #423

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "hogan.js": "^3.0.2",
     "lodash": "^4.17.4",
     "preact": "^8.1.0",
-    "preact-compat": "^3.16.0",
+    "preact-compat-algolia": "^3.17.0-beta.0",
     "prop-types": "^15.5.10",
     "rheostat": "algolia/rheostat#dist-preact",
     "to-factory": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instantsearch.js",
-  "version": "2.2.0",
+  "version": "2.2.1-beta.0",
   "description": "instantsearch.js is a library of widgets to build high performance instant search experiences using Algolia",
   "homepage": "https://community.algolia.com/instantsearch.js/",
   "main": "dist-es5-module/index.js",

--- a/src/lib/version.js
+++ b/src/lib/version.js
@@ -1,1 +1,1 @@
-export default '2.2.0';
+export default '2.2.1-beta.0';

--- a/yarn.lock
+++ b/yarn.lock
@@ -142,7 +142,7 @@ ajv@^5.0.0, ajv@^5.1.0, ajv@^5.1.5, ajv@^5.2.0, ajv@^5.2.3:
     json-schema-traverse "^0.3.0"
     json-stable-stringify "^1.0.1"
 
-algoliasearch-helper@^2.21.1:
+algoliasearch-helper@^2.22.0:
   version "2.22.0"
   resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-2.22.0.tgz#6904abf15cd9b65a32fc3d9eb9dfe50f53b27001"
   dependencies:
@@ -7593,7 +7593,17 @@ postcss@^6.0.1, postcss@^6.0.11, postcss@^6.0.2:
     source-map "^0.5.7"
     supports-color "^4.4.0"
 
-preact-compat@^3.16.0, preact-compat@^3.17.0:
+preact-compat-algolia@^3.17.0-beta.0:
+  version "3.17.0"
+  resolved "https://registry.yarnpkg.com/preact-compat-algolia/-/preact-compat-algolia-3.17.0.tgz#c104960eb64e6ad13394b71819e07ce32e79f890"
+  dependencies:
+    immutability-helper "^2.1.2"
+    preact-render-to-string "^3.6.0"
+    preact-transition-group "^1.1.0"
+    prop-types "^15.5.8"
+    standalone-react-addons-pure-render-mixin "^0.1.1"
+
+preact-compat@^3.17.0:
   version "3.17.0"
   resolved "https://registry.yarnpkg.com/preact-compat/-/preact-compat-3.17.0.tgz#528cfdfc301190c1a0f47567336be1f4be0266b3"
   dependencies:


### PR DESCRIPTION
This is to fix an [issue of preact-compat](https://github.com/developit/preact-compat/pull/423) on IE11. It uses an algolia fork of preact-compat, that we need to replace once the new version is out (3.17.1 or 3.18.0)