### PR TITLE
feat(connectHierarchicalMenu): add hasChildren to items

### DIFF
--- a/dev/app/builtin/stories/hierarchical-menu.stories.js
+++ b/dev/app/builtin/stories/hierarchical-menu.stories.js
@@ -67,6 +67,30 @@ export default () => {
       )
     )
     .add(
+      'with custom item template',
+      wrapWithHits(container => {
+        window.search.addWidget(
+          instantsearch.widgets.hierarchicalMenu({
+            container,
+            attributes: [
+              'hierarchicalCategories.lvl0',
+              'hierarchicalCategories.lvl1',
+              'hierarchicalCategories.lvl2',
+            ],
+            templates: {
+              item:
+              `<a class="{{cssClasses.link}}" href="{{url}}">
+                {{label}}
+              </a>
+              {{#hasChildren}}
+                <span>Has children</span>
+              {{/hasChildren}}`,
+            },
+          })
+        );
+      })
+    )
+    .add(
       'with header',
       wrapWithHits(container => {
         window.search.addWidget(

--- a/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.js
+++ b/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.js
@@ -229,12 +229,14 @@ describe('connectHierarchicalMenu', () => {
         value: 'Decoration',
         count: 880,
         isRefined: true,
+        hasChildren: true,
         data: [
           {
             label: 'Candle holders & candles',
             value: 'Decoration > Candle holders & candles',
             count: 193,
             isRefined: false,
+            hasChildren: false,
             data: null,
           },
           {
@@ -242,6 +244,7 @@ describe('connectHierarchicalMenu', () => {
             value: 'Decoration > Frames & pictures',
             count: 173,
             isRefined: false,
+            hasChildren: false,
             data: null,
           },
         ],
@@ -251,6 +254,7 @@ describe('connectHierarchicalMenu', () => {
         value: 'Outdoor',
         count: 47,
         isRefined: false,
+        hasChildren: false,
         data: null,
       },
     ]);

--- a/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
+++ b/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
@@ -163,7 +163,12 @@ export default function connectHierarchicalMenu(renderFn, unmountFn) {
             if (Array.isArray(subValue.data)) {
               subValue.data = this._prepareFacetValues(subValue.data, state);
             }
-            return { ...subValue, label, value };
+            return {
+              ...subValue,
+              label,
+              value,
+              hasChildren: Boolean(subValue.data && subValue.data.length > 0),
+            };
           });
       },
 

--- a/src/widgets/hierarchical-menu/__tests__/__snapshots__/hierarchical-menu-test.js.snap
+++ b/src/widgets/hierarchical-menu/__tests__/__snapshots__/hierarchical-menu-test.js.snap
@@ -21,10 +21,12 @@ exports[`hierarchicalMenu() render calls ReactDOM.render 1`] = `
   facetValues={
     Array [
       Object {
+        "hasChildren": false,
         "label": "foo",
         "value": undefined,
       },
       Object {
+        "hasChildren": false,
         "label": "bar",
         "value": undefined,
       },
@@ -72,10 +74,12 @@ exports[`hierarchicalMenu() render has a templates option 1`] = `
   facetValues={
     Array [
       Object {
+        "hasChildren": false,
         "label": "foo",
         "value": undefined,
       },
       Object {
+        "hasChildren": false,
         "label": "bar",
         "value": undefined,
       },
@@ -203,10 +207,12 @@ exports[`hierarchicalMenu() render understand provided cssClasses 1`] = `
   facetValues={
     Array [
       Object {
+        "hasChildren": false,
         "label": "foo",
         "value": undefined,
       },
       Object {
+        "hasChildren": false,
         "label": "bar",
         "value": undefined,
       },

--- a/src/widgets/hierarchical-menu/__tests__/hierarchical-menu-test.js
+++ b/src/widgets/hierarchical-menu/__tests__/hierarchical-menu-test.js
@@ -265,17 +265,18 @@ describe('hierarchicalMenu()', () => {
 
       data = { data: firstLevel };
       const expectedFacetValues = [
-        { label: 'one', value: 'one' },
+        { label: 'one', value: 'one', hasChildren: false },
         {
           label: 'two',
           value: 'two',
           data: [
-            { label: 'six', value: 'six' },
-            { label: 'seven', value: 'seven' },
-            { label: 'eight', value: 'eight' },
+            { label: 'six', value: 'six', hasChildren: false },
+            { label: 'seven', value: 'seven', hasChildren: false },
+            { label: 'eight', value: 'eight', hasChildren: false },
           ],
+          hasChildren: true,
         },
-        { label: 'three', value: 'three' },
+        { label: 'three', value: 'three', hasChildren: false },
       ];
       widget = hierarchicalMenu({ ...options, limit: 3 });
       widget.init({ helper, createURL, instantSearchInstance: {} });


### PR DESCRIPTION
This PR tries to implement the fix for #818. However it appears that we only retrieve values up to the most last open item. This means that even we can add the `hasChildren` data, this is incorrect as it will be true only if it's open and it's not a very useful information for the user since they would have already open the item.

[See it live](https://deploy-preview-2638--algolia-instantsearch.netlify.com/v2/dev-novel/?selectedStory=HierarchicalMenu.with%20custom%20item%20template).