### PR TITLE
docs: fix typos in index es6 and build script

### DIFF
--- a/index.es6.js
+++ b/index.es6.js
@@ -16,19 +16,19 @@ const instantSearchFactory = Object.assign(toFactory(InstantSearch), {
 
 Object.defineProperty(instantSearchFactory, 'widgets', {
   get() {
-    throw new ReferenceError(`
-      You can't access to 'instantsearch.widgets' directly from the ES6 build.
-      Import the widgets this way "import { searchBox } from 'instantsearch.js/es/widgets'"
-    `);
+    throw new ReferenceError(
+      `You can't access 'instantsearch.widgets' directly from the ES6 build.
+Import the widgets this way: 'import {SearchBox} from "instantsearch.js/es/widgets"'`
+    );
   },
 });
 
 Object.defineProperty(instantSearchFactory, 'connectors', {
   get() {
-    throw new ReferenceError(`
-      You can't access to 'instantsearch.connectors' directly from the ES6 build.
-      Import the connectors this way "import { connectSearchBox } from 'instantsearch.js/es/connectors'"
-    `);
+    throw new ReferenceError(
+      `You can't access 'instantsearch.connectors' directly from the ES6 build.
+Import the connectors this way: 'import {connectSearchBox} from "instantsearch.js/es/connectors"'`
+    );
   },
 });
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,7 +12,7 @@ csso dist/instantsearch-theme-algolia.css dist/instantsearch-theme-algolia.min.c
 
 wait
 
-printf "dist/instantsearch.min.js gzipped will weight `cat dist/instantsearch.min.js | gzip -9 | wc -c | pretty-bytes`\n\n"
+printf "dist/instantsearch.min.js gzipped will weigh `cat dist/instantsearch.min.js | gzip -9 | wc -c | pretty-bytes`\n\n"
 
 echo "➡️  Bundle instantsearch.js to ES5 build './dist-es5-module' via babel-cli"
 BABEL_ENV=production babel -q index.js -o dist-es5-module/index.js &


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

There was too much whitespace and a typo in the es6 build and a typo in the build script: 

```js
Object.defineProperty(instantSearchFactory, 'widgets', {
  get: function get() {
    throw new ReferenceError('\n      You can\'t access to \'instantsearch.widgets\' directly from the ES6 build.\n      Import the widgets this way "import { searchBox } from \'instantsearch.js/es/widgets\'"\n    ');
  }
});

Object.defineProperty(instantSearchFactory, 'connectors', {
  get: function get() {
    throw new ReferenceError('\n      You can\'t access to \'instantsearch.connectors\' directly from the ES6 build.\n      Import the connectors this way "import { connectSearchBox } from \'instantsearch.js/es/connectors\'"\n    ');
  }
});
```

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
  
  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot): 
  
  1. the documentation site (/)
  2. a widget playground (/dev-novel)
-->

```js
Object.defineProperty(instantSearchFactory, 'widgets', {
  get: function get() {
    throw new ReferenceError('You can\'t access \'instantsearch.widgets\' directly from the ES6 build.\nImport the widgets this way: "import { searchBox } from \'instantsearch.js/es/widgets\'"');
  }
});

Object.defineProperty(instantSearchFactory, 'connectors', {
  get: function get() {
    throw new ReferenceError('You can\'t access \'instantsearch.connectors\' directly from the ES6 build.\nImport the connectors this way: "import { connectSearchBox } from \'instantsearch.js/es/connectors\'"');
  }
});
```

  