### PR TITLE
Fix connect hierarchical menu

### DIFF
--- a/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.js
+++ b/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.js
@@ -4,6 +4,57 @@ const SearchResults = jsHelper.SearchResults;
 import connectBreadcrumb from '../connectBreadcrumb.js';
 
 describe('connectBreadcrumb', () => {
+  it('It should compute getConfiguration() correctly', () => {
+    const rendering = jest.fn();
+    const makeWidget = connectBreadcrumb(rendering);
+
+    const widget = makeWidget({ attributes: ['category', 'sub_category'] });
+
+    // when there is no hierarchicalFacets into current configuration
+    {
+      const config = widget.getConfiguration({});
+      expect(config).toEqual({
+        hierarchicalFacets: [
+          {
+            attributes: ['category', 'sub_category'],
+            name: 'category',
+            rootPath: null,
+            separator: ' > ',
+          },
+        ],
+      });
+    }
+
+    // when there is an identical hierarchicalFacets into current configuration
+    {
+      const spy = jest.spyOn(global.console, 'warn');
+      const config = widget.getConfiguration({
+        hierarchicalFacets: [{ name: 'category' }],
+      });
+      expect(config).toEqual({});
+      expect(spy).toHaveBeenCalled();
+      spy.mockReset();
+      spy.mockRestore();
+    }
+
+    // when there is already a different hierarchicalFacets into current configuration
+    {
+      const config = widget.getConfiguration({
+        hierarchicalFacets: [{ name: 'foo' }],
+      });
+      expect(config).toEqual({
+        hierarchicalFacets: [
+          {
+            attributes: ['category', 'sub_category'],
+            name: 'category',
+            rootPath: null,
+            separator: ' > ',
+          },
+        ],
+      });
+    }
+  });
+
   it('Renders during init and render', () => {
     const rendering = jest.fn();
     const makeWidget = connectBreadcrumb(rendering);

--- a/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.js
+++ b/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.js
@@ -6,6 +6,61 @@ const SearchResults = jsHelper.SearchResults;
 import connectHierarchicalMenu from '../connectHierarchicalMenu.js';
 
 describe('connectHierarchicalMenu', () => {
+  it('It should compute getConfiguration() correctly', () => {
+    const rendering = jest.fn();
+    const makeWidget = connectHierarchicalMenu(rendering);
+
+    const widget = makeWidget({ attributes: ['category', 'sub_category'] });
+
+    // when there is no hierarchicalFacets into current configuration
+    {
+      const config = widget.getConfiguration({});
+      expect(config).toEqual({
+        hierarchicalFacets: [
+          {
+            attributes: ['category', 'sub_category'],
+            name: 'category',
+            rootPath: null,
+            separator: ' > ',
+            showParentLevel: true,
+          },
+        ],
+        maxValuesPerFacet: 10,
+      });
+    }
+
+    // when there is an identical hierarchicalFacets into current configuration
+    {
+      const spy = jest.spyOn(global.console, 'warn');
+      const config = widget.getConfiguration({
+        hierarchicalFacets: [{ name: 'category' }],
+      });
+      expect(config).toEqual({});
+      expect(spy).toHaveBeenCalled();
+      spy.mockReset();
+      spy.mockRestore();
+    }
+
+    // when there is already a different hierarchicalFacets into current configuration
+    {
+      const config = widget.getConfiguration({
+        hierarchicalFacets: [{ name: 'foo' }],
+      });
+      expect(config).toEqual({
+        hierarchicalFacets: [
+          {
+            attributes: ['category', 'sub_category'],
+            name: 'category',
+            rootPath: null,
+            separator: ' > ',
+            showParentLevel: true,
+          },
+        ],
+        maxValuesPerFacet: 10,
+      });
+    }
+  });
+
   it('Renders during init and render', () => {
     // test that the dummyRendering is called with the isFirstRendering
     // flag set accordingly

--- a/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
+++ b/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
@@ -109,8 +109,8 @@ export default function connectHierarchicalMenu(renderFn) {
             console.warn(
               'using Breadcrumb & HierarchicalMenu on the same facet with different options'
             );
+            return {};
           }
-          return {};
         }
 
         return {


### PR DESCRIPTION
When:

If there is already`currentConfiguration.hierarchicalFacets` in the configuration, we would check if it's the same added and throw a warning.

Bug:

If it's not the same `hierarchicalFacets` we were returning an empty object as well.