### PR TITLE
refactor: move Hogan logic to utils

### DIFF
--- a/src/components/Template.js
+++ b/src/components/Template.js
@@ -1,13 +1,8 @@
-import PropTypes from 'prop-types';
 import React, { Component } from 'preact-compat';
-import hogan from 'hogan.js';
-
-import curry from 'lodash/curry';
+import PropTypes from 'prop-types';
 import cloneDeep from 'lodash/cloneDeep';
-import mapValues from 'lodash/mapValues';
 import isEqual from 'lodash/isEqual';
-
-import { isReactElement } from '../lib/utils.js';
+import { isReactElement, renderTemplate } from '../lib/utils';
 
 export class PureTemplate extends Component {
   shouldComponentUpdate(nextProps) {
@@ -125,49 +120,6 @@ function transformData(fn, templateKey, originalData) {
     );
   }
   return data;
-}
-
-function renderTemplate({
-  templates,
-  templateKey,
-  compileOptions,
-  helpers,
-  data,
-}) {
-  const template = templates[templateKey];
-  const templateType = typeof template;
-  const isTemplateString = templateType === 'string';
-  const isTemplateFunction = templateType === 'function';
-
-  if (!isTemplateString && !isTemplateFunction) {
-    throw new Error(
-      `Template must be 'string' or 'function', was '${templateType}' (key: ${templateKey})`
-    );
-  } else if (isTemplateFunction) {
-    return template(data);
-  } else {
-    const transformedHelpers = transformHelpersToHogan(
-      helpers,
-      compileOptions,
-      data
-    );
-    const preparedData = { ...data, helpers: transformedHelpers };
-    return hogan.compile(template, compileOptions).render(preparedData);
-  }
-}
-
-// We add all our template helper methods to the template as lambdas. Note
-// that lambdas in Mustache are supposed to accept a second argument of
-// `render` to get the rendered value, not the literal `{{value}}`. But
-// this is currently broken (see
-// https://github.com/twitter/hogan.js/issues/222).
-function transformHelpersToHogan(helpers, compileOptions, data) {
-  return mapValues(helpers, method =>
-    curry(function(text) {
-      const render = value => hogan.compile(value, compileOptions).render(this);
-      return method.call(data, text, render);
-    })
-  );
 }
 
 // Resolve transformData before Template, so transformData is always called

