### PR TITLE
docs(spelling): Github -> GitHub

### DIFF
--- a/docgen/src/data/communityHeader.json
+++ b/docgen/src/data/communityHeader.json
@@ -112,7 +112,7 @@
     "name": "v1",
     "url": "https://community.algolia.com/instantsearch.js/v1/"
   }, {
-    "name": "Github",
+    "name": "GitHub",
     "image": "<img src='assets/img/github-icon.svg'/>",
     "url": "https://github.com/algolia/instantsearch.js/"
   }],

--- a/docgen/src/guides/angular-integration.md
+++ b/docgen/src/guides/angular-integration.md
@@ -16,7 +16,7 @@ githubSource: docgen/src/guides/angular-integration.md
 
 Angular InstantSearch will help you to create instant-search experiences with [Algolia](https://www.algolia.com) with customisable UI components.
 
-We'd love for you to try it out and give us your opinion! The library is open source and can be found on [Github](https://github.com/algolia/angular-instantsearch).
+We'd love for you to try it out and give us your opinion! The library is open source and can be found on [GitHub](https://github.com/algolia/angular-instantsearch).
 
 Give it a try! It takes 5 minutes to build an instant-search example with our [getting started](https://algolia.gitbooks.io/angular-instantsearch).
 


### PR DESCRIPTION
This is the preferred way of spelling it according to them