### PR TITLE
docs: allow static example

### DIFF
--- a/docgen/assets/js/main.js
+++ b/docgen/assets/js/main.js
@@ -20,11 +20,12 @@ const header = new alg.communityHeader(docSearch);
 
 const container = document.querySelector('.documentation-container');
 const codeSamples = document.querySelectorAll('.code-sample');
+const codeSamplesRunnable = document.querySelectorAll('.code-sample-runnable');
 
 dropdowns();
 move();
 activateClipboard(codeSamples);
-bindRunExamples(codeSamples);
+bindRunExamples(codeSamplesRunnable);
 
 const sidebarContainer = document.querySelector('.sidebar');
 if(sidebarContainer) {

--- a/docgen/layouts/connector.pug
+++ b/docgen/layouts/connector.pug
@@ -9,7 +9,8 @@ include mixins/documentationjs/connector-usage.pug
 
 block navigation
   - let headings = [{tag: 'h2', id: 'description', text: 'Description'}, {tag: 'h2', id:'usage', text:'Usage'}, {tag: 'h2', id:'structure', text: 'Connector options'}]
-  - if(jsdoc.examples.length > 0) headings.push({tag:'h2', id:'example', text: 'Example'});
+  - if(jsdoc.examples && jsdoc.examples.length > 0) headings.push({tag:'h2', id:'example', text: 'Example'});
+  - if(jsdoc.staticExamples && jsdoc.staticExamples.length > 0) headings.push({tag:'h2', id:'example', text: 'Example'});
   +nav(navPath, navigation, mainTitle || title, withHeadings && headings || [])
 
 block content
@@ -17,11 +18,11 @@ block content
     a.anchor(href=`${navPath}#description`)
   p
     +description(jsdoc.description)
-    
+
   h2#usage Usage
     a.anchor(href=`${navPath}#usage`)
   +connectorUsage(jsdoc)
-  
+
   h2#structure Connector options
     a.anchor(href=`${navPath}#structure`)
   each t in jsdoc.relatedTypes
@@ -34,3 +35,9 @@ block content
       a.anchor(href=`${navPath}#example`)
     each example in jsdoc.examples
       p!=h.highlight(example.description)
+
+  if jsdoc.staticExamples && jsdoc.staticExamples.length > 0
+    h2#example Example
+      a.anchor(href=`${navPath}#example`)
+    each example in jsdoc.staticExamples
+      div!=h.highlight(example.description, { runnable: false })

--- a/docgen/layouts/mixins/documentationjs/widget-category-showcase.pug
+++ b/docgen/layouts/mixins/documentationjs/widget-category-showcase.pug
@@ -4,7 +4,7 @@ mixin widgetCategoryShowCase(category, symbols, title)
     h2(id=category)=title
       a.anchor(href=`${navPath}#${category}`)
     for symbol in categorySymbols
-      - const match = /container: '#(\S+)'/.exec(symbol.examples[0].description)
+      - const match = symbol.examples && symbol.examples.length > 0 && /container: '#(\S+)'/.exec(symbol.examples[0].description)
       h3(id=`${category}-${symbol.name}`)=symbol.name
         a.anchor(href=`${navPath}#${category}-${symbol.name}`)
       p

--- a/docgen/layouts/widget.pug
+++ b/docgen/layouts/widget.pug
@@ -12,6 +12,7 @@ block navigation
   - if(jsdoc.requirements != '') headings.push({tag: 'h2', id:'requirements', text:'Requirements'})
   - headings.push({tag: 'h2', id:'usage', text:'Usage'}, {tag:'h2', id:'structure', text: 'Options'});
   - if(jsdoc.examples && jsdoc.examples.length > 0) headings.push({tag:'h2', id:'example', text: 'Example'});
+  - if(jsdoc.staticExamples && jsdoc.staticExamples.length > 0) headings.push({tag:'h2', id:'example', text: 'Example'});
   +nav(navPath, navigation, mainTitle || title, withHeadings && headings || [])
 
 block content
@@ -58,3 +59,9 @@ block content
       a.anchor(href=`${navPath}#example`)
     each example in jsdoc.examples
       div!=h.highlight(example.description)
+
+  if jsdoc.staticExamples && jsdoc.staticExamples.length > 0
+      h2#example Example
+        a.anchor(href=`${navPath}#example`)
+      each example in jsdoc.staticExamples
+        div!=h.highlight(example.description, { runnable: false })

--- a/docgen/plugins/documentationjs-data.js
+++ b/docgen/plugins/documentationjs-data.js
@@ -114,9 +114,13 @@ function mapConnectors(connectors, symbols, files) {
   return forEach(connectors, symbol => {
     const fileName = `connectors/${symbol.name}.html`;
 
+    const relatedTypes = findRelatedTypes(symbol, symbols);
+    const staticExamples = symbol.tags.filter(t => t.title === 'staticExample');
+
     const symbolWithRelatedType = {
       ...symbol,
-      relatedTypes: findRelatedTypes(symbol, symbols),
+      relatedTypes,
+      staticExamples,
     };
 
     files[fileName] = {
@@ -140,12 +144,14 @@ function mapWidgets(widgets, symbols, files) {
     const fileName = `widgets/${symbol.name}.html`;
 
     const relatedTypes = findRelatedTypes(symbol, symbols);
-    const requirements = symbol.tags.find(t => t.title === 'requirements') || {description: ''};
+    const staticExamples = symbol.tags.filter(t => t.title === 'staticExample');
+    const requirements = symbol.tags.find(t => t.title === 'requirements') || { description: '' };
 
     const symbolWithRelatedType = {
       ...symbol,
       requirements: md.render(requirements.description),
       relatedTypes,
+      staticExamples,
     };
 
     files[fileName] = {

--- a/docgen/plugins/helpers.js
+++ b/docgen/plugins/helpers.js
@@ -11,7 +11,10 @@ export default function helpers(filenames, metalsmith, cb) {
     },
     highlight(src, opts) {
       const lang = opts && opts.lang;
-      return highlight(src, lang);
+      const inline = opts && opts.inline;
+      const runnable = opts && opts.runnable;
+
+      return highlight(src, lang, inline, runnable);
     },
     maybeActive(navPath, singlePathOrArrayOfPaths) {
       const pathsToTest = [].concat(singlePathOrArrayOfPaths);

--- a/docgen/syntaxHighlighting.js
+++ b/docgen/syntaxHighlighting.js
@@ -9,15 +9,17 @@ import 'codemirror/mode/javascript/javascript';
 import 'codemirror/mode/shell/shell';
 import escape from 'escape-html';
 
-export default function highlight(source, lang = 'javascript', inline = false) {
-  const theme = "mdn-like";
+export default function highlight(source, lang = 'javascript', inline = false, runnable = true) {
+  const inlineClassNames = ['CodeMirror', 'cm-s-mdn-like'];
+  const blockClassNames = [...inlineClassNames, 'code-sample'];
+
+  if (runnable) {
+    blockClassNames.push('code-sample-runnable');
+  }
 
   if (lang === 'html') {
     lang = 'htmlmixed';
   }
-
-  const blockTheme = 'cm-s-' + theme;
-  const spanTheme = 'cm-s-' + theme;
 
   let output = '';
   runMode(source, lang, (text, style) => {
@@ -31,8 +33,8 @@ export default function highlight(source, lang = 'javascript', inline = false) {
   });
 
   if (inline) {
-    return `<code class="CodeMirror ${spanTheme}">${output}</code>`;
+    return `<code class="${inlineClassNames.join(' ')}">${output}</code>`;
   }
 
-  return `<pre class="CodeMirror ${blockTheme} code-sample"><code>${output}</code></pre>`;
+  return `<pre class="${blockClassNames.join(' ')}"><code>${output}</code></pre>`;
 }


### PR DESCRIPTION
**Summary**

Right now we don't have to possibility to expose static code example in the documentation. We always have the `run` button in header preview. For some cases it might be interesting to support static code example (e.g. GeoSearch - we don't want to load Leaflet in the page just for the connector example). 

This PR adds a new JSDoc annotation called `@staticExample` to allow this kind of example. This annotation behaves the same way as `@example`, except that the example won't have the `run` button. 

Note that for now we don't support both example types at the same time. It works but the structure of the HTML page will be a bit weird since we duplicate the `h2`. We can probably merge them into only one, but lets interate on that when the needs occur.

fixes #2694 