### PR TITLE
feat(core): add an error event to monitor error from Algolia

### DIFF
--- a/docgen/layouts/instantsearch.pug
+++ b/docgen/layouts/instantsearch.pug
@@ -36,8 +36,11 @@ block content
     a.anchor(href=`${navPath}#events`)
   p InstantSearch is an EventEmitter and as such it emits events on specific parts of the lifecycle.
   h3 render
-  p 
+  p
     | The `render` event is triggered when the rendering of all the widgets is done. This
     | happens after a search result comes back from Algolia - which means that it is
     | triggered for the first once everything after all the widgets went through all
     | there lifecycle steps once (getConfiguration, init, render).
+  h3 error
+  p
+    | The `error` event is triggered when an error is reported when calling the API.

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -262,6 +262,9 @@ Usage: instantsearch({
     this.helper = helper;
     this._init(helper.state, this.helper);
     this.helper.on('result', this._render.bind(this, this.helper));
+    this.helper.on('error', e => {
+      this.emit('error', e);
+    });
 
     this._searchStalledTimer = null;
     this._isSearchStalled = true;

--- a/src/lib/__tests__/InstantSearch-test-integration.js
+++ b/src/lib/__tests__/InstantSearch-test-integration.js
@@ -1,0 +1,38 @@
+// import algoliaSearchHelper from 'algoliasearch-helper';
+import InstantSearch from '../InstantSearch';
+
+describe('InstantSearch lifecycle', () => {
+  it('emits an error if the API returns an error', () => {
+    const search = new InstantSearch({
+      // correct credentials so that the client does not retry
+      appId: 'latency',
+      apiKey: '6be0576ff61c053d5f9a3225e2a90f76',
+      // the index name does not exist so that we get an error
+      indexName: 'DOESNOTEXIST',
+    });
+
+    let sendError;
+    let reject;
+    const waitForError = new Promise((resolve, r) => {
+      sendError = resolve;
+      reject = r;
+    });
+
+    search.on('error', e => {
+      try {
+        expect(e).toEqual(expect.any(Error));
+      } catch (err) {
+        reject(err);
+      }
+      sendError();
+    });
+
+    search.addWidget({
+      render: () => {},
+    });
+
+    search.start();
+
+    return waitForError;
+  });
+});

--- a/src/lib/__tests__/__snapshots__/InstantSearch-test.js.snap
+++ b/src/lib/__tests__/__snapshots__/InstantSearch-test.js.snap
@@ -7,10 +7,11 @@ Array [
     "helper": AlgoliaSearchHelper {
       "_currentNbQueries": 0,
       "_events": Object {
+        "error": [Function],
         "result": [Function],
         "search": [Function],
       },
-      "_eventsCount": 2,
+      "_eventsCount": 3,
       "_lastQueryIdReceived": -1,
       "_queryId": 0,
       "client": Object {
@@ -94,10 +95,11 @@ Array [
       "helper": AlgoliaSearchHelper {
         "_currentNbQueries": 0,
         "_events": Object {
+          "error": [Function],
           "result": [Function],
           "search": [Function],
         },
-        "_eventsCount": 2,
+        "_eventsCount": 3,
         "_lastQueryIdReceived": -1,
         "_queryId": 0,
         "client": Object {


### PR DESCRIPTION
Fix #1585

Adds an event that is emitted when an error is received in place of results.