### PR TITLE
Avoid to always round the range in connectRange

### DIFF
--- a/dev/app/init-builtin-widgets.js
+++ b/dev/app/init-builtin-widgets.js
@@ -25,7 +25,7 @@ export default () => {
           })
         );
 
-        //Custom Widget to toggle refinement
+        // Custom Widget to toggle refinement
         window.search.addWidget({
           init({ helper }) {
             helper.toggleRefinement(
@@ -56,7 +56,7 @@ export default () => {
           })
         );
 
-        //Custom Widget to toggle refinement
+        // Custom Widget to toggle refinement
         window.search.addWidget({
           init({ helper }) {
             helper.toggleRefinement(
@@ -800,11 +800,6 @@ export default () => {
             templates: {
               header: 'Price',
             },
-            tooltips: {
-              format(rawValue) {
-                return `$${Math.round(rawValue).toLocaleString()}`;
-              },
-            },
           })
         );
       })
@@ -821,11 +816,6 @@ export default () => {
             },
             min: 100,
             max: 50,
-            tooltips: {
-              format(rawValue) {
-                return `$${Math.round(rawValue).toLocaleString()}`;
-              },
-            },
           })
         );
       })
@@ -838,9 +828,20 @@ export default () => {
             container,
             attributeName: 'price',
             step: 500,
+          })
+        );
+      })
+    )
+    .add(
+      'with tooltips',
+      wrapWithHits(container => {
+        window.search.addWidget(
+          instantsearch.widgets.rangeSlider({
+            container,
+            attributeName: 'price',
             tooltips: {
               format(rawValue) {
-                return `$${Math.round(rawValue).toLocaleString()}`;
+                return `$${rawValue}`;
               },
             },
           })
@@ -855,11 +856,6 @@ export default () => {
             container,
             attributeName: 'price',
             pips: false,
-            tooltips: {
-              format(rawValue) {
-                return `$${Math.round(rawValue).toLocaleString()}`;
-              },
-            },
           })
         );
       })
@@ -875,11 +871,6 @@ export default () => {
               header: 'Price',
             },
             min: 0,
-            tooltips: {
-              format(rawValue) {
-                return `$${Math.round(rawValue).toLocaleString()}`;
-              },
-            },
           })
         );
       })
@@ -895,11 +886,6 @@ export default () => {
               header: 'Price',
             },
             min: 36,
-            tooltips: {
-              format(rawValue) {
-                return `$${Math.round(rawValue).toLocaleString()}`;
-              },
-            },
           })
         );
       })
@@ -915,11 +901,6 @@ export default () => {
               header: 'Price',
             },
             max: 36,
-            tooltips: {
-              format(rawValue) {
-                return `$${Math.round(rawValue).toLocaleString()}`;
-              },
-            },
           })
         );
       })
@@ -936,11 +917,6 @@ export default () => {
             },
             min: 10,
             max: 500,
-            tooltips: {
-              format(rawValue) {
-                return `$${Math.round(rawValue).toLocaleString()}`;
-              },
-            },
           })
         );
       })

