### PR TITLE
docs(CodeSandbox): link to our CodeSandbox templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -18,11 +18,11 @@
 <!--
   ***************************
   If the current behavior is a bug, please provide all the steps to reproduce and a minimal
-  [JSFiddle](https://jsfiddle.net/) example or a repository on GitHub that we can `npm install`
+  [CodeSandbox](https://codesandbox.io/) example or a repository on GitHub that we can `npm install`
   and `npm start`.
 
   We have a simple online template for you to use as a base to explain your bug or issue:
-  https://jsfiddle.net/bobylito/9h7sgo10/
+  https://codesandbox.io/s/github/algolia/instantsearch-templates/tree/master/src/InstantSearch.js
 
   If you are requesting a new feature, we need to understand WHY would you
   need this feature (your use case) or how you are limited with the current API.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ topic using the [issues tab](https://github.com/algolia/instantsearch.js/issues)
 hesitate to thumb up an issue that corresponds to the problem you found.
 
 Another element that will help us go faster at solving the issue is to provide a reproducible
-test case. We often recommend to [use this jsFiddle template](https://jsfiddle.net/bobylito/9h7sgo10/).
+test case. We often recommend to [use this CodeSandbox template](https://codesandbox.io/s/github/algolia/instantsearch-templates/tree/master/src/InstantSearch.js).
 
 ## The code contribution process 🤘
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 InstantSearch.js is a library for building blazing fast search-as-you-type search UIs with [Algolia][algolia-website].
 
-InstantSearch.js is part of the InstantSearch family: 
-**InstantSearch.js** 
+InstantSearch.js is part of the InstantSearch family:
+**InstantSearch.js**
 | [React InstantSearch (web)][react-instantsearch-github]
 | [Vue InstantSearch (web)][vue-instantsearch-github]
 | [React-native InstantSearch (native)][react-instantsearch-github]
@@ -37,25 +37,40 @@ Using InstantSearch.js is as simple as adding this JS in your page:
 var search = instantsearch({
   appId: 'latency',
   apiKey: '6be0576ff61c053d5f9a3225e2a90f76',
-  indexName: 'movies',
+  indexName: 'instant_search',
+  searchParameters: {
+    hitsPerPage: 8
+  }
 });
 
-search.addWidget(instantsearch.widgets.hits({
-  container: document.querySelector('#movies'),
-  templates: {
-    item: '{{{_highlightResult.title.value}}}'
-  },
-}));
+search.addWidget(
+  instantsearch.widgets.hits({
+    container: document.querySelector('#products'),
+    templates: {
+      item: '{{{_highlightResult.name.value}}}'
+    }
+  })
+);
 
-search.addWidget(instantsearch.widgets.searchBox({
-  container: document.querySelector('#searchBox'),
-  placeholder: 'Search for movies',
-}));
+search.addWidget(
+  instantsearch.widgets.searchBox({
+    container: document.querySelector('#searchBox'),
+    placeholder: 'Search for products',
+    autofocus: false /* Only to avoid live preview taking focus */
+  })
+);
+
+search.addWidget(
+  instantsearch.widgets.refinementList({
+    container: document.querySelector('#brand'),
+    attributeName: 'brand'
+  })
+);
 
 search.start();
 ```
 
-You can [see this live](https://jsfiddle.net/bobylito/9h7sgo10/) on JSFiddle.
+You can [see this live](https://codesandbox.io/s/github/algolia/instantsearch-templates/tree/master/src/InstantSearch.js) on CodeSandbox.
 
 If you want to learn more about the library, you
 can follow the [getting started](https://community.algolia.com/instantsearch.js/v2/getting-started.html)


### PR DESCRIPTION
Since https://github.com/algolia/instantsearch-templates we now have a
good way to share code templates while being able to have them in GIT
for easy local development and linking.