### PR TITLE
docs: add DevNovel link

### DIFF
--- a/dev/app/builtin/stories/menu.stories.js
+++ b/dev/app/builtin/stories/menu.stories.js
@@ -9,7 +9,7 @@ const stories = storiesOf('Menu');
 export default () => {
   stories
     .add(
-      'Default',
+      'default',
       wrapWithHits(container => {
         window.search.addWidget(
           instantsearch.widgets.menu({

--- a/dev/app/builtin/stories/toggle.stories.js
+++ b/dev/app/builtin/stories/toggle.stories.js
@@ -9,7 +9,7 @@ const stories = storiesOf('Toggle');
 export default () => {
   stories
     .add(
-      'with single value',
+      'default',
       wrapWithHits(container => {
         window.search.addWidget(
           instantsearch.widgets.toggle({

--- a/docgen/layouts/widget.pug
+++ b/docgen/layouts/widget.pug
@@ -10,6 +10,7 @@ include mixins/documentationjs/widget-usage.pug
 block navigation
   - let headings = [{tag: 'h2', id: 'description', text: 'Description'}]
   - if(jsdoc.requirements != '') headings.push({tag: 'h2', id:'requirements', text:'Requirements'})
+  - headings.push({tag: 'h2', id:'live', text:'Live example'});
   - headings.push({tag: 'h2', id:'usage', text:'Usage'}, {tag:'h2', id:'structure', text: 'Options'});
   - if(jsdoc.examples && jsdoc.examples.length > 0) headings.push({tag:'h2', id:'example', text: 'Example'});
   - if(jsdoc.staticExamples && jsdoc.staticExamples.length > 0) headings.push({tag:'h2', id:'example', text: 'Example'});
@@ -26,6 +27,14 @@ block content
       a.anchor(href=`${navPath}#requirements`)
     p
       +description(jsdoc.requirements)
+
+  h2#live Live example
+    a.anchor(href=`${navPath}#live`)
+  p
+    if (jsdoc.devNovel)
+      | You can find an example #[a(href=`${navPath}#example`) at the end of the page] or a live example in #[a(href=`${publicPath}${jsdoc.devNovel}` target="_blank" rel="noopener") our widget showcase].
+    else
+      | You can find an example #[a(href=`${navPath}#example`) at the end of the page].
 
   h2#usage Usage
     a.anchor(href=`${navPath}#usage`)

--- a/docgen/plugins/documentationjs-data.js
+++ b/docgen/plugins/documentationjs-data.js
@@ -146,10 +146,12 @@ function mapWidgets(widgets, symbols, files) {
     const relatedTypes = findRelatedTypes(symbol, symbols);
     const staticExamples = symbol.tags.filter(t => t.title === 'staticExample');
     const requirements = symbol.tags.find(t => t.title === 'requirements') || { description: '' };
+    const devNovel = symbol.tags.find(t => t.title === 'devNovel') || false;
 
     const symbolWithRelatedType = {
       ...symbol,
       requirements: md.render(requirements.description),
+      devNovel: createDevNovelURL(devNovel),
       relatedTypes,
       staticExamples,
     };
@@ -222,4 +224,8 @@ function findRelatedTypes(functionSymbol, symbols) {
 
 function isCustomType(name) {
   return name && name !== 'Object' && name[0] === name[0].toUpperCase();
+}
+
+function createDevNovelURL(devNovel) {
+  return devNovel ? `dev-novel?selectedStory=${devNovel.description}.default` : '';
 }

--- a/src/widgets/analytics/analytics.js
+++ b/src/widgets/analytics/analytics.js
@@ -25,6 +25,7 @@ analytics({
  * This is a headless widget, which means that it does not have a rendered output in the
  * UI.
  * @type {WidgetFactory}
+ * @devNovel Analytics
  * @category analytics
  * @param {AnalyticsWidgetOptions} $0 The Analytics widget options.
  * @return {Widget} A new instance of the Analytics widget.

--- a/src/widgets/breadcrumb/breadcrumb.js
+++ b/src/widgets/breadcrumb/breadcrumb.js
@@ -132,6 +132,7 @@ breadcrumb({
  * }
  * ```
  * @type {WidgetFactory}
+ * @devNovel Breadcrumb
  * @category navigation
  * @param {BreadcrumbWidgetOptions} $0 The Breadcrumb widget options.
  * @return {Widget} A new Breadcrumb widget instance.

--- a/src/widgets/clear-all/clear-all.js
+++ b/src/widgets/clear-all/clear-all.js
@@ -94,6 +94,7 @@ clearAll({
  *
  * The current refined values widget can display a button that has the same behavior.
  * @type {WidgetFactory}
+ * @devNovel ClearAll
  * @category clear-filter
  * @param {ClearAllWidgetOptions} $0 The ClearAll widget options.
  * @returns {Widget} A new instance of the ClearAll widget.

--- a/src/widgets/current-refined-values/current-refined-values.js
+++ b/src/widgets/current-refined-values/current-refined-values.js
@@ -158,6 +158,7 @@ currentRefinedValues({
  *
  * This widget is usually in the top part of the search UI.
  * @type {WidgetFactory}
+ * @devNovel CurrentRefinedValues
  * @category clear-filter
  * @param {CurrentRefinedValuesWidgetOptions} $0 The CurrentRefinedValues widget options.
  * @returns {Object} A new CurrentRefinedValues widget instance.

--- a/src/widgets/geo-search/geo-search.js
+++ b/src/widgets/geo-search/geo-search.js
@@ -122,6 +122,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  * You are also repsonsible for loading the Google Maps library, it's not shipped with InstantSearch. You need to load the Google Maps library and pass a reference to the widget. You can find more information about how to install the library in [the Google Maps documentation](https://developers.google.com/maps/documentation/javascript/tutorial).
  *
  * @type {WidgetFactory}
+ * @devNovel GeoSearch
  * @param {GeoSearchWidgetOptions} $0 Options of the GeoSearch widget.
  * @return {Widget} A new instance of GeoSearch widget.
  * @example

--- a/src/widgets/hierarchical-menu/hierarchical-menu.js
+++ b/src/widgets/hierarchical-menu/hierarchical-menu.js
@@ -172,6 +172,7 @@ hierarchicalMenu({
  * }
  * ```
  * @type {WidgetFactory}
+ * @devNovel HierarchicalMenu
  * @category filter
  * @param {HierarchicalMenuWidgetOptions} $0 The HierarchicalMenu widget options.
  * @return {Widget} A new HierarchicalMenu widget instance.

--- a/src/widgets/hits-per-page-selector/hits-per-page-selector.js
+++ b/src/widgets/hits-per-page-selector/hits-per-page-selector.js
@@ -67,6 +67,7 @@ hitsPerPageSelector({
  *
  * You can specify the default hits per page using a boolean in the items[] array. If none is specified, this first hits per page option will be picked.
  * @type {WidgetFactory}
+ * @devNovel HitsPerPageSelector
  * @category basic
  * @param {HitsPerPageSelectorWidgetOptions} $0 The options of the HitPerPageSelector widget.
  * @return {Widget} A new instance of the HitPerPageSelector widget.

--- a/src/widgets/hits/hits.js
+++ b/src/widgets/hits/hits.js
@@ -89,6 +89,7 @@ hits({
  * together with a pagination widget, to let the user browse the results
  * beyond the first page.
  * @type {WidgetFactory}
+ * @devNovel Hits
  * @category basic
  * @param {HitsWidgetOptions} $0 Options of the Hits widget.
  * @return {Widget} A new instance of Hits widget.

--- a/src/widgets/infinite-hits/infinite-hits.js
+++ b/src/widgets/infinite-hits/infinite-hits.js
@@ -96,6 +96,7 @@ infiniteHits({
  * will let the user load more results to the list. This is particularly
  * handy on mobile implementations.
  * @type {WidgetFactory}
+ * @devNovel InfiniteHits
  * @category basic
  * @param {InfiniteHitsWidgetOptions} $0 The options for the InfiniteHits widget.
  * @return {Widget} Creates a new instance of the InfiniteHits widget.

--- a/src/widgets/menu/menu.js
+++ b/src/widgets/menu/menu.js
@@ -148,6 +148,7 @@ menu({
  * [attribute for faceting](https://www.algolia.com/doc/guides/searching/faceting/#declaring-attributes-for-faceting)
  * in your Algolia settings.
  * @type {WidgetFactory}
+ * @devNovel Menu
  * @category filter
  * @param {MenuWidgetOptions} $0 The Menu widget options.
  * @return {Widget} Creates a new instance of the Menu widget.

--- a/src/widgets/numeric-refinement-list/numeric-refinement-list.js
+++ b/src/widgets/numeric-refinement-list/numeric-refinement-list.js
@@ -116,6 +116,7 @@ numericRefinementList({
  * The values inside this attribute must be JavaScript numbers and not strings.
  *
  * @type {WidgetFactory}
+ * @devNovel NumericRefinementList
  * @category filter
  * @param {NumericRefinementListWidgetOptions} $0 The NumericRefinementList widget options
  * @return {Widget} Creates a new instance of the NumericRefinementList widget.

--- a/src/widgets/numeric-selector/numeric-selector.js
+++ b/src/widgets/numeric-selector/numeric-selector.js
@@ -68,6 +68,7 @@ const usage = `Usage: numericSelector({
  *
  * The values inside this attribute must be JavaScript numbers and not strings.
  * @type {WidgetFactory}
+ * @devNovel NumericSelector
  * @category filter
  * @param {NumericSelectorWidgetOptions} $0 The NumericSelector widget options.
  * @return {Widget} A new instance of NumericSelector widget.

--- a/src/widgets/pagination/pagination.js
+++ b/src/widgets/pagination/pagination.js
@@ -126,6 +126,7 @@ pagination({
  * beyond the 1000th hits by default. You can find more information on the [Algolia documentation](https://www.algolia.com/doc/guides/searching/pagination/#pagination-limitations).
  *
  * @type {WidgetFactory}
+ * @devNovel Pagination
  * @category navigation
  * @param {PaginationWidgetOptions} $0 Options for the Pagination widget.
  * @return {Widget} A new instance of Pagination widget.

--- a/src/widgets/price-ranges/price-ranges.js
+++ b/src/widgets/price-ranges/price-ranges.js
@@ -113,6 +113,7 @@ priceRanges({
  *
  * The values inside this attribute must be JavaScript numbers (not strings).
  * @type {WidgetFactory}
+ * @devNovel PriceRanges
  * @category filter
  * @param {PriceRangeWidgetOptions} $0 The PriceRanges widget options.
  * @return {Widget} A new instance of PriceRanges widget.

--- a/src/widgets/range-input/range-input.js
+++ b/src/widgets/range-input/range-input.js
@@ -127,6 +127,7 @@ rangeInput({
  *
  * The values inside this attribute must be JavaScript numbers (not strings).
  * @type {WidgetFactory}
+ * @devNovel RangeInput
  * @category filter
  * @param {RangeInputWidgetOptions} $0 The RangeInput widget options.
  * @return {Widget} A new instance of RangeInput widget.

--- a/src/widgets/range-slider/range-slider.js
+++ b/src/widgets/range-slider/range-slider.js
@@ -144,6 +144,7 @@ rangeSlider({
  * The values inside this attribute must be JavaScript numbers (not strings).
  *
  * @type {WidgetFactory}
+ * @devNovel RangeSlider
  * @category filter
  * @param {RangeSliderWidgetOptions} $0 RangeSlider widget options.
  * @return {Widget} A new RangeSlider widget instance.

--- a/src/widgets/refinement-list/refinement-list.js
+++ b/src/widgets/refinement-list/refinement-list.js
@@ -208,6 +208,7 @@ refinementList({
  * If you also want to use search for facet values on this attribute, you need to make it searchable using the [dashboard](https://www.algolia.com/explorer/display/) or using the [API](https://www.algolia.com/doc/guides/searching/faceting/#search-for-facet-values).
  *
  * @type {WidgetFactory}
+ * @devNovel RefinementList
  * @category filter
  * @param {RefinementListWidgetOptions} $0 The RefinementList widget options that you use to customize the widget.
  * @return {Widget} Creates a new instance of the RefinementList widget.

--- a/src/widgets/search-box/search-box.js
+++ b/src/widgets/search-box/search-box.js
@@ -234,6 +234,7 @@ searchBox({
  *
  * @type {WidgetFactory}
  * @devNovel SearchBox
+ * @category basic
  * @param {SearchBoxWidgetOptions} $0 Options used to configure a SearchBox widget.
  * @return {Widget} Creates a new instance of the SearchBox widget.
  * @example

--- a/src/widgets/search-box/search-box.js
+++ b/src/widgets/search-box/search-box.js
@@ -233,6 +233,7 @@ searchBox({
  * away.
  *
  * @type {WidgetFactory}
+ * @devNovel SearchBox
  * @param {SearchBoxWidgetOptions} $0 Options used to configure a SearchBox widget.
  * @return {Widget} Creates a new instance of the SearchBox widget.
  * @example

--- a/src/widgets/sort-by-selector/sort-by-selector.js
+++ b/src/widgets/sort-by-selector/sort-by-selector.js
@@ -62,6 +62,7 @@ sortBySelector({
  *
  * For the users it is like they are selecting a new sort order.
  * @type {WidgetFactory}
+ * @devNovel SortBySelector
  * @category sort
  * @param {SortByWidgetOptions} $0 Options for the SortBySelector widget
  * @return {Widget} Creates a new instance of the SortBySelector widget.

--- a/src/widgets/star-rating/star-rating.js
+++ b/src/widgets/star-rating/star-rating.js
@@ -130,6 +130,7 @@ starRating({
  * The values inside this attribute must be JavaScript numbers (not strings).
  *
  * @type {WidgetFactory}
+ * @devNovel StarRating
  * @category filter
  * @param {StarWidgetOptions} $0 StarRating widget options.
  * @return {Widget} A new StarRating widget instance.

--- a/src/widgets/stats/stats.js
+++ b/src/widgets/stats/stats.js
@@ -121,6 +121,7 @@ stats({
  * By default, it will display the **number of hits** and the time taken to compute the
  * results inside the engine.
  * @type {WidgetFactory}
+ * @devNovel Stats
  * @category metadata
  * @param {StatsWidgetOptions} $0 Stats widget options. Some keys are mandatory: `container`,
  * @return {Widget} A new stats widget instance

--- a/src/widgets/toggle/toggle.js
+++ b/src/widgets/toggle/toggle.js
@@ -136,6 +136,7 @@ toggle({
  * in your Algolia settings.
  *
  * @type {WidgetFactory}
+ * @devNovel Toggle
  * @category filter
  * @param {ToggleWidgetOptions} $0 Options for the Toggle widget.
  * @return {Widget} A new instance of the Toggle widget


### PR DESCRIPTION
**Summary**

This PR adds a "Live example" section in the documentation of the widgets. You can enable the DevNovel link by adding the annotation: `@devNovel NameOfTheWidgetInDevNovel`.

**Before**

![screen shot 2018-03-05 at 19 29 41](https://user-images.githubusercontent.com/6513513/36992585-a8eb957a-20ab-11e8-8311-ada150a83a13.png)

**After**

![screen shot 2018-03-05 at 19 30 51](https://user-images.githubusercontent.com/6513513/36992616-bfc42a5a-20ab-11e8-923a-4247f9cfcdfe.png)
