### PR TITLE
chore(doc): add breadcrumb to e-commerce demo

### DIFF
--- a/docgen/src/examples/e-commerce/index.html
+++ b/docgen/src/examples/e-commerce/index.html
@@ -34,12 +34,19 @@ title: E-Commerce search by Algolia
 
     <div class="results-wrapper">
       <section id="results-topbar">
-        <div id="breadcrumb"></div>
-        <div class="sort-by">
-          <label>Sort by</label>
-          <div id="sort-by-selector"></div>
+        <div id="results-topbar_left">
+          <div id="breadcrumb"></div>
+          <div id="stats" class="text-muted"></div>
         </div>
-        <div id="stats" class="text-muted"></div>
+        <div id="results-topbar_right">
+          <div class="sort-by">
+            <label>Sort by</label>
+            <div id="sort-by-selector"></div>
+          </div>
+        </div>
+
+
+
       </section>
       <main id="hits"></main>
       <section id="pagination"></section>

--- a/docgen/src/examples/e-commerce/index.html
+++ b/docgen/src/examples/e-commerce/index.html
@@ -1,6 +1,6 @@
----
-layout: example.pug
-title: E-Commerce search by Algolia
+--- 
+layout: example.pug 
+title: E-Commerce search by Algolia 
 ---
 <div class="container-fluid">
   <header class="content-wrapper">
@@ -34,6 +34,7 @@ title: E-Commerce search by Algolia
 
     <div class="results-wrapper">
       <section id="results-topbar">
+        <div id="breadcrumb"></div>
         <div class="sort-by">
           <label>Sort by</label>
           <div id="sort-by-selector"></div>

--- a/docgen/src/examples/e-commerce/main.scss
+++ b/docgen/src/examples/e-commerce/main.scss
@@ -313,6 +313,24 @@ aside {
     font-weight: normal;
     font-size: .8em;
   }
+  .ais-breadcrumb--home,  {
+    display: inline-block;
+  }
+  .ais-breadcrumb--separator {
+    position: relative;
+    display: inline-block;
+    height: 14px;
+    width: 14px;
+    &:after {
+      background: url("data:image/svg+xml;utf8,<svg viewBox='0 0 8 13' xmlns='http://www.w3.org/2000/svg'><path d='M1.5 1.5l5 4.98-5 5.02' stroke='%23697782' stroke-width='1.5' fill='none' fill-rule='evenodd' stroke-linecap='round' opacity='.4'/></svg>") no-repeat center center/contain;
+      content: ' ';
+      display: block;
+      position: absolute;
+      top: 2px;
+      height: 14px;
+      width: 14px;
+      }
+}
   #sort-by-selector {
     display: inline-block;
   }

--- a/docgen/src/examples/e-commerce/main.scss
+++ b/docgen/src/examples/e-commerce/main.scss
@@ -302,16 +302,34 @@ aside {
 }
 
 #results-topbar {
-  display: block;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   width: 100%;
   line-height: 22px;
-  @include clearfix;
   .sort-by {
     float: right;
   }
   label {
     font-weight: normal;
     font-size: .8em;
+  }
+
+  .ais-breadcrumb--root {
+    margin-top: 7px;
+    display: inline-block;
+  }
+
+  .ais-stats {
+    margin-top: -4px;
+  }
+  .ais-breadcrumb--disabledLabel {
+    &:hover {
+        text-decoration: none;
+        color: #444;
+        cursor: default;
+    }
+
   }
   .ais-breadcrumb--home,  {
     display: inline-block;

--- a/docgen/src/examples/e-commerce/search.js
+++ b/docgen/src/examples/e-commerce/search.js
@@ -20,26 +20,26 @@ search.addWidget(
   })
 );
 
-search.on('render', function() {
+search.on('render', function () {
   $('.product-picture img').addClass('transparent');
-  $('.product-picture img').one('load', function() {
-      $(this).removeClass('transparent');
-  }).each(function() {
-      if(this.complete) $(this).load();
+  $('.product-picture img').one('load', function () {
+    $(this).removeClass('transparent');
+  }).each(function () {
+    if (this.complete) $(this).load();
   });
 });
 
 var hitTemplate =
   '<article class="hit">' +
-      '<div class="product-picture-wrapper">' +
-        '<div class="product-picture"><img src="{{image}}" /></div>' +
-      '</div>' +
-      '<div class="product-desc-wrapper">' +
-        '<div class="product-name">{{{_highlightResult.name.value}}}</div>' +
-        '<div class="product-type">{{{_highlightResult.type.value}}}</div>' +
-        '<div class="product-price">${{price}}</div>' +
-        '<div class="product-rating">{{#stars}}<span class="ais-star-rating--star{{^.}}__empty{{/.}}"></span>{{/stars}}</div>' +
-      '</div>' +
+  '<div class="product-picture-wrapper">' +
+  '<div class="product-picture"><img src="{{image}}" /></div>' +
+  '</div>' +
+  '<div class="product-desc-wrapper">' +
+  '<div class="product-name">{{{_highlightResult.name.value}}}</div>' +
+  '<div class="product-type">{{{_highlightResult.type.value}}}</div>' +
+  '<div class="product-price">${{price}}</div>' +
+  '<div class="product-rating">{{#stars}}<span class="ais-star-rating--star{{^.}}__empty{{/.}}"></span>{{/stars}}</div>' +
+  '</div>' +
   '</article>';
 
 var noResultsTemplate =
@@ -50,8 +50,8 @@ var menuTemplate =
 
 var facetTemplateCheckbox =
   '<a href="javascript:void(0);" class="facet-item">' +
-    '<input type="checkbox" class="{{cssClasses.checkbox}}" value="{{label}}" {{#isRefined}}checked{{/isRefined}} />{{label}}' +
-    '<span class="facet-count">({{count}})</span>' +
+  '<input type="checkbox" class="{{cssClasses.checkbox}}" value="{{label}}" {{#isRefined}}checked{{/isRefined}} />{{label}}' +
+  '<span class="facet-count">({{count}})</span>' +
   '</a>';
 
 var facetTemplateColors =
@@ -65,7 +65,7 @@ search.addWidget(
       empty: noResultsTemplate,
       item: hitTemplate
     },
-    transformData: function(hit) {
+    transformData: function (hit) {
       hit.stars = [];
       for (var i = 1; i <= 5; ++i) {
         hit.stars.push(i <= hit.rating);
@@ -152,14 +152,21 @@ search.addWidget(
 );
 
 search.addWidget(
+  instantsearch.widgets.breadcrumb({
+    container: '#breadcrumb',
+    separator: ' > ',
+    attributes: ['category', 'sub_category', 'sub_sub_category'],
+  })
+);
+search.addWidget(
   instantsearch.widgets.sortBySelector({
     container: '#sort-by-selector',
     indices: [
-      {name: 'ikea', label: 'Featured'},
-      {name: 'ikea_price_asc', label: 'Price asc.'},
-      {name: 'ikea_price_desc', label: 'Price desc.'}
+      { name: 'ikea', label: 'Featured' },
+      { name: 'ikea_price_asc', label: 'Price asc.' },
+      { name: 'ikea_price_desc', label: 'Price desc.' }
     ],
-    label:'sort by'
+    label: 'sort by'
   })
 );
 


### PR DESCRIPTION
**Summary**
Add a breadcrumb to the e-commerce example (following #2451).

**Result**
Now there is a breadcrumb widget displayed on the example, making it easier to see the facet hierarchy.
![image](https://user-images.githubusercontent.com/21305268/31652687-38eea706-b320-11e7-813e-d55cbaf0ad7f.png)

