### PR TITLE
Feat/connect configure

### DIFF
--- a/dev/app/builtin/init-stories.js
+++ b/dev/app/builtin/init-stories.js
@@ -22,6 +22,7 @@ import initSortBySelectorStories from './stories/sort-by-selector.stories';
 import initStarRatingStories from './stories/star-rating.stories';
 import initStatsStories from './stories/stats.stories';
 import initToggleStories from './stories/toggle.stories';
+import initConfigureStories from './stories/configure.stories';
 
 export default () => {
   initAnalyticsStories();
@@ -48,4 +49,5 @@ export default () => {
   initStatsStories();
   initStarRatingStories();
   initToggleStories();
+  initConfigureStories();
 };

--- a/dev/app/builtin/stories/configure.stories.js
+++ b/dev/app/builtin/stories/configure.stories.js
@@ -1,0 +1,29 @@
+/* eslint-disable import/default */
+
+import { storiesOf } from 'dev-novel';
+
+import instantsearch from '../../../../index';
+import { wrapWithHits } from '../../utils/wrap-with-hits.js';
+
+const stories = storiesOf('Configure');
+
+export default () => {
+  stories.add(
+    'Force 1 hit per page',
+    wrapWithHits(container => {
+      const description = document.createElement('div');
+      description.innerHTML = `
+        <p>Search parameters provied to the Configure widget:</p>
+        <pre>searchParameters: { hitsPerPage: 1 }</pre>
+      `;
+
+      container.appendChild(description);
+
+      window.search.addWidget(
+        instantsearch.widgets.configure({
+          searchParameters: { hitsPerPage: 1 },
+        })
+      );
+    })
+  );
+};

--- a/dev/app/builtin/stories/configure.stories.js
+++ b/dev/app/builtin/stories/configure.stories.js
@@ -14,14 +14,14 @@ export default () => {
       const description = document.createElement('div');
       description.innerHTML = `
         <p>Search parameters provied to the Configure widget:</p>
-        <pre>searchParameters: { hitsPerPage: 1 }</pre>
+        <pre>{ hitsPerPage: 1 }</pre>
       `;
 
       container.appendChild(description);
 
       window.search.addWidget(
         instantsearch.widgets.configure({
-          searchParameters: { hitsPerPage: 1 },
+          hitsPerPage: 1,
         })
       );
     })

