### PR TITLE
fix(doc): add maximum width to images (fix #2685)

### DIFF
--- a/docgen/src/stylesheets/components/_documentation.sass
+++ b/docgen/src/stylesheets/components/_documentation.sass
@@ -106,6 +106,9 @@ $offset-height: 60px
             margin-right: 6px
             color: $logan
 
+    img
+      max-width: 100%
+
     .content
       & p:first-child
         margin-top: 0


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

See discussion in #2685.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

Images in the documentation container are restricted to `max-width: 100`.

Let me know if this is not the right way to solve this.

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
  
  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot): 
  
  1. the documentation site (/)
  2. a widget playground (/dev-novel)
-->

