### PR TITLE
chore: publish beta without tags

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -186,7 +186,10 @@ inquirer
           'git add src/lib/version.js yarn.lock package.json CHANGELOG.md README.md CONTRIBUTING.md'
         );
         shell.exec(`git commit -m "${commitMessage}"`);
-        shell.exec(`git tag "v${newVersion}"`);
+        // if tagged, it is not possible to generate a nice changelog without manual updates
+        if (strategy === 'stable') {
+          shell.exec(`git tag "v${newVersion}"`);
+        }
 
         shell.echo(
           colors.yellow.underline(
@@ -219,7 +222,6 @@ inquirer
               shell.exec('git push origin develop');
             } else {
               shell.exec(`git push origin ${currentBranch}`);
-              shell.exec('git push origin --tags');
               shell.exec('npm publish --tag beta');
             }
 


### PR DESCRIPTION
The motivation is that conventional changelog is based on tags to generate the latest changelog. The problem is that in our new setup we have two concurrent versions that could add to the changelog. If both did (2.x and develop) then when you have to merge and you will end with interlaced releases because of the data sorting. This is messy and the betas don't matter that much for most of the users.

The proposal prevents the tags from being done so that we ensure that we have a nice automatic changelog for actual releases. Beta releases will still be comited, and we will be able to see them.