### PR TITLE
Fix/escape hits

### DIFF
--- a/src/connectors/hits/__tests__/connectHits-test.js
+++ b/src/connectors/hits/__tests__/connectHits-test.js
@@ -139,6 +139,8 @@ describe('connectHits', () => {
       },
     ];
 
+    escapedHits.__escaped = true;
+
     const secondRenderingOptions = rendering.lastCall.args[0];
     expect(secondRenderingOptions.hits).toEqual(escapedHits);
     expect(secondRenderingOptions.results).toEqual(results);

--- a/src/lib/__tests__/escape-highlight-test.js
+++ b/src/lib/__tests__/escape-highlight-test.js
@@ -17,7 +17,7 @@ describe('escapeHits()', () => {
       },
     ];
 
-    expect(escapeHits(hits)).toEqual([
+    const output = [
       {
         _highlightResult: {
           foobar: {
@@ -30,7 +30,10 @@ describe('escapeHits()', () => {
           },
         },
       },
-    ]);
+    ];
+
+    output.__escaped = true;
+    expect(escapeHits(hits)).toEqual(output);
   });
 
   it('should escape highlighProperty nested object value', () => {
@@ -55,7 +58,7 @@ describe('escapeHits()', () => {
       },
     ];
 
-    expect(escapeHits(hits)).toEqual([
+    const output = [
       {
         _highlightResult: {
           foo: {
@@ -72,7 +75,10 @@ describe('escapeHits()', () => {
           },
         },
       },
-    ]);
+    ];
+
+    output.__escaped = true;
+    expect(escapeHits(hits)).toEqual(output);
   });
 
   it('should escape highlighProperty array of string', () => {
@@ -101,7 +107,7 @@ describe('escapeHits()', () => {
       },
     ];
 
-    expect(escapeHits(hits)).toEqual([
+    const output = [
       {
         _highlightResult: {
           foobar: [
@@ -116,7 +122,10 @@ describe('escapeHits()', () => {
           ],
         },
       },
-    ]);
+    ];
+
+    output.__escaped = true;
+    expect(escapeHits(hits)).toEqual(output);
   });
 
   it('should escape highlighProperty array of object', () => {
@@ -165,7 +174,7 @@ describe('escapeHits()', () => {
       },
     ];
 
-    expect(escapeHits(hits)).toEqual([
+    const output = [
       {
         _highlightResult: {
           foobar: [
@@ -204,11 +213,13 @@ describe('escapeHits()', () => {
           ],
         },
       },
-    ]);
+    ];
+    output.__escaped = true;
+    expect(escapeHits(hits)).toEqual(output);
   });
 
   it('should not escape twice the same results', () => {
-    const hits = [
+    let hits = [
       {
         _highlightResult: {
           foobar: {
@@ -218,8 +229,8 @@ describe('escapeHits()', () => {
       },
     ];
 
-    escapeHits(hits);
-    escapeHits(hits);
+    hits = escapeHits(hits);
+    hits = escapeHits(hits);
 
     const output = [
       {

--- a/src/lib/escape-highlight.js
+++ b/src/lib/escape-highlight.js
@@ -38,9 +38,7 @@ function recursiveEscape(input) {
 
 export default function escapeHits(hits) {
   if (hits.__escaped === undefined) {
-    hits.__escaped = true;
-
-    return hits.map(hit => {
+    hits = hits.map(hit => {
       if (hit._highlightResult) {
         hit._highlightResult = recursiveEscape(hit._highlightResult);
       }
@@ -51,6 +49,7 @@ export default function escapeHits(hits) {
 
       return hit;
     });
+    hits.__escaped = true;
   }
 
   return hits;


### PR DESCRIPTION
Hits were escaped twice if they were two Hits widgets on the page or using twice the `connectHits` connector.

It's impacting Angular-InstantSearch and a support user.