### PR TITLE
docs(website): Improve GitHub issue template from documentation link

### DIFF
--- a/docgen/assets/js/main.js
+++ b/docgen/assets/js/main.js
@@ -59,3 +59,11 @@ toggleDocumentationSidebar();
 window.addEventListener('resize', () => {
   toggleDocumentationSidebar();
 });
+
+const openIssueLink = document.querySelector('#link-open-issue');
+if (openIssueLink) {
+  openIssueLink.href = openIssueLink.href.replace(
+    /__LOCATION__/g,
+    window.location.href
+  );
+}

--- a/docgen/layouts/archetypes/content-with-menu.pug
+++ b/docgen/layouts/archetypes/content-with-menu.pug
@@ -14,7 +14,7 @@ body.documentation
         block content
         hr
         p
-          strong Can't find what you are looking for? #[a(href="https://github.com/algolia/instantsearch.js/issues/new?title=I could not find what I was looking for&body=Hi! I have a documentation issue on InstantSearch.js, I could not find what I was looking for which is: -- PLEASE FILL IN HERE --") Open an issue], we'll get back to you.
+          strong Can't find what you are looking for? #[a(href=`https://github.com/algolia/instantsearch.js/issues/new?title=Question on the page "${title}"&body=Hi! I have a documentation issue on InstantSearch.js. I could not find what I was looking for on the page "[${title}](__LOCATION__)".%0A%0A<!-- Describe what you're looking for here. -->&labels=Doc: question`, id="link-open-issue") Open an issue], we'll get back to you.
 
   include ../common/footer.pug
   script(src=webpack.assets['js/main.js'])


### PR DESCRIPTION
This PR improves the GitHub issue template when a user opens an issue clicking on the "[Open an issue](https://github.com/algolia/instantsearch.js/issues/new?title=Question%20on%20the%20page%20%22Customize%20widgets%22&body=Hi!%20I%20have%20a%20documentation%20issue%20on%20InstantSearch.js.%20I%20could%20not%20find%20what%20I%20was%20looking%20for%20on%20the%20page%20%22[Customize%20widgets](https://community.algolia.com/instantsearch.js/v2/guides/customization.html)%22.%0A%0A%3C!--%20Describe%20what%20you%27re%20looking%20for%20here.%20--%3E&labels=Doc:%20question)" link on the documentation website.

![Open an issue image](https://user-images.githubusercontent.com/6137112/38687254-8ae1ffea-3e76-11e8-9593-fb3225efd1d8.png)

## How

* The `title` has been retrieved from the article frontmatter
* The page location has been retrieved in JavaScript with `window.location.href`
* The new label `Doc: question` has been attached

## Result

The link generated is as follows:

[`https://github.com/algolia/instantsearch.js/issues/new?title=Question%20on%20the%20page%20%22Customize%20widgets%22&body=Hi!%20I%20have%20a%20documentation%20issue%20on%20InstantSearch.js.%20I%20could%20not%20find%20what%20I%20was%20looking%20for%20on%20the%20page%20%22[Customize%20widgets](https://community.algolia.com/instantsearch.js/v2/guides/customization.html)%22.%0A%0A%3C!--%20Describe%20what%20you%27re%20looking%20for%20here.%20--%3E&labels=Doc:%20question`](https://github.com/algolia/instantsearch.js/issues/new?title=Question%20on%20the%20page%20%22Customize%20widgets%22&body=Hi!%20I%20have%20a%20documentation%20issue%20on%20InstantSearch.js.%20I%20could%20not%20find%20what%20I%20was%20looking%20for%20on%20the%20page%20%22[Customize%20widgets](https://community.algolia.com/instantsearch.js/v2/guides/customization.html)%22.%0A%0A%3C!--%20Describe%20what%20you%27re%20looking%20for%20here.%20--%3E&labels=Doc:%20question)

Test yourself by clicking the link [on this guide](https://deploy-preview-2898--algolia-instantsearch.netlify.com/v2/guides/calendar-widget.html#conclusion) for example.

Closes #2882 

---

Let me know if you think of anything else (browser information, frontmatter information) useful we can add to the default issue content.