### PR TITLE
fix(connectGeoSearch): correctly dispose the connector

### DIFF
--- a/src/connectors/geo-search/__tests__/connectGeoSearch-test.js
+++ b/src/connectors/geo-search/__tests__/connectGeoSearch-test.js
@@ -1294,6 +1294,37 @@ describe('connectGeoSearch - dispose', () => {
     expect(actual).toMatchObject(expectation);
   });
 
+  it('expect reset multiple parameters', () => {
+    const render = jest.fn();
+    const unmount = jest.fn();
+
+    const customGeoSearch = connectGeoSearch(render, unmount);
+    const widget = customGeoSearch({
+      radius: 100,
+      precision: 25,
+      position: {
+        lat: 10,
+        lng: 12,
+      },
+    });
+
+    const client = createFakeClient();
+    const helper = createFakeHelper(client);
+
+    helper.setState(widget.getConfiguration(new SearchParameters()));
+
+    const expectation = {
+      aroundRadius: undefined,
+      aroundPrecision: undefined,
+      aroundLatLng: undefined,
+    };
+
+    const actual = widget.dispose({ state: helper.getState() });
+
+    expect(unmount).toHaveBeenCalled();
+    expect(actual).toMatchObject(expectation);
+  });
+
   describe('aroundLatLngViaIP', () => {
     it('expect reset aroundLatLngViaIP', () => {
       const render = jest.fn();

--- a/src/connectors/geo-search/__tests__/connectGeoSearch-test.js
+++ b/src/connectors/geo-search/__tests__/connectGeoSearch-test.js
@@ -1268,6 +1268,32 @@ describe('connectGeoSearch - getConfiguration', () => {
 });
 
 describe('connectGeoSearch - dispose', () => {
+  it('expect reset insideBoundingBox', () => {
+    const render = jest.fn();
+    const unmount = jest.fn();
+
+    const customGeoSearch = connectGeoSearch(render, unmount);
+    const widget = customGeoSearch({
+      enableGeolocationWithIP: false,
+    });
+
+    const client = createFakeClient();
+    const helper = createFakeHelper(client);
+
+    helper
+      .setState(widget.getConfiguration(new SearchParameters()))
+      .setQueryParameter('insideBoundingBox', '10,12,12,14');
+
+    const expectation = {
+      insideBoundingBox: undefined,
+    };
+
+    const actual = widget.dispose({ state: helper.getState() });
+
+    expect(unmount).toHaveBeenCalled();
+    expect(actual).toMatchObject(expectation);
+  });
+
   describe('aroundLatLngViaIP', () => {
     it('expect reset aroundLatLngViaIP', () => {
       const render = jest.fn();

--- a/src/connectors/geo-search/connectGeoSearch.js
+++ b/src/connectors/geo-search/connectGeoSearch.js
@@ -328,6 +328,8 @@ const connectGeoSearch = (renderFn, unmountFn) => {
           nextState = state.setQueryParameter('aroundPrecision');
         }
 
+        nextState = nextState.setQueryParameter('insideBoundingBox');
+
         return nextState;
       },
     };

--- a/src/connectors/geo-search/connectGeoSearch.js
+++ b/src/connectors/geo-search/connectGeoSearch.js
@@ -313,19 +313,19 @@ const connectGeoSearch = (renderFn, unmountFn) => {
         let nextState = state;
 
         if (enableGeolocationWithIP && !position) {
-          nextState = state.setQueryParameter('aroundLatLngViaIP');
+          nextState = nextState.setQueryParameter('aroundLatLngViaIP');
         }
 
         if (position) {
-          nextState = state.setQueryParameter('aroundLatLng');
+          nextState = nextState.setQueryParameter('aroundLatLng');
         }
 
         if (radius) {
-          nextState = state.setQueryParameter('aroundRadius');
+          nextState = nextState.setQueryParameter('aroundRadius');
         }
 
         if (precision) {
-          nextState = state.setQueryParameter('aroundPrecision');
+          nextState = nextState.setQueryParameter('aroundPrecision');
         }
 
         nextState = nextState.setQueryParameter('insideBoundingBox');


### PR DESCRIPTION
**Summary**

Right now there are two issues with the connector when the `dispose` function is called. The first one is that the parameter `insideBoundingBox` is not reset. The second one is that we always reset the parameters on the provided `state` argument instead of resetting the parameters on the new created value. It means that only the latest call will be reflected on the `SearchParameters`.

The PR fixes those two issues.