### PR TITLE
fix(InstantSearch.dispose): dont call `URLSync.getConfiguration`

### DIFF
--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -181,9 +181,11 @@ Usage: instantsearch({
       // re-compute remaining widgets to the state
       // in a case two widgets were using the same configuration but we removed one
       if (nextState) {
-        this.searchParameters = this.widgets.reduce(enhanceConfiguration({}), {
-          ...nextState,
-        });
+        // We dont want to re-add URlSync `getConfiguration` widget
+        // it can throw errors since it may re-add SearchParameters about something unmounted
+        this.searchParameters = this.widgets
+          .filter(w => w.constructor.name !== 'URLSync')
+          .reduce(enhanceConfiguration({}), { ...nextState });
 
         this.helper.setState(this.searchParameters);
       }
@@ -272,11 +274,7 @@ Usage: instantsearch({
    * @return {undefined} This method does not return anything
    */
   dispose() {
-    this.removeWidgets(
-      this.widgets
-        .slice()
-        .sort(widget => (widget.constructor.name === 'URLSync' ? -1 : 1))
-    );
+    this.removeWidgets(this.widgets);
   }
 
   createURL(params) {


### PR DESCRIPTION
Case:

If you have `urlSync: true` and refinement for a widget you dispose in the URL, the search will crash because calling `URLSync.getConfiguration()` will add back the removed refinement found in the URL for the next search.

Fix:

Don't call `URLSync.getConfiguration()` when a widget is disposed 👍 