### PR TITLE
 fix(numericSelector): make default value possible 

### DIFF
--- a/dev/app/builtin/stories/numeric-selector.stories.js
+++ b/dev/app/builtin/stories/numeric-selector.stories.js
@@ -17,9 +17,29 @@ export default () => {
           attributeName: 'popularity',
           options: [
             { label: 'Default', value: 0 },
-            { label: 'Top 10', value: 9991 },
-            { label: 'Top 100', value: 9901 },
-            { label: 'Top 500', value: 9501 },
+            { label: 'Top 10', value: 21459 },
+            { label: 'Top 100', value: 21369 },
+            { label: 'Top 500', value: 20969 },
+          ],
+        })
+      );
+    })
+  );
+  stories.add(
+    'with default value',
+    wrapWithHits(container => {
+      window.search.addWidget(
+        instantsearch.widgets.numericSelector({
+          container,
+          operator: '=',
+          attributeName: 'rating',
+          options: [
+            { label: 'No rating selected', value: undefined },
+            { label: 'Rating: 5', value: 5 },
+            { label: 'Rating: 4', value: 4 },
+            { label: 'Rating: 3', value: 3 },
+            { label: 'Rating: 2', value: 2 },
+            { label: 'Rating: 1', value: 1 },
           ],
         })
       );

--- a/docgen/plugins/assets.js
+++ b/docgen/plugins/assets.js
@@ -28,7 +28,7 @@ const defaults = {
  * @param {Object} userOptions (optional)
  *   @property {String} source Path to copy static assets from (relative to working directory). Defaults to './public'
  *   @property {String} destination Path to copy static assets to (relative to destination directory). Defaults to '.'
- * @return {Function} a Metalsmith plugin
+ * @return {function} a Metalsmith plugin
  */
 function assets(userOptions = {}) {
   const options = {

--- a/src/components/Selector.js
+++ b/src/components/Selector.js
@@ -20,13 +20,13 @@ export class RawSelector extends React.Component {
       <select
         className={this.props.cssClasses.select}
         onChange={this.handleChange}
-        value={currentValue}
+        value={`${currentValue}`}
       >
         {options.map(option => (
           <option
             className={this.props.cssClasses.item}
             key={option.label + option.value}
-            value={option.value}
+            value={`${option.value}`}
           >
             {option.label}
           </option>

--- a/src/components/__tests__/__snapshots__/Selector-test.js.snap
+++ b/src/components/__tests__/__snapshots__/Selector-test.js.snap
@@ -4,17 +4,17 @@ exports[`Selector should render <Selector/> with numbers 1`] = `
 <select
   className="custom-select"
   onChange={[Function]}
-  value={10}
+  value="10"
 >
   <option
     className="custom-item"
-    value={10}
+    value="10"
   >
     10 results per page
   </option>
   <option
     className="custom-item"
-    value={20}
+    value="20"
   >
     20 results per page
   </option>

--- a/src/connectors/numeric-selector/__tests__/connectNumericSelector-test.js
+++ b/src/connectors/numeric-selector/__tests__/connectNumericSelector-test.js
@@ -235,4 +235,57 @@ describe('connectNumericSelector', () => {
       refine = renderingParameters.refine;
     });
   });
+
+  it('The refine function can unselect with `undefined` and "undefined"', () => {
+    const rendering = sinon.stub();
+    const makeWidget = connectNumericSelector(rendering);
+    const listOptions = [
+      { name: '' },
+      { name: '10', value: 10 },
+      { name: '20', value: 20 },
+      { name: '30', value: 30 },
+    ];
+    const widget = makeWidget({
+      attributeName: 'numerics',
+      options: listOptions,
+    });
+
+    const config = widget.getConfiguration({}, {});
+    const helper = jsHelper(fakeClient, '', config);
+    helper.search = sinon.stub();
+
+    widget.init({
+      helper,
+      state: helper.state,
+      createURL: () => '#',
+      onHistoryChange: () => {},
+    });
+
+    const firstRenderingOptions = rendering.lastCall.args[0];
+    const { refine } = firstRenderingOptions;
+    expect(helper.state.getNumericRefinements('numerics')).toEqual({});
+    refine(listOptions[1].value);
+    expect(helper.state.getNumericRefinements('numerics')).toEqual({
+      '=': [10],
+    });
+    refine(listOptions[0].value);
+    expect(helper.state.getNumericRefinements('numerics')).toEqual({});
+
+    widget.render({
+      results: new SearchResults(helper.state, [{}]),
+      state: helper.state,
+      helper,
+      createURL: () => '#',
+    });
+
+    const secondRenderingOptions = rendering.lastCall.args[0];
+    const { refine: refineBis } = secondRenderingOptions;
+    expect(helper.state.getNumericRefinements('numerics')).toEqual({});
+    refineBis(listOptions[1].value);
+    expect(helper.state.getNumericRefinements('numerics')).toEqual({
+      '=': [10],
+    });
+    refineBis(listOptions[0].value);
+    expect(helper.state.getNumericRefinements('numerics')).toEqual({});
+  });
 });

--- a/src/connectors/numeric-selector/connectNumericSelector.js
+++ b/src/connectors/numeric-selector/connectNumericSelector.js
@@ -24,6 +24,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/c
 /**
  * @typedef {Object} NumericSelectorOption
  * @property {number} value The numerical value to refine with.
+ * If the value is `undefined` or `"undefined"`, the option resets the filter.
  * @property {string} label Label to display in the option.
  */
 

--- a/src/connectors/numeric-selector/connectNumericSelector.js
+++ b/src/connectors/numeric-selector/connectNumericSelector.js
@@ -104,19 +104,23 @@ export default function connectNumericSelector(renderFn) {
 
     return {
       getConfiguration(currentSearchParameters, searchParametersFromUrl) {
-        return {
-          numericRefinements: {
-            [attributeName]: {
-              [operator]: [this._getRefinedValue(searchParametersFromUrl)],
+        const value = this._getRefinedValue(searchParametersFromUrl);
+        if (value) {
+          return {
+            numericRefinements: {
+              [attributeName]: {
+                [operator]: [this._getRefinedValue(searchParametersFromUrl)],
+              },
             },
-          },
-        };
+          };
+        }
+        return {};
       },
 
       init({ helper, instantSearchInstance }) {
         this._refine = value => {
           helper.clearRefinements(attributeName);
-          if (value !== undefined) {
+          if (value !== undefined && value !== 'undefined') {
             helper.addNumericRefinement(attributeName, operator, value);
           }
           helper.search();

--- a/src/widgets/numeric-selector/numeric-selector.js
+++ b/src/widgets/numeric-selector/numeric-selector.js
@@ -37,6 +37,7 @@ const usage = `Usage: numericSelector({
 /**
  * @typedef {Object} NumericOption
  * @property {number} value The numerical value to refine with.
+ * If the value is `undefined` or `"undefined"`, the option resets the filter.
  * @property {string} label Label to display in the option.
  */
 
@@ -73,13 +74,16 @@ const usage = `Usage: numericSelector({
  * @example
  * search.addWidget(
  *   instantsearch.widgets.numericSelector({
- *     container: '#popularity-selector',
- *     attributeName: 'popularity',
- *     operator: '>=',
+ *     container: '#rating-selector',
+ *     attributeName: 'rating',
+ *     operator: '=',
  *     options: [
- *       {label: 'Top 10', value: 9900},
- *       {label: 'Top 100', value: 9800},
- *       {label: 'Top 500', value: 9700}
+ *       {label: 'All products'},
+ *       {label: 'Only 5 star products', value: 5},
+ *       {label: 'Only 4 star products', value: 4},
+ *       {label: 'Only 3 star products', value: 3},
+ *       {label: 'Only 2 star products', value: 2},
+ *       {label: 'Only 1 star products', value: 1},
  *     ]
  *   })
  * );


### PR DESCRIPTION
When we created the connectNumericSelector, we made sure to support `undefined` as a special value to unset the filters. However because the implementations are DOM based, the value is now a string. This patch fixes that (and adds the documentation to the feature)

I also updated the example because it was super hard to maintain and didn't have much sense in terms of feature. The new example also show case the undefined value :)