### PR TITLE
Support search config override per documentation page

### DIFF
--- a/docgen/CONTRIBUTING.md
+++ b/docgen/CONTRIBUTING.md
@@ -26,7 +26,7 @@ The name of the category of your page.
 
 > `string` | no default
 
-The layout of your page among [`docgen/layouts/`](docgen/layouts/) (i.e. [`main.pug`](docgen/layouts/main.pug)).
+The layout of your page among [`docgen/layouts/`](layouts/) (i.e. [`main.pug`](layouts/main.pug)).
 
 #### `category`
 
@@ -96,5 +96,5 @@ editable: true
 githubSource: docgen/src/widgets.md
 ---
 
-# The start of your page
+The start of your page...
 ```

--- a/docgen/CONTRIBUTING.md
+++ b/docgen/CONTRIBUTING.md
@@ -1,0 +1,100 @@
+# Contributing
+
+This guide explains how the documentation process works for InstantSearch.js.
+
+## Frontmatter
+
+The frontmatter of your [Markdown](https://en.wikipedia.org/wiki/Markdown) page describes the metadata that will be generated at compile time.
+
+We offer several attributes that allow to customize the rendering of your documentation or guide. You don't need to specify the ones that default to a value ([see example](#example)).
+
+### Attributes
+
+#### `title`
+
+> `string` | no default
+
+The title of your page.
+
+#### `mainTitle`
+
+> `string` | no default
+
+The name of the category of your page.
+
+#### `layout`
+
+> `string` | no default
+
+The layout of your page among [`docgen/layouts/`](docgen/layouts/) (i.e. [`main.pug`](docgen/layouts/main.pug)).
+
+#### `category`
+
+> `string` | no default
+
+The category of your page.
+
+#### `name`
+
+> `string` | no default
+
+The name to use for the file name of the [URL](https://en.wikipedia.org/wiki/URL).
+
+#### `withHeadings`
+
+> `boolean` | defaults to `false`
+
+`true` if the page should contain headings, `false` otherwise.
+
+#### `navWeight`
+
+> `number` | no default
+
+The number that describes the order of the page in the menu.
+
+#### `editable`
+
+> `boolean` | defaults to `false`
+
+`true` if you want to display the "Edit this page" link, `false` otherwise.
+
+#### `githubSource`
+
+> `string` | no default
+
+If the page is `editable`, link to its source on GitHub for the "Edit this page" link.
+
+#### `appId`
+
+> `string` | defaults to `latency`
+
+The Algolia application ID to run the code samples on.
+
+#### `apiKey`
+
+> `string` | defaults to `6be0576ff61c053d5f9a3225e2a90f76`
+
+The API key of the app to run the code samples on.
+
+#### `index`
+
+> `string` | defaults to `instant_search`
+
+The index name of the app to run the code samples on.
+
+### Example
+
+```markdown
+---
+title: Introduction
+mainTitle: Widgets
+layout: widget-showcase.pug
+category: widgets
+withHeadings: true
+navWeight: 100
+editable: true
+githubSource: docgen/src/widgets.md
+---
+
+# The start of your page
+```

--- a/docgen/assets/js/bindRunExamples.js
+++ b/docgen/assets/js/bindRunExamples.js
@@ -9,7 +9,8 @@ window.search = instantsearch({
   urlSync: false,
   searchParameters: {
     hitsPerPage: 3
-  }
+  },
+  ...window.searchConfig
 });
 
 const el = html => {

--- a/docgen/middlewares.js
+++ b/docgen/middlewares.js
@@ -3,6 +3,7 @@ import layouts from 'metalsmith-layouts';
 import msWebpack from 'ms-webpack';
 import navigation from 'metalsmith-navigation';
 import nav from './plugins/navigation.js';
+import searchConfig from './plugins/searchConfig.js';
 import sass from 'metalsmith-sass';
 import inPlace from 'metalsmith-in-place';
 import copy from 'metalsmith-copy';
@@ -42,6 +43,7 @@ const common = [
     source: '../dist',
     destination: './examples/tourism',
   }),
+  searchConfig(),
   ignore(fileName => {
     // This is a fix for VIM swp files inside src/,
     // We could also configure VIM to store swp files somewhere else

--- a/docgen/plugins/searchConfig.js
+++ b/docgen/plugins/searchConfig.js
@@ -1,0 +1,26 @@
+import {forEach} from 'lodash';
+
+// Injects search config from the frontmatter Markdown page to the `window` object.
+// This allows to run code snippets in any Algolia index.
+export default function() {
+  return function(files, metalsmith, done) {
+    forEach(files, (data, path) => {
+      const {appId, apiKey, indexName} = data;
+
+      if (appId || apiKey || indexName) {
+        data.contents =
+          data.contents +
+          `<script>
+            window.searchConfig = {
+              ${appId ? `appId: '${appId}',` : ''}
+              ${apiKey ? `apiKey: '${apiKey}',` : ''}
+              ${indexName ? `indexName: '${indexName}',` : ''}
+            };
+          </script>`
+          .replace(/\s/g, '');
+      }
+    });
+
+    done();
+  };
+}


### PR DESCRIPTION
This PR adds support for new frontmatter attributes to run code samples on specific Algolia indices depending on the page you're on.

*EDIT: as frontmatter attributes are not documented anywhere, I added a contributing guide explaining what each of them is used for.*

## The problem

Code snippets in the documentation can be run when we detect some patterns like `/widgets.(\S+)\(/g`. They are run on a hard coded Algolia index called `instant_search` on the `latency` app ([see code](https://github.com/algolia/instantsearch.js/blob/5cd002b0c2442cc952d59cecab335a55e61cbd35/docgen/assets/js/bindRunExamples.js#L8)).

Sometimes, you'd like your code snippet to be run on another index, or even another app. This is the case for my guide [Create a Calendar Widget](https://github.com/algolia/instantsearch.js/pull/2687) which relies on the index `concert_events_instantsearchjs`.

## This solution

I'm extracting the search configuration in the frontmatter of the guide/documentation and inject it in the `window` object.

```markdown
---
title: Create a calendar widget
appId: latency
apiKey: 6be0576ff61c053d5f9a3225e2a90f76
index: concert_events_instantsearchjs
---
```

Each article can now use its own search configuration. If no configuration provided, we default to the current one.

—

This is not a great solution but it is the only one that could work as far as I know.