### PR TITLE
docs(readme): fix Algolia link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![InstantSearch.js logo][logo]][website]
 
-InstantSearch.js is a library for building blazing fast search-as-you-type search UIs with [Algolia](algolia-website).
+InstantSearch.js is a library for building blazing fast search-as-you-type search UIs with [Algolia][algolia-website].
 
 InstantSearch.js is part of the InstantSearch family: 
 **InstantSearch.js** 


### PR DESCRIPTION
Algolia's link in the main description was using parentheses (`()`) instead of square brackets (`[]`) for [Markdown reference links](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#links), referencing to a [broken link](https://github.com/algolia/instantsearch.js/blob/develop/algolia-website).