--- a/src/components/__tests__/Template-test.js
+++ b/src/components/__tests__/Template-test.js
@@ -5,87 +5,35 @@ import sinon from 'sinon';
 import renderer from 'react-test-renderer';
 
 describe('Template', () => {
-  describe('without helpers', () => {
-    it('supports templates as strings', () => {
-      const props = getProps({
-        templates: { test: 'it works with {{type}}' },
-        data: { type: 'strings' },
-      });
-      const tree = renderer.create(<PureTemplate {...props} />).toJSON();
-      expect(tree).toMatchSnapshot();
+  it('throws an error when templates as functions returning a React element', () => {
+    const props = getProps({
+      templates: {
+        test: templateData => <p>it doesnt works with {templateData.type}</p>,
+      }, // eslint-disable-line react/display-name
+      data: { type: 'functions' },
     });
-
-    it('supports templates as functions returning a string', () => {
-      const props = getProps({
-        templates: {
-          test: templateData => `it also works with ${templateData.type}`,
-        },
-        data: { type: 'functions' },
-      });
-      const tree = renderer.create(<PureTemplate {...props} />).toJSON();
-      expect(tree).toMatchSnapshot();
-    });
-
-    it('throws an error when templates as functions returning a React element', () => {
-      const props = getProps({
-        templates: {
-          test: templateData => <p>it doesnt works with {templateData.type}</p>,
-        }, // eslint-disable-line react/display-name
-        data: { type: 'functions' },
-      });
-      expect(() => renderer.create(<PureTemplate {...props} />)).toThrow();
-    });
-
-    it('can configure compilation options', () => {
-      const props = getProps({
-        templates: { test: 'it configures compilation <%options%>' },
-        data: { options: 'delimiters' },
-        useCustomCompileOptions: { test: true },
-        templatesConfig: { compileOptions: { delimiters: '<% %>' } },
-      });
-      const tree = renderer.create(<PureTemplate {...props} />).toJSON();
-      expect(tree).toMatchSnapshot();
-    });
+    expect(() => renderer.create(<PureTemplate {...props} />)).toThrow();
   });
 
-  describe('using helpers', () => {
-    it('call the relevant function', () => {
-      const props = getProps({
-        templates: {
-          test:
-            'it supports {{#helpers.emphasis}}{{feature}}{{/helpers.emphasis}}',
-        },
-        data: { feature: 'helpers' },
-        templatesConfig: {
-          helpers: { emphasis: (text, render) => `<em>${render(text)}</em>` },
-        },
-      });
-      const tree = renderer.create(<PureTemplate {...props} />).toJSON();
-      expect(tree).toMatchSnapshot();
+  it('can configure compilation options', () => {
+    const props = getProps({
+      templates: { test: 'it configures compilation <%options%>' },
+      data: { options: 'delimiters' },
+      useCustomCompileOptions: { test: true },
+      templatesConfig: { compileOptions: { delimiters: '<% %>' } },
     });
+    const tree = renderer.create(<PureTemplate {...props} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 
-    it('sets the function context (`this`) to the template `data`', done => {
-      const data = { feature: 'helpers' };
-      const props = getProps({
-        templates: {
-          test:
-            'it supports {{#helpers.emphasis}}{{feature}}{{/helpers.emphasis}}',
-        },
-        data,
-        templatesConfig: {
-          helpers: {
-            emphasis() {
-              // context will be different when using arrow function (lexical scope used)
-              expect(this).toBe(data);
-              done();
-            },
-          },
-        },
-      });
+  it('forward rootProps to the first node', () => {
+    function fn() {}
 
-      const tree = renderer.create(<PureTemplate {...props} />).toJSON();
-      expect(tree).toMatchSnapshot();
+    const props = getProps({
+      rootProps: { className: 'hey', onClick: fn },
     });
+    const tree = renderer.create(<PureTemplate {...props} />).toJSON();
+    expect(tree).toMatchSnapshot();
   });
 
   describe('transform data usage', () => {
@@ -203,16 +151,6 @@ describe('Template', () => {
         renderer.create(<TemplateWithTransformData {...props} />);
       }).toThrow('`transformData` must return a `object`, got `boolean`.');
     });
-  });
-
-  it('forward rootProps to the first node', () => {
-    function fn() {}
-
-    const props = getProps({
-      rootProps: { className: 'hey', onClick: fn },
-    });
-    const tree = renderer.create(<PureTemplate {...props} />).toJSON();
-    expect(tree).toMatchSnapshot();
   });
 
   describe('shouldComponentUpdate', () => {

--- a/src/components/__tests__/__snapshots__/Template-test.js.snap
+++ b/src/components/__tests__/__snapshots__/Template-test.js.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Template can configure compilation options 1`] = `
+<div
+  dangerouslySetInnerHTML={
+    Object {
+      "__html": "it configures compilation delimiters",
+    }
+  }
+/>
+`;
+
 exports[`Template forward rootProps to the first node 1`] = `
 <div
   className="hey"
@@ -47,56 +57,6 @@ exports[`Template transform data usage transformData with an object is using a d
   dangerouslySetInnerHTML={
     Object {
       "__html": "",
-    }
-  }
-/>
-`;
-
-exports[`Template using helpers call the relevant function 1`] = `
-<div
-  dangerouslySetInnerHTML={
-    Object {
-      "__html": "it supports <em>helpers</em>",
-    }
-  }
-/>
-`;
-
-exports[`Template using helpers sets the function context (\`this\`) to the template \`data\` 1`] = `
-<div
-  dangerouslySetInnerHTML={
-    Object {
-      "__html": "it supports ",
-    }
-  }
-/>
-`;
-
-exports[`Template without helpers can configure compilation options 1`] = `
-<div
-  dangerouslySetInnerHTML={
-    Object {
-      "__html": "it configures compilation delimiters",
-    }
-  }
-/>
-`;
-
-exports[`Template without helpers supports templates as functions returning a string 1`] = `
-<div
-  dangerouslySetInnerHTML={
-    Object {
-      "__html": "it also works with functions",
-    }
-  }
-/>
-`;
-
-exports[`Template without helpers supports templates as strings 1`] = `
-<div
-  dangerouslySetInnerHTML={
-    Object {
-      "__html": "it works with strings",
     }
   }
 />

--- a/src/lib/__tests__/utils-test.js
+++ b/src/lib/__tests__/utils-test.js
@@ -148,6 +148,144 @@ describe('utils.prepareTemplateProps', () => {
   });
 });
 
+describe('utils.renderTemplate', () => {
+  it('expect to proccess templates as string', () => {
+    const templateKey = 'test';
+    const templates = { test: 'it works with {{type}}' };
+    const data = { type: 'strings' };
+
+    const actual = utils.renderTemplate({
+      templateKey,
+      templates,
+      data,
+    });
+
+    const expectation = 'it works with strings';
+
+    expect(actual).toBe(expectation);
+  });
+
+  it('expect to proccess templates as function', () => {
+    const templateKey = 'test';
+    const templates = { test: data => `it works with ${data.type}` };
+    const data = { type: 'functions' };
+
+    const actual = utils.renderTemplate({
+      templateKey,
+      templates,
+      data,
+    });
+
+    const expectation = 'it works with functions';
+
+    expect(actual).toBe(expectation);
+  });
+
+  it('expect to use custom compiler options', () => {
+    const templateKey = 'test';
+    const templates = { test: 'it works with <%options%>' };
+    const data = { options: 'custom delimiter' };
+    const compileOptions = { delimiters: '<% %>' };
+
+    const actual = utils.renderTemplate({
+      templateKey,
+      templates,
+      data,
+      compileOptions,
+    });
+
+    const expectation = 'it works with custom delimiter';
+
+    expect(actual).toBe(expectation);
+  });
+
+  it('expect to throw when the template is not a function or a string', () => {
+    const actual0 = () =>
+      utils.renderTemplate({
+        templateKey: 'test',
+        templates: {},
+      });
+
+    const actual1 = () =>
+      utils.renderTemplate({
+        templateKey: 'test',
+        templates: { test: null },
+      });
+
+    const actual2 = () =>
+      utils.renderTemplate({
+        templateKey: 'test',
+        templates: { test: 10 },
+      });
+
+    const expectation0 = `Template must be 'string' or 'function', was 'undefined' (key: test)`;
+    const expectation1 = `Template must be 'string' or 'function', was 'object' (key: test)`;
+    const expectation2 = `Template must be 'string' or 'function', was 'number' (key: test)`;
+
+    expect(() => actual0()).toThrow(expectation0);
+    expect(() => actual1()).toThrow(expectation1);
+    expect(() => actual2()).toThrow(expectation2);
+  });
+
+  describe('with helpers', () => {
+    it('expect to call the relevant function', () => {
+      const templateKey = 'test';
+      const templates = {
+        test: '{{#helpers.emphasis}}{{feature}}{{/helpers.emphasis}}',
+      };
+
+      const data = {
+        feature: 'helpers',
+      };
+
+      const helpers = {
+        emphasis: (text, render) => `<em>${render(text)}</em>`,
+      };
+
+      const actual = utils.renderTemplate({
+        templateKey,
+        templates,
+        data,
+        helpers,
+      });
+
+      const expectation = '<em>helpers</em>';
+
+      expect(actual).toBe(expectation);
+    });
+
+    it('expect to set the context (`this`) to the template `data`', done => {
+      const templateKey = 'test';
+      const templates = {
+        test: '{{#helpers.emphasis}}{{feature}}{{/helpers.emphasis}}',
+      };
+
+      const data = {
+        feature: 'helpers',
+      };
+
+      const helpers = {
+        emphasis() {
+          // context will be different when using arrow function (lexical scope used)
+          expect(this).toBe(data);
+          done();
+        },
+      };
+
+      const actual = utils.renderTemplate({
+        templateKey,
+        templates,
+        data,
+        helpers,
+      });
+
+      const expectation = '';
+
+      expect(actual).toBe(expectation);
+    });
+  });
+});
+
 describe('utils.getRefinements', () => {
   let helper;
   let results;

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -6,11 +6,15 @@ import isEmpty from 'lodash/isEmpty';
 import keys from 'lodash/keys';
 import uniq from 'lodash/uniq';
 import mapKeys from 'lodash/mapKeys';
+import mapValues from 'lodash/mapValues';
+import curry from 'lodash/curry';
+import hogan from 'hogan.js';
 
 export {
   getContainerNode,
   bemHelper,
   prepareTemplateProps,
+  renderTemplate,
   isSpecialClick,
   isDomElement,
   getRefinements,
@@ -144,6 +148,53 @@ function prepareTemplates(defaultTemplates = {}, templates = {}) {
       return config;
     },
     { templates: {}, useCustomCompileOptions: {} }
+  );
+}
+
+function renderTemplate({
+  templates,
+  templateKey,
+  compileOptions,
+  helpers,
+  data,
+}) {
+  const template = templates[templateKey];
+  const templateType = typeof template;
+  const isTemplateString = templateType === 'string';
+  const isTemplateFunction = templateType === 'function';
+
+  if (!isTemplateString && !isTemplateFunction) {
+    throw new Error(
+      `Template must be 'string' or 'function', was '${templateType}' (key: ${templateKey})`
+    );
+  }
+
+  if (isTemplateFunction) {
+    return template(data);
+  }
+
+  const transformedHelpers = transformHelpersToHogan(
+    helpers,
+    compileOptions,
+    data
+  );
+
+  return hogan.compile(template, compileOptions).render({
+    ...data,
+    helpers: transformedHelpers,
+  });
+}
+
+// We add all our template helper methods to the template as lambdas. Note
+// that lambdas in Mustache are supposed to accept a second argument of
+// `render` to get the rendered value, not the literal `{{value}}`. But
+// this is currently broken (see https://github.com/twitter/hogan.js/issues/222).
+function transformHelpersToHogan(helpers, compileOptions, data) {
+  return mapValues(helpers, method =>
+    curry(function(text) {
+      const render = value => hogan.compile(value, compileOptions).render(this);
+      return method.call(data, text, render);
+    })
   );
 }
 

--- a/src/widgets/search-box/search-box.js
+++ b/src/widgets/search-box/search-box.js
@@ -1,13 +1,8 @@
 import forEach from 'lodash/forEach';
-import isString from 'lodash/isString';
-import isFunction from 'lodash/isFunction';
 import cx from 'classnames';
-import Hogan from 'hogan.js';
-
-import connectSearchBox from '../../connectors/search-box/connectSearchBox.js';
-import defaultTemplates from './defaultTemplates.js';
-
-import { bemHelper, getContainerNode } from '../../lib/utils.js';
+import { bemHelper, getContainerNode, renderTemplate } from '../../lib/utils';
+import connectSearchBox from '../../connectors/search-box/connectSearchBox';
+import defaultTemplates from './defaultTemplates';
 
 const bem = bemHelper('ais-search-box');
 const KEY_ENTER = 13;
@@ -401,12 +396,20 @@ function addReset(input, reset, { reset: resetTemplate }, clearFunction) {
     ...reset,
   };
 
-  const resetCSSClasses = { root: cx(bem('reset'), reset.cssClasses.root) };
-  const stringNode = processTemplate(reset.template, {
-    cssClasses: resetCSSClasses,
+  const resetCSSClasses = {
+    root: cx(bem('reset'), reset.cssClasses.root),
+  };
+
+  const stringNode = renderTemplate({
+    templateKey: 'template',
+    templates: reset,
+    data: {
+      cssClasses: resetCSSClasses,
+    },
   });
 
   const htmlNode = createNodeFromString(stringNode, cx(bem('reset-wrapper')));
+
   input.parentNode.appendChild(htmlNode);
 
   htmlNode.addEventListener('click', event => {
@@ -433,14 +436,20 @@ function addMagnifier(input, magnifier, { magnifier: magnifierTemplate }) {
   const magnifierCSSClasses = {
     root: cx(bem('magnifier'), magnifier.cssClasses.root),
   };
-  const stringNode = processTemplate(magnifier.template, {
-    cssClasses: magnifierCSSClasses,
+
+  const stringNode = renderTemplate({
+    templateKey: 'template',
+    templates: magnifier,
+    data: {
+      cssClasses: magnifierCSSClasses,
+    },
   });
 
   const htmlNode = createNodeFromString(
     stringNode,
     cx(bem('magnifier-wrapper'))
   );
+
   input.parentNode.appendChild(htmlNode);
 }
 
@@ -458,14 +467,20 @@ function addLoadingIndicator(
   const loadingIndicatorCSSClasses = {
     root: cx(bem('loading-indicator'), loadingIndicator.cssClasses.root),
   };
-  const stringNode = processTemplate(loadingIndicator.template, {
-    cssClasses: loadingIndicatorCSSClasses,
+
+  const stringNode = renderTemplate({
+    templateKey: 'template',
+    templates: loadingIndicator,
+    data: {
+      cssClasses: loadingIndicatorCSSClasses,
+    },
   });
 
   const htmlNode = createNodeFromString(
     stringNode,
     cx(bem('loading-indicator-wrapper'))
   );
+
   input.parentNode.appendChild(htmlNode);
 }
 
@@ -477,11 +492,11 @@ function addLoadingIndicator(
  * @param {object} templates the default templates
  * @returns {undefined} returns nothing
  */
-function addPoweredBy(input, poweredBy, templates) {
+function addPoweredBy(input, poweredBy, { poweredBy: poweredbyTemplate }) {
   // Default values
   poweredBy = {
     cssClasses: {},
-    template: templates.poweredBy,
+    template: poweredbyTemplate,
     ...poweredBy,
   };
 
@@ -497,14 +512,17 @@ function addPoweredBy(input, poweredBy, templates) {
     `utm_content=${location.hostname}&` +
     'utm_campaign=poweredby';
 
-  const templateData = {
-    cssClasses: poweredByCSSClasses,
-    url,
-  };
+  const stringNode = renderTemplate({
+    templateKey: 'template',
+    templates: poweredBy,
+    data: {
+      cssClasses: poweredByCSSClasses,
+      url,
+    },
+  });
 
-  const template = poweredBy.template;
-  const stringNode = processTemplate(template, templateData);
   const htmlNode = createNodeFromString(stringNode);
+
   input.parentNode.insertBefore(htmlNode, input.nextSibling);
 }
 
@@ -514,20 +532,4 @@ function createNodeFromString(stringNode, rootClassname = '') {
   const tmpNode = document.createElement('div');
   tmpNode.innerHTML = `<span class="${rootClassname}">${stringNode.trim()}</span>`;
   return tmpNode.firstChild;
-}
-
-function processTemplate(template, templateData) {
-  let result;
-
-  if (isString(template)) {
-    result = Hogan.compile(template).render(templateData);
-  } else if (isFunction(template)) {
-    result = template(templateData);
-  }
-
-  if (!isString(result)) {
-    throw new Error('Wrong template options for the SearchBox widget');
-  }
-
-  return result;
 }


### PR DESCRIPTION
**Summary**

This PR extract the behaviour of the template processing from `<Template>` to `utils`. We can take leverage of the same logic without using the component. It means that non React widget can use the same function for processing the template (ex: SearchBox, Geo).

Still some questions about the usage of `compileOptions`. We do not provide a way to override it properly from `InstantSearch` except:

```js
const search = instantsearch(...)

search.templateConfig.compileOptions = { ... }
```

I didn't find any documentation / issue on the subject , so maybe get rid of this option in the next major release. It will also simplify the `prepareTemplates` function.