### PR TITLE
fix(geosearch): avoid reset map when it already moved

### DIFF
--- a/dev/app/builtin/stories/geo-search.stories.js
+++ b/dev/app/builtin/stories/geo-search.stories.js
@@ -750,5 +750,29 @@ export default () => {
           ],
         }
       )
+    )
+    .add(
+      'without results',
+      wrapWithHitsAndConfiguration(
+        (container, start) =>
+          injectGoogleMaps(() => {
+            container.style.height = '600px';
+
+            window.search.addWidget(
+              instantsearch.widgets.geoSearch({
+                googleReference: window.google,
+                container,
+                initialPosition,
+                initialZoom,
+                paddingBoundingBox,
+              })
+            );
+
+            start();
+          }),
+        {
+          query: 'dsdsdsds',
+        }
+      )
     );
 };

--- a/src/widgets/geo-search/GeoSearchRenderer.js
+++ b/src/widgets/geo-search/GeoSearchRenderer.js
@@ -155,7 +155,7 @@ const renderer = (
     return;
   }
 
-  if (!items.length && !isRefinedWithMap()) {
+  if (!items.length && !isRefinedWithMap() && !hasMapMoveSinceLastRefine()) {
     const initialMapPosition = position || initialPosition;
 
     renderState.isUserInteraction = false;

--- a/src/widgets/geo-search/__tests__/geo-search-test.js
+++ b/src/widgets/geo-search/__tests__/geo-search-test.js
@@ -774,7 +774,7 @@ describe('GeoSearch', () => {
   });
 
   describe('initial position', () => {
-    it('expect to init the position from "initialPosition" when no items are available & map is not yet render', () => {
+    it('expect to init the position from "initialPosition"', () => {
       const container = createContainer();
       const instantSearchInstance = createFakeInstantSearch();
       const helper = createFakeHelper();
@@ -812,7 +812,7 @@ describe('GeoSearch', () => {
       expect(mapInstance.setZoom).toHaveBeenCalledWith(8);
     });
 
-    it('expect to init the position from "position" when no items are available & map is not yet render', () => {
+    it('expect to init the position from "position"', () => {
       const container = createContainer();
       const instantSearchInstance = createFakeInstantSearch();
       const helper = createFakeHelper();
@@ -833,9 +833,8 @@ describe('GeoSearch', () => {
         },
       });
 
-      // Simulate the configuration
-      const initialState = widget.getConfiguration({});
-      helper.setState(initialState);
+      // Simulate the configuration for the position
+      helper.setState(widget.getConfiguration({}));
 
       widget.init({
         helper,
@@ -896,7 +895,7 @@ describe('GeoSearch', () => {
       expect(mapInstance.setZoom).not.toHaveBeenCalled();
     });
 
-    it('expect to not init the position when the refinement is coming from the map', () => {
+    it('expect to not init the position when the refinement is from the map', () => {
       const container = createContainer();
       const instantSearchInstance = createFakeInstantSearch();
       const helper = createFakeHelper();

--- a/src/widgets/geo-search/__tests__/geo-search-test.js
+++ b/src/widgets/geo-search/__tests__/geo-search-test.js
@@ -947,6 +947,60 @@ describe('GeoSearch', () => {
       expect(mapInstance.setCenter).not.toHaveBeenCalled();
       expect(mapInstance.setZoom).not.toHaveBeenCalled();
     });
+
+    it('expect to not init the position when the map has moved', () => {
+      const container = createContainer();
+      const instantSearchInstance = createFakeInstantSearch();
+      const helper = createFakeHelper();
+      const mapInstance = createFakeMapInstance();
+      const googleReference = createFakeGoogleReference({ mapInstance });
+
+      const widget = geoSearch({
+        googleReference,
+        container,
+        enableRefineOnMapMove: false,
+        initialZoom: 8,
+        initialPosition: {
+          lat: 10,
+          lng: 12,
+        },
+      });
+
+      widget.init({
+        helper,
+        instantSearchInstance,
+        state: helper.state,
+      });
+
+      simulateMapReadyEvent(googleReference);
+
+      expect(mapInstance.setCenter).not.toHaveBeenCalled();
+      expect(mapInstance.setZoom).not.toHaveBeenCalled();
+
+      widget.render({
+        helper,
+        instantSearchInstance,
+        results: {
+          hits: [{ objectID: 123, _geoloc: true }],
+        },
+      });
+
+      // Simulate a refinement
+      simulateEvent(mapInstance, 'dragstart');
+      simulateEvent(mapInstance, 'center_changed');
+      simulateEvent(mapInstance, 'idle');
+
+      widget.render({
+        helper,
+        instantSearchInstance,
+        results: {
+          hits: [],
+        },
+      });
+
+      expect(mapInstance.setCenter).not.toHaveBeenCalled();
+      expect(mapInstance.setZoom).not.toHaveBeenCalled();
+    });
   });
 
   describe('markers creation', () => {


### PR DESCRIPTION
**Summary**

On the current implementation of the GeoSearch there is an issue when there are no results. The map will not move on the first time when you click the zoom button. It's because we don't check that the map has moved (or not) when we trigger the initial position. The PR fixes this issue.

**Before**

![before](https://user-images.githubusercontent.com/6513513/38492945-c754e5f6-3bf0-11e8-917e-f198c2fd31e2.gif)

**After**

![after](https://user-images.githubusercontent.com/6513513/38492946-c9299b88-3bf0-11e8-870a-54f8d9c01273.gif)

You can also try it in [DevNovel](https://deploy-preview-2870--algolia-instantsearch.netlify.com/v2/dev-novel/?selectedStory=GeoSearch.without%20results).