--- a/src/connectors/configure/__tests__/connectConfigure-test.js
+++ b/src/connectors/configure/__tests__/connectConfigure-test.js
@@ -54,7 +54,8 @@ describe('connectConfigure', () => {
   });
 
   it('should apply new searchParameters on refine()', () => {
-    const makeWidget = connectConfigure();
+    const renderFn = jest.fn();
+    const makeWidget = connectConfigure(renderFn, jest.fn());
     const widget = makeWidget({ searchParameters: { analytics: true } });
 
     helper.setState(widget.getConfiguration());
@@ -63,7 +64,10 @@ describe('connectConfigure', () => {
     expect(widget.getConfiguration()).toEqual({ analytics: true });
     expect(helper.getState().analytics).toEqual(true);
 
-    widget._refine({ hitsPerPage: 3 });
+    const { refine } = renderFn.mock.calls[0][0];
+    expect(refine).toBe(widget._refine);
+
+    refine({ hitsPerPage: 3 });
 
     expect(widget.getConfiguration()).toEqual({ hitsPerPage: 3 });
     expect(helper.getState().analytics).toBe(undefined);

--- a/src/connectors/configure/__tests__/connectConfigure-test.js
+++ b/src/connectors/configure/__tests__/connectConfigure-test.js
@@ -18,13 +18,11 @@ describe('connectConfigure', () => {
     });
 
     it('with a renderFn but no unmountFn', () => {
-      const makeWidget = connectConfigure(jest.fn(), undefined);
-      expect(() => makeWidget({ searchParameters: {} })).toThrow();
+      expect(() => connectConfigure(jest.fn(), undefined)).toThrow();
     });
 
     it('with a unmountFn but no renderFn', () => {
-      const makeWidget = connectConfigure(undefined, jest.fn());
-      expect(() => makeWidget({ searchParameters: {} })).toThrow();
+      expect(() => connectConfigure(undefined, jest.fn())).toThrow();
     });
   });
 

--- a/src/connectors/configure/__tests__/connectConfigure-test.js
+++ b/src/connectors/configure/__tests__/connectConfigure-test.js
@@ -11,24 +11,21 @@ describe('connectConfigure', () => {
     helper = algoliasearchHelper(fakeClient, '', {});
   });
 
-  it('throws on bad usage', () => {
-    // without searchParameters
-    {
+  describe('throws on bad usage', () => {
+    it('without searchParameters', () => {
       const makeWidget = connectConfigure();
       expect(() => makeWidget()).toThrow();
-    }
+    });
 
-    // with a renderFn but no unmountFn
-    {
+    it('with a renderFn but no unmountFn', () => {
       const makeWidget = connectConfigure(jest.fn(), undefined);
       expect(() => makeWidget({ searchParameters: {} })).toThrow();
-    }
+    });
 
-    // with a unmountFn but no renderFn
-    {
+    it('with a unmountFn but no renderFn', () => {
       const makeWidget = connectConfigure(undefined, jest.fn());
       expect(() => makeWidget({ searchParameters: {} })).toThrow();
-    }
+    });
   });
 
   it('should apply searchParameters', () => {

--- a/src/connectors/configure/__tests__/connectConfigure-test.js
+++ b/src/connectors/configure/__tests__/connectConfigure-test.js
@@ -75,7 +75,7 @@ describe('connectConfigure', () => {
     expect(helper.getState().hitsPerPage).toBe(3);
   });
 
-  it('should dispose all the state setted by configure', () => {
+  it('should dispose all the state set by configure', () => {
     const makeWidget = connectConfigure();
     const widget = makeWidget({ searchParameters: { analytics: true } });
 

--- a/src/connectors/configure/__tests__/connectConfigure-test.js
+++ b/src/connectors/configure/__tests__/connectConfigure-test.js
@@ -1,0 +1,92 @@
+import algoliasearchHelper, { SearchParameters } from 'algoliasearch-helper';
+
+import connectConfigure from '../connectConfigure.js';
+
+const fakeClient = { addAlgoliaAgent: () => {}, search: jest.fn() };
+
+describe('connectConfigure', () => {
+  let helper;
+
+  beforeEach(() => {
+    helper = algoliasearchHelper(fakeClient, '', {});
+  });
+
+  it('throws on bad usage', () => {
+    // without searchParameters
+    {
+      const makeWidget = connectConfigure();
+      expect(() => makeWidget()).toThrow();
+    }
+
+    // with a renderFn but no unmountFn
+    {
+      const makeWidget = connectConfigure(jest.fn(), undefined);
+      expect(() => makeWidget({ searchParameters: {} })).toThrow();
+    }
+
+    // with a unmountFn but no renderFn
+    {
+      const makeWidget = connectConfigure(undefined, jest.fn());
+      expect(() => makeWidget({ searchParameters: {} })).toThrow();
+    }
+  });
+
+  it('should apply searchParameters', () => {
+    const makeWidget = connectConfigure();
+    const widget = makeWidget({ searchParameters: { analytics: true } });
+
+    const config = widget.getConfiguration(SearchParameters.make({}));
+    expect(config).toEqual({ analytics: true });
+  });
+
+  it('should apply searchParameters with a higher priority', () => {
+    const makeWidget = connectConfigure();
+    const widget = makeWidget({ searchParameters: { analytics: true } });
+
+    {
+      const config = widget.getConfiguration(
+        SearchParameters.make({ analytics: false })
+      );
+      expect(config).toEqual({ analytics: true });
+    }
+
+    {
+      const config = widget.getConfiguration(
+        SearchParameters.make({ analytics: false, extra: true })
+      );
+      expect(config).toEqual({ analytics: true });
+    }
+  });
+
+  it('should apply new searchParameters on refine()', () => {
+    const makeWidget = connectConfigure();
+    const widget = makeWidget({ searchParameters: { analytics: true } });
+
+    helper.setState(widget.getConfiguration());
+    widget.init({ helper });
+
+    expect(widget.getConfiguration()).toEqual({ analytics: true });
+    expect(helper.getState().analytics).toEqual(true);
+
+    widget._refine({ hitsPerPage: 3 });
+
+    expect(widget.getConfiguration()).toEqual({ hitsPerPage: 3 });
+    expect(helper.getState().analytics).toBe(undefined);
+    expect(helper.getState().hitsPerPage).toBe(3);
+  });
+
+  it('should dispose all the state setted by configure', () => {
+    const makeWidget = connectConfigure();
+    const widget = makeWidget({ searchParameters: { analytics: true } });
+
+    helper.setState(widget.getConfiguration());
+    widget.init({ helper });
+
+    expect(widget.getConfiguration()).toEqual({ analytics: true });
+    expect(helper.getState().analytics).toBe(true);
+
+    const nextState = widget.dispose({ state: helper.getState() });
+
+    expect(nextState.analytics).toBe(undefined);
+  });
+});

--- a/src/connectors/configure/connectConfigure.js
+++ b/src/connectors/configure/connectConfigure.js
@@ -66,6 +66,10 @@ export default function connectConfigure(renderFn, unmountFn) {
 
       refine(helper) {
         return searchParameters => {
+          // remove old `searchParameters` setted by the widget
+          helper.setState(this.removeSearchParameters(helper.getState()));
+
+          // merge new `searchParameters` with the setted one from other widgets
           const actualState = helper.getState();
           const nextSearchParameters = enhanceConfiguration({})(actualState, {
             getConfiguration: () => searchParameters,
@@ -75,7 +79,7 @@ export default function connectConfigure(renderFn, unmountFn) {
           helper.setState(nextSearchParameters).search();
 
           // update original `widgetParams.searchParameter` to the new refined one
-          widgetParams.searchParameters = nextSearchParameters;
+          widgetParams.searchParameters = searchParameters;
         };
       },
 
@@ -93,7 +97,10 @@ export default function connectConfigure(renderFn, unmountFn) {
 
       dispose({ state }) {
         if (isFunction(unmountFn)) unmountFn();
+        return this.removeSearchParameters(state);
+      },
 
+      removeSearchParameters(state) {
         // widgetParams are assumed 'controlled',
         // so they override whatever other widgets give the state
         return state.mutateMe(mutableState => {

--- a/src/connectors/configure/connectConfigure.js
+++ b/src/connectors/configure/connectConfigure.js
@@ -27,7 +27,7 @@ var customConfigureWidget = connectConfigure(
  */
 
 /**
- * **Configure** connector provides the logic to build a custom widget
+ * The **Configure** connector provides the logic to build a custom widget
  * that will give you ability to override or force some search parameters sent to Algolia API.
  *
  * @type {Connector}
@@ -66,10 +66,10 @@ export default function connectConfigure(renderFn, unmountFn) {
 
       refine(helper) {
         return searchParameters => {
-          // remove old `searchParameters` setted by the widget
+          // remove old `searchParameters` set by the widget
           helper.setState(this.removeSearchParameters(helper.getState()));
 
-          // merge new `searchParameters` with the setted one from other widgets
+          // merge new `searchParameters` with the ones set from other widgets
           const actualState = helper.getState();
           const nextSearchParameters = enhanceConfiguration({})(actualState, {
             getConfiguration: () => searchParameters,
@@ -78,7 +78,7 @@ export default function connectConfigure(renderFn, unmountFn) {
           // trigger a search with the new merged searchParameter
           helper.setState(nextSearchParameters).search();
 
-          // update original `widgetParams.searchParameter` to the new refined one
+          // update original `widgetParams.searchParameters` to the new refined one
           widgetParams.searchParameters = searchParameters;
         };
       },

--- a/src/connectors/configure/connectConfigure.js
+++ b/src/connectors/configure/connectConfigure.js
@@ -75,7 +75,7 @@ export default function connectConfigure(renderFn, unmountFn) {
             getConfiguration: () => searchParameters,
           });
 
-          // trigger a search with the new merged searchParameter
+          // trigger a search with the new merged searchParameters
           helper.setState(nextSearchParameters).search();
 
           // update original `widgetParams.searchParameters` to the new refined one

--- a/src/connectors/configure/connectConfigure.js
+++ b/src/connectors/configure/connectConfigure.js
@@ -1,4 +1,5 @@
 import isFunction from 'lodash/isFunction';
+import isPlainObject from 'lodash/isPlainObject';
 
 import { enhanceConfiguration } from '../../lib/utils.js';
 
@@ -37,7 +38,7 @@ var customConfigureWidget = connectConfigure(
 export default function connectConfigure(renderFn, unmountFn) {
   return (widgetParams = {}) => {
     if (
-      !widgetParams.searchParameters ||
+      !isPlainObject(widgetParams.searchParameters) ||
       (isFunction(renderFn) && !isFunction(unmountFn)) ||
       (!isFunction(renderFn) && isFunction(unmountFn))
     ) {

--- a/src/connectors/configure/connectConfigure.js
+++ b/src/connectors/configure/connectConfigure.js
@@ -69,11 +69,8 @@ export default function connectConfigure(renderFn, unmountFn) {
 
       refine(helper) {
         return searchParameters => {
-          // remove old `searchParameters` set by the widget
-          helper.setState(this.removeSearchParameters(helper.getState()));
-
           // merge new `searchParameters` with the ones set from other widgets
-          const actualState = helper.getState();
+          const actualState = this.removeSearchParameters(helper.getState());
           const nextSearchParameters = enhanceConfiguration({})(actualState, {
             getConfiguration: () => searchParameters,
           });
@@ -87,7 +84,7 @@ export default function connectConfigure(renderFn, unmountFn) {
       },
 
       render() {
-        if (isFunction(renderFn)) {
+        if (renderFn) {
           renderFn(
             {
               refine: this._refine,
@@ -99,7 +96,7 @@ export default function connectConfigure(renderFn, unmountFn) {
       },
 
       dispose({ state }) {
-        if (isFunction(unmountFn)) unmountFn();
+        if (unmountFn) unmountFn();
         return this.removeSearchParameters(state);
       },
 

--- a/src/connectors/configure/connectConfigure.js
+++ b/src/connectors/configure/connectConfigure.js
@@ -36,12 +36,15 @@ var customConfigureWidget = connectConfigure(
  * @return {function(CustomConfigureWidgetOptions)} Re-usable widget factory for a custom **Configure** widget.
  */
 export default function connectConfigure(renderFn, unmountFn) {
+  if (
+    (isFunction(renderFn) && !isFunction(unmountFn)) ||
+    (!isFunction(renderFn) && isFunction(unmountFn))
+  ) {
+    throw new Error(usage);
+  }
+
   return (widgetParams = {}) => {
-    if (
-      !isPlainObject(widgetParams.searchParameters) ||
-      (isFunction(renderFn) && !isFunction(unmountFn)) ||
-      (!isFunction(renderFn) && isFunction(unmountFn))
-    ) {
+    if (!isPlainObject(widgetParams.searchParameters)) {
       throw new Error(usage);
     }
 

--- a/src/connectors/configure/connectConfigure.js
+++ b/src/connectors/configure/connectConfigure.js
@@ -1,0 +1,106 @@
+import isFunction from 'lodash/isFunction';
+
+import { enhanceConfiguration } from '../../lib/utils.js';
+
+const usage = `Usage:
+var customConfigureWidget = connectConfigure(
+  function renderFn(params, isFirstRendering) {
+    // params = {
+    //   refine,
+    //   widgetParams
+    // }
+  },
+  function disposeFn() {}
+)
+`;
+
+/**
+ * @typedef {Object} CustomConfigureWidgetOptions
+ * @property {Object} searchParameters The Configure widget options are search parameters
+ */
+
+/**
+ * @typedef {Object} ConfigureRenderingOptions
+ * @property {function(searchParameters: Object)} refine Sets new `searchParameters` and trigger a search.
+ * @property {Object} widgetParams All original `CustomConfigureWidgetOptions` forwarded to the `renderFn`.
+ */
+
+/**
+ * **Configure** connector provides the logic to build a custom widget
+ * that will give you ability to override or force some search parameters sent to Algolia API.
+ *
+ * @type {Connector}
+ * @param {function(ConfigureRenderingOptions)} renderFn Rendering function for the custom **Configure** Widget.
+ * @param {function} unmountFn Unmount function called when the widget is disposed.
+ * @return {function(CustomConfigureWidgetOptions)} Re-usable widget factory for a custom **Configure** widget.
+ */
+export default function connectConfigure(renderFn, unmountFn) {
+  return (widgetParams = {}) => {
+    if (
+      !widgetParams.searchParameters ||
+      (isFunction(renderFn) && !isFunction(unmountFn)) ||
+      (!isFunction(renderFn) && isFunction(unmountFn))
+    ) {
+      throw new Error(usage);
+    }
+
+    return {
+      getConfiguration() {
+        return widgetParams.searchParameters;
+      },
+
+      init({ helper }) {
+        this._refine = this.refine(helper);
+
+        if (isFunction(renderFn)) {
+          renderFn(
+            {
+              refine: this._refine,
+              widgetParams,
+            },
+            true
+          );
+        }
+      },
+
+      refine(helper) {
+        return searchParameters => {
+          const actualState = helper.getState();
+          const nextSearchParameters = enhanceConfiguration({})(actualState, {
+            getConfiguration: () => searchParameters,
+          });
+
+          // trigger a search with the new merged searchParameter
+          helper.setState(nextSearchParameters).search();
+
+          // update original `widgetParams.searchParameter` to the new refined one
+          widgetParams.searchParameters = nextSearchParameters;
+        };
+      },
+
+      render() {
+        if (isFunction(renderFn)) {
+          renderFn(
+            {
+              refine: this._refine,
+              widgetParams,
+            },
+            false
+          );
+        }
+      },
+
+      dispose({ state }) {
+        if (isFunction(unmountFn)) unmountFn();
+
+        // widgetParams are assumed 'controlled',
+        // so they override whatever other widgets give the state
+        return state.mutateMe(mutableState => {
+          Object.keys(widgetParams.searchParameters).forEach(key => {
+            delete mutableState[key];
+          });
+        });
+      },
+    };
+  };
+}

--- a/src/connectors/configure/connectConfigure.js
+++ b/src/connectors/configure/connectConfigure.js
@@ -1,7 +1,7 @@
 import isFunction from 'lodash/isFunction';
 import isPlainObject from 'lodash/isPlainObject';
 
-import { enhanceConfiguration } from '../../lib/utils.js';
+import { enhanceConfiguration } from '../../lib/InstantSearch.js';
 
 const usage = `Usage:
 var customConfigureWidget = connectConfigure(

--- a/src/connectors/index.js
+++ b/src/connectors/index.js
@@ -45,3 +45,4 @@ export {
   default as connectBreadcrumb,
 } from './breadcrumb/connectBreadcrumb.js';
 export { default as connectGeoSearch } from './geo-search/connectGeoSearch.js';
+export { default as connectConfigure } from './configure/connectConfigure.js';

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -3,13 +3,11 @@
 import algoliasearch from 'algoliasearch/src/browser/builds/algoliasearchLite.js';
 import algoliasearchHelper from 'algoliasearch-helper';
 import forEach from 'lodash/forEach';
-import mergeWith from 'lodash/mergeWith';
-import union from 'lodash/union';
-import isPlainObject from 'lodash/isPlainObject';
 import { EventEmitter } from 'events';
 import urlSyncWidget from './url-sync.js';
 import version from './version.js';
 import createHelpers from './createHelpers.js';
+import { enhanceConfiguration } from './utils.js';
 
 function defaultCreateURL() {
   return '#';
@@ -363,34 +361,6 @@ Usage: instantsearch({
       }
     });
   }
-}
-
-function enhanceConfiguration(searchParametersFromUrl) {
-  return (configuration, widgetDefinition) => {
-    if (!widgetDefinition.getConfiguration) return configuration;
-
-    // Get the relevant partial configuration asked by the widget
-    const partialConfiguration = widgetDefinition.getConfiguration(
-      configuration,
-      searchParametersFromUrl
-    );
-
-    const customizer = (a, b) => {
-      // always create a unified array for facets refinements
-      if (Array.isArray(a)) {
-        return union(a, b);
-      }
-
-      // avoid mutating objects
-      if (isPlainObject(a)) {
-        return mergeWith({}, a, b, customizer);
-      }
-
-      return undefined;
-    };
-
-    return mergeWith({}, configuration, partialConfiguration, customizer);
-  };
 }
 
 export default InstantSearch;

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -3,11 +3,13 @@
 import algoliasearch from 'algoliasearch/src/browser/builds/algoliasearchLite.js';
 import algoliasearchHelper from 'algoliasearch-helper';
 import forEach from 'lodash/forEach';
+import mergeWith from 'lodash/mergeWith';
+import union from 'lodash/union';
+import isPlainObject from 'lodash/isPlainObject';
 import { EventEmitter } from 'events';
 import urlSyncWidget from './url-sync.js';
 import version from './version.js';
 import createHelpers from './createHelpers.js';
-import { enhanceConfiguration } from './utils.js';
 
 function defaultCreateURL() {
   return '#';
@@ -361,6 +363,34 @@ Usage: instantsearch({
       }
     });
   }
+}
+
+export function enhanceConfiguration(searchParametersFromUrl) {
+  return (configuration, widgetDefinition) => {
+    if (!widgetDefinition.getConfiguration) return configuration;
+
+    // Get the relevant partial configuration asked by the widget
+    const partialConfiguration = widgetDefinition.getConfiguration(
+      configuration,
+      searchParametersFromUrl
+    );
+
+    const customizer = (a, b) => {
+      // always create a unified array for facets refinements
+      if (Array.isArray(a)) {
+        return union(a, b);
+      }
+
+      // avoid mutating objects
+      if (isPlainObject(a)) {
+        return mergeWith({}, a, b, customizer);
+      }
+
+      return undefined;
+    };
+
+    return mergeWith({}, configuration, partialConfiguration, customizer);
+  };
 }
 
 export default InstantSearch;

--- a/src/lib/__tests__/enhanceConfiguration-test.js
+++ b/src/lib/__tests__/enhanceConfiguration-test.js
@@ -1,0 +1,89 @@
+import { enhanceConfiguration } from '../InstantSearch';
+
+const createWidget = (configuration = {}) => ({
+  getConfiguration: () => configuration,
+});
+
+describe('enhanceConfiguration', () => {
+  it('should return the same object if widget does not provide a configuration', () => {
+    const configuration = { analytics: true, page: 2 };
+    const widget = {};
+
+    const output = enhanceConfiguration({})(configuration, widget);
+    expect(output).toBe(configuration);
+  });
+
+  it('should return a new object if widget does provide a configuration', () => {
+    const configuration = { analytics: true, page: 2 };
+    const widget = createWidget(configuration);
+
+    const output = enhanceConfiguration({})(configuration, widget);
+    expect(output).not.toBe(configuration);
+  });
+
+  it('should add widget configuration to an empty state', () => {
+    const configuration = { analytics: true, page: 2 };
+    const widget = createWidget(configuration);
+
+    const output = enhanceConfiguration({})(configuration, widget);
+    expect(output).toEqual(configuration);
+  });
+
+  it('should call `getConfiguration` from widget correctly', () => {
+    const widget = { getConfiguration: jest.fn() };
+
+    const configuration = {};
+    const searchParametersFromUrl = {};
+    enhanceConfiguration(searchParametersFromUrl)(configuration, widget);
+
+    expect(widget.getConfiguration).toHaveBeenCalled();
+    expect(widget.getConfiguration).toHaveBeenCalledWith(
+      configuration,
+      searchParametersFromUrl
+    );
+  });
+
+  it('should replace boolean values', () => {
+    const actualConfiguration = { analytics: false };
+    const widget = createWidget({ analytics: true });
+
+    const output = enhanceConfiguration({})(actualConfiguration, widget);
+    expect(output.analytics).toBe(true);
+  });
+
+  it('should union array', () => {
+    {
+      const actualConfiguration = { refinements: ['foo'] };
+      const widget = createWidget({ refinements: ['foo', 'bar'] });
+
+      const output = enhanceConfiguration({})(actualConfiguration, widget);
+      expect(output.refinements).toEqual(['foo', 'bar']);
+    }
+
+    {
+      const actualConfiguration = { refinements: ['foo'] };
+      const widget = createWidget({ refinements: ['bar'] });
+
+      const output = enhanceConfiguration({})(actualConfiguration, widget);
+      expect(output.refinements).toEqual(['foo', 'bar']);
+    }
+
+    {
+      const actualConfiguration = { refinements: ['foo', 'bar'] };
+      const widget = createWidget({ refinements: [] });
+
+      const output = enhanceConfiguration({})(actualConfiguration, widget);
+      expect(output.refinements).toEqual(['foo', 'bar']);
+    }
+  });
+
+  it('should replace nested values', () => {
+    const actualConfiguration = { refinements: { lvl1: ['foo'], lvl2: false } };
+    const widget = createWidget({ refinements: { lvl1: ['bar'], lvl2: true } });
+
+    const output = enhanceConfiguration({})(actualConfiguration, widget);
+    expect(output).toEqual({
+      refinements: { lvl1: ['foo', 'bar'], lvl2: true },
+    });
+  });
+});

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -8,9 +8,6 @@ import uniq from 'lodash/uniq';
 import mapKeys from 'lodash/mapKeys';
 import mapValues from 'lodash/mapValues';
 import curry from 'lodash/curry';
-import mergeWith from 'lodash/mergeWith';
-import union from 'lodash/union';
-import isPlainObject from 'lodash/isPlainObject';
 import hogan from 'hogan.js';
 
 export {
@@ -30,7 +27,6 @@ export {
   isReactElement,
   deprecate,
   parseAroundLatLngFromString,
-  enhanceConfiguration,
 };
 
 /**
@@ -414,33 +410,5 @@ function parseAroundLatLngFromString(value) {
   return {
     lat: parseFloat(pattern[1]),
     lng: parseFloat(pattern[2]),
-  };
-}
-
-function enhanceConfiguration(searchParametersFromUrl) {
-  return (configuration, widgetDefinition) => {
-    if (!widgetDefinition.getConfiguration) return configuration;
-
-    // Get the relevant partial configuration asked by the widget
-    const partialConfiguration = widgetDefinition.getConfiguration(
-      configuration,
-      searchParametersFromUrl
-    );
-
-    const customizer = (a, b) => {
-      // always create a unified array for facets refinements
-      if (Array.isArray(a)) {
-        return union(a, b);
-      }
-
-      // avoid mutating objects
-      if (isPlainObject(a)) {
-        return mergeWith({}, a, b, customizer);
-      }
-
-      return undefined;
-    };
-
-    return mergeWith({}, configuration, partialConfiguration, customizer);
   };
 }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -8,6 +8,9 @@ import uniq from 'lodash/uniq';
 import mapKeys from 'lodash/mapKeys';
 import mapValues from 'lodash/mapValues';
 import curry from 'lodash/curry';
+import mergeWith from 'lodash/mergeWith';
+import union from 'lodash/union';
+import isPlainObject from 'lodash/isPlainObject';
 import hogan from 'hogan.js';
 
 export {
@@ -27,6 +30,7 @@ export {
   isReactElement,
   deprecate,
   parseAroundLatLngFromString,
+  enhanceConfiguration,
 };
 
 /**
@@ -410,5 +414,33 @@ function parseAroundLatLngFromString(value) {
   return {
     lat: parseFloat(pattern[1]),
     lng: parseFloat(pattern[2]),
+  };
+}
+
+function enhanceConfiguration(searchParametersFromUrl) {
+  return (configuration, widgetDefinition) => {
+    if (!widgetDefinition.getConfiguration) return configuration;
+
+    // Get the relevant partial configuration asked by the widget
+    const partialConfiguration = widgetDefinition.getConfiguration(
+      configuration,
+      searchParametersFromUrl
+    );
+
+    const customizer = (a, b) => {
+      // always create a unified array for facets refinements
+      if (Array.isArray(a)) {
+        return union(a, b);
+      }
+
+      // avoid mutating objects
+      if (isPlainObject(a)) {
+        return mergeWith({}, a, b, customizer);
+      }
+
+      return undefined;
+    };
+
+    return mergeWith({}, configuration, partialConfiguration, customizer);
   };
 }

--- a/src/widgets/configure/__tests__/configure-test.js
+++ b/src/widgets/configure/__tests__/configure-test.js
@@ -1,4 +1,3 @@
-import { SearchParameters } from 'algoliasearch-helper';
 import configure from '../configure';
 
 describe('configure', () => {
@@ -8,78 +7,5 @@ describe('configure', () => {
       () => configure(() => {}),
       () => configure(/ok/),
     ].forEach(widget => expect(widget).toThrowError(/Usage/));
-  });
-
-  it('Applies searchParameters if nothing in configuration yet', () => {
-    const widget = configure({ analytics: true });
-    const config = widget.getConfiguration(SearchParameters.make({}));
-    expect(config).toEqual({
-      analytics: true,
-    });
-  });
-
-  it('Applies searchParameters if nothing conflicting configuration', () => {
-    const widget = configure({ analytics: true });
-    const config = widget.getConfiguration(
-      SearchParameters.make({ query: 'testing' })
-    );
-    expect(config).toEqual({
-      analytics: true,
-    });
-  });
-
-  it('Applies searchParameters with a higher priority', () => {
-    const widget = configure({ analytics: true });
-    {
-      const config = widget.getConfiguration(
-        SearchParameters.make({ analytics: false })
-      );
-      expect(config).toEqual({
-        analytics: true,
-      });
-    }
-    {
-      const config = widget.getConfiguration(
-        SearchParameters.make({ analytics: false, extra: true })
-      );
-      expect(config).toEqual({
-        analytics: true,
-      });
-    }
-  });
-
-  it('disposes all of the state set by configure', () => {
-    const widget = configure({ analytics: true });
-
-    const nextState = widget.dispose({
-      state: SearchParameters.make({
-        analytics: true,
-        somethingElse: false,
-      }),
-    });
-
-    expect(nextState).toEqual(
-      SearchParameters.make({
-        somethingElse: false,
-      })
-    );
-  });
-
-  it('disposes all of the state set by configure in case of a conflict', () => {
-    const widget = configure({ analytics: true });
-
-    const nextState = widget.dispose({
-      state: SearchParameters.make({
-        // even though it's different, it will be deleted
-        analytics: false,
-        somethingElse: false,
-      }),
-    });
-
-    expect(nextState).toEqual(
-      SearchParameters.make({
-        somethingElse: false,
-      })
-    );
   });
 });

--- a/src/widgets/configure/configure.js
+++ b/src/widgets/configure/configure.js
@@ -32,8 +32,8 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  */
 export default function configure(searchParameters) {
   try {
-    // make it clear we do not have default renderFn && unmountFn for this widget
-    const makeWidget = connectConfigure(undefined, undefined);
+    // We do not have default renderFn && unmountFn for this widget
+    const makeWidget = connectConfigure();
     return makeWidget({ searchParameters });
   } catch (e) {
     throw new Error(usage);

--- a/src/widgets/configure/configure.js
+++ b/src/widgets/configure/configure.js
@@ -1,4 +1,5 @@
-import isPlainObject from 'lodash/isPlainObject';
+import connectConfigure from '../../connectors/configure/connectConfigure.js';
+
 const usage = `Usage:
 search.addWidget(
   instantsearch.widgets.configure({
@@ -29,23 +30,12 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  *   })
  * );
  */
-export default function configure(searchParameters = {}) {
-  if (!isPlainObject(searchParameters)) {
+export default function configure({ searchParameters }) {
+  try {
+    // make it clear we do not have default renderFn && unmountFn for this widget
+    const makeWidget = connectConfigure(undefined, undefined);
+    return makeWidget({ searchParameters });
+  } catch (e) {
     throw new Error(usage);
   }
-  return {
-    getConfiguration() {
-      return searchParameters;
-    },
-    init() {},
-    dispose({ state }) {
-      return state.mutateMe(mutableState => {
-        // widgetParams are assumed 'controlled',
-        // so they override whatever other widgets give the state
-        Object.keys(searchParameters).forEach(key => {
-          delete mutableState[key];
-        });
-      });
-    },
-  };
 }

--- a/src/widgets/configure/configure.js
+++ b/src/widgets/configure/configure.js
@@ -30,7 +30,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  *   })
  * );
  */
-export default function configure({ searchParameters }) {
+export default function configure(searchParameters) {
   try {
     // make it clear we do not have default renderFn && unmountFn for this widget
     const makeWidget = connectConfigure(undefined, undefined);


### PR DESCRIPTION
Fixes #2816 

* `renderFn` && `unmountFn` would be only called if they were provided
* `renderFn` gets a `refine()` function to apply new search parameters

Flow of `refine()` :

1. Remove last `searchParameters` applied on the state
2. Compute new state by merging the new `searchParameters` and the actual state
3. Trigger a search with the new state
4. Replace `widgetParams.searchParameters` by the new one

This should cover the cases we discussed in the issue 👍 