### PR TITLE
feat(reload): add a reload method on the InstantSearch component

### DIFF
--- a/dev/app/builtin/init-stories.js
+++ b/dev/app/builtin/init-stories.js
@@ -15,7 +15,7 @@ import initPriceRangesStories from './stories/price-ranges.stories';
 import initRangeInputStories from './stories/range-input.stories.js';
 import initRangeSliderStories from './stories/range-slider.stories';
 import initRefinementListStories from './stories/refinement-list.stories';
-import initRefreshCacheStories from './stories/refreshcache.stories';
+import initReloadStories from './stories/reload.stories';
 import initSearchBoxStories from './stories/search-box.stories';
 import initSortBySelectorStories from './stories/sort-by-selector.stories';
 import initStarRatingStories from './stories/star-rating.stories';
@@ -40,7 +40,7 @@ export default () => {
   initRangeInputStories();
   initRangeSliderStories();
   initRefinementListStories();
-  initRefreshCacheStories();
+  initReloadStories();
   initSearchBoxStories();
   initSortBySelectorStories();
   initStatsStories();

--- a/dev/app/builtin/init-stories.js
+++ b/dev/app/builtin/init-stories.js
@@ -15,6 +15,7 @@ import initPriceRangesStories from './stories/price-ranges.stories';
 import initRangeInputStories from './stories/range-input.stories.js';
 import initRangeSliderStories from './stories/range-slider.stories';
 import initRefinementListStories from './stories/refinement-list.stories';
+import initRefreshCacheStories from './stories/refreshcache.stories';
 import initSearchBoxStories from './stories/search-box.stories';
 import initSortBySelectorStories from './stories/sort-by-selector.stories';
 import initStarRatingStories from './stories/star-rating.stories';
@@ -39,6 +40,7 @@ export default () => {
   initRangeInputStories();
   initRangeSliderStories();
   initRefinementListStories();
+  initRefreshCacheStories();
   initSearchBoxStories();
   initSortBySelectorStories();
   initStatsStories();

--- a/dev/app/builtin/stories/refreshcache.stories.js
+++ b/dev/app/builtin/stories/refreshcache.stories.js
@@ -1,0 +1,24 @@
+/* eslint-disable import/default */
+
+import { storiesOf } from 'dev-novel';
+import instantsearch from '../../../../index';
+import { wrapWithHits } from '../../utils/wrap-with-hits.js';
+
+const stories = storiesOf('RefreshCache');
+
+export default () => {
+  stories.add(
+    'default',
+    wrapWithHits(container => {
+      const button = document.createElement('button');
+      button.addEventListener('click', () => window.search.clearCache());
+      button.innerHTML = 'Refresh cache';
+      const searchBoxContainer = document.createElement('div');
+      window.search.addWidget(
+        instantsearch.widgets.searchBox({ container: searchBoxContainer })
+      );
+      container.appendChild(button);
+      container.appendChild(searchBoxContainer);
+    })
+  );
+};

--- a/dev/app/builtin/stories/reload.stories.js
+++ b/dev/app/builtin/stories/reload.stories.js
@@ -4,15 +4,15 @@ import { storiesOf } from 'dev-novel';
 import instantsearch from '../../../../index';
 import { wrapWithHits } from '../../utils/wrap-with-hits.js';
 
-const stories = storiesOf('RefreshCache');
+const stories = storiesOf('Reload');
 
 export default () => {
   stories.add(
     'default',
     wrapWithHits(container => {
       const button = document.createElement('button');
-      button.addEventListener('click', () => window.search.clearCache());
-      button.innerHTML = 'Refresh cache';
+      button.addEventListener('click', () => window.search.reload());
+      button.innerHTML = 'Reload InstantSearch';
       const searchBoxContainer = document.createElement('div');
       window.search.addWidget(
         instantsearch.widgets.searchBox({ container: searchBoxContainer })

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -200,7 +200,18 @@ Usage: instantsearch({
   }
 
   /**
-   * The start methods ends the initialization of InstantSearch.js and triggers the
+   * The clearCache method clears the cached answers from Algolia and triggers a new search.
+   *
+   * @return {undefined} Does not return anything
+   */
+  clearCache() {
+    if (this.helper) {
+      this.helper.clearCache().search();
+    }
+  }
+
+  /**
+   * The start method ends the initialization of InstantSearch.js and triggers the
    * first search. This method should be called after all widgets have been added
    * to the instance of InstantSearch.js. InstantSearch.js also supports adding and removing
    * widgets after the start as an **EXPERIMENTAL** feature.
@@ -226,7 +237,7 @@ Usage: instantsearch({
     } else {
       this._createURL = defaultCreateURL;
       this._createAbsoluteURL = defaultCreateURL;
-      this._onHistoryChange = function() {};
+      this._onHistoryChange = function () { };
     }
 
     this.searchParameters = this.widgets.reduce(
@@ -245,8 +256,8 @@ Usage: instantsearch({
       helper.search = () => {
         const helperSearchFunction = algoliasearchHelper(
           {
-            addAlgoliaAgent: () => {},
-            search: () => {},
+            addAlgoliaAgent: () => { },
+            search: () => { },
           },
           helper.state.index,
           helper.state

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -200,11 +200,11 @@ Usage: instantsearch({
   }
 
   /**
-   * The clearCache method clears the cached answers from Algolia and triggers a new search.
+   * The reload method clears the cached answers from Algolia and triggers a new search.
    *
    * @return {undefined} Does not return anything
    */
-  clearCache() {
+  reload() {
     if (this.helper) {
       this.helper.clearCache().search();
     }

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -237,7 +237,7 @@ Usage: instantsearch({
     } else {
       this._createURL = defaultCreateURL;
       this._createAbsoluteURL = defaultCreateURL;
-      this._onHistoryChange = function () { };
+      this._onHistoryChange = function() {};
     }
 
     this.searchParameters = this.widgets.reduce(
@@ -256,8 +256,8 @@ Usage: instantsearch({
       helper.search = () => {
         const helperSearchFunction = algoliasearchHelper(
           {
-            addAlgoliaAgent: () => { },
-            search: () => { },
+            addAlgoliaAgent: () => {},
+            search: () => {},
           },
           helper.state.index,
           helper.state


### PR DESCRIPTION
**Summary**
Give the ability to the user to clear the cached answers from Algolia.
(see #1050)

**Result**
The user can now clear the cache by calling `clearCache()` on his/her `search` instance.
See the results in the `RefreshCache` story on dev-novel (network tab).

