### PR TITLE
fix(connectBreadcrumb): allow unmounting

### DIFF
--- a/dev/app/init-unmount-widgets.js
+++ b/dev/app/init-unmount-widgets.js
@@ -112,6 +112,31 @@ export default () => {
     )
   );
 
+  storiesOf('Breadcrumb').add(
+    'default',
+    wrapWithUnmount(
+      container =>
+        instantsearch.widgets.breadcrumb({
+          container,
+          attributes: [
+            'hierarchicalCategories.lvl0',
+            'hierarchicalCategories.lvl1',
+            'hierarchicalCategories.lvl2',
+          ],
+          rootPath: 'Cameras & Camcorders',
+        }),
+      {
+        searchParameters: {
+          hierarchicalFacetsRefinements: {
+            'hierarchicalCategories.lvl0': [
+              'Cameras & Camcorders > Digital Cameras',
+            ],
+          },
+        },
+      }
+    )
+  );
+
   storiesOf('Hits').add(
     'default',
     wrapWithUnmount(container => instantsearch.widgets.hits({ container }))

--- a/src/connectors/breadcrumb/connectBreadcrumb.js
+++ b/src/connectors/breadcrumb/connectBreadcrumb.js
@@ -163,21 +163,8 @@ export default function connectBreadcrumb(renderFn, unmountFn) {
         );
       },
 
-      dispose({ state }) {
+      dispose() {
         unmountFn();
-
-        // compute nextState for the search
-        let nextState = state;
-
-        if (state.isHierarchicalFacetRefined(hierarchicalFacetName)) {
-          nextState = state.removeHierarchicalFacetRefinement(
-            hierarchicalFacetName
-          );
-        }
-
-        nextState = nextState.removeHierarchicalFacet(hierarchicalFacetName);
-
-        return nextState;
       },
     };
   };

--- a/src/connectors/breadcrumb/connectBreadcrumb.js
+++ b/src/connectors/breadcrumb/connectBreadcrumb.js
@@ -50,9 +50,10 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  * This is commonly used in websites that have a large amount of content organized in a hierarchical manner (usually e-commerce websites).
  * @type {Connector}
  * @param {function(BreadcrumbRenderingOptions, boolean)} renderFn Rendering function for the custom **Breadcrumb* widget.
+ * @param {function} unmountFn Unmount function called when the widget is disposed.
  * @return {function(CustomBreadcrumbWidgetOptions)} Re-usable widget factory for a custom **Breadcrumb** widget.
  */
-export default function connectBreadcrumb(renderFn) {
+export default function connectBreadcrumb(renderFn, unmountFn) {
   checkRendering(renderFn, usage);
   return (widgetParams = {}) => {
     const { attributes, separator = ' > ', rootPath = null } = widgetParams;
@@ -160,6 +161,23 @@ export default function connectBreadcrumb(renderFn) {
           },
           false
         );
+      },
+
+      dispose({ state }) {
+        unmountFn();
+
+        // compute nextState for the search
+        let nextState = state;
+
+        if (state.isHierarchicalFacetRefined(hierarchicalFacetName)) {
+          nextState = state.removeHierarchicalFacetRefinement(
+            hierarchicalFacetName
+          );
+        }
+
+        nextState = nextState.removeHierarchicalFacet(hierarchicalFacetName);
+
+        return nextState;
       },
     };
   };

--- a/src/widgets/breadcrumb/breadcrumb.js
+++ b/src/widgets/breadcrumb/breadcrumb.js
@@ -2,7 +2,7 @@ import React, { render, unmountComponentAtNode } from 'preact-compat';
 import cx from 'classnames';
 
 import Breadcrumb from '../../components/Breadcrumb/Breadcrumb';
-import { connectBreadcrumb } from '../../connectors';
+import connectBreadcrumb from '../../connectors/breadcrumb/connectBreadcrumb';
 import defaultTemplates from './defaultTemplates.js';
 
 import {

--- a/src/widgets/breadcrumb/breadcrumb.js
+++ b/src/widgets/breadcrumb/breadcrumb.js
@@ -1,4 +1,4 @@
-import React, { render } from 'preact-compat';
+import React, { render, unmountComponentAtNode } from 'preact-compat';
 import cx from 'classnames';
 
 import Breadcrumb from '../../components/Breadcrumb/Breadcrumb';
@@ -183,7 +183,9 @@ export default function breadcrumb({
   });
 
   try {
-    const makeBreadcrumb = connectBreadcrumb(specializedRenderer);
+    const makeBreadcrumb = connectBreadcrumb(specializedRenderer, () =>
+      unmountComponentAtNode(containerNode)
+    );
     return makeBreadcrumb({ attributes, rootPath });
   } catch (e) {
     throw new Error(usage);


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

I got errors while implementing this widget in Vue InstantSearch, so I assume this widget was merged after the adding of `unmountFn`/`dispose`. 

I checked all other connectors, and this was the only one with this missing

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
  
  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot): 
  
  1. the documentation site (/)
  2. a widget playground (/dev-novel)
-->

1. added `unmountFn`
2. nothing at all

There's no implementation of the dispose, since you could imagine someone not showing the breadcrumb anymore, but it's acting on the same info as the hierarchical menu, and you don't want to unrefine that one when you only want to stop showing the breadcrumb