### PR TITLE
chore(scripts): make sure there's no `console`

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -227,4 +227,4 @@ inquirer
           });
       });
   })
-  .catch(e => console.error(e));
+  .catch(e => shell.echo(e));


### PR DESCRIPTION
These kind of scripts better have `shell.echo` to give info for consistency and eslint complaining

this should fix the build