### PR TITLE
fix(core): search is stalled at init

### DIFF
--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -264,12 +264,12 @@ Usage: instantsearch({
     this.helper.on('result', this._render.bind(this, this.helper));
 
     this._searchStalledTimer = null;
-    this._isSearchStalled = false;
+    this._isSearchStalled = true;
 
     this.helper.search();
 
     this.helper.on('search', () => {
-      if (!this._searchStalledTimer) {
+      if (!this._isSearchStalled && !this._searchStalledTimer) {
         this._searchStalledTimer = setTimeout(() => {
           this._isSearchStalled = true;
           this._render(

--- a/src/lib/__tests__/InstantSearch-test-2.js
+++ b/src/lib/__tests__/InstantSearch-test-2.js
@@ -143,4 +143,31 @@ describe('InstantSearch lifecycle', () => {
       });
     });
   });
+
+  it('does not break when adding a widget dynamically just after start', () => {
+    const searchFunctionSpy = jest.fn(h => {
+      h.setQuery('test').search();
+    });
+
+    const fakeClient = {
+      search: jest.fn(),
+      addAlgoliaAgent: () => {},
+    };
+
+    const search = new InstantSearch({
+      appId,
+      apiKey,
+      indexName,
+      searchFunction: searchFunctionSpy,
+      createAlgoliaClient: () => fakeClient,
+    });
+
+    search.start();
+
+    search.addWidget({
+      render: () => {},
+    });
+
+    jest.runAllTimers();
+  });
 });


### PR DESCRIPTION
Fix #2616 

This modifies the first steps of IS so that the stalled search
behaviour is not triggered before the first rendering.