### PR TITLE
chore(doc): add showParentLevel example

### DIFF
--- a/src/widgets/hierarchical-menu/hierarchical-menu.js
+++ b/src/widgets/hierarchical-menu/hierarchical-menu.js
@@ -99,8 +99,28 @@ hierarchicalMenu({
  * @property {number} [limit=10] How much facet values to get [*].
  * @property {string} [separator=" > "] Separator used in the attributes to separate level values. [*].
  * @property {string} [rootPath] Prefix path to use if the first level is not the root level.
- * @property {boolean} [showParentLevel=false] Show the siblings of the selected parent levels of the current refined value. This
+ * @property {boolean} [showParentLevel=true] Show the siblings of the selected parent level of the current refined value. This
  * does not impact the root level.
+ *
+ * The hierarchical menu is able to show or hide the siblings with `showParentLevel`.
+ *
+ * With `showParentLevel` set to `true` (default):
+ * - Parent lvl0
+ *   - **lvl1**
+ *     - **lvl2**
+ *     - lvl2
+ *     - lvl2
+ *   - lvl 1
+ *   - lvl 1
+ * - Parent lvl0
+ * - Parent lvl0
+ *
+ * With `showParentLevel` set to `false`:
+ * - Parent lvl0
+ *   - **lvl1**
+ *     - **lvl2**
+ * - Parent lvl0
+ * - Parent lvl0
  * @property {string[]|function} [sortBy=['name:asc']] How to sort refinements. Possible values: `count|isRefined|name:asc|name:desc`.
  *
  * You can also use a sort function that behaves like the standard Javascript [compareFunction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#Syntax).


### PR DESCRIPTION
Add an example to show what is the expected behaviour of the `showParentLevel` option.

Schema proposed by @Giovanni-Mattucci