### PR TITLE
fix(GeoSearch): add API Key for Google Maps

### DIFF
--- a/dev/app/builtin/stories/geo-search.stories.js
+++ b/dev/app/builtin/stories/geo-search.stories.js
@@ -17,7 +17,10 @@ const wrapWithHitsAndConfiguration = (story, searchParameters) =>
   });
 
 const injectGoogleMaps = fn => {
-  injectScript('https://maps.googleapis.com/maps/api/js?v=3.31', fn);
+  injectScript(
+    'https://maps.googleapis.com/maps/api/js?v=3.31&key=AIzaSyCl2TTJXpwxGuuc2zQZkAlIkWhpYbyjjP8',
+    fn
+  );
 };
 
 export default () => {


### PR DESCRIPTION
This PR adds an API Key for Google Maps to avoid the service to blocked in DevNovel. The key has some domain restrictions so an external user should not be able to use it.