### PR TITLE
[POC] GeoSearch

### DIFF
--- a/dev/app/built-in-widgets/geo-search-google-maps.stories.js
+++ b/dev/app/built-in-widgets/geo-search-google-maps.stories.js
@@ -27,7 +27,7 @@ export default () => {
     'with IP',
     wrapWithHitsAndConfiguration(container => {
       window.search.addWidget(
-        instantsearch.widgets.geoSearch({
+        instantsearch.widgets.geoSearchWithGoogleMaps({
           container,
         })
       );
@@ -37,7 +37,7 @@ export default () => {
       'with IP & radius',
       wrapWithHitsAndConfiguration(container => {
         window.search.addWidget(
-          instantsearch.widgets.geoSearch({
+          instantsearch.widgets.geoSearchWithGoogleMaps({
             container,
             radius,
           })
@@ -48,7 +48,7 @@ export default () => {
       'with IP & radius & precision',
       wrapWithHitsAndConfiguration(container => {
         window.search.addWidget(
-          instantsearch.widgets.geoSearch({
+          instantsearch.widgets.geoSearchWithGoogleMaps({
             container,
             radius,
             precision,
@@ -62,7 +62,7 @@ export default () => {
     'with position',
     wrapWithHitsAndConfiguration(container => {
       window.search.addWidget(
-        instantsearch.widgets.geoSearch({
+        instantsearch.widgets.geoSearchWithGoogleMaps({
           container,
           position,
         })
@@ -73,7 +73,7 @@ export default () => {
       'with position & radius',
       wrapWithHitsAndConfiguration(container => {
         window.search.addWidget(
-          instantsearch.widgets.geoSearch({
+          instantsearch.widgets.geoSearchWithGoogleMaps({
             container,
             radius,
             position,
@@ -85,7 +85,7 @@ export default () => {
       'with position & radius & precision',
       wrapWithHitsAndConfiguration(container => {
         window.search.addWidget(
-          instantsearch.widgets.geoSearch({
+          instantsearch.widgets.geoSearchWithGoogleMaps({
             container,
             radius,
             precision,
@@ -113,7 +113,7 @@ export default () => {
       );
 
       window.search.addWidget(
-        instantsearch.widgets.geoSearch({
+        instantsearch.widgets.geoSearchWithGoogleMaps({
           container: mapElement,
           radius: 20000,
           enableGeolocationWithIP: false,
@@ -137,7 +137,7 @@ export default () => {
       );
 
       window.search.addWidget(
-        instantsearch.widgets.geoSearch({
+        instantsearch.widgets.geoSearchWithGoogleMaps({
           container: mapElement,
           radius: 20000,
           enableGeolocationWithIP: false,
@@ -152,7 +152,7 @@ export default () => {
     'disable refine on move',
     wrapWithHitsAndConfiguration(container => {
       window.search.addWidget(
-        instantsearch.widgets.geoSearch({
+        instantsearch.widgets.geoSearchWithGoogleMaps({
           container,
           enableRefineOnMapMove: false,
         })

--- a/dev/app/built-in-widgets/geo-search-google-maps.stories.js
+++ b/dev/app/built-in-widgets/geo-search-google-maps.stories.js
@@ -120,31 +120,6 @@ export default () => {
         })
       );
     })
-  ).add(
-    'with position from Places with refine disable on move',
-    wrapWithHitsAndConfiguration(container => {
-      const placesElemeent = document.createElement('input');
-      const mapElement = document.createElement('div');
-
-      container.appendChild(placesElemeent);
-      container.appendChild(mapElement);
-
-      window.search.addWidget(
-        instantsearchPlacesWidget({
-          container: placesElemeent,
-          defaultPosition: [37.7749, -122.4194],
-        })
-      );
-
-      window.search.addWidget(
-        instantsearch.widgets.geoSearchWithGoogleMaps({
-          container: mapElement,
-          radius: 20000,
-          enableGeolocationWithIP: false,
-          enableRefineOnMapMove: false,
-        })
-      );
-    })
   );
 
   // Only UI

--- a/dev/app/built-in-widgets/geo-search-google-maps.stories.js
+++ b/dev/app/built-in-widgets/geo-search-google-maps.stories.js
@@ -149,14 +149,51 @@ export default () => {
 
   // Only UI
   Stories.add(
-    'disable refine on move',
+    'with control & refine on map move',
     wrapWithHitsAndConfiguration(container => {
       window.search.addWidget(
         instantsearch.widgets.geoSearchWithGoogleMaps({
           container,
-          enableRefineOnMapMove: false,
+          enableControlRefineWithMap: true,
+          enableRefineOnMapMove: true,
         })
       );
     })
-  );
+  )
+    .add(
+      'with control & disable refine on map move',
+      wrapWithHitsAndConfiguration(container => {
+        window.search.addWidget(
+          instantsearch.widgets.geoSearchWithGoogleMaps({
+            container,
+            enableControlRefineWithMap: true,
+            enableRefineOnMapMove: false,
+          })
+        );
+      })
+    )
+    .add(
+      'without control & refine on map move',
+      wrapWithHitsAndConfiguration(container => {
+        window.search.addWidget(
+          instantsearch.widgets.geoSearchWithGoogleMaps({
+            container,
+            enableControlRefineWithMap: false,
+            enableRefineOnMapMove: true,
+          })
+        );
+      })
+    )
+    .add(
+      'without control & disable refine on map move',
+      wrapWithHitsAndConfiguration(container => {
+        window.search.addWidget(
+          instantsearch.widgets.geoSearchWithGoogleMaps({
+            container,
+            enableControlRefineWithMap: false,
+            enableRefineOnMapMove: false,
+          })
+        );
+      })
+    );
 };

--- a/dev/app/built-in-widgets/geo-search-leaflet.css
+++ b/dev/app/built-in-widgets/geo-search-leaflet.css
@@ -1,0 +1,3 @@
+.ap-dropdown-menu {
+  z-index: 10000 !important;
+}

--- a/dev/app/built-in-widgets/geo-search-leaflet.stories.js
+++ b/dev/app/built-in-widgets/geo-search-leaflet.stories.js
@@ -1,0 +1,163 @@
+/* eslint-disable import/default */
+
+import { storiesOf } from 'dev-novel';
+import instantsearchPlacesWidget from 'places.js/instantsearchWidget';
+import instantsearch from '../../../index.js';
+import wrapWithHits from '../wrap-with-hits.js';
+import './geo-search-leaflet.css';
+
+const wrapWithHitsAndConfiguration = story =>
+  wrapWithHits(story, {
+    indexName: 'airbnb',
+    searchParameters: {
+      hitsPerPage: 50,
+    },
+  });
+
+export default () => {
+  const Stories = storiesOf('GeoSearch (Leaflet)');
+  const radius = 5000;
+  const precision = 2500;
+  const position = {
+    lat: 37.7749,
+    lng: -122.4194,
+  };
+
+  // With IP
+  Stories.add(
+    'with IP',
+    wrapWithHitsAndConfiguration(container => {
+      window.search.addWidget(
+        instantsearch.widgets.geoSearchWithLeaflet({
+          container,
+        })
+      );
+    })
+  )
+    .add(
+      'with IP & radius',
+      wrapWithHitsAndConfiguration(container => {
+        window.search.addWidget(
+          instantsearch.widgets.geoSearchWithLeaflet({
+            container,
+            radius,
+          })
+        );
+      })
+    )
+    .add(
+      'with IP & radius & precision',
+      wrapWithHitsAndConfiguration(container => {
+        window.search.addWidget(
+          instantsearch.widgets.geoSearchWithLeaflet({
+            container,
+            radius,
+            precision,
+          })
+        );
+      })
+    );
+
+  // With position
+  Stories.add(
+    'with position',
+    wrapWithHitsAndConfiguration(container => {
+      window.search.addWidget(
+        instantsearch.widgets.geoSearchWithLeaflet({
+          container,
+          position,
+        })
+      );
+    })
+  )
+    .add(
+      'with position & radius',
+      wrapWithHitsAndConfiguration(container => {
+        window.search.addWidget(
+          instantsearch.widgets.geoSearchWithLeaflet({
+            container,
+            radius,
+            position,
+          })
+        );
+      })
+    )
+    .add(
+      'with position & radius & precision',
+      wrapWithHitsAndConfiguration(container => {
+        window.search.addWidget(
+          instantsearch.widgets.geoSearchWithLeaflet({
+            container,
+            radius,
+            precision,
+            position,
+          })
+        );
+      })
+    );
+
+  // With Places
+  Stories.add(
+    'with position from Places',
+    wrapWithHitsAndConfiguration(container => {
+      const placesElemeent = document.createElement('input');
+      const mapElement = document.createElement('div');
+
+      container.appendChild(placesElemeent);
+      container.appendChild(mapElement);
+
+      window.search.addWidget(
+        instantsearchPlacesWidget({
+          container: placesElemeent,
+          defaultPosition: [37.7749, -122.4194],
+        })
+      );
+
+      window.search.addWidget(
+        instantsearch.widgets.geoSearchWithLeaflet({
+          container: mapElement,
+          radius: 20000,
+          enableGeolocationWithIP: false,
+        })
+      );
+    })
+  ).add(
+    'with position from Places with refine disable on move',
+    wrapWithHitsAndConfiguration(container => {
+      const placesElemeent = document.createElement('input');
+      const mapElement = document.createElement('div');
+
+      container.appendChild(placesElemeent);
+      container.appendChild(mapElement);
+
+      window.search.addWidget(
+        instantsearchPlacesWidget({
+          container: placesElemeent,
+          defaultPosition: [37.7749, -122.4194],
+        })
+      );
+
+      window.search.addWidget(
+        instantsearch.widgets.geoSearchWithLeaflet({
+          container: mapElement,
+          radius: 20000,
+          enableGeolocationWithIP: false,
+          enableRefineOnMapMove: false,
+        })
+      );
+    })
+  );
+
+  // Only UI
+  Stories.add(
+    'disable refine on move',
+    wrapWithHitsAndConfiguration(container => {
+      window.search.addWidget(
+        instantsearch.widgets.geoSearchWithLeaflet({
+          container,
+          enableRefineOnMapMove: false,
+        })
+      );
+    })
+  );
+};

--- a/dev/app/built-in-widgets/geo-search-leaflet.stories.js
+++ b/dev/app/built-in-widgets/geo-search-leaflet.stories.js
@@ -121,43 +121,55 @@ export default () => {
         })
       );
     })
-  ).add(
-    'with position from Places with refine disable on move',
-    wrapWithHitsAndConfiguration(container => {
-      const placesElemeent = document.createElement('input');
-      const mapElement = document.createElement('div');
-
-      container.appendChild(placesElemeent);
-      container.appendChild(mapElement);
-
-      window.search.addWidget(
-        instantsearchPlacesWidget({
-          container: placesElemeent,
-          defaultPosition: [37.7749, -122.4194],
-        })
-      );
-
-      window.search.addWidget(
-        instantsearch.widgets.geoSearchWithLeaflet({
-          container: mapElement,
-          radius: 20000,
-          enableGeolocationWithIP: false,
-          enableRefineOnMapMove: false,
-        })
-      );
-    })
   );
 
   // Only UI
   Stories.add(
-    'disable refine on move',
+    'with control & refine on map move',
     wrapWithHitsAndConfiguration(container => {
       window.search.addWidget(
         instantsearch.widgets.geoSearchWithLeaflet({
           container,
-          enableRefineOnMapMove: false,
+          enableControlRefineWithMap: true,
+          enableRefineOnMapMove: true,
         })
       );
     })
-  );
+  )
+    .add(
+      'with control & disable refine on map move',
+      wrapWithHitsAndConfiguration(container => {
+        window.search.addWidget(
+          instantsearch.widgets.geoSearchWithLeaflet({
+            container,
+            enableControlRefineWithMap: true,
+            enableRefineOnMapMove: false,
+          })
+        );
+      })
+    )
+    .add(
+      'without control & refine on map move',
+      wrapWithHitsAndConfiguration(container => {
+        window.search.addWidget(
+          instantsearch.widgets.geoSearchWithLeaflet({
+            container,
+            enableControlRefineWithMap: false,
+            enableRefineOnMapMove: true,
+          })
+        );
+      })
+    )
+    .add(
+      'without control & disable refine on map move',
+      wrapWithHitsAndConfiguration(container => {
+        window.search.addWidget(
+          instantsearch.widgets.geoSearchWithLeaflet({
+            container,
+            enableControlRefineWithMap: false,
+            enableRefineOnMapMove: false,
+          })
+        );
+      })
+    );
 };

--- a/dev/app/built-in-widgets/geo-search-mapbox.css
+++ b/dev/app/built-in-widgets/geo-search-mapbox.css
@@ -1,0 +1,7 @@
+.mapboxgl-marker {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 1px solid #021566;
+  background-color: #4264fb;
+}

--- a/dev/app/built-in-widgets/geo-search-mapbox.stories.js
+++ b/dev/app/built-in-widgets/geo-search-mapbox.stories.js
@@ -1,0 +1,175 @@
+/* eslint-disable import/default */
+
+import { storiesOf } from 'dev-novel';
+import instantsearchPlacesWidget from 'places.js/instantsearchWidget';
+import instantsearch from '../../../index.js';
+import wrapWithHits from '../wrap-with-hits.js';
+import './geo-search-mapbox.css';
+
+const wrapWithHitsAndConfiguration = story =>
+  wrapWithHits(story, {
+    indexName: 'airbnb',
+    searchParameters: {
+      hitsPerPage: 50,
+    },
+  });
+
+export default () => {
+  const Stories = storiesOf('GeoSearch (Mapbox)');
+  const radius = 5000;
+  const precision = 2500;
+  const position = {
+    lat: 37.7749,
+    lng: -122.4194,
+  };
+
+  // With IP
+  Stories.add(
+    'with IP',
+    wrapWithHitsAndConfiguration(container => {
+      window.search.addWidget(
+        instantsearch.widgets.geoSearchWithMapbox({
+          container,
+        })
+      );
+    })
+  )
+    .add(
+      'with IP & radius',
+      wrapWithHitsAndConfiguration(container => {
+        window.search.addWidget(
+          instantsearch.widgets.geoSearchWithMapbox({
+            container,
+            radius,
+          })
+        );
+      })
+    )
+    .add(
+      'with IP & radius & precision',
+      wrapWithHitsAndConfiguration(container => {
+        window.search.addWidget(
+          instantsearch.widgets.geoSearchWithMapbox({
+            container,
+            radius,
+            precision,
+          })
+        );
+      })
+    );
+
+  // With position
+  Stories.add(
+    'with position',
+    wrapWithHitsAndConfiguration(container => {
+      window.search.addWidget(
+        instantsearch.widgets.geoSearchWithMapbox({
+          container,
+          position,
+        })
+      );
+    })
+  )
+    .add(
+      'with position & radius',
+      wrapWithHitsAndConfiguration(container => {
+        window.search.addWidget(
+          instantsearch.widgets.geoSearchWithMapbox({
+            container,
+            radius,
+            position,
+          })
+        );
+      })
+    )
+    .add(
+      'with position & radius & precision',
+      wrapWithHitsAndConfiguration(container => {
+        window.search.addWidget(
+          instantsearch.widgets.geoSearchWithMapbox({
+            container,
+            radius,
+            precision,
+            position,
+          })
+        );
+      })
+    );
+
+  // With Places
+  Stories.add(
+    'with position from Places',
+    wrapWithHitsAndConfiguration(container => {
+      const placesElemeent = document.createElement('input');
+      const mapElement = document.createElement('div');
+
+      container.appendChild(placesElemeent);
+      container.appendChild(mapElement);
+
+      window.search.addWidget(
+        instantsearchPlacesWidget({
+          container: placesElemeent,
+          defaultPosition: [37.7749, -122.4194],
+        })
+      );
+
+      window.search.addWidget(
+        instantsearch.widgets.geoSearchWithMapbox({
+          container: mapElement,
+          radius: 20000,
+          enableGeolocationWithIP: false,
+        })
+      );
+    })
+  );
+
+  // Only UI
+  Stories.add(
+    'with control & refine on map move',
+    wrapWithHitsAndConfiguration(container => {
+      window.search.addWidget(
+        instantsearch.widgets.geoSearchWithMapbox({
+          container,
+          enableControlRefineWithMap: true,
+          enableRefineOnMapMove: true,
+        })
+      );
+    })
+  )
+    .add(
+      'with control & disable refine on map move',
+      wrapWithHitsAndConfiguration(container => {
+        window.search.addWidget(
+          instantsearch.widgets.geoSearchWithMapbox({
+            container,
+            enableControlRefineWithMap: true,
+            enableRefineOnMapMove: false,
+          })
+        );
+      })
+    )
+    .add(
+      'without control & refine on map move',
+      wrapWithHitsAndConfiguration(container => {
+        window.search.addWidget(
+          instantsearch.widgets.geoSearchWithMapbox({
+            container,
+            enableControlRefineWithMap: false,
+            enableRefineOnMapMove: true,
+          })
+        );
+      })
+    )
+    .add(
+      'without control & disable refine on map move',
+      wrapWithHitsAndConfiguration(container => {
+        window.search.addWidget(
+          instantsearch.widgets.geoSearchWithMapbox({
+            container,
+            enableControlRefineWithMap: false,
+            enableRefineOnMapMove: false,
+          })
+        );
+      })
+    );
+};

--- a/dev/app/built-in-widgets/geo-search.stories.js
+++ b/dev/app/built-in-widgets/geo-search.stories.js
@@ -1,0 +1,162 @@
+/* eslint-disable import/default */
+
+import { storiesOf } from 'dev-novel';
+import instantsearchPlacesWidget from 'places.js/instantsearchWidget';
+import instantsearch from '../../../index.js';
+import wrapWithHits from '../wrap-with-hits.js';
+
+const wrapWithHitsAndConfiguration = story =>
+  wrapWithHits(story, {
+    indexName: 'airbnb',
+    searchParameters: {
+      hitsPerPage: 50,
+    },
+  });
+
+export default () => {
+  const Stories = storiesOf('GeoSearch (Google Maps)');
+  const radius = 5000;
+  const precision = 2500;
+  const position = {
+    lat: 37.7749,
+    lng: -122.4194,
+  };
+
+  // With IP
+  Stories.add(
+    'with IP',
+    wrapWithHitsAndConfiguration(container => {
+      window.search.addWidget(
+        instantsearch.widgets.geoSearch({
+          container,
+        })
+      );
+    })
+  )
+    .add(
+      'with IP & radius',
+      wrapWithHitsAndConfiguration(container => {
+        window.search.addWidget(
+          instantsearch.widgets.geoSearch({
+            container,
+            radius,
+          })
+        );
+      })
+    )
+    .add(
+      'with IP & radius & precision',
+      wrapWithHitsAndConfiguration(container => {
+        window.search.addWidget(
+          instantsearch.widgets.geoSearch({
+            container,
+            radius,
+            precision,
+          })
+        );
+      })
+    );
+
+  // With position
+  Stories.add(
+    'with position',
+    wrapWithHitsAndConfiguration(container => {
+      window.search.addWidget(
+        instantsearch.widgets.geoSearch({
+          container,
+          position,
+        })
+      );
+    })
+  )
+    .add(
+      'with position & radius',
+      wrapWithHitsAndConfiguration(container => {
+        window.search.addWidget(
+          instantsearch.widgets.geoSearch({
+            container,
+            radius,
+            position,
+          })
+        );
+      })
+    )
+    .add(
+      'with position & radius & precision',
+      wrapWithHitsAndConfiguration(container => {
+        window.search.addWidget(
+          instantsearch.widgets.geoSearch({
+            container,
+            radius,
+            precision,
+            position,
+          })
+        );
+      })
+    );
+
+  // With Places
+  Stories.add(
+    'with position from Places',
+    wrapWithHitsAndConfiguration(container => {
+      const placesElemeent = document.createElement('input');
+      const mapElement = document.createElement('div');
+
+      container.appendChild(placesElemeent);
+      container.appendChild(mapElement);
+
+      window.search.addWidget(
+        instantsearchPlacesWidget({
+          container: placesElemeent,
+          defaultPosition: [37.7749, -122.4194],
+        })
+      );
+
+      window.search.addWidget(
+        instantsearch.widgets.geoSearch({
+          container: mapElement,
+          radius: 20000,
+          enableGeolocationWithIP: false,
+        })
+      );
+    })
+  ).add(
+    'with position from Places with refine disable on move',
+    wrapWithHitsAndConfiguration(container => {
+      const placesElemeent = document.createElement('input');
+      const mapElement = document.createElement('div');
+
+      container.appendChild(placesElemeent);
+      container.appendChild(mapElement);
+
+      window.search.addWidget(
+        instantsearchPlacesWidget({
+          container: placesElemeent,
+          defaultPosition: [37.7749, -122.4194],
+        })
+      );
+
+      window.search.addWidget(
+        instantsearch.widgets.geoSearch({
+          container: mapElement,
+          radius: 20000,
+          enableGeolocationWithIP: false,
+          enableRefineOnMapMove: false,
+        })
+      );
+    })
+  );
+
+  // Only UI
+  Stories.add(
+    'disable refine on move',
+    wrapWithHitsAndConfiguration(container => {
+      window.search.addWidget(
+        instantsearch.widgets.geoSearch({
+          container,
+          enableRefineOnMapMove: false,
+        })
+      );
+    })
+  );
+};

--- a/dev/app/init-builtin-widgets.js
+++ b/dev/app/init-builtin-widgets.js
@@ -3,11 +3,13 @@ import { action, storiesOf } from 'dev-novel';
 import instantsearch from '../../index.js';
 import addGeoSearchGoogleMapsStories from './built-in-widgets/geo-search-google-maps.stories';
 import addGeoSearchLeafletStories from './built-in-widgets/geo-search-leaflet.stories';
+import addGeoSearchMapboxStories from './built-in-widgets/geo-search-mapbox.stories';
 import wrapWithHits from './wrap-with-hits.js';
 
 export default () => {
   addGeoSearchGoogleMapsStories();
   addGeoSearchLeafletStories();
+  addGeoSearchMapboxStories();
 
   storiesOf('Analytics').add(
     'default',

--- a/dev/app/init-builtin-widgets.js
+++ b/dev/app/init-builtin-widgets.js
@@ -1,10 +1,12 @@
 /* eslint-disable import/default */
 import { action, storiesOf } from 'dev-novel';
 import instantsearch from '../../index.js';
-
+import addGeoSearchStories from './built-in-widgets/geo-search.stories';
 import wrapWithHits from './wrap-with-hits.js';
 
 export default () => {
+  addGeoSearchStories();
+
   storiesOf('Analytics').add(
     'default',
     wrapWithHits(container => {

--- a/dev/app/init-builtin-widgets.js
+++ b/dev/app/init-builtin-widgets.js
@@ -2,10 +2,12 @@
 import { action, storiesOf } from 'dev-novel';
 import instantsearch from '../../index.js';
 import addGeoSearchGoogleMapsStories from './built-in-widgets/geo-search-google-maps.stories';
+import addGeoSearchLeafletStories from './built-in-widgets/geo-search-leaflet.stories';
 import wrapWithHits from './wrap-with-hits.js';
 
 export default () => {
   addGeoSearchGoogleMapsStories();
+  addGeoSearchLeafletStories();
 
   storiesOf('Analytics').add(
     'default',

--- a/dev/app/init-builtin-widgets.js
+++ b/dev/app/init-builtin-widgets.js
@@ -1,11 +1,11 @@
 /* eslint-disable import/default */
 import { action, storiesOf } from 'dev-novel';
 import instantsearch from '../../index.js';
-import addGeoSearchStories from './built-in-widgets/geo-search.stories';
+import addGeoSearchGoogleMapsStories from './built-in-widgets/geo-search-google-maps.stories';
 import wrapWithHits from './wrap-with-hits.js';
 
 export default () => {
-  addGeoSearchStories();
+  addGeoSearchGoogleMapsStories();
 
   storiesOf('Analytics').add(
     'default',

--- a/dev/webpack.config.js
+++ b/dev/webpack.config.js
@@ -131,7 +131,7 @@ module.exports = {
         entry: {
           vendor: [
             ...Object.keys(require('../package.json').dependencies).filter(
-              pkg => !pkg.includes('rheostat')
+              pkg => !pkg.includes('react-google-maps')
             ),
             'dev-novel',
           ],

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "jest": "21.1.0",
     "jsdom-global": "3.0.2",
     "json": "9.0.6",
+    "leaflet": "1.2.0",
     "mkdirp": "0.5.1",
     "mversion": "1.10.1",
     "node-sass": "4.5.3",

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "preact-compat": "^3.16.0",
     "preact-rheostat": "^2.1.1",
     "prop-types": "^15.5.10",
+    "react-google-maps": "^9.0.1",
     "to-factory": "^1.0.0"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "jsdom-global": "3.0.2",
     "json": "9.0.6",
     "leaflet": "1.2.0",
+    "mapbox-gl": "0.41.0",
     "mkdirp": "0.5.1",
     "mversion": "1.10.1",
     "node-sass": "4.5.3",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "mkdirp": "0.5.1",
     "mversion": "1.10.1",
     "node-sass": "4.5.3",
+    "places.js": "1.4.15",
     "postcss-loader": "2.0.6",
     "prettier": "1.7.4",
     "pretty-bytes-cli": "2.0.0",

--- a/src/components/GeoSearch/GoogleMapsProvider.js
+++ b/src/components/GeoSearch/GoogleMapsProvider.js
@@ -1,0 +1,179 @@
+/* global google */
+
+import { flowRight } from 'lodash';
+import React, { Component } from 'preact-compat';
+import PropTypes from 'prop-types';
+import {
+  withScriptjs,
+  withGoogleMap,
+  GoogleMap,
+  Marker,
+} from 'react-google-maps';
+import { getBoundsZoomLevel } from './utils';
+
+class GoogleMapsProvider extends Component {
+  static propTypes = {
+    markers: PropTypes.arrayOf(
+      PropTypes.shape({
+        objectID: PropTypes.string.isRequired,
+        _geoloc: PropTypes.shape({
+          lat: PropTypes.number.isRequired,
+          lng: PropTypes.number.isRequired,
+        }).isRequired,
+      }).isRequired
+    ).isRequired,
+    refine: PropTypes.func.isRequired,
+    clearRefinementWithMap: PropTypes.func.isRequired,
+    isRefinedWithMap: PropTypes.bool.isRequired,
+    enableRefineOnMapMove: PropTypes.bool.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.hasMapMoveSinceLastRefine = false;
+
+    const markers = this.computeMarkerWithLatLng(props.markers);
+    const nextState = {
+      markers,
+    };
+
+    if (markers.length) {
+      const bounds = this.computeBoundsFromMarker(markers);
+
+      nextState.zoom = this.computeZoomFromBounds(bounds);
+      nextState.center = bounds.getCenter();
+    }
+
+    this.state = nextState;
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const markers = this.computeMarkerWithLatLng(nextProps.markers);
+    const nextState = {
+      markers,
+    };
+
+    // Avoid the state? Probably don't need it since the map has
+    // it's own state and we read everything from it.
+    if (markers.length && !nextProps.isRefinedWithMap) {
+      this.hasMapMoveSinceLastRefine = false;
+
+      const bounds = this.computeBoundsFromMarker(markers);
+
+      nextState.zoom = this.computeZoomFromBounds(bounds);
+      nextState.center = bounds.getCenter();
+    }
+
+    this.setState(nextState);
+  }
+
+  computeMarkerWithLatLng(markers) {
+    return markers.map(({ _geoloc, ...marker }) => ({
+      ...marker,
+      _position: new google.maps.LatLng(_geoloc.lat, _geoloc.lng),
+    }));
+  }
+
+  computeBoundsFromMarker(markers) {
+    return markers.reduce(
+      (acc, marker) => acc.extend(marker._position),
+      new google.maps.LatLngBounds()
+    );
+  }
+
+  computeZoomFromBounds(bounds) {
+    return getBoundsZoomLevel(bounds, {
+      width: 625,
+      height: 350,
+    });
+  }
+
+  refine = () => {
+    this.hasMapMoveSinceLastRefine = false;
+
+    const ne = this.map.getBounds().getNorthEast();
+    const sw = this.map.getBounds().getSouthWest();
+
+    this.props.refine({
+      ne: { lat: ne.lat(), lng: ne.lng() },
+      sw: { lat: sw.lat(), lng: sw.lng() },
+    });
+  };
+
+  onChange = () => {
+    this.hasMapMoveSinceLastRefine = true;
+
+    this.setState({
+      center: this.map.getCenter(),
+      zoom: this.map.getZoom(),
+    });
+  };
+
+  onChangeWithRefine = () => {
+    if (this.props.enableRefineOnMapMove) {
+      this.refine();
+    }
+
+    this.onChange();
+  };
+
+  onDragEnd = () => {
+    if (this.props.enableRefineOnMapMove) {
+      this.refine();
+    }
+  };
+
+  render() {
+    const { zoom, center, markers } = this.state;
+    const {
+      clearRefinementWithMap,
+      isRefinedWithMap,
+      enableRefineOnMapMove,
+    } = this.props;
+
+    return (
+      <div>
+        <GoogleMap
+          ref={c => (this.map = c)}
+          zoom={zoom}
+          center={center}
+          onCenterChanged={this.onChange}
+          onZoomChanged={this.onChangeWithRefine}
+          onDragEnd={this.onDragEnd}
+          defaultOptions={{
+            gestureHandling: 'cooperative',
+            mapTypeControl: false,
+            streetViewControl: false,
+          }}
+        >
+          {markers.map(({ objectID, _position }) => (
+            <Marker key={objectID} position={_position} />
+          ))}
+        </GoogleMap>
+
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+          }}
+        >
+          <button onClick={clearRefinementWithMap} disabled={!isRefinedWithMap}>
+            Clear the refinement with the current map view
+          </button>
+
+          {!enableRefineOnMapMove && (
+            <button
+              onClick={this.refine}
+              disabled={!this.hasMapMoveSinceLastRefine}
+            >
+              Refine with the current map view
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
+}
+
+export default flowRight(withScriptjs, withGoogleMap)(GoogleMapsProvider);

--- a/src/components/GeoSearch/GoogleMapsProvider.js
+++ b/src/components/GeoSearch/GoogleMapsProvider.js
@@ -27,6 +27,7 @@ class GoogleMapsProvider extends Component {
     isRefinedWithMap: PropTypes.bool.isRequired,
     isRefinePositionChanged: PropTypes.bool.isRequired,
     enableRefineOnMapMove: PropTypes.bool.isRequired,
+    enableControlRefineWithMap: PropTypes.bool.isRequired,
   };
 
   constructor(props) {
@@ -36,6 +37,7 @@ class GoogleMapsProvider extends Component {
 
     const markers = this.computeMarkerWithLatLng(props.markers);
     const nextState = {
+      enableRefineOnMapMove: props.enableRefineOnMapMove,
       markers,
     };
 
@@ -119,7 +121,7 @@ class GoogleMapsProvider extends Component {
   };
 
   onChangeWithRefine = () => {
-    if (this.props.enableRefineOnMapMove) {
+    if (this.state.enableRefineOnMapMove) {
       this.refine();
     }
 
@@ -127,17 +129,30 @@ class GoogleMapsProvider extends Component {
   };
 
   onDragEnd = () => {
-    if (this.props.enableRefineOnMapMove) {
+    if (this.state.enableRefineOnMapMove) {
       this.refine();
     }
   };
 
+  onChangeMapMoveControl = event => {
+    this.setState({
+      enableRefineOnMapMove: event.currentTarget.checked,
+    });
+  };
+
+  renderRedoSearchHere = () => (
+    <button onClick={this.refine} disabled={!this.hasMapMoveSinceLastRefine}>
+      Redo search here
+    </button>
+  );
+
   render() {
-    const { zoom, center, markers } = this.state;
+    const { zoom, center, markers, enableRefineOnMapMove } = this.state;
+
     const {
       clearRefinementWithMap,
       isRefinedWithMap,
-      enableRefineOnMapMove,
+      enableControlRefineWithMap,
     } = this.props;
 
     return (
@@ -176,14 +191,26 @@ class GoogleMapsProvider extends Component {
             Clear the refinement with the current map view
           </button>
 
-          {!enableRefineOnMapMove && (
-            <button
-              onClick={this.refine}
-              disabled={!this.hasMapMoveSinceLastRefine}
-            >
-              Refine with the current map view
-            </button>
+          {enableControlRefineWithMap && (
+            <div>
+              {enableRefineOnMapMove || !this.hasMapMoveSinceLastRefine ? (
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={enableRefineOnMapMove}
+                    onChange={this.onChangeMapMoveControl}
+                  />
+                  Search as I move the map
+                </label>
+              ) : (
+                this.renderRedoSearchHere()
+              )}
+            </div>
           )}
+
+          {!enableControlRefineWithMap &&
+            !enableRefineOnMapMove &&
+            this.renderRedoSearchHere()}
         </div>
       </div>
     );

--- a/src/components/GeoSearch/GoogleMapsProvider.js
+++ b/src/components/GeoSearch/GoogleMapsProvider.js
@@ -25,6 +25,7 @@ class GoogleMapsProvider extends Component {
     refine: PropTypes.func.isRequired,
     clearRefinementWithMap: PropTypes.func.isRequired,
     isRefinedWithMap: PropTypes.bool.isRequired,
+    isRefinePositionChanged: PropTypes.bool.isRequired,
     enableRefineOnMapMove: PropTypes.bool.isRequired,
   };
 
@@ -54,11 +55,18 @@ class GoogleMapsProvider extends Component {
       markers,
     };
 
+    // Restore hasMapMoveSinceLastRefine when refinement change
+    // but the refinement is not with the map
+    // ex: with places we can set the refinement with the
+    // autocomplete bar & we can move the map without
+    // the refine action
+    if (nextProps.isRefinePositionChanged && !nextProps.isRefinedWithMap) {
+      this.hasMapMoveSinceLastRefine = false;
+    }
+
     // Avoid the state? Probably don't need it since the map has
     // it's own state and we read everything from it.
     if (markers.length && !nextProps.isRefinedWithMap) {
-      this.hasMapMoveSinceLastRefine = false;
-
       const bounds = this.computeBoundsFromMarker(markers);
 
       nextState.zoom = this.computeZoomFromBounds(bounds);
@@ -158,7 +166,13 @@ class GoogleMapsProvider extends Component {
             justifyContent: 'space-between',
           }}
         >
-          <button onClick={clearRefinementWithMap} disabled={!isRefinedWithMap}>
+          <button
+            onClick={() => {
+              this.hasMapMoveSinceLastRefine = false;
+              clearRefinementWithMap();
+            }}
+            disabled={!isRefinedWithMap}
+          >
             Clear the refinement with the current map view
           </button>
 

--- a/src/components/GeoSearch/utils.js
+++ b/src/components/GeoSearch/utils.js
@@ -1,0 +1,27 @@
+export const getBoundsZoomLevel = (bounds, mapDim) => {
+  const WORLD_DIM = { height: 256, width: 256 };
+  const ZOOM_MAX = 21;
+
+  const latRad = lat => {
+    const sin = Math.sin(lat * Math.PI / 180);
+    const radX2 = Math.log((1 + sin) / (1 - sin)) / 2;
+
+    return Math.max(Math.min(radX2, Math.PI), -Math.PI) / 2;
+  };
+
+  const zoom = (mapPx, worldPx, fraction) =>
+    Math.floor(Math.log(mapPx / worldPx / fraction) / Math.LN2);
+
+  const ne = bounds.getNorthEast();
+  const sw = bounds.getSouthWest();
+
+  const latFraction = (latRad(ne.lat()) - latRad(sw.lat())) / Math.PI;
+
+  const lngDiff = ne.lng() - sw.lng();
+  const lngFraction = (lngDiff < 0 ? lngDiff + 360 : lngDiff) / 360;
+
+  const latZoom = zoom(mapDim.height, WORLD_DIM.height, latFraction);
+  const lngZoom = zoom(mapDim.width, WORLD_DIM.width, lngFraction);
+
+  return Math.min(latZoom, lngZoom, ZOOM_MAX);
+};

--- a/src/connectors/geo-search/connectGeoSearch.js
+++ b/src/connectors/geo-search/connectGeoSearch.js
@@ -5,6 +5,7 @@ export default function connectGeoSearch(fn) {
       radius,
       minRadius,
       precision,
+      enableControlRefineWithMap,
       enableGeolocationWithIP = true,
       enableRefineOnMapMove = true,
     } = widgetParams;
@@ -77,6 +78,7 @@ export default function connectGeoSearch(fn) {
             refine: refine(helper),
             clearRefinementWithMap: clearRefinementWithMap(helper),
             isRefinePositionChanged: false,
+            enableControlRefineWithMap,
             enableRefineOnMapMove,
             instantSearchInstance,
             widgetParams,
@@ -118,6 +120,7 @@ export default function connectGeoSearch(fn) {
             hits: results.hits.filter(h => h._geoloc),
             refine: refine(helper),
             clearRefinementWithMap: clearRefinementWithMap(helper),
+            enableControlRefineWithMap,
             isRefinePositionChanged,
             enableRefineOnMapMove,
             instantSearchInstance,

--- a/src/connectors/geo-search/connectGeoSearch.js
+++ b/src/connectors/geo-search/connectGeoSearch.js
@@ -1,0 +1,127 @@
+export default function connectGeoSearch(fn) {
+  return (widgetParams = {}) => {
+    const {
+      position,
+      radius,
+      minRadius,
+      precision,
+      enableGeolocationWithIP = true,
+      enableRefineOnMapMove = true,
+    } = widgetParams;
+
+    if (radius !== undefined && minRadius !== undefined) {
+      throw new Error('Usage: only one of the radius should be pass');
+    }
+
+    const state = {
+      isRefinedWithMap: false,
+      lastRefinePosition: '',
+    };
+
+    const refine = helper => ({ ne, sw }) => {
+      const boundingBox = [ne.lat, ne.lng, sw.lat, sw.lng];
+
+      helper.setQueryParameter('insideBoundingBox', [boundingBox]).search();
+
+      state.isRefinedWithMap = true;
+    };
+
+    const clearRefinementWithMap = helper => () => {
+      helper.setQueryParameter('insideBoundingBox').search();
+
+      state.isRefinedWithMap = false;
+    };
+
+    return {
+      getConfiguration(configuration) {
+        const partial = {};
+
+        // We should check that the previous configuration
+        // don't already use the following property
+
+        if (position) {
+          partial.aroundLatLng = `${position.lat}, ${position.lng}`;
+        }
+
+        if (!position && enableGeolocationWithIP) {
+          partial.aroundLatLngViaIP = true;
+        }
+
+        if (radius) {
+          partial.aroundRadius = radius;
+        }
+
+        if (minRadius) {
+          partial.minimumAroundRadius = minRadius;
+        }
+
+        if (precision) {
+          partial.aroundPrecision = precision;
+        }
+
+        return {
+          ...configuration,
+          ...partial,
+        };
+      },
+
+      init({ helper, instantSearchInstance }) {
+        const isFirstRendering = true;
+
+        state.lastRefinePosition = helper.getQueryParameter('aroundLatLng');
+
+        fn(
+          {
+            ...state,
+            hits: [],
+            refine: refine(helper),
+            clearRefinementWithMap: clearRefinementWithMap(helper),
+            enableRefineOnMapMove,
+            instantSearchInstance,
+            widgetParams,
+          },
+          isFirstRendering
+        );
+      },
+
+      render({ results, helper, instantSearchInstance }) {
+        const isFirstRendering = false;
+        const currentPosition = helper.getQueryParameter('aroundLatLng');
+        const currentPositionIP = helper.getQueryParameter('aroundLatLngViaIP');
+        const currentBox = helper.getQueryParameter('insideBoundingBox');
+
+        // Hacky condition for enable to override the current search
+        // when we currently refine with the map. It avoid the rendering
+        // and trigger a search without the boundingBox. We defenitly
+        // need to find an other solutions...
+        if (currentBox && state.lastRefinePosition !== currentPosition) {
+          clearRefinementWithMap(helper)();
+
+          return;
+        }
+
+        // Pretty mulch the same with IP
+        if (currentPositionIP && state.lastRefinePosition !== currentPosition) {
+          helper.setQueryParameter('aroundLatLngViaIP', false).search();
+
+          return;
+        }
+
+        state.lastRefinePosition = helper.getQueryParameter('aroundLatLng');
+
+        fn(
+          {
+            ...state,
+            hits: results.hits.filter(h => h._geoloc),
+            refine: refine(helper),
+            clearRefinementWithMap: clearRefinementWithMap(helper),
+            enableRefineOnMapMove,
+            instantSearchInstance,
+            widgetParams,
+          },
+          isFirstRendering
+        );
+      },
+    };
+  };
+}

--- a/src/connectors/geo-search/connectGeoSearch.js
+++ b/src/connectors/geo-search/connectGeoSearch.js
@@ -76,6 +76,7 @@ export default function connectGeoSearch(fn) {
             hits: [],
             refine: refine(helper),
             clearRefinementWithMap: clearRefinementWithMap(helper),
+            isRefinePositionChanged: false,
             enableRefineOnMapMove,
             instantSearchInstance,
             widgetParams,
@@ -86,22 +87,24 @@ export default function connectGeoSearch(fn) {
 
       render({ results, helper, instantSearchInstance }) {
         const isFirstRendering = false;
-        const currentPosition = helper.getQueryParameter('aroundLatLng');
+        const currentRefinePosition = helper.getQueryParameter('aroundLatLng');
         const currentPositionIP = helper.getQueryParameter('aroundLatLngViaIP');
         const currentBox = helper.getQueryParameter('insideBoundingBox');
+        const isRefinePositionChanged =
+          state.lastRefinePosition !== currentRefinePosition;
 
         // Hacky condition for enable to override the current search
         // when we currently refine with the map. It avoid the rendering
         // and trigger a search without the boundingBox. We defenitly
         // need to find an other solutions...
-        if (currentBox && state.lastRefinePosition !== currentPosition) {
+        if (currentBox && isRefinePositionChanged) {
           clearRefinementWithMap(helper)();
 
           return;
         }
 
         // Pretty mulch the same with IP
-        if (currentPositionIP && state.lastRefinePosition !== currentPosition) {
+        if (currentPositionIP && isRefinePositionChanged) {
           helper.setQueryParameter('aroundLatLngViaIP', false).search();
 
           return;
@@ -115,6 +118,7 @@ export default function connectGeoSearch(fn) {
             hits: results.hits.filter(h => h._geoloc),
             refine: refine(helper),
             clearRefinementWithMap: clearRefinementWithMap(helper),
+            isRefinePositionChanged,
             enableRefineOnMapMove,
             instantSearchInstance,
             widgetParams,

--- a/src/widgets/geo-search/GoogleMapsRenderer.js
+++ b/src/widgets/geo-search/GoogleMapsRenderer.js
@@ -9,6 +9,7 @@ const renderer = ({
   isRefinedWithMap,
   isRefinePositionChanged,
   enableRefineOnMapMove,
+  enableControlRefineWithMap,
   widgetParams,
 }) => {
   const { container } = widgetParams;
@@ -25,16 +26,19 @@ const renderer = ({
 
   render(
     <GoogleMapProvider
+      // GoogleMaps props
       googleMapURL="https://maps.googleapis.com/maps/api/js?v=3.exp&libraries=geometry,drawing,places"
       loadingElement={<div style={loadingElementStyle} />}
       containerElement={<div />}
       mapElement={<div style={mapElementStyle} />}
+      // Widget props
       markers={hits}
       refine={refine}
       clearRefinementWithMap={clearRefinementWithMap}
       isRefinedWithMap={isRefinedWithMap}
       isRefinePositionChanged={isRefinePositionChanged}
       enableRefineOnMapMove={enableRefineOnMapMove}
+      enableControlRefineWithMap={enableControlRefineWithMap}
     />,
     getContainerNode(container)
   );

--- a/src/widgets/geo-search/GoogleMapsRenderer.js
+++ b/src/widgets/geo-search/GoogleMapsRenderer.js
@@ -1,0 +1,41 @@
+import React, { render } from 'preact-compat';
+import { getContainerNode } from '../../lib/utils.js';
+import GoogleMapProvider from '../../components/GeoSearch/GoogleMapsProvider';
+
+const renderer = ({
+  hits,
+  refine,
+  clearRefinementWithMap,
+  isRefinedWithMap,
+  enableRefineOnMapMove,
+  widgetParams,
+}) => {
+  const { container } = widgetParams;
+
+  const loadingElementStyle = {
+    height: '100%',
+  };
+
+  const mapElementStyle = {
+    height: '350px',
+    marginTop: '10px',
+    marginBottom: '10px',
+  };
+
+  render(
+    <GoogleMapProvider
+      googleMapURL="https://maps.googleapis.com/maps/api/js?v=3.exp&libraries=geometry,drawing,places"
+      loadingElement={<div style={loadingElementStyle} />}
+      containerElement={<div />}
+      mapElement={<div style={mapElementStyle} />}
+      markers={hits}
+      refine={refine}
+      clearRefinementWithMap={clearRefinementWithMap}
+      isRefinedWithMap={isRefinedWithMap}
+      enableRefineOnMapMove={enableRefineOnMapMove}
+    />,
+    getContainerNode(container)
+  );
+};
+
+export default renderer;

--- a/src/widgets/geo-search/GoogleMapsRenderer.js
+++ b/src/widgets/geo-search/GoogleMapsRenderer.js
@@ -7,6 +7,7 @@ const renderer = ({
   refine,
   clearRefinementWithMap,
   isRefinedWithMap,
+  isRefinePositionChanged,
   enableRefineOnMapMove,
   widgetParams,
 }) => {
@@ -32,6 +33,7 @@ const renderer = ({
       refine={refine}
       clearRefinementWithMap={clearRefinementWithMap}
       isRefinedWithMap={isRefinedWithMap}
+      isRefinePositionChanged={isRefinePositionChanged}
       enableRefineOnMapMove={enableRefineOnMapMove}
     />,
     getContainerNode(container)

--- a/src/widgets/geo-search/LeafletRenderer.js
+++ b/src/widgets/geo-search/LeafletRenderer.js
@@ -127,6 +127,11 @@ const renderer = (
       if (renderState.isUserInteraction) {
         renderState.hasMapMoveSinceLastRefine = true;
 
+        if (renderState.enableRefineOnMapMove) {
+          renderState.hasMapMoveSinceLastRefine = false;
+          refineWithBounds(refine, event.target.getBounds());
+        }
+
         if (enableControlRefineWithMap && !renderState.enableRefineOnMapMove) {
           renderRedoSearchButton({
             renderState,
@@ -134,11 +139,7 @@ const renderer = (
           });
         }
 
-        if (enableControlRefineWithMap && renderState.enableRefineOnMapMove) {
-          refineWithBounds(refine, event.target.getBounds());
-        }
-
-        if (!enableControlRefineWithMap) {
+        if (!enableControlRefineWithMap && !renderState.enableRefineOnMapMove) {
           renderState.buttonRefineOnMapMove.removeAttribute('disabled');
         }
       }

--- a/src/widgets/geo-search/LeafletRenderer.js
+++ b/src/widgets/geo-search/LeafletRenderer.js
@@ -1,0 +1,167 @@
+import L from 'leaflet';
+import { getContainerNode } from '../../lib/utils.js';
+
+const removeMarkers = (markers = []) =>
+  markers.forEach(marker => marker.remove());
+
+const addMarkers = (map, hits) =>
+  hits.map(({ _geoloc }) => L.marker([_geoloc.lat, _geoloc.lng]).addTo(map));
+
+const refineWithBounds = (refine, bounds) => {
+  const ne = bounds.getNorthEast();
+  const sw = bounds.getSouthWest();
+
+  refine({
+    ne: { lat: ne.lat, lng: ne.lng },
+    sw: { lat: sw.lat, lng: sw.lng },
+  });
+};
+
+const renderer = (
+  {
+    hits,
+    refine,
+    clearRefinementWithMap,
+    isRefinedWithMap,
+    isRefinePositionChanged,
+    enableRefineOnMapMove,
+    widgetParams,
+  },
+  isFirstRendering
+) => {
+  const { container, cssClasses, renderState } = widgetParams;
+
+  if (isFirstRendering) {
+    // Inital component state
+    renderState.hasMapMoveSinceLastRefine = false;
+    renderState.isUserInteraction = true;
+
+    const node = getContainerNode(container);
+
+    // Setup DOM element
+    const linkElement = document.createElement('link');
+    linkElement.rel = 'stylesheet';
+    linkElement.href = 'https://unpkg.com/leaflet@1.2.0/dist/leaflet.css';
+    document.head.appendChild(linkElement);
+    renderState.linkElement = linkElement;
+
+    const rootElement = document.createElement('div');
+    rootElement.className = cssClasses.root;
+    rootElement.style.height = '350px';
+    rootElement.style.marginTop = '10px';
+    node.appendChild(rootElement);
+    renderState.rootElement = rootElement;
+
+    const containerButtonElement = document.createElement('div');
+    containerButtonElement.style.display = 'flex';
+    containerButtonElement.style.justifyContent = 'space-between';
+    containerButtonElement.style.marginTop = '10px';
+    node.appendChild(containerButtonElement);
+    renderState.containerButtonElement = containerButtonElement;
+
+    const buttonClearMapRefinement = document.createElement('button');
+    buttonClearMapRefinement.className = 'ais-button-clear';
+    buttonClearMapRefinement.textContent =
+      'Clear the refinement with the current map view';
+    containerButtonElement.appendChild(buttonClearMapRefinement);
+    buttonClearMapRefinement.addEventListener('click', () => {
+      renderState.hasMapMoveSinceLastRefine = false;
+      clearRefinementWithMap();
+    });
+    renderState.buttonClearMapRefinement = buttonClearMapRefinement;
+
+    if (!enableRefineOnMapMove) {
+      const buttonRefineOnMapMove = document.createElement('button');
+      buttonRefineOnMapMove.className = 'ais-button-refine';
+      buttonRefineOnMapMove.textContent = 'Refine with the current map view';
+      containerButtonElement.appendChild(buttonRefineOnMapMove);
+      buttonRefineOnMapMove.addEventListener('click', () => {
+        renderState.hasMapMoveSinceLastRefine = false;
+        refineWithBounds(refine, renderState.map.getBounds());
+      });
+      renderState.buttonRefineOnMapMove = buttonRefineOnMapMove;
+    }
+
+    // Setup the map
+    renderState.map = L.map(rootElement, {
+      // Disable the animation because the bounds may not be correctly
+      // updated with `fitBounds`
+      // see: https://github.com/Leaflet/Leaflet/issues/3249
+      zoomAnimation: false,
+    });
+
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution:
+        '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
+    }).addTo(renderState.map);
+
+    // Setup events on map
+    renderState.map.on('dragend', event => {
+      if (enableRefineOnMapMove) {
+        renderState.hasMapMoveSinceLastRefine = false;
+        refineWithBounds(refine, event.target.getBounds());
+      }
+    });
+
+    renderState.map.on('zoomend', event => {
+      if (renderState.isUserInteraction) {
+        renderState.hasMapMoveSinceLastRefine = true;
+
+        if (enableRefineOnMapMove) {
+          refineWithBounds(refine, event.target.getBounds());
+        } else {
+          renderState.buttonRefineOnMapMove.removeAttribute('disabled');
+        }
+      }
+    });
+  }
+
+  // Restore hasMapMoveSinceLastRefine when refinement change
+  // but the refinement is not with the map
+  // ex: with places we can set the refinement with the
+  // autocomplete bar & we can move the map without
+  // the refine action
+  if (isRefinePositionChanged && !isRefinedWithMap) {
+    renderState.hasMapMoveSinceLastRefine = false;
+  }
+
+  // Register the callback on each render
+  // to update the closure scope
+  renderState.map.off('dragstart');
+  renderState.map.on('dragstart', () => {
+    renderState.hasMapMoveSinceLastRefine = true;
+    if (!enableRefineOnMapMove) {
+      renderState.buttonRefineOnMapMove.removeAttribute('disabled');
+    }
+  });
+
+  removeMarkers(renderState.markers);
+
+  renderState.markers = addMarkers(renderState.map, hits);
+
+  if (renderState.markers.length && !isRefinedWithMap) {
+    // Ugly hack for enable to detect user interaction
+    // rather than interaction trigger by the program
+    // see: https://stackoverflow.com/questions/31992278/detect-user-initiated-pan-zoom-operations-on-leaflet
+    // see: https://github.com/Leaflet/Leaflet/issues/2934
+    renderState.isUserInteraction = false;
+    renderState.map.fitBounds(L.featureGroup(renderState.markers).getBounds());
+    renderState.isUserInteraction = true;
+  }
+
+  if (isRefinedWithMap) {
+    renderState.buttonClearMapRefinement.removeAttribute('disabled');
+  } else {
+    renderState.buttonClearMapRefinement.setAttribute('disabled', true);
+  }
+
+  if (!enableRefineOnMapMove) {
+    if (renderState.hasMapMoveSinceLastRefine) {
+      renderState.buttonRefineOnMapMove.removeAttribute('disabled');
+    } else {
+      renderState.buttonRefineOnMapMove.setAttribute('disabled', true);
+    }
+  }
+};
+
+export default renderer;

--- a/src/widgets/geo-search/MapboxRenderer.js
+++ b/src/widgets/geo-search/MapboxRenderer.js
@@ -113,6 +113,8 @@ const renderer = (
       style: 'mapbox://styles/mapbox/streets-v9',
     });
 
+    renderState.map.addControl(new mapbox.NavigationControl(), 'top-left');
+
     // Setup the events
     renderState.map.on('dragend', event => {
       if (renderState.enableRefineOnMapMove) {

--- a/src/widgets/geo-search/MapboxRenderer.js
+++ b/src/widgets/geo-search/MapboxRenderer.js
@@ -1,0 +1,229 @@
+import mapbox from 'mapbox-gl';
+import { getContainerNode } from '../../lib/utils.js';
+
+const removeMarkers = (markers = []) =>
+  markers.forEach(marker => marker.remove());
+
+const addMarkers = (map, hits) =>
+  hits.map(({ _geoloc }) =>
+    new mapbox.Marker().setLngLat([_geoloc.lng, _geoloc.lat]).addTo(map)
+  );
+
+const refineWithBounds = (refine, bounds) => {
+  const ne = bounds.getNorthEast();
+  const sw = bounds.getSouthWest();
+
+  refine({
+    ne: { lat: ne.lat, lng: ne.lng },
+    sw: { lat: sw.lat, lng: sw.lng },
+  });
+};
+
+const renderRedoSearchButton = ({ renderState, refine }) => {
+  renderState.containerControl.innerHTML = '';
+  const button = document.createElement('button');
+  button.textContent = 'Redo search here';
+  button.addEventListener('click', () => {
+    renderState.hasMapMoveSinceLastRefine = false;
+    refineWithBounds(refine, renderState.map.getBounds());
+  });
+  renderState.containerControl.appendChild(button);
+};
+
+const renderer = (
+  {
+    hits,
+    refine,
+    clearRefinementWithMap,
+    isRefinedWithMap,
+    isRefinePositionChanged,
+    enableRefineOnMapMove,
+    enableControlRefineWithMap,
+    widgetParams,
+  },
+  isFirstRendering
+) => {
+  const { container, cssClasses, renderState } = widgetParams;
+
+  if (isFirstRendering) {
+    const node = getContainerNode(container);
+
+    // Setup state
+    renderState.enableRefineOnMapMove = enableRefineOnMapMove;
+    renderState.hasMapMoveSinceLastRefine = false;
+    renderState.isUserInteraction = true;
+
+    // Setup DOM element
+    const linkElement = document.createElement('link');
+    linkElement.rel = 'stylesheet';
+    linkElement.href =
+      'https://api.tiles.mapbox.com/mapbox-gl-js/v0.41.0/mapbox-gl.css';
+    document.head.appendChild(linkElement);
+    renderState.linkElement = linkElement;
+
+    const rootElement = document.createElement('div');
+    rootElement.className = cssClasses.root;
+    rootElement.style.height = '350px';
+    rootElement.style.marginTop = '10px';
+    node.appendChild(rootElement);
+    renderState.rootElement = rootElement;
+
+    const containerButtonElement = document.createElement('div');
+    containerButtonElement.style.display = 'flex';
+    containerButtonElement.style.justifyContent = 'space-between';
+    containerButtonElement.style.marginTop = '10px';
+    node.appendChild(containerButtonElement);
+    renderState.containerButtonElement = containerButtonElement;
+
+    const buttonClearMapRefinement = document.createElement('button');
+    buttonClearMapRefinement.className = 'ais-button-clear';
+    buttonClearMapRefinement.textContent =
+      'Clear the refinement with the current map view';
+    containerButtonElement.appendChild(buttonClearMapRefinement);
+    buttonClearMapRefinement.addEventListener('click', () => {
+      renderState.hasMapMoveSinceLastRefine = false;
+      clearRefinementWithMap();
+    });
+    renderState.buttonClearMapRefinement = buttonClearMapRefinement;
+
+    if (enableControlRefineWithMap) {
+      const containerControl = document.createElement('div');
+      containerControl.className = 'ais-control';
+      containerButtonElement.appendChild(containerControl);
+      renderState.containerControl = containerControl;
+    }
+
+    if (!enableControlRefineWithMap && !renderState.enableRefineOnMapMove) {
+      const buttonRefineOnMapMove = document.createElement('button');
+      buttonRefineOnMapMove.className = 'ais-button-refine';
+      buttonRefineOnMapMove.textContent = 'Redo search here';
+      containerButtonElement.appendChild(buttonRefineOnMapMove);
+      buttonRefineOnMapMove.addEventListener('click', () => {
+        renderState.hasMapMoveSinceLastRefine = false;
+        refineWithBounds(refine, renderState.map.getBounds());
+      });
+      renderState.buttonRefineOnMapMove = buttonRefineOnMapMove;
+    }
+
+    // Setup the map
+    mapbox.accessToken =
+      'pk.eyJ1Ijoic2Ftb3VzcyIsImEiOiJjajlrNHJ2eG80MTh6MndweXp5ZDA3d3k1In0.kFqtSoryexZtULo1GGKe0w';
+    renderState.map = new mapbox.Map({
+      container: rootElement,
+      style: 'mapbox://styles/mapbox/streets-v9',
+    });
+
+    // Setup the events
+    renderState.map.on('dragend', event => {
+      if (renderState.enableRefineOnMapMove) {
+        renderState.hasMapMoveSinceLastRefine = false;
+        refineWithBounds(refine, event.target.getBounds());
+      }
+    });
+
+    renderState.map.on('zoomend', event => {
+      if (renderState.isUserInteraction) {
+        renderState.hasMapMoveSinceLastRefine = true;
+
+        // With control
+        if (enableControlRefineWithMap && renderState.enableRefineOnMapMove) {
+          renderState.hasMapMoveSinceLastRefine = false;
+          refineWithBounds(refine, event.target.getBounds());
+        }
+
+        if (enableControlRefineWithMap && !renderState.enableRefineOnMapMove) {
+          renderRedoSearchButton({
+            renderState,
+            refine,
+          });
+        }
+
+        // Without control
+        if (!enableControlRefineWithMap && renderState.enableRefineOnMapMove) {
+          renderState.hasMapMoveSinceLastRefine = false;
+          refineWithBounds(refine, event.target.getBounds());
+        }
+
+        if (!enableControlRefineWithMap && !renderState.enableRefineOnMapMove) {
+          renderState.buttonRefineOnMapMove.removeAttribute('disabled');
+        }
+      }
+    });
+  }
+
+  // Restore hasMapMoveSinceLastRefine when refinement change
+  // but the refinement is not with the map
+  // ex: with places we can set the refinement with the
+  // autocomplete bar & we can move the map without
+  // the refine action
+  if (isRefinePositionChanged && !isRefinedWithMap) {
+    renderState.hasMapMoveSinceLastRefine = false;
+  }
+
+  // Register the callback on each render
+  // to update the closure scope
+  renderState.map.off('dragstart');
+  renderState.map.on('dragstart', () => {
+    renderState.hasMapMoveSinceLastRefine = true;
+
+    if (enableControlRefineWithMap && !renderState.enableRefineOnMapMove) {
+      renderRedoSearchButton({
+        renderState,
+        refine,
+      });
+    }
+
+    if (!enableControlRefineWithMap && !renderState.enableRefineOnMapMove) {
+      renderState.buttonRefineOnMapMove.removeAttribute('disabled');
+    }
+  });
+
+  removeMarkers(renderState.markers);
+
+  renderState.markers = addMarkers(renderState.map, hits);
+
+  if (renderState.markers.length && !isRefinedWithMap) {
+    renderState.isUserInteraction = false;
+    renderState.map.fitBounds(
+      renderState.markers.reduce(
+        (acc, marker) => acc.extend(marker.getLngLat()),
+        new mapbox.LngLatBounds()
+      ),
+      {
+        padding: 25,
+        animate: false,
+      }
+    );
+    renderState.isUserInteraction = true;
+  }
+
+  if (isRefinedWithMap) {
+    renderState.buttonClearMapRefinement.removeAttribute('disabled');
+  } else {
+    renderState.buttonClearMapRefinement.setAttribute('disabled', true);
+  }
+
+  if (enableControlRefineWithMap) {
+    renderState.containerControl.innerHTML = '';
+    const label = document.createElement('label');
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.checked = renderState.enableRefineOnMapMove;
+    label.appendChild(checkbox);
+    label.append('Search as I move the map');
+    checkbox.addEventListener('change', event => {
+      renderState.enableRefineOnMapMove = event.currentTarget.checked;
+    });
+    renderState.containerControl.appendChild(label);
+  }
+
+  if (!enableControlRefineWithMap && !renderState.enableRefineOnMapMove) {
+    if (renderState.hasMapMoveSinceLastRefine) {
+      renderState.buttonRefineOnMapMove.removeAttribute('disabled');
+    } else {
+      renderState.buttonRefineOnMapMove.setAttribute('disabled', true);
+    }
+  }
+};
+
+export default renderer;

--- a/src/widgets/geo-search/geo-search.js
+++ b/src/widgets/geo-search/geo-search.js
@@ -1,0 +1,70 @@
+import React, { render } from 'preact-compat';
+import cx from 'classnames';
+import { bemHelper, getContainerNode } from '../../lib/utils.js';
+import connectGeoSearch from '../../connectors/geo-search/connectGeoSearch';
+import GoogleMapProvider from '../../components/GeoSearch/GoogleMapsProvider';
+
+const bem = bemHelper('ais-geo');
+
+const renderer = ({
+  hits,
+  refine,
+  clearRefinementWithMap,
+  isRefinedWithMap,
+  enableRefineOnMapMove,
+  widgetParams,
+}) => {
+  const { container } = widgetParams;
+
+  const loadingElementStyle = {
+    height: '100%',
+  };
+
+  const mapElementStyle = {
+    height: '350px',
+    marginTop: '10px',
+    marginBottom: '10px',
+  };
+
+  render(
+    <GoogleMapProvider
+      googleMapURL="https://maps.googleapis.com/maps/api/js?v=3.exp&libraries=geometry,drawing,places"
+      loadingElement={<div style={loadingElementStyle} />}
+      containerElement={<div />}
+      mapElement={<div style={mapElementStyle} />}
+      markers={hits}
+      refine={refine}
+      clearRefinementWithMap={clearRefinementWithMap}
+      isRefinedWithMap={isRefinedWithMap}
+      enableRefineOnMapMove={enableRefineOnMapMove}
+    />,
+    getContainerNode(container)
+  );
+};
+
+export default function geoSearch(props = {}) {
+  const widgetParams = {
+    cssClasses: {},
+    ...props,
+  };
+
+  if (!widgetParams.container) {
+    throw new Error(`Must provide a container.`);
+  }
+
+  try {
+    const makeGeoSearch = connectGeoSearch(renderer);
+
+    return makeGeoSearch({
+      ...widgetParams,
+      renderState: {},
+      cssClasses: {
+        root: cx(bem(null), widgetParams.cssClasses.root),
+        item: cx(bem('item'), widgetParams.cssClasses.item),
+        empty: cx(bem(null, 'empty'), widgetParams.cssClasses.empty),
+      },
+    });
+  } catch (e) {
+    throw new Error(`See usage.`);
+  }
+}

--- a/src/widgets/geo-search/geo-search.js
+++ b/src/widgets/geo-search/geo-search.js
@@ -9,6 +9,7 @@ const bem = bemHelper('ais-geo');
 const geoSearch = renderer => (props = {}) => {
   const widgetParams = {
     cssClasses: {},
+    enableControlRefineWithMap: true,
     ...props,
   };
 

--- a/src/widgets/geo-search/geo-search.js
+++ b/src/widgets/geo-search/geo-search.js
@@ -1,48 +1,11 @@
-import React, { render } from 'preact-compat';
 import cx from 'classnames';
-import { bemHelper, getContainerNode } from '../../lib/utils.js';
+import { bemHelper } from '../../lib/utils.js';
 import connectGeoSearch from '../../connectors/geo-search/connectGeoSearch';
-import GoogleMapProvider from '../../components/GeoSearch/GoogleMapsProvider';
+import GoogleMapsRenderer from './GoogleMapsRenderer';
 
 const bem = bemHelper('ais-geo');
 
-const renderer = ({
-  hits,
-  refine,
-  clearRefinementWithMap,
-  isRefinedWithMap,
-  enableRefineOnMapMove,
-  widgetParams,
-}) => {
-  const { container } = widgetParams;
-
-  const loadingElementStyle = {
-    height: '100%',
-  };
-
-  const mapElementStyle = {
-    height: '350px',
-    marginTop: '10px',
-    marginBottom: '10px',
-  };
-
-  render(
-    <GoogleMapProvider
-      googleMapURL="https://maps.googleapis.com/maps/api/js?v=3.exp&libraries=geometry,drawing,places"
-      loadingElement={<div style={loadingElementStyle} />}
-      containerElement={<div />}
-      mapElement={<div style={mapElementStyle} />}
-      markers={hits}
-      refine={refine}
-      clearRefinementWithMap={clearRefinementWithMap}
-      isRefinedWithMap={isRefinedWithMap}
-      enableRefineOnMapMove={enableRefineOnMapMove}
-    />,
-    getContainerNode(container)
-  );
-};
-
-export default function geoSearch(props = {}) {
+const geoSearch = renderer => (props = {}) => {
   const widgetParams = {
     cssClasses: {},
     ...props,
@@ -67,4 +30,6 @@ export default function geoSearch(props = {}) {
   } catch (e) {
     throw new Error(`See usage.`);
   }
-}
+};
+
+export const geoSearchWithGoogleMaps = geoSearch(GoogleMapsRenderer);

--- a/src/widgets/geo-search/geo-search.js
+++ b/src/widgets/geo-search/geo-search.js
@@ -2,6 +2,7 @@ import cx from 'classnames';
 import { bemHelper } from '../../lib/utils.js';
 import connectGeoSearch from '../../connectors/geo-search/connectGeoSearch';
 import GoogleMapsRenderer from './GoogleMapsRenderer';
+import LeafletRenderer from './LeafletRenderer';
 
 const bem = bemHelper('ais-geo');
 
@@ -33,3 +34,4 @@ const geoSearch = renderer => (props = {}) => {
 };
 
 export const geoSearchWithGoogleMaps = geoSearch(GoogleMapsRenderer);
+export const geoSearchWithLeaflet = geoSearch(LeafletRenderer);

--- a/src/widgets/geo-search/geo-search.js
+++ b/src/widgets/geo-search/geo-search.js
@@ -3,6 +3,7 @@ import { bemHelper } from '../../lib/utils.js';
 import connectGeoSearch from '../../connectors/geo-search/connectGeoSearch';
 import GoogleMapsRenderer from './GoogleMapsRenderer';
 import LeafletRenderer from './LeafletRenderer';
+import MapboxRenderer from './MapboxRenderer';
 
 const bem = bemHelper('ais-geo');
 
@@ -36,3 +37,4 @@ const geoSearch = renderer => (props = {}) => {
 
 export const geoSearchWithGoogleMaps = geoSearch(GoogleMapsRenderer);
 export const geoSearchWithLeaflet = geoSearch(LeafletRenderer);
+export const geoSearchWithMapbox = geoSearch(MapboxRenderer);

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -45,3 +45,4 @@ export { default as stats } from '../widgets/stats/stats.js';
 export { default as toggle } from '../widgets/toggle/toggle.js';
 export { default as analytics } from '../widgets/analytics/analytics.js';
 export { default as menuSelect } from '../widgets/menu-select/menu-select.js';
+export { default as geoSearch } from '../widgets/geo-search/geo-search.js';

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -45,4 +45,4 @@ export { default as stats } from '../widgets/stats/stats.js';
 export { default as toggle } from '../widgets/toggle/toggle.js';
 export { default as analytics } from '../widgets/analytics/analytics.js';
 export { default as menuSelect } from '../widgets/menu-select/menu-select.js';
-export { default as geoSearch } from '../widgets/geo-search/geo-search.js';
+export * from '../widgets/geo-search/geo-search.js';

--- a/yarn.lock
+++ b/yarn.lock
@@ -462,6 +462,12 @@ atob@~1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/atob/-/atob-1.1.3.tgz#95f13629b12c3a51a5d215abdce2aa9f32f80773"
 
+autocomplete.js@^0.28.2:
+  version "0.28.3"
+  resolved "https://registry.yarnpkg.com/autocomplete.js/-/autocomplete.js-0.28.3.tgz#b90dc01688613ab16488bbb6f5314fd2a365ec4b"
+  dependencies:
+    immediate "^3.2.3"
+
 autodll-webpack-plugin@0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/autodll-webpack-plugin/-/autodll-webpack-plugin-0.2.1.tgz#74976a098d813ab1438fd5ca38f36c874d035d13"
@@ -3449,7 +3455,7 @@ eventemitter3@1.x.x:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-1.2.0.tgz#1c86991d816ad1e504750e73874224ecf3bec508"
 
-events@^1.0.0, events@^1.1.0:
+events@^1.0.0, events@^1.1.0, events@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
 
@@ -4654,6 +4660,10 @@ image-size@^0.5.0:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.5.5.tgz#09dfd4ab9d20e29eb1c3e80b8990378df9e3cb9c"
 
+immediate@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.2.3.tgz#d140fa8f614659bd6541233097ddaac25cdd991c"
+
 immutability-helper@^2.1.2:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/immutability-helper/-/immutability-helper-2.4.0.tgz#00d421e2957c17f0f0781475f05ffd837e73458d"
@@ -4780,6 +4790,10 @@ inquirer@^0.12.0:
     string-width "^1.0.1"
     strip-ansi "^3.0.0"
     through "^2.3.6"
+
+insert-css@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/insert-css/-/insert-css-2.0.0.tgz#eb5d1097b7542f4c79ea3060d3aee07d053880f4"
 
 internal-ip@^2.0.2:
   version "2.0.3"
@@ -7138,6 +7152,15 @@ pkg-dir@^2.0.0:
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
   dependencies:
     find-up "^2.1.0"
+
+places.js@1.4.15:
+  version "1.4.15"
+  resolved "https://registry.yarnpkg.com/places.js/-/places.js-1.4.15.tgz#9f44e8b51ad9339c512b41a0df70bd5ed2fec833"
+  dependencies:
+    algoliasearch "^3.24.0"
+    autocomplete.js "^0.28.2"
+    events "^1.1.1"
+    insert-css "^2.0.0"
 
 platform@^1.3.1:
   version "1.3.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1307,7 +1307,7 @@ babel-runtime@6.25.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0, babel-runtime@^6.9.0:
+babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0, babel-runtime@^6.9.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -1748,6 +1748,10 @@ camelcase@^4.0.0, camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
+can-use-dom@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/can-use-dom/-/can-use-dom-0.1.0.tgz#22cc4a34a0abc43950f42c6411024a3f6366b45a"
+
 caniuse-api@^1.5.2:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/caniuse-api/-/caniuse-api-1.6.1.tgz#b534e7c734c4f81ec5fbe8aca2ad24354b962c6c"
@@ -1830,6 +1834,10 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
+
+change-emitter@^0.1.2:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/change-emitter/-/change-emitter-0.1.6.tgz#e8b2fe3d7f1ab7d69a32199aff91ea6931409515"
 
 character-entities-html4@^1.0.0:
   version "1.1.1"
@@ -3639,7 +3647,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.16, fbjs@^0.8.5, fbjs@^0.8.9:
+fbjs@^0.8.1, fbjs@^0.8.16, fbjs@^0.8.5, fbjs@^0.8.9:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
@@ -4238,6 +4246,10 @@ gonzales-pe@^4.1.1:
   dependencies:
     minimist "1.1.x"
 
+google-maps-infobox@^1.1.13:
+  version "1.1.15"
+  resolved "https://registry.yarnpkg.com/google-maps-infobox/-/google-maps-infobox-1.1.15.tgz#22a28a97cf72a2cd8493eef755c71fc1a2995170"
+
 got@^3.2.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/got/-/got-3.3.1.tgz#e5d0ed4af55fc3eef4d56007769d98192bcb2eca"
@@ -4780,7 +4792,7 @@ interpret@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.4.tgz#820cdd588b868ffb191a809506d6c9c8f212b1b0"
 
-invariant@^2.2.0, invariant@^2.2.2:
+invariant@^2.2.0, invariant@^2.2.1, invariant@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:
@@ -5958,7 +5970,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@4.17.4, lodash@^4.0.0, lodash@^4.1.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.16.1, lodash@^4.16.6, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.8.0, lodash@~4.17.4:
+lodash@4.17.4, lodash@^4.0.0, lodash@^4.1.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.16.1, lodash@^4.16.2, lodash@^4.16.6, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.8.0, lodash@~4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -6072,6 +6084,14 @@ marked-terminal@^1.6.2:
 marked@^0.3.6:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.6.tgz#b2c6c618fccece4ef86c4fc6cb8a7cbf5aeda8d7"
+
+marker-clusterer-plus@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/marker-clusterer-plus/-/marker-clusterer-plus-2.1.4.tgz#f8eff74d599dab3b7d0e3fed5264ea0e704f5d67"
+
+markerwithlabel@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/markerwithlabel/-/markerwithlabel-2.0.1.tgz#822f4eb68c488c2509c5ebdb75982eb84a856096"
 
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
@@ -7705,6 +7725,22 @@ react-element-to-jsx-string@^12.0.0:
     sortobject "1.1.1"
     stringify-object "3.2.0"
 
+react-google-maps@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/react-google-maps/-/react-google-maps-9.0.1.tgz#01790c98b0922e8066eb4c89f5fdc217e7be6601"
+  dependencies:
+    babel-runtime "^6.11.6"
+    can-use-dom "^0.1.0"
+    google-maps-infobox "^1.1.13"
+    invariant "^2.2.1"
+    lodash "^4.16.2"
+    marker-clusterer-plus "^2.1.4"
+    markerwithlabel "^2.0.1"
+    prop-types "^15.5.8"
+    recompose "^0.25.0"
+    scriptjs "^2.5.8"
+    warning "^3.0.0"
+
 react-inspector@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-2.2.0.tgz#2aa0778c3512063f598d7a89a28a5d5c7733cad7"
@@ -7847,6 +7883,15 @@ rechoir@^0.6.2:
   resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
   dependencies:
     resolve "^1.1.6"
+
+recompose@^0.25.0:
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.25.1.tgz#5eb9d6cf6e25a9ffad73cbbae5658b5b55d6e728"
+  dependencies:
+    change-emitter "^0.1.2"
+    fbjs "^0.8.1"
+    hoist-non-react-statics "^2.3.1"
+    symbol-observable "^1.0.4"
 
 redent@^1.0.0:
   version "1.0.0"
@@ -8321,6 +8366,10 @@ schema-utils@^0.3.0:
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.3.0.tgz#f5877222ce3e931edae039f17eb3716e7137f8cf"
   dependencies:
     ajv "^5.0.0"
+
+scriptjs@^2.5.8:
+  version "2.5.8"
+  resolved "https://registry.yarnpkg.com/scriptjs/-/scriptjs-2.5.8.tgz#d0c43955c2e6bad33b6e4edf7b53b8965aa7ca5f"
 
 scss-tokenizer@^0.2.3:
   version "0.2.3"
@@ -8945,6 +8994,10 @@ svgo@^0.7.0:
     mkdirp "~0.5.1"
     sax "~1.2.1"
     whet.extend "~0.9.9"
+
+symbol-observable@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 
 symbol-tree@^3.2.1:
   version "3.2.2"
@@ -9588,6 +9641,12 @@ walker@~1.0.5:
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
   dependencies:
     makeerror "1.0.x"
+
+warning@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
+  dependencies:
+    loose-envify "^1.0.0"
 
 watch@1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5709,6 +5709,10 @@ lcov-parse@0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-0.0.10.tgz#1b0b8ff9ac9c7889250582b70b71315d9da6d9a3"
 
+leaflet@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.2.0.tgz#fd5d93d9cb00091f5f8a69206d0d6744c1c82697"
+
 leven@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,36 @@
 # yarn lockfile v1
 
 
+"@mapbox/gl-matrix@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@mapbox/gl-matrix/-/gl-matrix-0.0.1.tgz#e5126aab4d64c36b81c7a97d0ae0dddde5773d2b"
+
+"@mapbox/point-geometry@0.1.0", "@mapbox/point-geometry@^0.1.0", "@mapbox/point-geometry@~0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz#8a83f9335c7860effa2eeeca254332aa0aeed8f2"
+
+"@mapbox/shelf-pack@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@mapbox/shelf-pack/-/shelf-pack-3.1.0.tgz#1edea9c0bf6715b217171ba60646c201af520f6a"
+
+"@mapbox/tiny-sdf@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@mapbox/tiny-sdf/-/tiny-sdf-1.1.0.tgz#b0b8f5c22005e6ddb838f421ffd257c1f74f9a20"
+
+"@mapbox/unitbezier@^0.0.0":
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz#15651bd553a67b8581fb398810c98ad86a34524e"
+
+"@mapbox/vector-tile@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@mapbox/vector-tile/-/vector-tile-1.3.0.tgz#c495f972525befccefcd838f45ffa37ef3b70fe8"
+  dependencies:
+    "@mapbox/point-geometry" "~0.1.0"
+
+"@mapbox/whoots-js@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@mapbox/whoots-js/-/whoots-js-3.0.0.tgz#c1de4293081424da3ac30c23afa850af1019bb54"
+
 "@semantic-release/commit-analyzer@^3.0.1":
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/@semantic-release/commit-analyzer/-/commit-analyzer-3.0.7.tgz#dc955444a6d3d2ae9b8e21f90c2c80c4e9142b2f"
@@ -54,6 +84,10 @@ JSONStream@^1.0.4:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
 
+"JSV@>= 4.0.x":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/JSV/-/JSV-4.0.2.tgz#d077f6825571f82132f9dffaed587b4029feff57"
+
 abab@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -81,23 +115,33 @@ acorn-globals@^3.1.0:
   dependencies:
     acorn "^4.0.4"
 
-acorn-jsx@^3.0.0:
+acorn-jsx@^3.0.0, acorn-jsx@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
   dependencies:
     acorn "^3.0.4"
 
-acorn@^3.0.4:
+acorn-object-spread@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-object-spread/-/acorn-object-spread-1.0.0.tgz#48ead0f4a8eb16995a17a0db9ffc6acaada4ba68"
+  dependencies:
+    acorn "^3.1.0"
+
+acorn@^3.0.4, acorn@^3.1.0, acorn@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
-acorn@^4.0.3, acorn@^4.0.4:
+acorn@^4.0.0, acorn@^4.0.3, acorn@^4.0.4:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
 acorn@^5.0.0, acorn@^5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.1.2.tgz#911cb53e036807cf0fa778dc5d370fbd864246d7"
+
+acorn@^5.1.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.2.1.tgz#317ac7821826c22c702d66189ab8359675f135d7"
 
 add-stream@^1.0.0:
   version "1.0.0"
@@ -236,6 +280,10 @@ ansi-styles@^3.1.0, ansi-styles@^3.2.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
   dependencies:
     color-convert "^1.9.0"
+
+ansi-styles@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.0.0.tgz#cb102df1c56f5123eab8b67cd7b98027a0279178"
 
 ansicolors@~0.2.1:
   version "0.2.1"
@@ -1395,7 +1443,7 @@ babylon@7.0.0-beta.22:
   version "7.0.0-beta.22"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.22.tgz#74f0ad82ed7c7c3cfeab74cf684f815104161b65"
 
-babylon@^6.18.0:
+babylon@^6.15.0, babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
 
@@ -1410,6 +1458,10 @@ balanced-match@^0.4.2:
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+
+base64-js@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-0.0.2.tgz#024f0f72afa25b75f9c0ee73cd4f55ec1bed9784"
 
 base64-js@^1.0.2:
   version "1.2.1"
@@ -1527,6 +1579,13 @@ boom@5.x.x:
   dependencies:
     hoek "4.x.x"
 
+bops@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/bops/-/bops-0.0.6.tgz#082d1d55fa01e60dbdc2ebc2dba37f659554cf3a"
+  dependencies:
+    base64-js "0.0.2"
+    to-utf8 "0.0.1"
+
 boundary@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/boundary/-/boundary-1.0.1.tgz#4d67dc2602c0cc16dd9bce7ebf87e948290f5812"
@@ -1561,6 +1620,15 @@ braces@^1.8.2:
     expand-range "^1.8.1"
     preserve "^0.2.0"
     repeat-element "^1.1.2"
+
+brfs@^1.4.0:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/brfs/-/brfs-1.4.3.tgz#db675d6f5e923e6df087fca5859c9090aaed3216"
+  dependencies:
+    quote-stream "^1.0.1"
+    resolve "^1.1.5"
+    static-module "^1.1.0"
+    through2 "^2.0.0"
 
 brorand@^1.0.1:
   version "1.1.0"
@@ -1602,6 +1670,10 @@ browserify-des@^1.0.0:
     cipher-base "^1.0.1"
     des.js "^1.0.0"
     inherits "^2.0.1"
+
+browserify-package-json@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/browserify-package-json/-/browserify-package-json-1.0.1.tgz#98dde8aa5c561fd6d3fe49bbaa102b74b396fdea"
 
 browserify-rsa@^4.0.0:
   version "4.0.1"
@@ -1647,6 +1719,25 @@ bser@^2.0.0:
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"
   dependencies:
     node-int64 "^0.4.0"
+
+buble@^0.15.1:
+  version "0.15.2"
+  resolved "https://registry.yarnpkg.com/buble/-/buble-0.15.2.tgz#547fc47483f8e5e8176d82aa5ebccb183b02d613"
+  dependencies:
+    acorn "^3.3.0"
+    acorn-jsx "^3.0.1"
+    acorn-object-spread "^1.0.0"
+    chalk "^1.1.3"
+    magic-string "^0.14.0"
+    minimist "^1.2.0"
+    os-homedir "^1.0.1"
+
+bubleify@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/bubleify/-/bubleify-0.7.0.tgz#d08ea642ffd085ff8711c8843f57072f0d5eb8f6"
+  dependencies:
+    buble "^0.15.1"
+    object-assign "^4.0.1"
 
 buffer-crc32@^0.2.1:
   version "0.2.13"
@@ -1709,6 +1800,15 @@ bundlesize@0.15.3:
 bytes@3.0.0, bytes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
+
+call-matcher@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/call-matcher/-/call-matcher-1.0.1.tgz#5134d077984f712a54dad3cbf62de28dce416ca8"
+  dependencies:
+    core-js "^2.0.0"
+    deep-equal "^1.0.0"
+    espurify "^1.6.0"
+    estraverse "^4.0.0"
 
 caller-path@^0.1.0:
   version "0.1.0"
@@ -1840,6 +1940,14 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
+
+chalk@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.4.0.tgz#5199a3ddcd0c1efe23bc08c1b027b06176e0c64f"
+  dependencies:
+    ansi-styles "~1.0.0"
+    has-color "~0.1.0"
+    strip-ansi "~0.1.0"
 
 change-emitter@^0.1.2:
   version "0.1.6"
@@ -2142,13 +2250,19 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.4.6, concat-stream@^1.5.2, concat-stream@^1.6.0:
+concat-stream@^1.4.6, concat-stream@^1.5.2, concat-stream@^1.6.0, concat-stream@~1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
+
+concat-stream@~1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.2.1.tgz#f35100b6c46378bfba8b6b80f9f0d0ccdf13dc60"
+  dependencies:
+    bops "0.0.6"
 
 config-chain@~1.1.8:
   version "1.1.11"
@@ -2355,7 +2469,7 @@ conventional-commits-parser@^2.0.0:
     through2 "^2.0.0"
     trim-off-newlines "^1.0.0"
 
-convert-source-map@^1.4.0, convert-source-map@^1.5.0:
+convert-source-map@^1.1.1, convert-source-map@^1.4.0, convert-source-map@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
 
@@ -2384,7 +2498,7 @@ core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
-core-js@^2.4.0, core-js@^2.5.0:
+core-js@^2.0.0, core-js@^2.4.0, core-js@^2.5.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.1.tgz#ae6874dc66937789b80754ff5428df66819ca50b"
 
@@ -2597,6 +2711,10 @@ css@^2.0.0:
     source-map-resolve "^0.3.0"
     urix "^0.1.0"
 
+csscolorparser@~1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/csscolorparser/-/csscolorparser-1.0.3.tgz#b34f391eea4da8f3e98231e2ccd8df9c041f171b"
+
 cssesc@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-0.1.0.tgz#c814903e45623371a0477b40109aaafbeeaddbb4"
@@ -2733,7 +2851,7 @@ decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
-deep-equal@^1.0.1:
+deep-equal@^1.0.0, deep-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
 
@@ -2994,6 +3112,12 @@ dot-prop@^4.1.0:
   dependencies:
     is-obj "^1.0.0"
 
+duplexer2@~0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.0.2.tgz#c614dcf67e2fb14995a91711e5a617e8a60a31db"
+  dependencies:
+    readable-stream "~1.1.9"
+
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
@@ -3010,6 +3134,10 @@ duplexify@^3.2.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
+
+earcut@^2.0.3:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/earcut/-/earcut-2.1.2.tgz#542add0ca3a7b713452720e1d053937d3daf3784"
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"
@@ -3221,6 +3349,25 @@ escodegen@^1.6.1:
   optionalDependencies:
     source-map "~0.5.6"
 
+escodegen@~0.0.24:
+  version "0.0.28"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-0.0.28.tgz#0e4ff1715f328775d6cab51ac44a406cd7abffd3"
+  dependencies:
+    esprima "~1.0.2"
+    estraverse "~1.3.0"
+  optionalDependencies:
+    source-map ">= 0.1.2"
+
+escodegen@~1.3.2:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.3.3.tgz#f024016f5a88e046fd12005055e939802e6c5f23"
+  dependencies:
+    esprima "~1.1.1"
+    estraverse "~1.5.0"
+    esutils "~1.0.0"
+  optionalDependencies:
+    source-map "~0.1.33"
+
 escope@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/escope/-/escope-3.6.0.tgz#e01975e812781a163a6dadfdd80398dc64c889c3"
@@ -3415,9 +3562,23 @@ esprima@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
 
+esprima@~1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-1.0.4.tgz#9f557e08fc3b4d26ece9dd34f8fbf476b62585ad"
+
+esprima@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-1.1.1.tgz#5b6f1547f4d102e670e140c509be6771d6aeb549"
+
 esprima@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.0.0.tgz#53cf247acda77313e551c3aa2e73342d3fb4f7d9"
+
+espurify@^1.3.0, espurify@^1.6.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/espurify/-/espurify-1.7.0.tgz#1c5cf6cbccc32e6f639380bd4f991fab9ba9d226"
+  dependencies:
+    core-js "^2.0.0"
 
 esquery@^1.0.0:
   version "1.0.0"
@@ -3436,9 +3597,21 @@ estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
+estraverse@~1.3.0:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.3.2.tgz#37c2b893ef13d723f276d878d60d8535152a6c42"
+
+estraverse@~1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.5.1.tgz#867a3e8e58a9f84618afb6c2ddbcd916b7cbaf71"
+
 esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
+
+esutils@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/esutils/-/esutils-1.0.0.tgz#8151d358e20c8acc7fb745e7472c0025fe496570"
 
 etag@~1.8.1:
   version "1.8.1"
@@ -3619,6 +3792,15 @@ extsprintf@1.3.0, extsprintf@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
 
+falafel@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/falafel/-/falafel-2.1.0.tgz#96bb17761daba94f46d001738b3cedf3a67fe06c"
+  dependencies:
+    acorn "^5.0.0"
+    foreach "^2.0.5"
+    isarray "0.0.1"
+    object-keys "^1.0.6"
+
 fast-deep-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
@@ -3785,6 +3967,13 @@ flat-cache@^1.2.1:
 flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
+
+flow-remove-types@^1.1.2:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/flow-remove-types/-/flow-remove-types-1.2.3.tgz#6131aefc7da43364bb8b479758c9dec7735d1a18"
+  dependencies:
+    babylon "^6.15.0"
+    vlq "^0.2.1"
 
 follow-redirects@0.0.7:
   version "0.0.7"
@@ -3985,6 +4174,24 @@ generate-object-property@^1.1.0:
   resolved "https://registry.yarnpkg.com/generate-object-property/-/generate-object-property-1.2.0.tgz#9c0e1c40308ce804f4783618b937fa88f99d50d0"
   dependencies:
     is-property "^1.0.0"
+
+geojson-area@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/geojson-area/-/geojson-area-0.1.0.tgz#d48d807082cfadf4a78df1349be50f38bf1894ae"
+  dependencies:
+    wgs84 "0.0.0"
+
+geojson-rewind@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/geojson-rewind/-/geojson-rewind-0.2.0.tgz#ea558e9e44ff03b8655d0a08b75078dc33a15e79"
+  dependencies:
+    concat-stream "~1.2.1"
+    geojson-area "0.1.0"
+    minimist "0.0.5"
+
+geojson-vt@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/geojson-vt/-/geojson-vt-2.4.0.tgz#3c1cf44493f35eb4d2c70c95da6550de66072c05"
 
 get-caller-file@^1.0.1:
   version "1.0.2"
@@ -4305,6 +4512,10 @@ graceful-fs@~1.2.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
+grid-index@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/grid-index/-/grid-index-1.0.0.tgz#ad2c5d54ce5b35437faff1d70a9aeb3d1d261110"
+
 growl@1.9.2:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
@@ -4386,6 +4597,10 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
+has-color@~0.1.0:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/has-color/-/has-color-0.1.7.tgz#67144a5260c34fc3cca677d041daf52fe7b78b2f"
+
 has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
@@ -4398,7 +4613,7 @@ has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
 
-has@^1.0.1:
+has@^1.0.0, has@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
   dependencies:
@@ -4648,7 +4863,7 @@ icss-utils@^2.1.0:
   dependencies:
     postcss "^6.0.1"
 
-ieee754@^1.1.4:
+ieee754@^1.1.4, ieee754@^1.1.6:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
 
@@ -5624,6 +5839,13 @@ jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
 
+jsonlint-lines-primitives@~1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/jsonlint-lines-primitives/-/jsonlint-lines-primitives-1.6.0.tgz#bb89f60c8b9b612fd913ddaa236649b840d86611"
+  dependencies:
+    JSV ">= 4.0.x"
+    nomnom ">= 1.5.x"
+
 jsonparse@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
@@ -5650,6 +5872,10 @@ jsx-ast-utils@^2.0.0:
 just-extend@^1.1.26:
   version "1.1.26"
   resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-1.1.26.tgz#dba4ad2786d319f1d10afab106e004b5a0851ac2"
+
+kdbush@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/kdbush/-/kdbush-1.0.1.tgz#3cbd03e9dead9c0f6f66ccdb96450e5cecc640e0"
 
 kind-of@^2.0.1:
   version "2.0.1"
@@ -5806,6 +6032,14 @@ lodash._baseget@^3.0.0:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/lodash._baseget/-/lodash._baseget-3.7.2.tgz#1b6ae1d5facf3c25532350a13c1197cb8bb674f4"
 
+lodash._baseisequal@^3.0.0:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz#d8025f76339d29342767dcc887ce5cb95a5b51f1"
+  dependencies:
+    lodash.isarray "^3.0.0"
+    lodash.istypedarray "^3.0.0"
+    lodash.keys "^3.0.0"
+
 lodash._bindcallback@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
@@ -5914,6 +6148,17 @@ lodash.isarguments@^3.0.0:
 lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
+
+lodash.isequal@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-3.0.4.tgz#1c35eb3b6ef0cd1ff51743e3ea3cf7fdffdacb64"
+  dependencies:
+    lodash._baseisequal "^3.0.0"
+    lodash._bindcallback "^3.0.0"
+
+lodash.istypedarray@^3.0.0:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz#c9a477498607501d8e8494d283b87c39281cef62"
 
 lodash.kebabcase@^4.0.0:
   version "4.1.1"
@@ -6060,6 +6305,12 @@ macaddress@^0.2.8:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/macaddress/-/macaddress-0.2.8.tgz#5904dc537c39ec6dbefeae902327135fa8511f12"
 
+magic-string@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.14.0.tgz#57224aef1701caeed273b17a39a956e72b172462"
+  dependencies:
+    vlq "^0.2.1"
+
 make-dir@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.1.0.tgz#19b4369fe48c116f53c2af95ad102c0e39e85d51"
@@ -6075,6 +6326,46 @@ makeerror@1.0.x:
 map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
+
+mapbox-gl-supported@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mapbox-gl-supported/-/mapbox-gl-supported-1.2.0.tgz#cbd34df894206cadda9a33c8d9a4609f26bb1989"
+
+mapbox-gl@0.41.0:
+  version "0.41.0"
+  resolved "https://registry.yarnpkg.com/mapbox-gl/-/mapbox-gl-0.41.0.tgz#68839ac1d45c1e90a230d7a6c17434b5e2cfbb73"
+  dependencies:
+    "@mapbox/gl-matrix" "^0.0.1"
+    "@mapbox/point-geometry" "^0.1.0"
+    "@mapbox/shelf-pack" "^3.1.0"
+    "@mapbox/tiny-sdf" "^1.1.0"
+    "@mapbox/unitbezier" "^0.0.0"
+    "@mapbox/vector-tile" "^1.3.0"
+    "@mapbox/whoots-js" "^3.0.0"
+    brfs "^1.4.0"
+    bubleify "^0.7.0"
+    csscolorparser "~1.0.2"
+    earcut "^2.0.3"
+    geojson-rewind "^0.2.0"
+    geojson-vt "^2.4.0"
+    grid-index "^1.0.0"
+    jsonlint-lines-primitives "~1.6.0"
+    lodash.isequal "^3.0.4"
+    mapbox-gl-supported "^1.2.0"
+    minimist "0.0.8"
+    package-json-versionify "^1.0.2"
+    pbf "^3.0.5"
+    quickselect "^1.0.0"
+    rw "^1.3.3"
+    shuffle-seed "^1.1.6"
+    sort-object "^0.3.2"
+    supercluster "^2.3.0"
+    through2 "^2.0.3"
+    tinyqueue "^1.1.0"
+    unassertify "^2.0.0"
+    unflowify "^1.0.0"
+    vt-pbf "^3.0.1"
+    webworkify "^1.4.0"
 
 markdown-table@^0.4.0:
   version "0.4.0"
@@ -6257,6 +6548,10 @@ minimatch@~0.2.11:
     lru-cache "2"
     sigmund "~1.0.0"
 
+minimist@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.5.tgz#d7aa327bcecf518f9106ac6b8f003fa3bcea8566"
+
 minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
@@ -6336,6 +6631,12 @@ ms@0.7.1:
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
+multi-stage-sourcemap@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/multi-stage-sourcemap/-/multi-stage-sourcemap-0.2.1.tgz#b09fc8586eaa17f81d575c4ad02e0f7a3f6b1105"
+  dependencies:
+    source-map "^0.1.34"
 
 multicast-dns-service-types@^1.1.0:
   version "1.1.0"
@@ -6590,6 +6891,13 @@ node-uuid@~1.4.7:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.8.tgz#b040eb0923968afabf8d32fb1f17f1167fdab907"
 
+"nomnom@>= 1.5.x":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.8.1.tgz#2151f722472ba79e50a76fc125bb8c8f2e4dc2a7"
+  dependencies:
+    chalk "~0.4.0"
+    underscore "~1.6.0"
+
 nopt@1.0.10:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
@@ -6734,13 +7042,21 @@ object-inspect@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.3.0.tgz#5b1eb8e6742e2ee83342a637034d844928ba2f6d"
 
+object-inspect@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-0.4.0.tgz#f5157c116c1455b243b06ee97703392c5ad89fec"
+
 object-is@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.0.1.tgz#0aa60ec9989a0b3ed795cf4d06f62cf1ad6539b6"
 
-object-keys@^1.0.10, object-keys@^1.0.11, object-keys@^1.0.8, object-keys@^1.0.9, object-keys@~1.0.0:
+object-keys@^1.0.10, object-keys@^1.0.11, object-keys@^1.0.6, object-keys@^1.0.8, object-keys@^1.0.9, object-keys@~1.0.0:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
+
+object-keys@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-0.4.0.tgz#28a6aae7428dd2c3a92f3d95f21335dd204e0336"
 
 object.assign@^4.0.3, object.assign@^4.0.4:
   version "4.0.4"
@@ -6942,6 +7258,12 @@ p-series@^1.0.0:
   dependencies:
     p-reduce "^1.0.0"
 
+package-json-versionify@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/package-json-versionify/-/package-json-versionify-1.0.4.tgz#5860587a944873a6b7e6d26e8e51ffb22315bf17"
+  dependencies:
+    browserify-package-json "^1.0.0"
+
 package-json@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/package-json/-/package-json-1.2.0.tgz#c8ecac094227cdf76a316874ed05e27cc939a0e0"
@@ -7098,6 +7420,13 @@ path-type@^2.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
   dependencies:
     pify "^2.0.0"
+
+pbf@^3.0.5:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/pbf/-/pbf-3.1.0.tgz#f70004badcb281761eabb1e76c92f179f08189e9"
+  dependencies:
+    ieee754 "^1.1.6"
+    resolve-protobuf-schema "^2.0.0"
 
 pbkdf2@^3.0.3:
   version "3.0.14"
@@ -7599,6 +7928,10 @@ proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
 
+protocol-buffers-schema@^2.0.2:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/protocol-buffers-schema/-/protocol-buffers-schema-2.2.0.tgz#d29c6cd73fb655978fb6989691180db844119f61"
+
 proxy-addr@~2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.2.tgz#6571504f47bb988ec8180253f85dd7e14952bdec"
@@ -7674,6 +8007,25 @@ querystringify@0.0.x:
 querystringify@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-1.0.0.tgz#6286242112c5b712fa654e526652bf6a13ff05cb"
+
+quickselect@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/quickselect/-/quickselect-1.0.0.tgz#02630818f9aae4ecab26f0103f98d061c17c58f3"
+
+quote-stream@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/quote-stream/-/quote-stream-1.0.2.tgz#84963f8c9c26b942e153feeb53aae74652b7e0b2"
+  dependencies:
+    buffer-equal "0.0.1"
+    minimist "^1.1.3"
+    through2 "^2.0.0"
+
+quote-stream@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/quote-stream/-/quote-stream-0.0.0.tgz#cde29e94c409b16e19dc7098b89b6658f9721d3b"
+  dependencies:
+    minimist "0.0.8"
+    through2 "~0.4.1"
 
 randomatic@^1.1.3:
   version "1.1.7"
@@ -7847,7 +8199,7 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
-readable-stream@1.0, "readable-stream@>=1.0.33-1 <1.1.0-0":
+readable-stream@1.0, "readable-stream@>=1.0.33-1 <1.1.0-0", readable-stream@~1.0.17, readable-stream@~1.0.27-1:
   version "1.0.34"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
   dependencies:
@@ -7856,7 +8208,7 @@ readable-stream@1.0, "readable-stream@>=1.0.33-1 <1.1.0-0":
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-"readable-stream@>=1.1.13-1 <1.2.0-0":
+"readable-stream@>=1.1.13-1 <1.2.0-0", readable-stream@~1.1.9:
   version "1.1.14"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
   dependencies:
@@ -8225,6 +8577,12 @@ resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
 
+resolve-protobuf-schema@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-protobuf-schema/-/resolve-protobuf-schema-2.0.0.tgz#e67b062a67f02d11bd6886e70efda788407e0fb4"
+  dependencies:
+    protocol-buffers-schema "^2.0.2"
+
 resolve-url@~0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
@@ -8232,6 +8590,12 @@ resolve-url@~0.2.1:
 resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
+
+resolve@^1.1.5:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
+  dependencies:
+    path-parse "^1.0.5"
 
 resolve@^1.1.6, resolve@^1.2.0:
   version "1.4.0"
@@ -8291,6 +8655,10 @@ run-async@^2.2.0:
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
   dependencies:
     is-promise "^2.1.0"
+
+rw@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
 
 rx-lite-aggregates@^4.0.8:
   version "4.0.8"
@@ -8404,6 +8772,10 @@ scss-tokenizer@^0.2.3:
   dependencies:
     js-base64 "^2.1.8"
     source-map "^0.4.2"
+
+seedrandom@^2.4.2:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/seedrandom/-/seedrandom-2.4.3.tgz#2438504dad33917314bff18ac4d794f16d6aaecc"
 
 select-hose@^2.0.0:
   version "2.0.0"
@@ -8540,6 +8912,10 @@ shallow-clone@^0.1.2:
     lazy-cache "^0.2.3"
     mixin-object "^2.0.1"
 
+shallow-copy@~0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/shallow-copy/-/shallow-copy-0.0.1.tgz#415f42702d73d810330292cc5ee86eae1a11a170"
+
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
@@ -8565,6 +8941,12 @@ shelljs@^0.6.0:
 shellwords@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
+
+shuffle-seed@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/shuffle-seed/-/shuffle-seed-1.1.6.tgz#533c12683bab3b4fa3e8751fc4e562146744260b"
+  dependencies:
+    seedrandom "^2.4.2"
 
 sigmund@~1.0.0:
   version "1.0.1"
@@ -8634,11 +9016,26 @@ sockjs@0.3.18:
     faye-websocket "^0.10.0"
     uuid "^2.0.2"
 
+sort-asc@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/sort-asc/-/sort-asc-0.1.0.tgz#ab799df61fc73ea0956c79c4b531ed1e9e7727e9"
+
+sort-desc@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/sort-desc/-/sort-desc-0.1.1.tgz#198b8c0cdeb095c463341861e3925d4ee359a9ee"
+
 sort-keys@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-1.1.2.tgz#441b6d4d346798f1b4e49e8920adfba0e543f9ad"
   dependencies:
     is-plain-obj "^1.0.0"
+
+sort-object@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/sort-object/-/sort-object-0.3.2.tgz#98e0d199ede40e07c61a84403c61d6c3b290f9e2"
+  dependencies:
+    sort-asc "^0.1.0"
+    sort-desc "^0.1.1"
 
 sortobject@1.1.1:
   version "1.1.1"
@@ -8673,7 +9070,11 @@ source-map@0.5.x, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, sourc
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
-source-map@^0.1.38:
+"source-map@>= 0.1.2", source-map@^0.6.1, source-map@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+
+source-map@^0.1.34, source-map@^0.1.38, source-map@~0.1.33:
   version "0.1.43"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
   dependencies:
@@ -8684,10 +9085,6 @@ source-map@^0.4.2, source-map@^0.4.4:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
   dependencies:
     amdefine ">=0.0.4"
-
-source-map@^0.6.1, source-map@~0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
 spdx-correct@~1.0.0:
   version "1.0.2"
@@ -8769,6 +9166,28 @@ stack-trace@0.0.9:
 standalone-react-addons-pure-render-mixin@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/standalone-react-addons-pure-render-mixin/-/standalone-react-addons-pure-render-mixin-0.1.1.tgz#3c7409f4c79c40de9ac72c616cf679a994f37551"
+
+static-eval@~0.2.0:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/static-eval/-/static-eval-0.2.4.tgz#b7d34d838937b969f9641ca07d48f8ede263ea7b"
+  dependencies:
+    escodegen "~0.0.24"
+
+static-module@^1.1.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/static-module/-/static-module-1.5.0.tgz#27da9883c41a8cd09236f842f0c1ebc6edf63d86"
+  dependencies:
+    concat-stream "~1.6.0"
+    duplexer2 "~0.0.2"
+    escodegen "~1.3.2"
+    falafel "^2.1.0"
+    has "^1.0.0"
+    object-inspect "~0.4.0"
+    quote-stream "~0.0.0"
+    readable-stream "~1.0.27-1"
+    shallow-copy "~0.0.1"
+    static-eval "~0.2.0"
+    through2 "~0.4.1"
 
 "statuses@>= 1.3.1 < 2":
   version "1.4.0"
@@ -8910,6 +9329,10 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
+strip-ansi@~0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-0.1.1.tgz#39e8a98d044d150660abe4a6808acf70bb7bc991"
+
 strip-bom@3.0.0, strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
@@ -8983,6 +9406,12 @@ styled-normalize@^2.0.0:
 stylis@^3.2.1:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.4.0.tgz#55c6530ebceeca5976d54fb4adc67578afee828d"
+
+supercluster@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/supercluster/-/supercluster-2.3.0.tgz#87ab56081bbea9a1d724df5351ee9e8c3af2f48b"
+  dependencies:
+    kdbush "^1.0.1"
 
 supports-color@3.1.2:
   version "3.1.2"
@@ -9155,14 +9584,21 @@ through2@^1.0.0:
     readable-stream ">=1.1.13-1 <1.2.0-0"
     xtend ">=4.0.0 <4.1.0-0"
 
-through2@^2.0.0, through2@^2.0.2:
+through2@^2.0.0, through2@^2.0.2, through2@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
   dependencies:
     readable-stream "^2.1.5"
     xtend "~4.0.1"
 
-through@2, "through@>=2.2.7 <3", through@^2.3.6, through@~2.3.4:
+through2@~0.4.1:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-0.4.2.tgz#dbf5866031151ec8352bb6c4db64a2292a840b9b"
+  dependencies:
+    readable-stream "~1.0.17"
+    xtend "~2.1.1"
+
+through@2, "through@>=2.2.7 <3", through@^2.3.6, through@^2.3.7, through@^2.3.8, through@~2.3.4:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
@@ -9202,6 +9638,10 @@ tinycolor2@^1.1.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.1.tgz#f4fad333447bc0b07d4dc8e9209d8f39a8ac77e8"
 
+tinyqueue@^1.1.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/tinyqueue/-/tinyqueue-1.2.3.tgz#b6a61de23060584da29f82362e45df1ec7353f3d"
+
 tmatch@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/tmatch/-/tmatch-2.0.1.tgz#0c56246f33f30da1b8d3d72895abaf16660f38cf"
@@ -9231,6 +9671,10 @@ to-fast-properties@^1.0.3:
 to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
+
+to-utf8@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/to-utf8/-/to-utf8-0.0.1.tgz#d17aea72ff2fba39b9e43601be7b3ff72e089852"
 
 toposort@^1.0.0:
   version "1.0.6"
@@ -9379,6 +9823,29 @@ uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
 
+unassert@^1.3.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/unassert/-/unassert-1.5.1.tgz#cbc88ec387417c5a5e4c02d3cd07be98bd75ff76"
+  dependencies:
+    acorn "^4.0.0"
+    call-matcher "^1.0.1"
+    deep-equal "^1.0.0"
+    espurify "^1.3.0"
+    estraverse "^4.1.0"
+    esutils "^2.0.2"
+    object-assign "^4.1.0"
+
+unassertify@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/unassertify/-/unassertify-2.1.0.tgz#6b07abf5c6598ba3852a27a676caad1df526a96d"
+  dependencies:
+    acorn "^5.1.0"
+    convert-source-map "^1.1.1"
+    escodegen "^1.6.1"
+    multi-stage-sourcemap "^0.2.1"
+    through "^2.3.7"
+    unassert "^1.3.1"
+
 unc-path-regex@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
@@ -9387,9 +9854,20 @@ underscore.string@~2.2.0rc:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-2.2.1.tgz#d7c0fa2af5d5a1a67f4253daee98132e733f0f19"
 
+underscore@~1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.6.0.tgz#8b38b10cacdef63337b8b24e4ff86d45aea529a8"
+
 underscore@~1.8.3:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
+
+unflowify@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/unflowify/-/unflowify-1.0.1.tgz#a2ea0d25c0affcc46955e6473575f7c5a1f4a696"
+  dependencies:
+    flow-remove-types "^1.1.2"
+    through "^2.3.8"
 
 unherit@^1.0.4:
   version "1.1.0"
@@ -9647,11 +10125,23 @@ vinyl@^0.4.0:
     clone "^0.2.0"
     clone-stats "^0.0.1"
 
+vlq@^0.2.1:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.3.tgz#8f3e4328cf63b1540c0d67e1b2778386f8975b26"
+
 vm-browserify@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
   dependencies:
     indexof "0.0.1"
+
+vt-pbf@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/vt-pbf/-/vt-pbf-3.1.0.tgz#d7e63f585b362cbff6b84fcd052c159112e0acc7"
+  dependencies:
+    "@mapbox/point-geometry" "0.1.0"
+    "@mapbox/vector-tile" "^1.3.0"
+    pbf "^3.0.5"
 
 walk@^2.3.9:
   version "2.3.9"
@@ -9875,6 +10365,14 @@ websocket-extensions@>=0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.2.tgz#0e18781de629a18308ce1481650f67ffa2693a5d"
 
+webworkify@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/webworkify/-/webworkify-1.4.0.tgz#71245d1e34cacf54e426bd955f8cc6ee12d024c2"
+
+wgs84@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/wgs84/-/wgs84-0.0.0.tgz#34fdc555917b6e57cf2a282ed043710c049cdc76"
+
 wgxpath@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wgxpath/-/wgxpath-1.0.0.tgz#eef8a4b9d558cc495ad3a9a2b751597ecd9af690"
@@ -10019,6 +10517,12 @@ xmlbuilder@~9.0.1:
 "xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
+
+xtend@~2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-2.1.2.tgz#6efecc2a4dad8e6962c4901b337ce7ba87b5d28b"
+  dependencies:
+    object-keys "~0.4.0"
 
 y18n@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
**Summary**

👋 This is a POC for the GeoSearch (with Google Maps for now). Take a look at the **behaviour only** don't look at the code it's not the **point of the PR**. Since we have preview with Netlify, this is a convenient way to receive feedbacks 🙂

- Initially the search will refine with the IP **or** the given position
- When the map is moved the results will be filter with the bounding box
- The widget don't compute any radius automatically because (IMO) it depends a lot of the use case, you can still configure it at the instantiation.
- When no results are found, we keep the same bounds & zoom that has been set with the last results found. We avoid to lost the context of the search for the user.

Again check the behaviour of the search, I will replicate the Google Maps example with Leaflet (at least).

Some example of GeoSearch:

- [Airbnb](https://www.airbnb.com/s/New-York--NY--United-States/homes?refinement_path=%2Fhomes&allow_override%5B%5D=&place_id=ChIJOwg_06VPwokRYv534QaPC8g&s_tag=SZqkWyWk)
- [Yelp](https://www.yelp.com/search?find_desc=Restaurants&find_loc=New+York,+NY&start=0&l=g:-73.72465136926621,40.7384032871027,-74.15586474817246,40.47776024357566)
- [Foursquare](https://foursquare.com/explore?mode=url&near=New%20York%2C%20NY%2C%20United%20States&nearGeoId=72057594043056517)
- [Booking](https://www.booking.com/searchresults.html?aid=397596;label=gog235jc-index-XX-XX-XX-unspec-fr-com-L%3Axu-O%3AosSx-B%3Achrome-N%3AXX-S%3Abo-U%3Ac-H%3As;sid=2e5374e1379c747207f5be99e2a4a730;city=-1456928;from_idr=1;index_postcard=1&;ilp=1;d_dcp=1;i_upcc=1#map_opened-map-header-cta)

Not yet implemented: 
- clustering
- shape

**Result**

You can play with the `GeoSearch` widget on [dev-novel](https://deploy-preview-2527--algolia-instantsearch.netlify.com/v2/dev-novel/?selectedStory=GeoSearch). You need to reload the page when you switch between the stories otherwise the map is a bit lost.

Ideas of keywords for the search: 
- `studio` 
- `cosy`


