### PR TITLE
fix(theme): searchbar should have normal size input

### DIFF
--- a/src/css/theme/_search-box.scss
+++ b/src/css/theme/_search-box.scss
@@ -1,15 +1,13 @@
 .ais-search-box {
   display: inline-block;
   position: relative;
-  max-width: 300px;
-  width: 100%;
   height: 46px;
   white-space: nowrap;
-  box-sizing: border-box;
   font-size: 14px;
 
   &--input {
-    appearence: none;
+    appearance: none;
+    font: inherit;
     background: $white;
     display: inline-block;
     border: 1px solid #D4D8E3;


### PR DESCRIPTION
Usually you want the searchbox to have the same font size (at least) as your body text. Otherwise it'll look awkardly small without other styling.

Also fixed a typo in `appearance` and deduplicated two properties

before|after
---|---
<img width="330" alt="screen shot 2017-11-01 at 07 50 15" src="https://user-images.githubusercontent.com/6270048/32264991-79a059e4-bee1-11e7-966c-a5cff2600947.png"> | <img width="351" alt="screen shot 2017-11-01 at 07 50 27" src="https://user-images.githubusercontent.com/6270048/32264990-7983bee2-bee1-11e7-9ac4-e4b9bfae0fba.png">
