### PR TITLE
chore(pkg): use jsDelivr default file feature

### DIFF
--- a/docgen/layouts/widget-showcase.pug
+++ b/docgen/layouts/widget-showcase.pug
@@ -3,7 +3,7 @@ include mixins/nav.pug
 include mixins/documentationjs/widget-category-showcase.pug
 
 block head
-  script(src="https://cdn.jsdelivr.net/npm/instantsearch.js@2/dist/instantsearch.min.js")
+  script(src="https://cdn.jsdelivr.net/npm/instantsearch.js@2")
 
 block navigation
   - let headings2 = headings || []

--- a/docgen/src/examples/getting-started-boilerplate/index.html
+++ b/docgen/src/examples/getting-started-boilerplate/index.html
@@ -41,7 +41,7 @@
     </div>
 
     <!-- js -->
-    <script src="https://cdn.jsdelivr.net/npm/instantsearch.js@2.0.0/dist/instantsearch.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/instantsearch.js@2.0.0"></script>
     <script src="app.js"></script>
   </body>
 </html>

--- a/docgen/src/getting-started.md.hbs
+++ b/docgen/src/getting-started.md.hbs
@@ -42,7 +42,7 @@ Use a built version of **InstantSearch.js** from the [jsDeliver](https://www.jsd
 
 ```html
 <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/instantsearch.js@{{pkg.version}}/dist/instantsearch.min.css">
-<script src="https://cdn.jsdelivr.net/npm/instantsearch.js@{{pkg.version}}/dist/instantsearch.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/instantsearch.js@{{pkg.version}}"></script>
 ```
 
 We also provide you a default Algolia theme for the widgets to be effectively styled:

--- a/docgen/src/guides/usage.md.hbs
+++ b/docgen/src/guides/usage.md.hbs
@@ -20,7 +20,7 @@ This method uses built bersion of **InstantSearch.js** from the [jsDeliver](http
 
 ```html
 <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/instantsearch.js@{{pkg.version}}/dist/instantsearch.min.css">
-<script src="https://cdn.jsdelivr.net/npm/instantsearch.js@{{pkg.version}}/dist/instantsearch.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/instantsearch.js@{{pkg.version}}"></script>
 ```
 
 We also provide you a default Algolia theme for the widgets to be effectively styled:

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "main": "dist-es5-module/index.js",
   "module": "./es/index.js",
+  "jsdelivr": "dist/instantsearch.min.js",
   "scripts": {
     "build": "./scripts/build.sh",
     "dev": "./scripts/dev.sh",


### PR DESCRIPTION
We can reduce the urls we give to users for the JavaScript package by
informing jsDelivr what's the right default file to serve when nothing
provided after the @version.

This is also handy as it does not ties the user and us to a particular
schema to follow over time, if we ever decide to move our build, change
it and rename things, it would be transparent for the user.

For v2 that's "too late" but still good to use it for documentation and
ease of use.

For the theme and style ideally it would be in another package too
("IS.css?" :D)