### PR TITLE
fix(url-sync): make URLSync consistent even if search is tampered

### DIFF
--- a/dev/app/init-builtin-widgets.js
+++ b/dev/app/init-builtin-widgets.js
@@ -5,6 +5,19 @@ import instantsearch from '../../index.js';
 import wrapWithHits from './wrap-with-hits.js';
 
 export default () => {
+  storiesOf('instantsearch').add(
+    'With searchfunction that prevent search',
+    wrapWithHits(() => {}, {
+      searchFunction: helper => {
+        const query = helper.state.query;
+        if (query === '') {
+          return;
+        }
+        helper.search();
+      },
+    })
+  );
+
   storiesOf('Analytics').add(
     'default',
     wrapWithHits(container => {

--- a/dev/app/wrap-with-hits.js
+++ b/dev/app/wrap-with-hits.js
@@ -5,10 +5,7 @@ import instantsearch from '../../index.js';
 import item from './templates/item.html';
 import empty from './templates/no-results.html';
 
-export default (
-  initWidget,
-  instantSearchConfig = {}
-) => container => {
+export default (initWidget, instantSearchConfig = {}) => container => {
   const {
     appId = 'latency',
     apiKey = '6be0576ff61c053d5f9a3225e2a90f76',

--- a/dev/app/wrap-with-hits.js
+++ b/dev/app/wrap-with-hits.js
@@ -1,4 +1,5 @@
 /* eslint-disable import/default */
+import { action } from 'dev-novel';
 
 import instantsearch from '../../index.js';
 import item from './templates/item.html';
@@ -6,13 +7,17 @@ import empty from './templates/no-results.html';
 
 export default (
   initWidget,
-  {
+  instantSearchConfig = {}
+) => container => {
+  const {
     appId = 'latency',
     apiKey = '6be0576ff61c053d5f9a3225e2a90f76',
     indexName = 'instant_search',
     searchParameters = {},
-  } = {}
-) => container => {
+    ...otherInstantSearchConfig
+  } = instantSearchConfig;
+
+  const urlLogger = action('[URL sync] pushstate: query string');
   window.search = instantsearch({
     appId,
     apiKey,
@@ -21,6 +26,21 @@ export default (
       hitsPerPage: 3,
       ...searchParameters,
     },
+    urlSync: {
+      urlUtils: {
+        onpopstate() {},
+        pushState(qs) {
+          urlLogger(this.createURL(qs));
+        },
+        createURL(qs) {
+          return qs;
+        },
+        readUrl() {
+          return '';
+        },
+      },
+    },
+    ...otherInstantSearchConfig,
   });
 
   container.innerHTML = `

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "test:functional:dev": "babel-node scripts/dev-functional-tests",
     "test:functional:dev:debug-server": "PORT=9090 babel-node scripts/dev-functional-tests-debug-server",
     "argos": "argos upload functional-tests/screenshots --token $ARGOS_TOKEN || true",
-    "serve": "./scripts/serve.sh"
+    "serve": "./scripts/serve.sh",
+    "fix:prettier": "eslint --fix -c .eslintrc.js ."
   },
   "repository": "algolia/instantsearch.js",
   "files": [

--- a/src/lib/__tests__/__snapshots__/url-sync-test.js.snap
+++ b/src/lib/__tests__/__snapshots__/url-sync-test.js.snap
@@ -1,3 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`urlSync mechanics Generates urls on change 1`] = `"q=query&idx=&p=0"`;
+
+exports[`urlSync mechanics updates the URL durding the first rendering if it has change since the initial configuration 1`] = `"q=query&idx=&p=0"`;

--- a/src/lib/__tests__/url-sync-test.js
+++ b/src/lib/__tests__/url-sync-test.js
@@ -1,5 +1,6 @@
 import urlSync from '../url-sync.js';
 import jsHelper from 'algoliasearch-helper';
+const SearchParameters = jsHelper.SearchParameters;
 
 jest.useFakeTimers();
 
@@ -27,7 +28,8 @@ describe('urlSync mechanics', () => {
     const helper = jsHelper({ addAlgoliaAgent: () => {} });
     const urlUtils = makeTestUrlUtils();
     const urlSyncWidget = urlSync({ urlUtils, threshold: 0 });
-    urlSyncWidget.render({ helper });
+    urlSyncWidget.init({ state: SearchParameters.make({}) });
+    urlSyncWidget.render({ helper, state: helper.state });
 
     expect(urlUtils.lastQs).toEqual('');
     helper.setQuery('query');
@@ -41,11 +43,32 @@ describe('urlSync mechanics', () => {
     const helper = jsHelper({ addAlgoliaAgent: () => {} });
     const urlUtils = makeTestUrlUtils();
     const urlSyncWidget = urlSync({ urlUtils, threshold: 0 });
-    urlSyncWidget.render({ helper });
+    urlSyncWidget.init({ state: SearchParameters.make({}) });
+    urlSyncWidget.render({ helper, state: helper.state });
     helper.setQuery('query');
 
     jest.runOnlyPendingTimers();
 
     expect(urlUtils.lastQs).not.toEqual(expect.stringContaining('is_v'));
   });
+  test(
+    'updates the URL durding the first rendering if it has change since the initial configuration',
+    () => {
+      const helper = jsHelper({ addAlgoliaAgent: () => {} });
+      const urlUtils = makeTestUrlUtils();
+      const urlSyncWidget = urlSync({ urlUtils, threshold: 0 });
+      urlSyncWidget.init({ state: SearchParameters.make({}) });
+
+      // In this scenario, there should have been a search here
+      // but it was prevented by a search function
+      helper.setQuery('query');
+      // the change even is setup at the first rendering
+      urlSyncWidget.render({ helper, state: helper.state });
+
+      // because the state has changed before the first rendering,
+      // we expect the URL to be updated
+      jest.runOnlyPendingTimers();
+      expect(urlUtils.lastQs).toMatchSnapshot();
+    }
+  );
 });

--- a/src/lib/__tests__/url-sync-test.js
+++ b/src/lib/__tests__/url-sync-test.js
@@ -51,24 +51,21 @@ describe('urlSync mechanics', () => {
 
     expect(urlUtils.lastQs).not.toEqual(expect.stringContaining('is_v'));
   });
-  test(
-    'updates the URL durding the first rendering if it has change since the initial configuration',
-    () => {
-      const helper = jsHelper({ addAlgoliaAgent: () => {} });
-      const urlUtils = makeTestUrlUtils();
-      const urlSyncWidget = urlSync({ urlUtils, threshold: 0 });
-      urlSyncWidget.init({ state: SearchParameters.make({}) });
+  test('updates the URL durding the first rendering if it has change since the initial configuration', () => {
+    const helper = jsHelper({ addAlgoliaAgent: () => {} });
+    const urlUtils = makeTestUrlUtils();
+    const urlSyncWidget = urlSync({ urlUtils, threshold: 0 });
+    urlSyncWidget.init({ state: SearchParameters.make({}) });
 
-      // In this scenario, there should have been a search here
-      // but it was prevented by a search function
-      helper.setQuery('query');
-      // the change even is setup at the first rendering
-      urlSyncWidget.render({ helper, state: helper.state });
+    // In this scenario, there should have been a search here
+    // but it was prevented by a search function
+    helper.setQuery('query');
+    // the change even is setup at the first rendering
+    urlSyncWidget.render({ helper, state: helper.state });
 
-      // because the state has changed before the first rendering,
-      // we expect the URL to be updated
-      jest.runOnlyPendingTimers();
-      expect(urlUtils.lastQs).toMatchSnapshot();
-    }
-  );
+    // because the state has changed before the first rendering,
+    // we expect the URL to be updated
+    jest.runOnlyPendingTimers();
+    expect(urlUtils.lastQs).toMatchSnapshot();
+  });
 });

--- a/src/lib/url-sync.js
+++ b/src/lib/url-sync.js
@@ -120,7 +120,7 @@ class URLSync {
     );
   }
 
-  init({state}) {
+  init({ state }) {
     this.initState = state;
   }
 
@@ -144,7 +144,6 @@ class URLSync {
 
       const initStateQs = this.getQueryString(this.initState);
       const stateQs = this.getQueryString(state);
-      console.log(initStateQs, stateQs);
       if (initStateQs !== stateQs) {
         // force update the URL, if the state has changed since the initial URL read
         // We do this in order to make a URL update when there is search function

--- a/src/lib/url-sync.js
+++ b/src/lib/url-sync.js
@@ -120,6 +120,10 @@ class URLSync {
     );
   }
 
+  init({state}) {
+    this.initState = state;
+  }
+
   getConfiguration(currentConfiguration) {
     // we need to create a REAL helper to then get its state. Because some parameters
     // like hierarchicalFacet.rootPath are then triggering a default refinement that would
@@ -132,11 +136,22 @@ class URLSync {
     return this.searchParametersFromUrl;
   }
 
-  render({ helper }) {
+  render({ helper, state }) {
     if (this.firstRender) {
       this.firstRender = false;
       this.onHistoryChange(this.onPopState.bind(this, helper));
-      helper.on('change', state => this.renderURLFromState(state));
+      helper.on('change', s => this.renderURLFromState(s));
+
+      const initStateQs = this.getQueryString(this.initState);
+      const stateQs = this.getQueryString(state);
+      console.log(initStateQs, stateQs);
+      if (initStateQs !== stateQs) {
+        // force update the URL, if the state has changed since the initial URL read
+        // We do this in order to make a URL update when there is search function
+        // that prevent the search of the initial rendering
+        // See: https://github.com/algolia/instantsearch.js/issues/2523#issuecomment-339356157
+        this.renderURLFromState(state);
+      }
     }
   }
 
@@ -152,13 +167,21 @@ class URLSync {
   }
 
   renderURLFromState(state) {
+    const qs = this.getQueryString(state);
+    clearTimeout(this.urlUpdateTimeout);
+    this.urlUpdateTimeout = setTimeout(() => {
+      this.urlUtils.pushState(qs, { getHistoryState: this.getHistoryState });
+    }, this.threshold);
+  }
+
+  getQueryString(state) {
     const currentQueryString = this.urlUtils.readUrl();
     const foreignConfig = AlgoliaSearchHelper.getForeignConfigurationInQueryString(
       currentQueryString,
       { mapping: this.mapping }
     );
 
-    const qs = urlHelper.getQueryStringFromState(
+    return urlHelper.getQueryStringFromState(
       state.filter(this.trackedParameters),
       {
         moreAttributes: foreignConfig,
@@ -166,11 +189,6 @@ class URLSync {
         safe: true,
       }
     );
-
-    clearTimeout(this.urlUpdateTimeout);
-    this.urlUpdateTimeout = setTimeout(() => {
-      this.urlUtils.pushState(qs, { getHistoryState: this.getHistoryState });
-    }, this.threshold);
   }
 
   // External API's


### PR DESCRIPTION
When there is a search function that prevents the initial rendering,
the first actual change should be able to update the URL.

Fix #2523
