### PR TITLE
 fix(routing): should apply stateMapping when doing initial write

### DIFF
--- a/src/lib/RoutingManager.js
+++ b/src/lib/RoutingManager.js
@@ -96,7 +96,8 @@ export default class RoutingManager {
       // We do this in order to make a URL update when there is search function
       // that prevent the search of the initial rendering
       // See: https://github.com/algolia/instantsearch.js/issues/2523#issuecomment-339356157
-      this.router.write(firstRenderState);
+      const route = this.stateMapping.stateToRoute(firstRenderState);
+      this.router.write(route);
     }
   }
 

--- a/src/lib/__tests__/RoutingManager-test.js
+++ b/src/lib/__tests__/RoutingManager-test.js
@@ -258,5 +258,61 @@ describe('RoutingManager', () => {
         });
       });
     });
+
+    test('should apply state mapping on differences after searchfunction', done => {
+      const router = {
+        write: jest.fn(),
+        read: jest.fn(() => ({})),
+        onUpdate: jest.fn(),
+      };
+      const stateMapping = {
+        stateToRoute(uiState) {
+          return {
+            query: uiState.query && uiState.query.toUpperCase(),
+          };
+        },
+        routeToState(routeState) {
+          return routeState;
+        },
+      };
+      const search = instantsearch({
+        appId: 'latency',
+        apiKey: '6be0576ff61c053d5f9a3225e2a90f76',
+        indexName: 'ikea',
+        routing: {
+          router,
+          stateMapping,
+        },
+        searchFunction: helper => {
+          helper.setQuery('test').search();
+        },
+      });
+
+      const widget = {
+        render: jest.fn(),
+        getWidgetSearchParameters: jest.fn(),
+        getWidgetState(uiState, { searchParameters }) {
+          return {
+            ...uiState,
+            query: searchParameters.query,
+          };
+        },
+      };
+      search.addWidget(widget);
+
+      search.start();
+
+      search.once('render', () => {
+        // initialization is done at this point
+
+        expect(search.helper.state.query).toEqual('test');
+
+        expect(router.write).toHaveBeenLastCalledWith({
+          query: 'TEST',
+        });
+
+        done();
+      });
+    });
   });
 });


### PR DESCRIPTION
When using the `searchFunction`, the URL should be updated if it adds some parameters during the execution of this function. This was done, but the stateMapping was not applied which lead to initial non-expected URLs.