### PR TITLE
fix(removeWidget): check for widgets.length on next tick

### DIFF
--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -193,10 +193,16 @@ Usage: instantsearch({
       }
     });
 
-    // no need to trigger a search if we don't have any widgets left
-    if (this.widgets.length > 0) {
-      this.helper.search();
-    }
+    // If there's multiple call to `removeWidget()` let's wait until they are all made
+    // and then check for widgets.length & make a search on next tick
+    //
+    // This solves an issue where you unmount a page and removing widget by widget
+    setTimeout(() => {
+      // no need to trigger a search if we don't have any widgets left
+      if (this.widgets.length > 0) {
+        this.helper.search();
+      }
+    }, 0);
   }
 
   /**


### PR DESCRIPTION
I'm using the `removeWidget` API for Angular InstantSearch when the app need to unmount a widget.

If the page is unmounting all the widgets, it will call `removeWidget()` for every widget present on the page and this will result of make multiple requests to Algolia even thought we are unmounting the whole page.

In order to workaround this issue, I'm deferring the execution of the condition `this.widgets.length > 0` on the next tick so every widgets would have been removed.

This is an easy-fix for now until we can maybe think about a better API with InstantSearch core 👍 