### PR TITLE
docs(connectRange): specify `undefined` as an infinite bound for `refine()`

### DIFF
--- a/src/connectors/range/connectRange.js
+++ b/src/connectors/range/connectRange.js
@@ -36,7 +36,8 @@ Full documentation available at https://community.algolia.com/instantsearch.js/c
 /**
  * @typedef {Object} RangeRenderingOptions
  * @property {function(Array<number, number>)} refine Sets a range to filter the results on. Both values
- * are optional, and will default to the higher and lower bounds.
+ * are optional, and will default to the higher and lower bounds. You can use `undefined` to remove a
+ * previously set bound or to set an infinite bound.
  * @property {{min: number, max: number}} range Results bounds without the current range filter.
  * @property {Array<number, number>} start Current numeric bounds of the search.
  * @property {{from: function, to: function}} formatter Transform for the rendering `from` and/or `to` values.


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

As discussed in #2677, I specified the use of `undefined` to remove a previously set bound or to add an infinite bound in the `refine()` method of the `connectRange` doc.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->