### PR TITLE
fix(connectBreadcrumb): update typo in property type items

### DIFF
--- a/src/connectors/breadcrumb/connectBreadcrumb.js
+++ b/src/connectors/breadcrumb/connectBreadcrumb.js
@@ -22,7 +22,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
 `;
 
 /**
- * @typedef {Object} CustomBreadcrumbItem
+ * @typedef {Object} BreadcrumbItem
  * @property {string} name Name of the category or subcategory.
  * @property {string} value Value of breadcrumb item.
  */


### PR DESCRIPTION
**Summary**

Use the correct type for the `BreadcrumbItem`.

**Before**

![screen shot 2018-03-08 at 11 53 00](https://user-images.githubusercontent.com/6513513/37147456-455e4160-22c7-11e8-9283-26ab58886f9e.png)

**After**

*Waiting preview...*