### PR TITLE
fix(rangeSlider): handles were blocked

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,8 +134,8 @@
     "events": "1.1.0",
     "hogan.js": "3.0.2",
     "lodash": "4.17.5",
-    "preact": "8.1.0",
-    "preact-compat": "3.17.0",
+    "preact": "8.2.7",
+    "preact-compat": "3.18.0",
     "preact-rheostat": "2.1.1",
     "prop-types": "15.5.10",
     "to-factory": "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7753,17 +7753,7 @@ postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.19:
     source-map "^0.6.1"
     supports-color "^5.2.0"
 
-preact-compat@3.17.0:
-  version "3.17.0"
-  resolved "https://registry.yarnpkg.com/preact-compat/-/preact-compat-3.17.0.tgz#528cfdfc301190c1a0f47567336be1f4be0266b3"
-  dependencies:
-    immutability-helper "^2.1.2"
-    preact-render-to-string "^3.6.0"
-    preact-transition-group "^1.1.0"
-    prop-types "^15.5.8"
-    standalone-react-addons-pure-render-mixin "^0.1.1"
-
-preact-compat@^3.17.0:
+preact-compat@3.18.0, preact-compat@^3.17.0:
   version "3.18.0"
   resolved "https://registry.yarnpkg.com/preact-compat/-/preact-compat-3.18.0.tgz#ca430cc1f67193fb9feaf7c510832957b2ebe701"
   dependencies:
@@ -7792,11 +7782,7 @@ preact-transition-group@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/preact-transition-group/-/preact-transition-group-1.1.1.tgz#f0a49327ea515ece34ea2be864c4a7d29e5d6e10"
 
-preact@8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-8.1.0.tgz#f035b808eebb74e46d56246b02ca0f190b6d6574"
-
-preact@^8.2.5:
+preact@8.2.7, preact@^8.2.5:
   version "8.2.7"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.2.7.tgz#316249fb678cd5e93e7cee63cea7bfb62dbd6814"
 


### PR DESCRIPTION
This was because rheostat (our preact version) was using incompatible
versions from ours (preact and preact-compat). 

This PR makes sure that we are using the same exact version as the min.
for rhoestat in order to end up with the same dependencies when resolving
the dependencies.