### PR TITLE
fix(docgen): pass the relatedTypes to the struct mixin in connectors layout

### DIFF
--- a/docgen/layouts/connector.pug
+++ b/docgen/layouts/connector.pug
@@ -27,7 +27,7 @@ block content
     a.anchor(href=`${navPath}#structure`)
   each t in jsdoc.relatedTypes
     if t
-      +struct(t)
+      +struct(t, jsdoc.relatedTypes)
 
   if jsdoc.examples && jsdoc.examples.length > 0
     script(src="//code.jquery.com/jquery-3.2.1.slim.min.js")


### PR DESCRIPTION
**Summary**

In the connectors layout we forgot to pass the `relatedTypes` to the `struct` mixin. This leads to empty types in the documentation.

**Before**

![screen shot 2018-03-08 at 11 09 17](https://user-images.githubusercontent.com/6513513/37145565-75d073be-22c1-11e8-83e4-740cfd421fcf.png)

> https://community.algolia.com/instantsearch.js/v2/connectors/connectGeoSearch.html

**After**

![screen shot 2018-03-08 at 11 10 06](https://user-images.githubusercontent.com/6513513/37145574-7a4c557a-22c1-11e8-8f73-6ba07086499d.png)

> https://deploy-preview-2780--algolia-instantsearch.netlify.com/v2/connectors/connectgeosearch