### PR TITLE
chore(deps): rollback enzyme-to-json to 3.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "doctoc": "1.3.1",
     "enzyme": "3.3.0",
     "enzyme-adapter-react-15": "1.0.5",
-    "enzyme-to-json": "3.3.2",
+    "enzyme-to-json": "3.3.1",
     "eslint": "4.18.2",
     "eslint-config-algolia": "13.1.0",
     "eslint-config-prettier": "2.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3239,9 +3239,9 @@ enzyme-adapter-utils@^1.1.0:
     object.assign "^4.0.4"
     prop-types "^15.6.0"
 
-enzyme-to-json@3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-3.3.2.tgz#5caf0b3729ffea3aa14702f12c37e93b501a9d96"
+enzyme-to-json@3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-3.3.1.tgz#64239dcd417e2fb552f4baa6632de4744b9b5b93"
   dependencies:
     lodash "^4.17.4"
 


### PR DESCRIPTION
Apparently 3.3.2 was unpublished.