### PR TITLE
chore(release): ability to release a beta from develop

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -321,15 +321,22 @@ npm run release-maintenance
 
 **Be sure to use `$ npm run` instead of `$ yarn run` to avoid issues**
 
-#### Beta version
+#### Beta version β
 
-Beta version release is available on any branch except `master`, `maintainance` or `develop`. The
+Beta version release is available on any branch except `master`, `maintainance`. The
 main use cases are for releasing a patch before the official release, or create custom builds
-with new features. In those cases we will either use the feature branch itself or the `feat/2.*`
-branch.
+with new features (or friday releases).
+
+If you're on a feature branch (either for a fix or a new minor/major version), you can run:
 
 ```sh
 npm run release
+```
+
+You can also release a beta version from `develop`, using the beta flag in the command line:
+
+```sh
+npm run release -- --beta
 ```
 
 **Be sure to use `$ npm run` instead of `$ yarn run` to avoid issues**

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -9,6 +9,9 @@ const inquirer = require('inquirer');
 const shell = require('shelljs');
 shell.fatal = true;
 
+// Read CLI flags
+const forceBeta = process.argv.includes('--beta');
+
 const {
   updateChangelog,
   getChangelog,
@@ -66,7 +69,7 @@ if (currentBranch === 'master') {
   process.exit(1);
 }
 
-const strategy = currentBranch === 'develop' ? 'stable' : 'beta';
+const strategy = currentBranch !== 'develop' || forceBeta ? 'beta' : 'stable';
 
 // called if process aborted before publish,
 // nothing is pushed nor published remove local changes


### PR DESCRIPTION
This commit adds a new flag to the release command to be able to force a
new beta version from develop.

`npm run release -- --beta`

Remaining tasks:
 - [x] Update contributing guide