### PR TITLE
docs(router): router => routing for root option name

### DIFF
--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -84,7 +84,7 @@ Usage: instantsearch({
 
     if (urlSync && routing) {
       throw new Error(
-        'InstantSearch configuration error: it is not possible to use `urlSync` and `router` at the same time'
+        'InstantSearch configuration error: it is not possible to use `urlSync` and `routing` at the same time'
       );
     }
 

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -47,7 +47,7 @@ import * as stateMappings from './stateMappings/index.js';
  */
 
 /**
- * @typedef {Object} RouterOptions
+ * @typedef {Object} RoutingOptions
  * @property {Router} [router=HistoryRouter()] The router is the part that will save the UI State.
  * By default, it uses an instance of the HistoryRouter with the default parameters.
  * @property {StateMapping} [stateMapping=SimpleStateMapping()] This object transforms the UI state into
@@ -111,7 +111,7 @@ import * as stateMappings from './stateMappings/index.js';
  * @property {boolean|UrlSyncOptions} [urlSync] Url synchronization configuration.
  * Setting to `true` will synchronize the needed search parameters with the browser url.
  * @property {number} [stalledSearchDelay=200] Time before a search is considered stalled.
- * @property {RouterOptions} [router] the router configuration used to save the UI State into the URL or
+ * @property {RoutingOptions} [routing] the router configuration used to save the UI State into the URL or
  * any client side persistence.
  */
 


### PR DESCRIPTION
Before this commit the documentation stated that the new option was
router instead of routing. routing is the one being implemented and
the right option name that was decided in #2829