### PR TITLE
Fix: escape highlight

### DIFF
--- a/dev/app/builtin/stories/hits.stories.js
+++ b/dev/app/builtin/stories/hits.stories.js
@@ -21,6 +21,7 @@ export default () => {
           window.search.addWidget(
             instantsearch.widgets.hits({
               container,
+              escapeHits: true,
               templates: {
                 item: `
                   <div class="hit" id="hit-{{objectID}}">

--- a/dev/app/builtin/stories/hits.stories.js
+++ b/dev/app/builtin/stories/hits.stories.js
@@ -7,10 +7,52 @@ import { wrapWithHits } from '../../utils/wrap-with-hits.js';
 const stories = storiesOf('Hits');
 
 export default () => {
-  stories.add(
-    'default',
-    wrapWithHits(container => {
-      window.search.addWidget(instantsearch.widgets.hits({ container }));
-    })
-  );
+  stories
+    .add(
+      'default',
+      wrapWithHits(container => {
+        window.search.addWidget(instantsearch.widgets.hits({ container }));
+      })
+    )
+    .add(
+      'with highlighted array',
+      wrapWithHits(
+        container => {
+          window.search.addWidget(
+            instantsearch.widgets.hits({
+              container,
+              templates: {
+                item: `
+                  <div class="hit" id="hit-{{objectID}}">
+                    <div class="hit-content">
+                      <div>
+                        <span>{{{_highlightResult.name.value}}}</span>
+                        <span>\${{price}}</span>
+                        <span>{{rating}} stars</span>
+                      </div>
+                      <div class="hit-type">
+                        {{{_highlightResult.type.value}}}
+                      </div>
+                      <div class="hit-description">
+                        {{{_highlightResult.description.value}}}
+                      </div>
+                      <div class="hit-tags">
+                      {{#_highlightResult.tags}}
+                        <span>{{{value}}}</span>
+                      {{/_highlightResult.tags}}
+                      </div>
+                    </div>
+                  </div>
+                `,
+              },
+            })
+          );
+        },
+        {
+          appId: 'KY4PR9ORUL',
+          apiKey: 'a5ca312adab3b79e14054154efa00b37',
+          indexName: 'highlight_array',
+        }
+      )
+    );
 };

--- a/dev/style.css
+++ b/dev/style.css
@@ -17,22 +17,22 @@
   padding: 50px 40px 40px;
 }
 
-#results-display .hit {
+.hit {
   align-items: center;
   display: flex;
   margin: 10px 10px;
 }
 
-#results-display .hit .hit-picture img {
+.hit .hit-picture img {
   height: auto;
   width: 80px;
 }
 
-#results-display .hit .hit-content {
+.hit .hit-content {
   padding: 0 10px;
 }
 
-#results-display .hit .hit-type {
+.hit .hit-type {
   color: #888;
   font-size: 13px;
 }

--- a/src/lib/__tests__/escape-highlight-test.js
+++ b/src/lib/__tests__/escape-highlight-test.js
@@ -37,18 +37,18 @@ describe('escapeHits()', () => {
     const hits = [
       {
         _highlightResult: {
-          foobar: {
-            value: {
-              foo: '<script>__ais-highlight__bar__/ais-highlight__</script>',
-              bar: '<script>__ais-highlight__foo__/ais-highlight__</script>',
+          foo: {
+            bar: {
+              value:
+                '<script>__ais-highlight__foobar__/ais-highlight__</script>',
             },
           },
         },
         _snippetResult: {
-          foobar: {
-            value: {
-              foo: '<script>__ais-highlight__bar__/ais-highlight__</script>',
-              bar: '<script>__ais-highlight__foo__/ais-highlight__</script>',
+          foo: {
+            bar: {
+              value:
+                '<script>__ais-highlight__foobar__/ais-highlight__</script>',
             },
           },
         },
@@ -58,18 +58,16 @@ describe('escapeHits()', () => {
     expect(escapeHits(hits)).toEqual([
       {
         _highlightResult: {
-          foobar: {
-            value: {
-              foo: '&lt;script&gt;<em>bar</em>&lt;/script&gt;',
-              bar: '&lt;script&gt;<em>foo</em>&lt;/script&gt;',
+          foo: {
+            bar: {
+              value: '&lt;script&gt;<em>foobar</em>&lt;/script&gt;',
             },
           },
         },
         _snippetResult: {
-          foobar: {
-            value: {
-              foo: '&lt;script&gt;<em>bar</em>&lt;/script&gt;',
-              bar: '&lt;script&gt;<em>foo</em>&lt;/script&gt;',
+          foo: {
+            bar: {
+              value: '&lt;script&gt;<em>foobar</em>&lt;/script&gt;',
             },
           },
         },

--- a/src/lib/__tests__/escape-highlight-test.js
+++ b/src/lib/__tests__/escape-highlight-test.js
@@ -4,12 +4,12 @@ describe('escapeHits()', () => {
   it('should escape highlighProperty simple text value', () => {
     const hits = [
       {
-        _snippetResult: {
+        _highlightResult: {
           foobar: {
             value: '<script>__ais-highlight__foobar__/ais-highlight__</script>',
           },
         },
-        _highlightResult: {
+        _snippetResult: {
           foobar: {
             value: '<script>__ais-highlight__foobar__/ais-highlight__</script>',
           },
@@ -75,7 +75,7 @@ describe('escapeHits()', () => {
     ]);
   });
 
-  it('should escape highlighProperty array of string as value', () => {
+  it('should escape highlighProperty array of string', () => {
     const hits = [
       {
         _highlightResult: {
@@ -113,6 +113,94 @@ describe('escapeHits()', () => {
           foobar: [
             { value: '&lt;script&gt;<em>bar</em>&lt;/script&gt;' },
             { value: '&lt;script&gt;<em>foo</em>&lt;/script&gt;' },
+          ],
+        },
+      },
+    ]);
+  });
+
+  it('should escape highlighProperty array of object', () => {
+    const hits = [
+      {
+        _highlightResult: {
+          foobar: [
+            {
+              foo: {
+                bar: {
+                  value:
+                    '<script>__ais-highlight__bar__/ais-highlight__</script>',
+                },
+              },
+            },
+            {
+              foo: {
+                bar: {
+                  value:
+                    '<script>__ais-highlight__foo__/ais-highlight__</script>',
+                },
+              },
+            },
+          ],
+        },
+        _snippetResult: {
+          foobar: [
+            {
+              foo: {
+                bar: {
+                  value:
+                    '<script>__ais-highlight__bar__/ais-highlight__</script>',
+                },
+              },
+            },
+            {
+              foo: {
+                bar: {
+                  value:
+                    '<script>__ais-highlight__foo__/ais-highlight__</script>',
+                },
+              },
+            },
+          ],
+        },
+      },
+    ];
+
+    expect(escapeHits(hits)).toEqual([
+      {
+        _highlightResult: {
+          foobar: [
+            {
+              foo: {
+                bar: {
+                  value: '&lt;script&gt;<em>bar</em>&lt;/script&gt;',
+                },
+              },
+            },
+            {
+              foo: {
+                bar: {
+                  value: '&lt;script&gt;<em>foo</em>&lt;/script&gt;',
+                },
+              },
+            },
+          ],
+        },
+        _snippetResult: {
+          foobar: [
+            {
+              foo: {
+                bar: {
+                  value: '&lt;script&gt;<em>bar</em>&lt;/script&gt;',
+                },
+              },
+            },
+            {
+              foo: {
+                bar: {
+                  value: '&lt;script&gt;<em>foo</em>&lt;/script&gt;',
+                },
+              },
+            },
           ],
         },
       },

--- a/src/lib/__tests__/escape-highlight-test.js
+++ b/src/lib/__tests__/escape-highlight-test.js
@@ -81,20 +81,24 @@ describe('escapeHits()', () => {
     const hits = [
       {
         _highlightResult: {
-          foobar: {
-            value: [
-              '<script>__ais-highlight__bar__/ais-highlight__</script>',
-              '<script>__ais-highlight__foo__/ais-highlight__</script>',
-            ],
-          },
+          foobar: [
+            {
+              value: '<script>__ais-highlight__bar__/ais-highlight__</script>',
+            },
+            {
+              value: '<script>__ais-highlight__foo__/ais-highlight__</script>',
+            },
+          ],
         },
         _snippetResult: {
-          foobar: {
-            value: [
-              '<script>__ais-highlight__bar__/ais-highlight__</script>',
-              '<script>__ais-highlight__foo__/ais-highlight__</script>',
-            ],
-          },
+          foobar: [
+            {
+              value: '<script>__ais-highlight__bar__/ais-highlight__</script>',
+            },
+            {
+              value: '<script>__ais-highlight__foo__/ais-highlight__</script>',
+            },
+          ],
         },
       },
     ];
@@ -102,20 +106,16 @@ describe('escapeHits()', () => {
     expect(escapeHits(hits)).toEqual([
       {
         _highlightResult: {
-          foobar: {
-            value: [
-              '&lt;script&gt;<em>bar</em>&lt;/script&gt;',
-              '&lt;script&gt;<em>foo</em>&lt;/script&gt;',
-            ],
-          },
+          foobar: [
+            { value: '&lt;script&gt;<em>bar</em>&lt;/script&gt;' },
+            { value: '&lt;script&gt;<em>foo</em>&lt;/script&gt;' },
+          ],
         },
         _snippetResult: {
-          foobar: {
-            value: [
-              '&lt;script&gt;<em>bar</em>&lt;/script&gt;',
-              '&lt;script&gt;<em>foo</em>&lt;/script&gt;',
-            ],
-          },
+          foobar: [
+            { value: '&lt;script&gt;<em>bar</em>&lt;/script&gt;' },
+            { value: '&lt;script&gt;<em>foo</em>&lt;/script&gt;' },
+          ],
         },
       },
     ]);

--- a/src/lib/escape-highlight.js
+++ b/src/lib/escape-highlight.js
@@ -27,8 +27,11 @@ function recursiveEscape(input) {
         value.value = mapValues(value.value, replaceWithEmAndEscape);
       }
 
-      if (isArray(value.value)) {
-        value.value = value.value.map(replaceWithEmAndEscape);
+      if (isArray(value)) {
+        value = value.map(item => ({
+          ...item,
+          value: replaceWithEmAndEscape(item.value),
+        }));
       }
 
       return { ...output, [key]: value };

--- a/src/lib/escape-highlight.js
+++ b/src/lib/escape-highlight.js
@@ -1,7 +1,7 @@
 import reduce from 'lodash/reduce';
 import escape from 'lodash/escape';
-import isPlainObject from 'lodash/isPlainObject';
 import isArray from 'lodash/isArray';
+import isPlainObject from 'lodash/isPlainObject';
 
 export const tagConfig = {
   highlightPreTag: '__ais-highlight__',
@@ -15,31 +15,25 @@ function replaceWithEmAndEscape(value) {
 }
 
 function recursiveEscape(input) {
-  return reduce(
-    input,
-    (output, attribute, key) => {
-      if (typeof attribute.value === 'string') {
-        attribute.value = replaceWithEmAndEscape(attribute.value);
-      }
+  if (isPlainObject(input) && typeof input.value !== 'string') {
+    return reduce(
+      input,
+      (acc, item, key) => ({
+        ...acc,
+        [key]: recursiveEscape(item),
+      }),
+      {}
+    );
+  }
 
-      if (isPlainObject(attribute)) {
-        attribute = recursiveEscape(attribute);
-      }
+  if (isArray(input)) {
+    return input.map(recursiveEscape);
+  }
 
-      if (isArray(attribute)) {
-        attribute = attribute.map(item => ({
-          ...item,
-          value: replaceWithEmAndEscape(item.value),
-        }));
-      }
-
-      return {
-        ...output,
-        [key]: attribute,
-      };
-    },
-    {}
-  );
+  return {
+    ...input,
+    value: replaceWithEmAndEscape(input.value),
+  };
 }
 
 export default function escapeHits(hits) {

--- a/src/lib/escape-highlight.js
+++ b/src/lib/escape-highlight.js
@@ -2,7 +2,6 @@ import reduce from 'lodash/reduce';
 import escape from 'lodash/escape';
 import isPlainObject from 'lodash/isPlainObject';
 import isArray from 'lodash/isArray';
-import mapValues from 'lodash/mapValues';
 
 export const tagConfig = {
   highlightPreTag: '__ais-highlight__',
@@ -18,23 +17,26 @@ function replaceWithEmAndEscape(value) {
 function recursiveEscape(input) {
   return reduce(
     input,
-    (output, value, key) => {
-      if (typeof value.value === 'string') {
-        value.value = replaceWithEmAndEscape(value.value);
+    (output, attribute, key) => {
+      if (typeof attribute.value === 'string') {
+        attribute.value = replaceWithEmAndEscape(attribute.value);
       }
 
-      if (isPlainObject(value.value)) {
-        value.value = mapValues(value.value, replaceWithEmAndEscape);
+      if (isPlainObject(attribute)) {
+        attribute = recursiveEscape(attribute);
       }
 
-      if (isArray(value)) {
-        value = value.map(item => ({
+      if (isArray(attribute)) {
+        attribute = attribute.map(item => ({
           ...item,
           value: replaceWithEmAndEscape(item.value),
         }));
       }
 
-      return { ...output, [key]: value };
+      return {
+        ...output,
+        [key]: attribute,
+      };
     },
     {}
   );


### PR DESCRIPTION
**Summary**

The test sample was not correctly structure so the implementation worked with the test but not with the actual Algolia response. I add a story with the same dataset that React InstantSearch use in Storybook. 

**Before**

![screen shot 2018-01-03 at 15 26 21](https://user-images.githubusercontent.com/6513513/34524158-b8460104-f09a-11e7-8c02-5d23a6bf2803.png)

**After**

![screen shot 2018-01-03 at 15 26 56](https://user-images.githubusercontent.com/6513513/34524161-bae6018e-f09a-11e7-9742-660df19daed5.png)

You can also play with the example on [`dev-novel`](https://deploy-preview-2646--algolia-instantsearch.netlify.com/v2/dev-novel/?selectedStory=Hits.with%20highlighted%20array).
  