### PR TITLE
docs(tokens): remove [*] which were confusing

### DIFF
--- a/src/widgets/hierarchical-menu/hierarchical-menu.js
+++ b/src/widgets/hierarchical-menu/hierarchical-menu.js
@@ -96,8 +96,8 @@ hierarchicalMenu({
  * @typedef {Object} HierarchicalMenuWidgetOptions
  * @property {string|HTMLElement} container CSS Selector or HTMLElement to insert the widget.
  * @property {string[]} attributes Array of attributes to use to generate the hierarchy of the menu.
- * @property {number} [limit=10] How much facet values to get [*].
- * @property {string} [separator=" > "] Separator used in the attributes to separate level values. [*].
+ * @property {number} [limit=10] How much facet values to get.
+ * @property {string} [separator=" > "] Separator used in the attributes to separate level values.
  * @property {string} [rootPath] Prefix path to use if the first level is not the root level.
  * @property {boolean} [showParentLevel=true] Show the siblings of the selected parent level of the current refined value. This
  * does not impact the root level.

--- a/src/widgets/menu-select/menu-select.js
+++ b/src/widgets/menu-select/menu-select.js
@@ -89,9 +89,9 @@ menuSelect({
  * @property {string} attributeName Name of the attribute for faceting
  * @property {string[]|function} [sortBy=['name:asc']] How to sort refinements. Possible values: `count|isRefined|name:asc|name:desc`.
  *
- * You can also use a sort function that behaves like the standard Javascript [compareFunction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#Syntax). [*]
+ * You can also use a sort function that behaves like the standard Javascript [compareFunction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#Syntax).
  * @property {MenuSelectTemplates} [templates] Customize the output through templating.
- * @property {string} [limit=10] How many facets values to retrieve [*].
+ * @property {string} [limit=10] How many facets values to retrieve.
  * @property {MenuSelectTransforms} [transformData] Set of functions to update the data before passing them to the templates.
  * @property {boolean} [autoHideContainer=true] Hide the container when there are no items in the menu select.
  * @property {MenuSelectCSSClasses} [cssClasses] CSS classes to add to the wrapping elements.

--- a/src/widgets/menu/menu.js
+++ b/src/widgets/menu/menu.js
@@ -128,9 +128,9 @@ menu({
  * @property {string} attributeName Name of the attribute for faceting
  * @property {string[]|function} [sortBy=['name:asc']] How to sort refinements. Possible values: `count|isRefined|name:asc|name:desc`.
  *
- * You can also use a sort function that behaves like the standard Javascript [compareFunction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#Syntax). [*]
+ * You can also use a sort function that behaves like the standard Javascript [compareFunction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#Syntax).
  * @property {MenuTemplates} [templates] Customize the output through templating.
- * @property {string} [limit=10] How many facets values to retrieve [*].
+ * @property {string} [limit=10] How many facets values to retrieve.
  * @property {boolean|MenuShowMoreOptions} [showMore=false] Limit the number of results and display a showMore button.
  * @property {MenuShowMoreTemplates} [templates] Templates to use for the widget.
  * @property {MenuTransforms} [transformData] Set of functions to update the data before passing them to the templates.


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

[*] used to mean "not required", but wasn't very obvious (we had two internal questions about it recently) and wasn't applied everywhere.

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
  
  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot): 
  
  1. the documentation site (/)
  2. a widget playground (/dev-novel)
-->

No more `[*]` in the docs
