### PR TITLE
chore: modernise some tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,6 +137,9 @@
       "<rootDir>/node_modules/",
       "<rootDir>/dist*",
       "<rootDir>/functional-tests"
+    ],
+    "snapshotSerializers": [
+      "enzyme-to-json/serializer"
     ]
   },
   "bundlesize": [

--- a/src/components/RangeInput/__tests__/RangeInput-test.js
+++ b/src/components/RangeInput/__tests__/RangeInput-test.js
@@ -1,9 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import serializer from 'enzyme-to-json/serializer';
 import { RawRangeInput } from '../RangeInput';
-
-expect.addSnapshotSerializer(serializer);
 
 describe('RawRangeInput', () => {
   const defaultProps = {

--- a/src/components/RefinementList/__tests__/RefinementListItem-test.js
+++ b/src/components/RefinementList/__tests__/RefinementListItem-test.js
@@ -1,53 +1,32 @@
 import React from 'react';
-import { createRenderer } from 'react-test-renderer/shallow';
+import { shallow } from 'enzyme';
 import RefinementListItem from '../RefinementListItem';
-import Template from '../../Template';
-import sinon from 'sinon';
-import expect from 'expect';
-import expectJSX from 'expect-jsx';
-expect.extend(expectJSX);
-describe('RefinementListItem', () => {
-  let renderer;
-  let props;
 
-  beforeEach(() => {
-    props = {
-      facetValue: 'Hello',
-      facetValueToRefine: 'wi',
-      isRefined: false,
-      handleClick: sinon.spy(),
-      itemClassName: 'item class',
-      templateData: { template: 'data' },
-      templateKey: 'item key',
-      templateProps: { template: 'props' },
-      subItems: <div />,
-    };
-    renderer = createRenderer();
-  });
+describe('RefinementListItem', () => {
+  const props = {
+    facetValue: 'Hello',
+    facetValueToRefine: 'wi',
+    isRefined: false,
+    handleClick: jest.fn(),
+    itemClassName: 'item class',
+    templateData: { template: 'data' },
+    templateKey: 'item key',
+    templateProps: { template: 'props' },
+    subItems: <div />,
+  };
 
   it('renders an item', () => {
-    const out = render(props);
-
-    expect(out).toEqualJSX(
-      <div className={props.itemClassName} onClick={props.handleClick}>
-        <Template
-          data={props.templateData}
-          templateKey={props.templateKey}
-          {...props.templateProps}
-        />
-        {props.subItems}
-      </div>
-    );
+    const wrapper = shallow(<RefinementListItem {...props} />);
+    expect(wrapper).toMatchSnapshot();
   });
 
   it('calls the right function', () => {
     const out = render(props);
-    out.props.onClick();
-    expect(props.handleClick.calledOnce).toBe(true);
+    out.simulate('click');
+    expect(props.handleClick).toHaveBeenCalledTimes(1);
   });
 
   function render(askedProps) {
-    renderer.render(<RefinementListItem {...askedProps} />);
-    return renderer.getRenderOutput();
+    return shallow(<RefinementListItem {...askedProps} />);
   }
 });

--- a/src/components/RefinementList/__tests__/__snapshots__/RefinementListItem-test.js.snap
+++ b/src/components/RefinementList/__tests__/__snapshots__/RefinementListItem-test.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RefinementListItem renders an item 1`] = `
+<div
+  className="item class"
+  onClick={[Function]}
+>
+  <Component
+    data={
+      Object {
+        "template": "data",
+      }
+    }
+    template="props"
+    templateKey="item key"
+  />
+  <div />
+</div>
+`;

--- a/src/components/Stats/__tests__/Stats-test.js
+++ b/src/components/Stats/__tests__/Stats-test.js
@@ -1,37 +1,20 @@
 import React from 'react';
-import expect from 'expect';
-import { createRenderer } from 'react-test-renderer/shallow';
+import { shallow } from 'enzyme';
 import { RawStats as Stats } from '../Stats';
-import Template from '../../Template';
-
-import expectJSX from 'expect-jsx';
-expect.extend(expectJSX);
 
 describe('Stats', () => {
-  let renderer;
-
-  beforeEach(() => {
-    renderer = createRenderer();
-  });
-
   it('should render <Template data= />', () => {
-    const out = render();
+    const out = shallow(<Stats {...getProps()} templateProps={{}} />);
+
     const defaultProps = {
       cssClasses: {},
       hasManyResults: true,
       hasNoResults: false,
       hasOneResult: false,
     };
-    expect(out).toEqualJSX(
-      <Template data={getProps(defaultProps)} templateKey="body" />
-    );
+    expect(out.props().data).toMatchObject(defaultProps);
+    expect(out).toMatchSnapshot();
   });
-
-  function render(extraProps = {}) {
-    const props = getProps(extraProps);
-    renderer.render(<Stats {...props} templateProps={{}} />);
-    return renderer.getRenderOutput();
-  }
 
   function getProps(extraProps = {}) {
     return {

--- a/src/components/Stats/__tests__/__snapshots__/Stats-test.js.snap
+++ b/src/components/Stats/__tests__/__snapshots__/Stats-test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Stats should render <Template data= /> 1`] = `
+<Component
+  data={
+    Object {
+      "cssClasses": Object {},
+      "hasManyResults": true,
+      "hasNoResults": false,
+      "hasOneResult": false,
+      "hitsPerPage": 10,
+      "nbHits": 1234,
+      "nbPages": 124,
+      "page": 0,
+      "processingTimeMS": 42,
+      "query": "a query",
+    }
+  }
+  templateKey="body"
+/>
+`;

--- a/src/decorators/__tests__/__snapshots__/autoHideContainer-test.js.snap
+++ b/src/decorators/__tests__/__snapshots__/autoHideContainer-test.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`autoHideContainer should render autoHideContainer(<TestComponent />) 1`] = `
+<div
+  style={
+    Object {
+      "display": "none",
+    }
+  }
+>
+  <TestComponent
+    hello="son"
+    shouldAutoHideContainer={true}
+  />
+</div>
+`;

--- a/src/decorators/__tests__/autoHideContainer-test.js
+++ b/src/decorators/__tests__/autoHideContainer-test.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { createRenderer } from 'react-test-renderer/shallow';
+import { shallow } from 'enzyme';
 import autoHideContainer from '../autoHideContainer';
 
 class TestComponent extends React.Component {
@@ -18,11 +18,9 @@ describe('autoHideContainer', () => {
   let props = {};
 
   it('should render autoHideContainer(<TestComponent />)', () => {
-    const renderer = createRenderer();
     props.hello = 'son';
     const AutoHide = autoHideContainer(TestComponent);
-    renderer.render(<AutoHide shouldAutoHideContainer {...props} />);
-    const out = renderer.getRenderOutput();
+    const out = shallow(<AutoHide shouldAutoHideContainer {...props} />);
     expect(out).toMatchSnapshot();
   });
 

--- a/src/decorators/__tests__/autoHideContainer-test.js
+++ b/src/decorators/__tests__/autoHideContainer-test.js
@@ -1,12 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import expect from 'expect';
 import { createRenderer } from 'react-test-renderer/shallow';
 import autoHideContainer from '../autoHideContainer';
-import expectJSX from 'expect-jsx';
-expect.extend(expectJSX);
-import sinon from 'sinon';
 
 class TestComponent extends React.Component {
   render() {
@@ -27,11 +23,7 @@ describe('autoHideContainer', () => {
     const AutoHide = autoHideContainer(TestComponent);
     renderer.render(<AutoHide shouldAutoHideContainer {...props} />);
     const out = renderer.getRenderOutput();
-    expect(out).toEqualJSX(
-      <div style={{ display: 'none' }}>
-        <TestComponent hello="son" shouldAutoHideContainer />
-      </div>
-    );
+    expect(out).toMatchSnapshot();
   });
 
   describe('props.shouldAutoHideContainer', () => {
@@ -48,16 +40,16 @@ describe('autoHideContainer', () => {
     });
 
     it('creates a component', () => {
-      expect(component).toExist();
+      expect(component).toBeDefined();
     });
 
     it('shows the container at first', () => {
-      expect(container.style.display).toNotEqual('none');
+      expect(container.style.display).not.toEqual('none');
     });
 
     describe('when set to true', () => {
       beforeEach(() => {
-        sinon.spy(component, 'render');
+        jest.spyOn(component, 'render');
         props.shouldAutoHideContainer = true;
         ReactDOM.render(<AutoHide {...props} />, container);
         innerContainer = container.firstElementChild;
@@ -68,7 +60,7 @@ describe('autoHideContainer', () => {
       });
 
       it('call component.render()', () => {
-        expect(component.render.called).toBe(true);
+        expect(component.render).toHaveBeenCalled();
       });
 
       describe('when set back to false', () => {
@@ -78,11 +70,11 @@ describe('autoHideContainer', () => {
         });
 
         it('shows the container', () => {
-          expect(innerContainer.style.display).toNotEqual('none');
+          expect(innerContainer.style.display).not.toEqual('none');
         });
 
         it('calls component.render()', () => {
-          expect(component.render.calledTwice).toBe(true);
+          expect(component.render).toHaveBeenCalledTimes(2);
         });
       });
     });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

We're using `toMatchJSX` and imported `expect` and `sinon` in the tests. It's easier to rely on what Jest already provides with snapshots and `jest.spyOn`. 

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
  
  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot): 
  
  1. the documentation site (/)
  2. a widget playground (/dev-novel)
-->

1. added the enzyme snapshot format
2. use enzyme in `RefinementListItem`
3. use enzyme in `Stats`
4. use enzyme and modern Jest in `autoHideContainer`

This obviously isn't all tests, but it isn't a straightforward process because of the things renamed in `import expect from "expect"` vs. `global.expect`. For that reason I think it's best to keep this iterative and just use modern techniques in new tests, update tests when we reach them, since there's still quite a lot of them using `toEqualJSX` (39)