--- a/dev/app/init-builtin-widgets.js
+++ b/dev/app/init-builtin-widgets.js
@@ -849,6 +849,18 @@ export default () => {
       })
     )
     .add(
+      'with precision',
+      wrapWithHits(container => {
+        window.search.addWidget(
+          instantsearch.widgets.rangeSlider({
+            container,
+            attributeName: 'price',
+            precision: 2,
+          })
+        );
+      })
+    )
+    .add(
       'without pips',
       wrapWithHits(container => {
         window.search.addWidget(

--- a/src/components/Breadcrumb/Breadcrumb.js
+++ b/src/components/Breadcrumb/Breadcrumb.js
@@ -26,20 +26,22 @@ class Breadcrumb extends PureComponent {
 
     const breadcrumb = items.map((item, idx) => {
       const isLast = idx === items.length - 1;
-      const label = isLast
-        ? <a className={`${cssClasses.disabledLabel} ${cssClasses.label}`}>
-            {item.name}
-          </a>
-        : <a
-            className={cssClasses.label}
-            href={createURL(item.value)}
-            onClick={e => {
-              e.preventDefault();
-              refine(item.value);
-            }}
-          >
-            {item.name}
-          </a>;
+      const label = isLast ? (
+        <a className={`${cssClasses.disabledLabel} ${cssClasses.label}`}>
+          {item.name}
+        </a>
+      ) : (
+        <a
+          className={cssClasses.label}
+          href={createURL(item.value)}
+          onClick={e => {
+            e.preventDefault();
+            refine(item.value);
+          }}
+        >
+          {item.name}
+        </a>
+      );
 
       return [
         <Template

--- a/src/components/Template.js
+++ b/src/components/Template.js
@@ -42,7 +42,7 @@ export class PureTemplate extends React.Component {
 
     if (isReactElement(content)) {
       throw new Error(
-        'Support for templates as React elements has been removed, please use react-instantsearch',
+        'Support for templates as React elements has been removed, please use react-instantsearch'
       );
     }
 
@@ -60,7 +60,7 @@ PureTemplate.propTypes = {
   rootProps: PropTypes.object,
   templateKey: PropTypes.string,
   templates: PropTypes.objectOf(
-    PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+    PropTypes.oneOfType([PropTypes.string, PropTypes.func])
   ),
   templatesConfig: PropTypes.shape({
     helpers: PropTypes.objectOf(PropTypes.func),
@@ -71,7 +71,7 @@ PureTemplate.propTypes = {
         PropTypes.shape({
           o: PropTypes.string,
           c: PropTypes.string,
-        }),
+        })
       ),
       delimiters: PropTypes.string,
       disableLambda: PropTypes.bool,
@@ -113,7 +113,7 @@ function transformData(fn, templateKey, originalData) {
     }
   } else {
     throw new Error(
-      `transformData must be a function or an object, was ${typeFn} (key : ${templateKey})`,
+      `transformData must be a function or an object, was ${typeFn} (key : ${templateKey})`
     );
   }
 
@@ -121,7 +121,7 @@ function transformData(fn, templateKey, originalData) {
   const expectedType = typeof originalData;
   if (dataType !== expectedType) {
     throw new Error(
-      `\`transformData\` must return a \`${expectedType}\`, got \`${dataType}\`.`,
+      `\`transformData\` must return a \`${expectedType}\`, got \`${dataType}\`.`
     );
   }
   return data;
@@ -141,7 +141,7 @@ function renderTemplate({
 
   if (!isTemplateString && !isTemplateFunction) {
     throw new Error(
-      `Template must be 'string' or 'function', was '${templateType}' (key: ${templateKey})`,
+      `Template must be 'string' or 'function', was '${templateType}' (key: ${templateKey})`
     );
   } else if (isTemplateFunction) {
     return template(data);
@@ -149,7 +149,7 @@ function renderTemplate({
     const transformedHelpers = transformHelpersToHogan(
       helpers,
       compileOptions,
-      data,
+      data
     );
     const preparedData = { ...data, helpers: transformedHelpers };
     return hogan.compile(template, compileOptions).render(preparedData);
@@ -166,7 +166,7 @@ function transformHelpersToHogan(helpers, compileOptions, data) {
     curry(function(text) {
       const render = value => hogan.compile(value, compileOptions).render(this);
       return method.call(data, text, render);
-    }),
+    })
   );
 }
 

--- a/src/connectors/breadcrumb/connectBreadcrumb.js
+++ b/src/connectors/breadcrumb/connectBreadcrumb.js
@@ -74,6 +74,7 @@ export default function connectBreadcrumb(renderFn) {
               !isEqual(isFacetSet.attributes, attributes) ||
               isFacetSet.separator !== separator
             ) {
+              // eslint-disable-next-line no-console
               console.warn(
                 'Using Breadcrumb & HierarchicalMenu on the same facet with different options. Adding that one will override the configuration of the HierarchicalMenu. Check your options.'
               );

--- a/src/connectors/breadcrumb/connectBreadcrumb.js
+++ b/src/connectors/breadcrumb/connectBreadcrumb.js
@@ -5,7 +5,7 @@ import { checkRendering } from '../../lib/utils.js';
 const usage = `Usage:
 var customBreadcrumb = connectBreadcrumb(function renderFn(params, isFirstRendering) {
   // params = {
-  //   createURL,  
+  //   createURL,
   //   items,
   //   refine,
   //   instantSearchInstance,

--- a/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
+++ b/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
@@ -94,7 +94,7 @@ export default function connectHierarchicalMenu(renderFn) {
     return {
       getConfiguration: currentConfiguration => {
         if (currentConfiguration.hierarchicalFacets) {
-          let isFacetSet = find(
+          const isFacetSet = find(
             currentConfiguration.hierarchicalFacets,
             ({ name }) => name === hierarchicalFacetName
           );

--- a/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
+++ b/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
@@ -110,7 +110,7 @@ export default function connectHierarchicalMenu(renderFn) {
               'using Breadcrumb & HierarchicalMenu on the same facet with different options'
             );
           }
-          return;
+          return {};
         }
 
         return {

--- a/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
+++ b/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
@@ -105,6 +105,7 @@ export default function connectHierarchicalMenu(renderFn) {
               isFacetSet.separator === separator
             )
           ) {
+            // eslint-disable-next-line no-console
             console.warn(
               'using Breadcrumb & HierarchicalMenu on the same facet with different options'
             );

--- a/src/connectors/range/__tests__/connectRange-test.js
+++ b/src/connectors/range/__tests__/connectRange-test.js
@@ -479,14 +479,40 @@ describe('connectRange', () => {
       expect(actual).toEqual(expectation);
     });
 
-    it('expect to return not rounded range values when precision is greater than 0', () => {
-      const stats = { min: 1.19, max: 499.19 };
+    it('expect to return rounded range values when precision is 1', () => {
+      const stats = { min: 1.12345, max: 499.56789 };
       const widget = connectRange(rendering)({
         attributeName,
         precision: 1,
       });
 
-      const expectation = { min: 1.19, max: 499.19 };
+      const expectation = { min: 1.1, max: 499.6 };
+      const actual = widget._getCurrentRange(stats);
+
+      expect(actual).toEqual(expectation);
+    });
+
+    it('expect to return rounded range values when precision is 2', () => {
+      const stats = { min: 1.12345, max: 499.56789 };
+      const widget = connectRange(rendering)({
+        attributeName,
+        precision: 2,
+      });
+
+      const expectation = { min: 1.12, max: 499.57 };
+      const actual = widget._getCurrentRange(stats);
+
+      expect(actual).toEqual(expectation);
+    });
+
+    it('expect to return rounded range values when precision is 3', () => {
+      const stats = { min: 1.12345, max: 499.56789 };
+      const widget = connectRange(rendering)({
+        attributeName,
+        precision: 3,
+      });
+
+      const expectation = { min: 1.123, max: 499.568 };
       const actual = widget._getCurrentRange(stats);
 
       expect(actual).toEqual(expectation);

--- a/src/connectors/range/__tests__/connectRange-test.js
+++ b/src/connectors/range/__tests__/connectRange-test.js
@@ -466,13 +466,27 @@ describe('connectRange', () => {
       expect(actual).toEqual(expectation);
     });
 
-    it('expect to return rounded range values', () => {
+    it('expect to return rounded range values when precision is 0', () => {
       const stats = { min: 1.79, max: 499.99 };
       const widget = connectRange(rendering)({
         attributeName,
+        precision: 0,
       });
 
       const expectation = { min: 1, max: 500 };
+      const actual = widget._getCurrentRange(stats);
+
+      expect(actual).toEqual(expectation);
+    });
+
+    it('expect to return not rounded range values when precision is greater than 0', () => {
+      const stats = { min: 1.19, max: 499.19 };
+      const widget = connectRange(rendering)({
+        attributeName,
+        precision: 1,
+      });
+
+      const expectation = { min: 1.19, max: 499.19 };
       const actual = widget._getCurrentRange(stats);
 
       expect(actual).toEqual(expectation);

--- a/src/connectors/range/connectRange.js
+++ b/src/connectors/range/connectRange.js
@@ -81,6 +81,8 @@ export default function connectRange(renderFn) {
 
     return {
       _getCurrentRange(stats) {
+        const pow = Math.pow(10, precision);
+
         let min;
         if (hasMinBound) {
           min = minBound;
@@ -100,8 +102,8 @@ export default function connectRange(renderFn) {
         }
 
         return {
-          min: precision === 0 ? Math.floor(min) : min,
-          max: precision === 0 ? Math.ceil(max) : max,
+          min: Math.floor(min * pow) / pow,
+          max: Math.ceil(max * pow) / pow,
         };
       },
 

--- a/src/connectors/range/connectRange.js
+++ b/src/connectors/range/connectRange.js
@@ -100,8 +100,8 @@ export default function connectRange(renderFn) {
         }
 
         return {
-          min: Math.floor(min),
-          max: Math.ceil(max),
+          min: precision === 0 ? Math.floor(min) : min,
+          max: precision === 0 ? Math.ceil(max) : max,
         };
       },
 

--- a/src/css/default/_breadcrumb.scss
+++ b/src/css/default/_breadcrumb.scss
@@ -1,16 +1,15 @@
 .ais-breadcrumb--label,
 .ais-breadcrumb--separator,
-.ais-breadcrumb--home,
-{
-    display: inline;
-    color: #3369e7;
+.ais-breadcrumb--home {
+  display: inline;
+  color: #3369E7;
 }
 
 .ais-breadcrumb--item {
-    display: inline;
+  display: inline;
 }
 
 .ais-breadcrumb--disabledLabel {
-    color: rgb(68, 68, 68);
-    display: inline;
+  color: rgb(68, 68, 68);
+  display: inline;
 }

--- a/src/css/theme/_breadcrumb.scss
+++ b/src/css/theme/_breadcrumb.scss
@@ -1,31 +1,33 @@
 .ais-breadcrumb--root {
-    .ais-breadcrumb--label,
-    .ais-breadcrumb--separator,
-    .ais-breadcrumb--home,
-    {
-        div {
-            display: inline;
-        }
-        display: inline;
-        color: #3369e7;
+  .ais-breadcrumb--label,
+  .ais-breadcrumb--separator,
+  .ais-breadcrumb--home {
+    display: inline;
+    color: #3369E7;
+
+    div {
+      display: inline;
     }
-    .ais-breadcrumb--disabledLabel {
-        color: rgb(68, 68, 68);
-        display: inline;
+  }
+
+  .ais-breadcrumb--disabledLabel {
+    color: rgb(68, 68, 68);
+    display: inline;
+  }
+
+  .ais-breadcrumb--separator {
+    position: relative;
+    display: inline-block;
+    height: 14px;
+    width: 14px;
+    &::after {
+      background: url("data:image/svg+xml;utf8,<svg viewBox='0 0 8 13' xmlns='http://www.w3.org/2000/svg'><path d='M1.5 1.5l5 4.98-5 5.02' stroke='%23697782' stroke-width='1.5' fill='none' fill-rule='evenodd' stroke-linecap='round' opacity='.4'/></svg>") no-repeat center center / contain;
+      content: ' ';
+      display: block;
+      position: absolute;
+      top: 2px;
+      height: 14px;
+      width: 14px;
     }
-    .ais-breadcrumb--separator {
-        position: relative;
-        display: inline-block;
-        height: 14px;
-        width: 14px;
-        &:after {
-            background: url("data:image/svg+xml;utf8,<svg viewBox='0 0 8 13' xmlns='http://www.w3.org/2000/svg'><path d='M1.5 1.5l5 4.98-5 5.02' stroke='%23697782' stroke-width='1.5' fill='none' fill-rule='evenodd' stroke-linecap='round' opacity='.4'/></svg>") no-repeat center center/contain;
-            content: ' ';
-            display: block;
-            position: absolute;
-            top: 2px;
-            height: 14px;
-            width: 14px;
-        }
-    }
+  }
 }

--- a/src/widgets/range-input/range-input.js
+++ b/src/widgets/range-input/range-input.js
@@ -110,7 +110,7 @@ rangeInput({
  * @property {string} attributeName Name of the attribute for faceting.
  * @property {number} [min] Minimal slider value, default to automatically computed from the result set.
  * @property {number} [max] Maximal slider value, defaults to automatically computed from the result set.
- * @property {number} [precision = 2] Number of digits after decimal point to use.
+ * @property {number} [precision = 0] Number of digits after decimal point to use.
  * @property {RangeInputClasses} [cssClasses] CSS classes to add.
  * @property {RangeInputTemplates} [templates] Templates to use for the widget.
  * @property {RangeInputLabels} [labels] Labels to use for the widget.

--- a/src/widgets/range-slider/__tests__/range-slider-test.js
+++ b/src/widgets/range-slider/__tests__/range-slider-test.js
@@ -260,7 +260,7 @@ describe('rangeSlider', () => {
 
         expect(helper.search).toHaveBeenCalledTimes(1);
         expect(state1).toEqual(
-          state0.addNumericRefinement(attributeName, '>=', targetValue)
+          state0.addNumericRefinement(attributeName, '>=', 3)
         );
       });
 
@@ -274,7 +274,7 @@ describe('rangeSlider', () => {
 
         expect(helper.search).toHaveBeenCalledTimes(1);
         expect(state1).toEqual(
-          state0.addNumericRefinement(attributeName, '<=', targetValue)
+          state0.addNumericRefinement(attributeName, '<=', 4999)
         );
       });
 
@@ -289,8 +289,8 @@ describe('rangeSlider', () => {
         expect(helper.search).toHaveBeenCalledTimes(1);
         expect(state1).toEqual(
           state0
-            .addNumericRefinement(attributeName, '>=', targetValue[0])
-            .addNumericRefinement(attributeName, '<=', targetValue[1])
+            .addNumericRefinement(attributeName, '>=', 3)
+            .addNumericRefinement(attributeName, '<=', 4999)
         );
       });
 

--- a/src/widgets/range-slider/range-slider.js
+++ b/src/widgets/range-slider/range-slider.js
@@ -78,7 +78,7 @@ rangeSlider({
   [ max ],
   [ pips = true ],
   [ step = 1 ],
-  [ precision = 2 ],
+  [ precision = 0 ],
   [ tooltips=true ],
   [ templates.{header, footer} ],
   [ cssClasses.{root, header, body, footer} ],
@@ -126,6 +126,7 @@ rangeSlider({
  * @property  {RangeSliderCssClasses} [cssClasses] CSS classes to add to the wrapping elements.
  * @property  {boolean} [pips=true] Show slider pips.
  * @property  {number} [step=1] Every handle move will jump that number of steps.
+ * @property  {number} [precision = 0] Number of digits after decimal point to use.
  * @property  {boolean|RangeSliderCollapsibleOptions} [collapsible=false] Hide the widget body and footer when clicking on header.
  * @property  {number} [min] Minimal slider value, default to automatically computed from the result set.
  * @property  {number} [max] Maximal slider value, defaults to automatically computed from the result set.
@@ -172,7 +173,7 @@ export default function rangeSlider(
     cssClasses: userCssClasses = {},
     step = 1,
     pips = true,
-    precision = 2,
+    precision = 0,
     tooltips = true,
     autoHideContainer = true,
   } = {}


### PR DESCRIPTION
**Summary**

In the `connectRange` we always round the range even with a precision greater than 0. Now we round the range only for a precision of 0 and leave the original value in the other case.

**Result**

You can play with the `RangeInput` on dev-novel.

**Before:**

<img width="390" alt="screen shot 2017-10-18 at 11 48 02" src="https://user-images.githubusercontent.com/6513513/31712141-7c916450-b3fa-11e7-92f7-02aa953340ff.png">

**After:**

<img width="386" alt="screen shot 2017-10-18 at 11 40 49" src="https://user-images.githubusercontent.com/6513513/31712144-81085502-b3fa-11e7-8000-3b6c0d89b06b.png">