### PR TITLE
Correct invalid URL

### DIFF
--- a/docgen/src/widgets.md
+++ b/docgen/src/widgets.md
@@ -26,5 +26,5 @@ search.addWidget(instantsearch.searchbox(/* searchbox parameters */));
 ```
 
 In the next sections we showcase the widgets InstantSearch.js provides. If you want to learn
-more about the API, have a look at the [common widget API](widget-common-api.html).
+more about the API, have a look at the [common widgets API](widgets-common-api.html).
 


### PR DESCRIPTION
This is pretty self explanatory, but the URL for the Common Widgets API is incorrect. This PR fixes it.