### PR TITLE
feat: Update client and helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
   },
   "dependencies": {
     "algoliasearch": "3.27.0",
-    "algoliasearch-helper": "2.25.1",
+    "algoliasearch-helper": "2.26.0",
     "classnames": "2.2.5",
     "events": "1.1.0",
     "hogan.js": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -130,8 +130,8 @@
     "webpack-dev-server": "2.11.2"
   },
   "dependencies": {
-    "algoliasearch": "3.25.1",
-    "algoliasearch-helper": "2.24.0",
+    "algoliasearch": "3.27.0",
+    "algoliasearch-helper": "2.25.1",
     "classnames": "2.2.5",
     "events": "1.1.0",
     "hogan.js": "3.0.2",

--- a/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.js
+++ b/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.js
@@ -75,7 +75,7 @@ describe('connectBreadcrumb', () => {
     // Verify that the widget has not been rendered yet at this point
     expect(rendering.mock.calls).toHaveLength(0);
 
-    const helper = jsHelper({ addAlgoliaAgent: () => {} }, '', config);
+    const helper = jsHelper({}, '', config);
     helper.search = jest.fn();
 
     widget.init({
@@ -154,7 +154,7 @@ describe('connectBreadcrumb', () => {
     const widget = makeWidget({ attributes: ['category', 'sub_category'] });
 
     const config = widget.getConfiguration({});
-    const helper = jsHelper({ addAlgoliaAgent: () => {} }, '', config);
+    const helper = jsHelper({}, '', config);
     helper.search = jest.fn();
 
     helper.toggleRefinement('category', 'Decoration');
@@ -208,7 +208,7 @@ describe('connectBreadcrumb', () => {
     const widget = makeWidget({ attributes: ['category', 'sub_category'] });
 
     const config = widget.getConfiguration({});
-    const helper = jsHelper({ addAlgoliaAgent: () => {} }, '', config);
+    const helper = jsHelper({}, '', config);
     helper.search = jest.fn();
 
     widget.init({
@@ -267,7 +267,7 @@ describe('connectBreadcrumb', () => {
     });
 
     const config = widget.getConfiguration({});
-    const helper = jsHelper({ addAlgoliaAgent: () => {} }, '', config);
+    const helper = jsHelper({}, '', config);
     helper.search = jest.fn();
 
     widget.init({
@@ -427,7 +427,7 @@ describe('connectBreadcrumb', () => {
     const widget = makeWidget({ attributes: ['category', 'sub_category'] });
 
     const config = widget.getConfiguration({});
-    const helper = jsHelper({ addAlgoliaAgent: () => {} }, '', config);
+    const helper = jsHelper({}, '', config);
     helper.search = jest.fn();
 
     widget.init({

--- a/src/connectors/clear-all/__tests__/connectClearAll-test.js
+++ b/src/connectors/clear-all/__tests__/connectClearAll-test.js
@@ -7,7 +7,7 @@ import connectClearAll from '../connectClearAll.js';
 
 describe('connectClearAll', () => {
   it('Renders during init and render', () => {
-    const helper = jsHelper({ addAlgoliaAgent: () => {} });
+    const helper = jsHelper({});
     helper.search = sinon.stub();
     // test that the dummyRendering is called with the isFirstRendering
     // flag set accordingly
@@ -58,7 +58,7 @@ describe('connectClearAll', () => {
     // test the function received by the rendering function
     // to clear the refinements
 
-    const helper = jsHelper({ addAlgoliaAgent: () => {} }, '', {
+    const helper = jsHelper({}, '', {
       facets: ['myFacet'],
     });
     helper.search = sinon.stub();
@@ -105,7 +105,7 @@ describe('connectClearAll', () => {
     // test the function received by the rendering function
     // to clear the refinements
 
-    const helper = jsHelper({ addAlgoliaAgent: () => {} }, '', {
+    const helper = jsHelper({}, '', {
       facets: ['myFacet'],
     });
     helper.search = sinon.stub();
@@ -152,7 +152,7 @@ describe('connectClearAll', () => {
   it('some refinements from results <=> hasRefinements = true', () => {
     // test if the values sent to the rendering function
     // are consistent with the search state
-    const helper = jsHelper({ addAlgoliaAgent: () => {} }, undefined, {
+    const helper = jsHelper({}, undefined, {
       facets: ['aFacet'],
     });
     helper.toggleRefinement('aFacet', 'some value');
@@ -184,7 +184,7 @@ describe('connectClearAll', () => {
   it('(clearsQuery: true) query not empty <=> hasRefinements = true', () => {
     // test if the values sent to the rendering function
     // are consistent with the search state
-    const helper = jsHelper({ addAlgoliaAgent: () => {} }, undefined, {
+    const helper = jsHelper({}, undefined, {
       facets: ['aFacet'],
     });
     helper.setQuery('no empty');
@@ -219,7 +219,7 @@ describe('connectClearAll', () => {
     // test if the values sent to the rendering function
     // are consistent with the search state
 
-    const helper = jsHelper({ addAlgoliaAgent: () => {} });
+    const helper = jsHelper({});
     helper.setQuery('not empty');
     helper.search = sinon.stub();
 

--- a/src/connectors/configure/__tests__/connectConfigure-test.js
+++ b/src/connectors/configure/__tests__/connectConfigure-test.js
@@ -2,7 +2,10 @@ import algoliasearchHelper, { SearchParameters } from 'algoliasearch-helper';
 
 import connectConfigure from '../connectConfigure.js';
 
-const fakeClient = { addAlgoliaAgent: () => {}, search: jest.fn() };
+const fakeClient = {
+  addAlgoliaAgent: () => {},
+  search: jest.fn(() => Promise.resolve({ results: [{}] })),
+};
 
 describe('connectConfigure', () => {
   let helper;

--- a/src/connectors/configure/__tests__/connectConfigure-test.js
+++ b/src/connectors/configure/__tests__/connectConfigure-test.js
@@ -3,7 +3,6 @@ import algoliasearchHelper, { SearchParameters } from 'algoliasearch-helper';
 import connectConfigure from '../connectConfigure.js';
 
 const fakeClient = {
-  addAlgoliaAgent: () => {},
   search: jest.fn(() => Promise.resolve({ results: [{}] })),
 };
 

--- a/src/connectors/current-refined-values/__tests__/connectCurrentRefinedValues-test.js
+++ b/src/connectors/current-refined-values/__tests__/connectCurrentRefinedValues-test.js
@@ -5,7 +5,7 @@ import connectCurrentRefinedValues from '../connectCurrentRefinedValues.js';
 
 describe('connectCurrentRefinedValues', () => {
   it('Renders during init and render', () => {
-    const helper = jsHelper({ addAlgoliaAgent: () => {} });
+    const helper = jsHelper({});
     helper.search = sinon.stub();
     // test that the dummyRendering is called with the isFirstRendering
     // flag set accordingly
@@ -58,7 +58,7 @@ describe('connectCurrentRefinedValues', () => {
   it('Provide a function to clear the refinement', () => {
     // For each refinements we get a function that we can call
     // for removing a single refinement
-    const helper = jsHelper({ addAlgoliaAgent: () => {} }, '', {
+    const helper = jsHelper({}, '', {
       facets: ['myFacet'],
     });
     helper.search = sinon.stub();
@@ -100,7 +100,7 @@ describe('connectCurrentRefinedValues', () => {
   });
 
   it('should clear also the search query', () => {
-    const helper = jsHelper({ addAlgoliaAgent: () => {} }, '', {});
+    const helper = jsHelper({}, '', {});
     helper.search = jest.fn();
 
     const rendering = jest.fn();
@@ -128,7 +128,7 @@ describe('connectCurrentRefinedValues', () => {
   });
 
   it('should provide the query as a refinement if clearsQuery is true', () => {
-    const helper = jsHelper({ addAlgoliaAgent: () => {} }, '', {});
+    const helper = jsHelper({}, '', {});
     helper.search = jest.fn();
 
     const rendering = jest.fn();

--- a/src/connectors/geo-search/__tests__/connectGeoSearch-test.js
+++ b/src/connectors/geo-search/__tests__/connectGeoSearch-test.js
@@ -6,10 +6,6 @@ import algoliasearchHelper, {
 } from 'algoliasearch-helper';
 import connectGeoSearch from '../connectGeoSearch';
 
-const createFakeClient = () => ({
-  addAlgoliaAgent: () => {},
-});
-
 const createFakeHelper = client => {
   const helper = algoliasearchHelper(client);
 
@@ -44,7 +40,7 @@ describe('connectGeoSearch - rendering', () => {
     const customGeoSearch = connectGeoSearch(render, unmount);
     const widget = customGeoSearch();
 
-    const client = createFakeClient();
+    const client = {};
     const helper = createFakeHelper(client);
     const instantSearchInstance = { client, helper };
 
@@ -123,8 +119,7 @@ describe('connectGeoSearch - rendering', () => {
       enableRefineOnMapMove: false,
     });
 
-    const client = createFakeClient();
-    const helper = createFakeHelper(client);
+    const helper = createFakeHelper({});
 
     widget.init({
       state: helper.state,
@@ -154,8 +149,7 @@ describe('connectGeoSearch - rendering', () => {
     const customGeoSearch = connectGeoSearch(render, unmount);
     const widget = customGeoSearch();
 
-    const client = createFakeClient();
-    const helper = createFakeHelper(client);
+    const helper = createFakeHelper({});
 
     widget.render({
       results: new SearchResults(helper.getState(), [
@@ -193,8 +187,7 @@ describe('connectGeoSearch - rendering', () => {
       },
     });
 
-    const client = createFakeClient();
-    const helper = createFakeHelper(client);
+    const helper = createFakeHelper({});
 
     // Simulate the configuration or external setter
     helper.setQueryParameter('aroundLatLng', '10, 12');
@@ -271,8 +264,7 @@ describe('connectGeoSearch - rendering', () => {
       },
     });
 
-    const client = createFakeClient();
-    const helper = createFakeHelper(client);
+    const helper = createFakeHelper({});
 
     // Simulate the configuration or external setter
     helper.setQueryParameter('insideBoundingBox', [
@@ -327,8 +319,7 @@ describe('connectGeoSearch - rendering', () => {
     const customGeoSearch = connectGeoSearch(render, unmount);
     const widget = customGeoSearch();
 
-    const client = createFakeClient();
-    const helper = createFakeHelper(client);
+    const helper = createFakeHelper({});
 
     const northEast = {
       lat: 12,
@@ -393,8 +384,7 @@ describe('connectGeoSearch - rendering', () => {
     const customGeoSearch = connectGeoSearch(render, unmount);
     const widget = customGeoSearch();
 
-    const client = createFakeClient();
-    const helper = createFakeHelper(client);
+    const helper = createFakeHelper({});
 
     const northEast = {
       lat: 12,
@@ -459,8 +449,7 @@ describe('connectGeoSearch - rendering', () => {
     const customGeoSearch = connectGeoSearch(render, unmount);
     const widget = customGeoSearch();
 
-    const client = createFakeClient();
-    const helper = createFakeHelper(client);
+    const helper = createFakeHelper({});
 
     const northEast = {
       lat: 12,
@@ -525,8 +514,7 @@ describe('connectGeoSearch - rendering', () => {
     const customGeoSearch = connectGeoSearch(render, unmount);
     const widget = customGeoSearch();
 
-    const client = createFakeClient();
-    const helper = createFakeHelper(client);
+    const helper = createFakeHelper({});
 
     const northEast = {
       lat: 12,
@@ -592,8 +580,7 @@ describe('connectGeoSearch - rendering', () => {
       const customGeoSearch = connectGeoSearch(render, unmount);
       const widget = customGeoSearch();
 
-      const client = createFakeClient();
-      const helper = createFakeHelper(client);
+      const helper = createFakeHelper({});
 
       const northEast = {
         lat: 12,
@@ -643,8 +630,7 @@ describe('connectGeoSearch - rendering', () => {
       const customGeoSearch = connectGeoSearch(render, unmount);
       const widget = customGeoSearch();
 
-      const client = createFakeClient();
-      const helper = createFakeHelper(client);
+      const helper = createFakeHelper({});
 
       const northEast = {
         lat: 12,
@@ -696,8 +682,7 @@ describe('connectGeoSearch - rendering', () => {
       const customGeoSearch = connectGeoSearch(render, unmount);
       const widget = customGeoSearch();
 
-      const client = createFakeClient();
-      const helper = createFakeHelper(client);
+      const helper = createFakeHelper({});
 
       const northEast = {
         lat: 12,
@@ -760,8 +745,7 @@ describe('connectGeoSearch - rendering', () => {
       const customGeoSearch = connectGeoSearch(render, unmount);
       const widget = customGeoSearch();
 
-      const client = createFakeClient();
-      const helper = createFakeHelper(client);
+      const helper = createFakeHelper({});
 
       const northEast = {
         lat: 12,
@@ -826,8 +810,7 @@ describe('connectGeoSearch - rendering', () => {
       const customGeoSearch = connectGeoSearch(render, unmount);
       const widget = customGeoSearch();
 
-      const client = createFakeClient();
-      const helper = createFakeHelper(client);
+      const helper = createFakeHelper({});
 
       widget.init({
         state: helper.state,
@@ -865,8 +848,7 @@ describe('connectGeoSearch - rendering', () => {
       const customGeoSearch = connectGeoSearch(render, unmount);
       const widget = customGeoSearch();
 
-      const client = createFakeClient();
-      const helper = createFakeHelper(client);
+      const helper = createFakeHelper({});
 
       widget.render({
         results: new SearchResults(helper.getState(), [
@@ -898,8 +880,7 @@ describe('connectGeoSearch - rendering', () => {
       const customGeoSearch = connectGeoSearch(render, unmount);
       const widget = customGeoSearch();
 
-      const client = createFakeClient();
-      const helper = createFakeHelper(client);
+      const helper = createFakeHelper({});
 
       widget.init({
         state: helper.state,
@@ -937,8 +918,7 @@ describe('connectGeoSearch - rendering', () => {
       const customGeoSearch = connectGeoSearch(render, unmount);
       const widget = customGeoSearch();
 
-      const client = createFakeClient();
-      const helper = createFakeHelper(client);
+      const helper = createFakeHelper({});
 
       const results = new SearchResults(helper.getState(), [
         {
@@ -970,8 +950,7 @@ describe('connectGeoSearch - rendering', () => {
       const customGeoSearch = connectGeoSearch(render, unmount);
       const widget = customGeoSearch();
 
-      const client = createFakeClient();
-      const helper = createFakeHelper(client);
+      const helper = createFakeHelper({});
 
       const results = new SearchResults(helper.getState(), [
         {
@@ -1277,8 +1256,7 @@ describe('connectGeoSearch - dispose', () => {
       enableGeolocationWithIP: false,
     });
 
-    const client = createFakeClient();
-    const helper = createFakeHelper(client);
+    const helper = createFakeHelper({});
 
     helper
       .setState(widget.getConfiguration(new SearchParameters()))
@@ -1308,8 +1286,7 @@ describe('connectGeoSearch - dispose', () => {
       },
     });
 
-    const client = createFakeClient();
-    const helper = createFakeHelper(client);
+    const helper = createFakeHelper({});
 
     helper.setState(widget.getConfiguration(new SearchParameters()));
 
@@ -1333,8 +1310,7 @@ describe('connectGeoSearch - dispose', () => {
       const customGeoSearch = connectGeoSearch(render, unmount);
       const widget = customGeoSearch();
 
-      const client = createFakeClient();
-      const helper = createFakeHelper(client);
+      const helper = createFakeHelper({});
 
       helper.setState(widget.getConfiguration(new SearchParameters()));
 
@@ -1357,8 +1333,7 @@ describe('connectGeoSearch - dispose', () => {
         enableGeolocationWithIP: false,
       });
 
-      const client = createFakeClient();
-      const helper = createFakeHelper(client);
+      const helper = createFakeHelper({});
 
       helper
         .setState(widget.getConfiguration(new SearchParameters()))
@@ -1386,8 +1361,7 @@ describe('connectGeoSearch - dispose', () => {
         },
       });
 
-      const client = createFakeClient();
-      const helper = createFakeHelper(client);
+      const helper = createFakeHelper({});
 
       helper
         .setState(widget.getConfiguration(new SearchParameters()))
@@ -1417,8 +1391,7 @@ describe('connectGeoSearch - dispose', () => {
         },
       });
 
-      const client = createFakeClient();
-      const helper = createFakeHelper(client);
+      const helper = createFakeHelper({});
 
       helper.setState(widget.getConfiguration(new SearchParameters()));
 
@@ -1439,8 +1412,7 @@ describe('connectGeoSearch - dispose', () => {
       const customGeoSearch = connectGeoSearch(render, unmount);
       const widget = customGeoSearch();
 
-      const client = createFakeClient();
-      const helper = createFakeHelper(client);
+      const helper = createFakeHelper({});
 
       helper
         .setState(widget.getConfiguration(new SearchParameters()))
@@ -1467,8 +1439,7 @@ describe('connectGeoSearch - dispose', () => {
         radius: 1000,
       });
 
-      const client = createFakeClient();
-      const helper = createFakeHelper(client);
+      const helper = createFakeHelper({});
 
       helper.setState(widget.getConfiguration(new SearchParameters()));
 
@@ -1489,8 +1460,7 @@ describe('connectGeoSearch - dispose', () => {
       const customGeoSearch = connectGeoSearch(render, unmount);
       const widget = customGeoSearch();
 
-      const client = createFakeClient();
-      const helper = createFakeHelper(client);
+      const helper = createFakeHelper({});
 
       helper
         .setState(widget.getConfiguration(new SearchParameters()))
@@ -1517,8 +1487,7 @@ describe('connectGeoSearch - dispose', () => {
         precision: 1000,
       });
 
-      const client = createFakeClient();
-      const helper = createFakeHelper(client);
+      const helper = createFakeHelper({});
 
       helper.setState(widget.getConfiguration(new SearchParameters()));
 
@@ -1539,8 +1508,7 @@ describe('connectGeoSearch - dispose', () => {
       const customGeoSearch = connectGeoSearch(render, unmount);
       const widget = customGeoSearch();
 
-      const client = createFakeClient();
-      const helper = createFakeHelper(client);
+      const helper = createFakeHelper({});
 
       helper
         .setState(widget.getConfiguration(new SearchParameters()))

--- a/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.js
+++ b/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.js
@@ -88,7 +88,7 @@ describe('connectHierarchicalMenu', () => {
     // test if widget is not rendered yet at this point
     expect(rendering.callCount).toBe(0);
 
-    const helper = jsHelper({ addAlgoliaAgent: () => {} }, '', config);
+    const helper = jsHelper({}, '', config);
     helper.search = sinon.stub();
 
     widget.init({
@@ -128,11 +128,7 @@ describe('connectHierarchicalMenu', () => {
       attributes: ['category', 'sub_category'],
     });
 
-    const helper = jsHelper(
-      { addAlgoliaAgent: () => {} },
-      '',
-      widget.getConfiguration({})
-    );
+    const helper = jsHelper({}, '', widget.getConfiguration({}));
     helper.search = sinon.stub();
 
     helper.toggleRefinement('category', 'value');
@@ -173,11 +169,7 @@ describe('connectHierarchicalMenu', () => {
       attributes: ['category', 'subCategory'],
     });
 
-    const helper = jsHelper(
-      { addAlgoliaAgent: () => {} },
-      '',
-      widget.getConfiguration({})
-    );
+    const helper = jsHelper({}, '', widget.getConfiguration({}));
     helper.search = sinon.stub();
 
     helper.toggleRefinement('category', 'Decoration');
@@ -265,11 +257,7 @@ describe('connectHierarchicalMenu', () => {
         attributes: ['category', 'subCategory'],
       });
 
-      const helper = jsHelper(
-        { addAlgoliaAgent: () => {} },
-        '',
-        widget.getConfiguration({})
-      );
+      const helper = jsHelper({}, '', widget.getConfiguration({}));
       helper.search = sinon.stub();
 
       widget.init({

--- a/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
+++ b/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
@@ -5,8 +5,6 @@ const SearchParameters = jsHelper.SearchParameters;
 
 import connectHitsPerPage from '../connectHitsPerPage.js';
 
-const fakeClient = { addAlgoliaAgent: () => {} };
-
 describe('connectHitsPerPage', () => {
   it('should throw when there is two default items defined', () => {
     expect(() => {
@@ -37,7 +35,7 @@ describe('connectHitsPerPage', () => {
     // test if widget is not rendered yet at this point
     expect(rendering.callCount).toBe(0);
 
-    const helper = jsHelper(fakeClient, '', {
+    const helper = jsHelper({}, '', {
       hitsPerPage: 3,
     });
     helper.search = sinon.stub();
@@ -117,7 +115,7 @@ describe('connectHitsPerPage', () => {
       ],
     });
 
-    const helper = jsHelper(fakeClient, '', {
+    const helper = jsHelper({}, '', {
       hitsPerPage: 11,
     });
     helper.search = sinon.stub();
@@ -162,7 +160,7 @@ describe('connectHitsPerPage', () => {
       ],
     });
 
-    const helper = jsHelper(fakeClient, '', {
+    const helper = jsHelper({}, '', {
       hitsPerPage: 7,
     });
     helper.search = sinon.stub();
@@ -199,7 +197,7 @@ describe('connectHitsPerPage', () => {
       ],
     });
 
-    const helper = jsHelper(fakeClient, '', {
+    const helper = jsHelper({}, '', {
       hitsPerPage: 7,
     });
     helper.search = sinon.stub();
@@ -243,11 +241,7 @@ describe('connectHitsPerPage', () => {
         ],
       });
 
-      const helper = jsHelper(
-        { addAlgoliaAgent: () => {} },
-        '',
-        widget.getConfiguration({})
-      );
+      const helper = jsHelper({}, '', widget.getConfiguration({}));
       helper.search = sinon.stub();
 
       widget.init({

--- a/src/connectors/hits/__tests__/connectHits-test.js
+++ b/src/connectors/hits/__tests__/connectHits-test.js
@@ -5,8 +5,6 @@ const SearchResults = jsHelper.SearchResults;
 
 import connectHits from '../connectHits.js';
 
-const fakeClient = { addAlgoliaAgent: () => {} };
-
 describe('connectHits', () => {
   it('Renders during init and render', () => {
     // test that the dummyRendering is called with the isFirstRendering
@@ -23,7 +21,7 @@ describe('connectHits', () => {
     // test if widget is not rendered yet at this point
     expect(rendering.callCount).toBe(0);
 
-    const helper = jsHelper(fakeClient, '', {});
+    const helper = jsHelper({}, '', {});
     helper.search = sinon.stub();
 
     widget.init({
@@ -61,7 +59,7 @@ describe('connectHits', () => {
     const makeWidget = connectHits(rendering);
     const widget = makeWidget({});
 
-    const helper = jsHelper(fakeClient, '', {});
+    const helper = jsHelper({}, '', {});
     helper.search = sinon.stub();
 
     widget.init({
@@ -97,7 +95,7 @@ describe('connectHits', () => {
     const makeWidget = connectHits(rendering);
     const widget = makeWidget({ escapeHits: true });
 
-    const helper = jsHelper(fakeClient, '', {});
+    const helper = jsHelper({}, '', {});
     helper.search = sinon.stub();
 
     widget.init({

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.js
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.js
@@ -5,8 +5,6 @@ const SearchResults = jsHelper.SearchResults;
 
 import connectInfiniteHits from '../connectInfiniteHits.js';
 
-const fakeClient = { addAlgoliaAgent: () => {} };
-
 describe('connectInfiniteHits', () => {
   it('Renders during init and render', () => {
     // test that the dummyRendering is called with the isFirstRendering
@@ -26,7 +24,7 @@ describe('connectInfiniteHits', () => {
     // test if widget is not rendered yet at this point
     expect(rendering.callCount).toBe(0);
 
-    const helper = jsHelper(fakeClient, '');
+    const helper = jsHelper({}, '');
     helper.search = sinon.stub();
 
     widget.init({
@@ -70,7 +68,7 @@ describe('connectInfiniteHits', () => {
     const makeWidget = connectInfiniteHits(rendering);
     const widget = makeWidget();
 
-    const helper = jsHelper(fakeClient, '', {});
+    const helper = jsHelper({}, '', {});
     helper.search = sinon.stub();
 
     widget.init({
@@ -145,7 +143,7 @@ describe('connectInfiniteHits', () => {
     const makeWidget = connectInfiniteHits(rendering);
     const widget = makeWidget({ escapeHits: true });
 
-    const helper = jsHelper(fakeClient, '', {});
+    const helper = jsHelper({}, '', {});
     helper.search = sinon.stub();
 
     widget.init({

--- a/src/connectors/menu/__tests__/connectMenu-test.js
+++ b/src/connectors/menu/__tests__/connectMenu-test.js
@@ -7,8 +7,6 @@ import jsHelper, {
 
 import connectMenu from '../connectMenu.js';
 
-const fakeClient = { addAlgoliaAgent: () => {} };
-
 describe('connectMenu', () => {
   let rendering;
   let makeWidget;
@@ -86,7 +84,7 @@ describe('connectMenu', () => {
     // test if widget is not rendered yet at this point
     expect(rendering.callCount).toBe(0);
 
-    const helper = jsHelper(fakeClient, '', config);
+    const helper = jsHelper({}, '', config);
     helper.search = sinon.stub();
 
     widget.init({
@@ -132,7 +130,7 @@ describe('connectMenu', () => {
       attributeName: 'category',
     });
 
-    const helper = jsHelper(fakeClient, '', widget.getConfiguration({}));
+    const helper = jsHelper({}, '', widget.getConfiguration({}));
     helper.search = sinon.stub();
 
     helper.toggleRefinement('category', 'value');
@@ -171,7 +169,7 @@ describe('connectMenu', () => {
       attributeName: 'category',
     });
 
-    const helper = jsHelper(fakeClient, '', widget.getConfiguration({}));
+    const helper = jsHelper({}, '', widget.getConfiguration({}));
     helper.search = sinon.stub();
 
     helper.toggleRefinement('category', 'Decoration');
@@ -271,7 +269,7 @@ describe('connectMenu', () => {
 
       // When
       const config = widget.getConfiguration({});
-      const helper = jsHelper(fakeClient, '', config);
+      const helper = jsHelper({}, '', config);
       helper.search = jest.fn();
 
       widget.init({
@@ -296,7 +294,7 @@ describe('connectMenu', () => {
 
       // When
       const config = widget.getConfiguration({});
-      const helper = jsHelper(fakeClient, '', config);
+      const helper = jsHelper({}, '', config);
 
       helper.search = jest.fn();
       helper.toggleRefinement('category', 'Decoration');
@@ -358,7 +356,7 @@ describe('connectMenu', () => {
 
       // When
       const config = widget.getConfiguration({});
-      const helper = jsHelper(fakeClient, '', config);
+      const helper = jsHelper({}, '', config);
 
       helper.search = jest.fn();
       helper.toggleRefinement('category', 'Decoration');
@@ -407,11 +405,7 @@ describe('connectMenu', () => {
         attributeName: 'category',
       });
 
-      const helper = jsHelper(
-        { addAlgoliaAgent: () => {} },
-        '',
-        widget.getConfiguration({})
-      );
+      const helper = jsHelper({}, '', widget.getConfiguration({}));
       helper.search = sinon.stub();
 
       widget.init({

--- a/src/connectors/numeric-refinement-list/__tests__/connectNumericRefinementList-test.js
+++ b/src/connectors/numeric-refinement-list/__tests__/connectNumericRefinementList-test.js
@@ -6,8 +6,6 @@ import jsHelper, {
 
 import connectNumericRefinementList from '../connectNumericRefinementList.js';
 
-const fakeClient = { addAlgoliaAgent: () => {} };
-
 const encodeValue = (start, end) =>
   window.encodeURI(JSON.stringify({ start, end }));
 const mapOptionsToItems = ({ start, end, name: label }) => ({
@@ -36,7 +34,7 @@ describe('connectNumericRefinementList', () => {
     // test if widget is not rendered yet at this point
     expect(rendering.callCount).toBe(0);
 
-    const helper = jsHelper(fakeClient);
+    const helper = jsHelper({});
     helper.search = sinon.stub();
 
     widget.init({
@@ -93,7 +91,7 @@ describe('connectNumericRefinementList', () => {
       ],
     });
 
-    const helper = jsHelper(fakeClient);
+    const helper = jsHelper({});
     helper.search = sinon.stub();
 
     widget.init({
@@ -172,7 +170,7 @@ describe('connectNumericRefinementList', () => {
       ],
     });
 
-    const helper = jsHelper(fakeClient);
+    const helper = jsHelper({});
     helper.search = sinon.stub();
 
     widget.init({
@@ -227,7 +225,7 @@ describe('connectNumericRefinementList', () => {
       options: listOptions,
     });
 
-    const helper = jsHelper(fakeClient);
+    const helper = jsHelper({});
     helper.search = sinon.stub();
 
     widget.init({
@@ -278,7 +276,7 @@ describe('connectNumericRefinementList', () => {
       options: listOptions,
     });
 
-    const helper = jsHelper(fakeClient);
+    const helper = jsHelper({});
     helper.search = sinon.stub();
 
     widget.init({
@@ -339,7 +337,7 @@ describe('connectNumericRefinementList', () => {
       options: listOptions,
     });
 
-    const helper = jsHelper(fakeClient);
+    const helper = jsHelper({});
     helper.search = jest.fn();
 
     widget.init({
@@ -383,7 +381,7 @@ describe('connectNumericRefinementList', () => {
       ],
     });
 
-    const helper = jsHelper(fakeClient);
+    const helper = jsHelper({});
     helper.search = sinon.stub();
     helper.setPage(2);
 
@@ -417,7 +415,7 @@ describe('connectNumericRefinementList', () => {
         ],
       });
 
-      const helper = jsHelper({ addAlgoliaAgent: () => {} }, '');
+      const helper = jsHelper({}, '');
       helper.search = () => {};
 
       widget.init({

--- a/src/connectors/numeric-selector/__tests__/connectNumericSelector-test.js
+++ b/src/connectors/numeric-selector/__tests__/connectNumericSelector-test.js
@@ -5,8 +5,6 @@ import jsHelper, {
 
 import connectNumericSelector from '../connectNumericSelector.js';
 
-const fakeClient = { addAlgoliaAgent: () => {} };
-
 describe('connectNumericSelector', () => {
   it('Renders during init and render', () => {
     // test that the dummyRendering is called with the isFirstRendering
@@ -35,7 +33,7 @@ describe('connectNumericSelector', () => {
     // test if widget is not rendered yet at this point
     expect(rendering).not.toHaveBeenCalled();
 
-    const helper = jsHelper(fakeClient, '', config);
+    const helper = jsHelper({}, '', config);
     helper.search = jest.fn();
 
     widget.init({
@@ -133,7 +131,7 @@ describe('connectNumericSelector', () => {
     });
 
     const config = widget.getConfiguration({}, {});
-    const helper = jsHelper(fakeClient, '', config);
+    const helper = jsHelper({}, '', config);
     helper.search = jest.fn();
 
     widget.init({
@@ -201,7 +199,7 @@ describe('connectNumericSelector', () => {
     });
 
     const config = widget.getConfiguration({}, {});
-    const helper = jsHelper(fakeClient, '', config);
+    const helper = jsHelper({}, '', config);
     helper.search = jest.fn();
 
     widget.init({
@@ -251,7 +249,7 @@ describe('connectNumericSelector', () => {
     });
 
     const config = widget.getConfiguration({}, {});
-    const helper = jsHelper(fakeClient, '', config);
+    const helper = jsHelper({}, '', config);
     helper.search = jest.fn();
 
     widget.init({
@@ -304,7 +302,7 @@ describe('connectNumericSelector', () => {
       });
 
       const config = widget.getConfiguration({}, {});
-      const helper = jsHelper(fakeClient, '', config);
+      const helper = jsHelper({}, '', config);
       helper.search = jest.fn();
 
       widget.init({

--- a/src/connectors/pagination/__tests__/connectPagination-test.js
+++ b/src/connectors/pagination/__tests__/connectPagination-test.js
@@ -7,8 +7,6 @@ import jsHelper, {
 
 import connectPagination from '../connectPagination.js';
 
-const fakeClient = { addAlgoliaAgent: () => {} };
-
 describe('connectPagination', () => {
   it('connectPagination - Renders during init and render', () => {
     // test that the dummyRendering is called with the isFirstRendering
@@ -22,7 +20,7 @@ describe('connectPagination', () => {
     // does not have a getConfiguration method
     expect(widget.getConfiguration).toBe(undefined);
 
-    const helper = jsHelper(fakeClient);
+    const helper = jsHelper({});
     helper.search = sinon.stub();
 
     widget.init({
@@ -82,7 +80,7 @@ describe('connectPagination', () => {
 
     const widget = makeWidget();
 
-    const helper = jsHelper(fakeClient);
+    const helper = jsHelper({});
     helper.search = sinon.stub();
 
     widget.init({
@@ -124,7 +122,7 @@ describe('connectPagination', () => {
 
     const widget = makeWidget();
 
-    const helper = jsHelper(fakeClient);
+    const helper = jsHelper({});
     helper.search = jest.fn();
 
     widget.init({
@@ -190,7 +188,7 @@ describe('connectPagination', () => {
       padding: 5,
     });
 
-    const helper = jsHelper(fakeClient);
+    const helper = jsHelper({});
     helper.search = jest.fn();
 
     widget.init({
@@ -254,7 +252,7 @@ describe('connectPagination', () => {
       const makeWidget = connectPagination(rendering);
       const widget = makeWidget({});
 
-      const helper = jsHelper(fakeClient, '');
+      const helper = jsHelper({}, '');
       helper.search = jest.fn();
 
       widget.init({

--- a/src/connectors/price-ranges/__tests__/connectPriceRanges-test.js
+++ b/src/connectors/price-ranges/__tests__/connectPriceRanges-test.js
@@ -7,8 +7,6 @@ import jsHelper, {
 
 import connectPriceRanges from '../connectPriceRanges.js';
 
-const fakeClient = { addAlgoliaAgent: () => {} };
-
 describe('connectPriceRanges', () => {
   it('Renders during init and render', () => {
     // test that the dummyRendering is called with the isFirstRendering
@@ -25,7 +23,7 @@ describe('connectPriceRanges', () => {
     const config = widget.getConfiguration();
     expect(config).toEqual({ facets: [attributeName] });
 
-    const helper = jsHelper(fakeClient, '', config);
+    const helper = jsHelper({}, '', config);
     helper.search = sinon.stub();
 
     widget.init({
@@ -51,7 +49,8 @@ describe('connectPriceRanges', () => {
         {
           hits: [{ test: 'oneTime' }],
           facets: { price: { 10: 1, 20: 1, 30: 1 } },
-        facets_stats: { // eslint-disable-line
+          facets_stats: {
+            // eslint-disable-line
             price: {
               avg: 20,
               max: 30,
@@ -102,7 +101,7 @@ describe('connectPriceRanges', () => {
       attributeName,
     });
 
-    const helper = jsHelper(fakeClient, '', widget.getConfiguration());
+    const helper = jsHelper({}, '', widget.getConfiguration());
     helper.search = sinon.stub();
 
     widget.init({
@@ -129,7 +128,8 @@ describe('connectPriceRanges', () => {
         {
           hits: [{ test: 'oneTime' }],
           facets: { price: { 10: 1, 20: 1, 30: 1 } },
-        facets_stats: { // eslint-disable-line
+          facets_stats: {
+            // eslint-disable-line
             price: {
               avg: 20,
               max: 30,
@@ -169,7 +169,7 @@ describe('connectPriceRanges', () => {
       });
 
       const config = widget.getConfiguration({}, {});
-      const helper = jsHelper(fakeClient, '', config);
+      const helper = jsHelper({}, '', config);
       helper.search = jest.fn();
 
       widget.init({

--- a/src/connectors/price-ranges/__tests__/connectPriceRanges-test.js
+++ b/src/connectors/price-ranges/__tests__/connectPriceRanges-test.js
@@ -49,8 +49,8 @@ describe('connectPriceRanges', () => {
         {
           hits: [{ test: 'oneTime' }],
           facets: { price: { 10: 1, 20: 1, 30: 1 } },
+          // eslint-disable-next-line
           facets_stats: {
-            // eslint-disable-line
             price: {
               avg: 20,
               max: 30,
@@ -128,8 +128,8 @@ describe('connectPriceRanges', () => {
         {
           hits: [{ test: 'oneTime' }],
           facets: { price: { 10: 1, 20: 1, 30: 1 } },
+          // eslint-disable-next-line
           facets_stats: {
-            // eslint-disable-line
             price: {
               avg: 20,
               max: 30,

--- a/src/connectors/range/__tests__/connectRange-test.js
+++ b/src/connectors/range/__tests__/connectRange-test.js
@@ -7,8 +7,6 @@ import jsHelper, {
 
 import connectRange from '../connectRange.js';
 
-const fakeClient = { addAlgoliaAgent: () => {} };
-
 describe('connectRange', () => {
   it('Renders during init and render', () => {
     // test that the dummyRendering is called with the isFirstRendering
@@ -26,7 +24,7 @@ describe('connectRange', () => {
       disjunctiveFacets: [attributeName],
     });
 
-    const helper = jsHelper(fakeClient, '', config);
+    const helper = jsHelper({}, '', config);
     helper.search = sinon.stub();
 
     widget.init({
@@ -134,7 +132,7 @@ describe('connectRange', () => {
       attributeName,
     });
 
-    const helper = jsHelper(fakeClient, '', widget.getConfiguration());
+    const helper = jsHelper({}, '', widget.getConfiguration());
     helper.search = sinon.stub();
 
     widget.init({
@@ -201,7 +199,7 @@ describe('connectRange', () => {
     const attributeName = 'price';
     const widget = makeWidget({ attributeName, min: 0, max: 500 });
 
-    const helper = jsHelper(fakeClient, '', widget.getConfiguration());
+    const helper = jsHelper({}, '', widget.getConfiguration());
     helper.search = sinon.stub();
 
     widget.init({
@@ -240,7 +238,7 @@ describe('connectRange', () => {
       indexName: 'movie',
     });
 
-    const helper = jsHelper(fakeClient, '', configuration);
+    const helper = jsHelper({}, '', configuration);
     helper.search = sinon.stub();
 
     widget.init({
@@ -276,7 +274,7 @@ describe('connectRange', () => {
     const attributeName = 'price';
     const widget = makeWidget({ attributeName });
 
-    const helper = jsHelper(fakeClient, '', widget.getConfiguration());
+    const helper = jsHelper({}, '', widget.getConfiguration());
     helper.search = sinon.stub();
 
     widget.init({
@@ -524,7 +522,7 @@ describe('connectRange', () => {
   describe('_getCurrentRefinement', () => {
     const attributeName = 'price';
     const rendering = () => {};
-    const createHelper = () => jsHelper(fakeClient);
+    const createHelper = () => jsHelper({});
 
     it('expect to return default refinement', () => {
       const widget = connectRange(rendering)({ attributeName });
@@ -567,7 +565,7 @@ describe('connectRange', () => {
     const attributeName = 'price';
     const rendering = () => {};
     const createHelper = () => {
-      const helper = jsHelper(fakeClient);
+      const helper = jsHelper({});
       helper.search = jest.fn();
       const initialClearRefinements = helper.clearRefinements;
       helper.clearRefinements = jest.fn((...args) =>
@@ -918,7 +916,7 @@ describe('connectRange', () => {
       });
 
       const config = widget.getConfiguration({}, {});
-      const helper = jsHelper(fakeClient, '', config);
+      const helper = jsHelper({}, '', config);
       helper.search = jest.fn();
 
       widget.init({

--- a/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
+++ b/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
@@ -6,8 +6,6 @@ import { tagConfig } from '../../../lib/escape-highlight.js';
 
 import connectRefinementList from '../connectRefinementList.js';
 
-const fakeClient = { addAlgoliaAgent: () => {} };
-
 describe('connectRefinementList', () => {
   const createWidgetFactory = () => {
     const rendering = jest.fn();
@@ -106,7 +104,7 @@ describe('connectRefinementList', () => {
     // test if widget is not rendered yet at this point
     expect(rendering).not.toHaveBeenCalled();
 
-    const helper = jsHelper(fakeClient, '', config);
+    const helper = jsHelper({}, '', config);
     helper.search = jest.fn();
 
     widget.init({
@@ -153,7 +151,7 @@ describe('connectRefinementList', () => {
       attributeName: 'category',
     });
 
-    const helper = jsHelper(fakeClient, '', widget.getConfiguration({}));
+    const helper = jsHelper({}, '', widget.getConfiguration({}));
     helper.search = jest.fn();
 
     helper.toggleRefinement('category', 'value');
@@ -195,7 +193,7 @@ describe('connectRefinementList', () => {
       showMoreLimit: 10,
     });
 
-    const helper = jsHelper(fakeClient, '', widget.getConfiguration({}));
+    const helper = jsHelper({}, '', widget.getConfiguration({}));
     helper.search = jest.fn();
 
     widget.init({
@@ -241,7 +239,7 @@ describe('connectRefinementList', () => {
       limit: 1,
     });
 
-    const helper = jsHelper(fakeClient, '', widget.getConfiguration({}));
+    const helper = jsHelper({}, '', widget.getConfiguration({}));
     helper.search = jest.fn();
 
     widget.init({
@@ -292,7 +290,7 @@ describe('connectRefinementList', () => {
       showMoreLimit: 10,
     });
 
-    const helper = jsHelper(fakeClient, '', widget.getConfiguration({}));
+    const helper = jsHelper({}, '', widget.getConfiguration({}));
     helper.search = jest.fn();
 
     widget.init({
@@ -343,7 +341,7 @@ describe('connectRefinementList', () => {
       showMoreLimit: 10,
     });
 
-    const helper = jsHelper(fakeClient, '', widget.getConfiguration({}));
+    const helper = jsHelper({}, '', widget.getConfiguration({}));
     helper.search = jest.fn();
 
     widget.init({
@@ -397,7 +395,7 @@ describe('connectRefinementList', () => {
       showMoreLimit: 3,
     });
 
-    const helper = jsHelper(fakeClient, '', widget.getConfiguration({}));
+    const helper = jsHelper({}, '', widget.getConfiguration({}));
     helper.search = jest.fn();
 
     widget.init({
@@ -489,7 +487,7 @@ describe('connectRefinementList', () => {
       limit: 2,
     });
 
-    const helper = jsHelper(fakeClient, '', widget.getConfiguration({}));
+    const helper = jsHelper({}, '', widget.getConfiguration({}));
     helper.search = jest.fn();
 
     widget.init({
@@ -566,7 +564,7 @@ describe('connectRefinementList', () => {
       limit: 2,
     });
 
-    const helper = jsHelper(fakeClient, '', {
+    const helper = jsHelper({}, '', {
       ...widget.getConfiguration({}),
       maxValuesPerFacet: 3,
     });
@@ -647,7 +645,7 @@ describe('connectRefinementList', () => {
       limit: 2,
     });
 
-    const helper = jsHelper(fakeClient, '', widget.getConfiguration({}));
+    const helper = jsHelper({}, '', widget.getConfiguration({}));
     helper.search = jest.fn();
     helper.searchForFacetValues = jest.fn().mockReturnValue(
       Promise.resolve({
@@ -746,7 +744,7 @@ describe('connectRefinementList', () => {
       limit: 2,
     });
 
-    const helper = jsHelper(fakeClient, '', {
+    const helper = jsHelper({}, '', {
       ...widget.getConfiguration({}),
       // Here we simulate that another widget has set some highlight tags
       ...tagConfig,
@@ -850,7 +848,7 @@ describe('connectRefinementList', () => {
       escapeFacetValues: true,
     });
 
-    const helper = jsHelper(fakeClient, '', {
+    const helper = jsHelper({}, '', {
       ...widget.getConfiguration({}),
       // Here we simulate that another widget has set some highlight tags
       ...tagConfig,
@@ -958,7 +956,7 @@ describe('connectRefinementList', () => {
       });
 
       const initialConfig = widget.getConfiguration({}, {});
-      const helper = jsHelper(fakeClient, '', initialConfig);
+      const helper = jsHelper({}, '', initialConfig);
       helper.search = jest.fn();
 
       widget.init({

--- a/src/connectors/search-box/__tests__/connectSearchBox-test.js
+++ b/src/connectors/search-box/__tests__/connectSearchBox-test.js
@@ -5,8 +5,6 @@ import jsHelper, {
 
 import connectSearchBox from '../connectSearchBox.js';
 
-const fakeClient = { addAlgoliaAgent: () => {} };
-
 describe('connectSearchBox', () => {
   it('Renders during init and render', () => {
     // test that the dummyRendering is called with the isFirstRendering
@@ -20,7 +18,7 @@ describe('connectSearchBox', () => {
 
     expect(widget.getConfiguration).toBe(undefined);
 
-    const helper = jsHelper(fakeClient);
+    const helper = jsHelper({});
     helper.search = () => {};
 
     widget.init({
@@ -67,7 +65,7 @@ describe('connectSearchBox', () => {
 
     const widget = makeWidget();
 
-    const helper = jsHelper(fakeClient);
+    const helper = jsHelper({});
     helper.search = jest.fn();
 
     widget.init({
@@ -111,7 +109,7 @@ describe('connectSearchBox', () => {
 
     const widget = makeWidget();
 
-    const helper = jsHelper(fakeClient, '', {
+    const helper = jsHelper({}, '', {
       query: 'bup',
     });
     helper.search = jest.fn();
@@ -166,7 +164,7 @@ describe('connectSearchBox', () => {
       queryHook,
     });
 
-    const helper = jsHelper(fakeClient);
+    const helper = jsHelper({});
     helper.search = jest.fn();
 
     widget.init({
@@ -226,7 +224,7 @@ describe('connectSearchBox', () => {
 
     const widget = makeWidget();
 
-    const helper = jsHelper(fakeClient);
+    const helper = jsHelper({});
     helper.search = () => {};
 
     widget.init({
@@ -266,7 +264,7 @@ describe('connectSearchBox', () => {
 
     const widget = makeWidget();
 
-    const helper = jsHelper(fakeClient);
+    const helper = jsHelper({});
     helper.search = jest.fn();
     helper.setQuery('foobar');
 
@@ -296,7 +294,7 @@ describe('connectSearchBox', () => {
       });
 
       const initialConfig = {};
-      const helper = jsHelper(fakeClient, '', initialConfig);
+      const helper = jsHelper({}, '', initialConfig);
       helper.search = jest.fn();
 
       widget.init({

--- a/src/connectors/sort-by-selector/__tests__/connectSortBySelector-test.js
+++ b/src/connectors/sort-by-selector/__tests__/connectSortBySelector-test.js
@@ -8,8 +8,6 @@ import jsHelper, {
 import connectSortBySelector from '../connectSortBySelector.js';
 import instantSearch from '../../../lib/main.js';
 
-const fakeClient = { addAlgoliaAgent: () => {} };
-
 describe('connectSortBySelector', () => {
   it('Renders during init and render', () => {
     // test that the dummyRendering is called with the isFirstRendering
@@ -20,7 +18,7 @@ describe('connectSortBySelector', () => {
       apiKey: '',
       appId: '',
       indexName: 'defaultIndex',
-      createAlgoliaClient: () => fakeClient,
+      createAlgoliaClient: () => ({}),
     });
 
     const indices = [
@@ -31,7 +29,7 @@ describe('connectSortBySelector', () => {
 
     expect(widget.getConfiguration).toBe(undefined);
 
-    const helper = jsHelper(fakeClient, indices[0].name);
+    const helper = jsHelper({}, indices[0].name);
     helper.search = sinon.stub();
 
     widget.init({
@@ -92,7 +90,7 @@ describe('connectSortBySelector', () => {
       apiKey: '',
       appId: '',
       indexName: 'defaultIndex',
-      createAlgoliaClient: () => fakeClient,
+      createAlgoliaClient: () => ({}),
     });
 
     const indices = [
@@ -103,7 +101,7 @@ describe('connectSortBySelector', () => {
       indices,
     });
 
-    const helper = jsHelper(fakeClient, indices[0].name);
+    const helper = jsHelper({}, indices[0].name);
     helper.search = sinon.stub();
 
     widget.init({
@@ -152,7 +150,7 @@ describe('connectSortBySelector', () => {
         apiKey: '',
         appId: '',
         indexName: 'relevance',
-        createAlgoliaClient: () => fakeClient,
+        createAlgoliaClient: () => ({}),
       });
       const indices = [
         { label: 'Sort products by relevance', name: 'relevance' },
@@ -166,7 +164,7 @@ describe('connectSortBySelector', () => {
       });
 
       const initialConfig = {};
-      const helper = jsHelper(fakeClient, 'relevance', initialConfig);
+      const helper = jsHelper({}, 'relevance', initialConfig);
       helper.search = jest.fn();
 
       widget.init({

--- a/src/connectors/star-rating/__tests__/connectStarRating-test.js
+++ b/src/connectors/star-rating/__tests__/connectStarRating-test.js
@@ -7,8 +7,6 @@ import jsHelper, {
 
 import connectStarRating from '../connectStarRating.js';
 
-const fakeClient = { addAlgoliaAgent: () => {} };
-
 describe('connectStarRating', () => {
   it('Renders during init and render', () => {
     // test that the dummyRendering is called with the isFirstRendering
@@ -26,7 +24,7 @@ describe('connectStarRating', () => {
       disjunctiveFacets: [attributeName],
     });
 
-    const helper = jsHelper(fakeClient, '', config);
+    const helper = jsHelper({}, '', config);
     helper.search = sinon.stub();
 
     widget.init({
@@ -114,7 +112,7 @@ describe('connectStarRating', () => {
 
     const config = widget.getConfiguration({});
 
-    const helper = jsHelper(fakeClient, '', config);
+    const helper = jsHelper({}, '', config);
     helper.search = sinon.stub();
 
     widget.init({
@@ -217,7 +215,7 @@ describe('connectStarRating', () => {
       });
 
       const initialConfig = widget.getConfiguration({});
-      const helper = jsHelper(fakeClient, '', initialConfig);
+      const helper = jsHelper({}, '', initialConfig);
       helper.search = jest.fn();
 
       widget.init({

--- a/src/connectors/stats/__tests__/connectStats-test.js
+++ b/src/connectors/stats/__tests__/connectStats-test.js
@@ -5,8 +5,6 @@ const SearchResults = jsHelper.SearchResults;
 
 import connectStats from '../connectStats.js';
 
-const fakeClient = { addAlgoliaAgent: () => {} };
-
 describe('connectStats', () => {
   it('Renders during init and render', () => {
     // test that the dummyRendering is called with the isFirstRendering
@@ -20,7 +18,7 @@ describe('connectStats', () => {
 
     expect(widget.getConfiguration).toEqual(undefined);
 
-    const helper = jsHelper(fakeClient);
+    const helper = jsHelper({});
     helper.search = sinon.stub();
 
     widget.init({

--- a/src/connectors/toggle/__tests__/connectToggle-test.js
+++ b/src/connectors/toggle/__tests__/connectToggle-test.js
@@ -7,8 +7,6 @@ import jsHelper, {
 
 import connectToggle from '../connectToggle.js';
 
-const fakeClient = { addAlgoliaAgent: () => {} };
-
 describe('connectToggle', () => {
   it('Renders during init and render', () => {
     // test that the dummyRendering is called with the isFirstRendering
@@ -28,7 +26,7 @@ describe('connectToggle', () => {
       disjunctiveFacets: [attributeName],
     });
 
-    const helper = jsHelper(fakeClient, '', config);
+    const helper = jsHelper({}, '', config);
     helper.search = sinon.stub();
 
     widget.init({
@@ -73,8 +71,8 @@ describe('connectToggle', () => {
         {
           facets: {
             isShippingFree: {
-            'true': 45, // eslint-disable-line
-            'false': 40, // eslint-disable-line
+              true: 45, // eslint-disable-line
+              false: 40, // eslint-disable-line
             },
           },
           nbHits: 85,
@@ -122,7 +120,7 @@ describe('connectToggle', () => {
       label,
     });
 
-    const helper = jsHelper(fakeClient, '', widget.getConfiguration());
+    const helper = jsHelper({}, '', widget.getConfiguration());
     helper.search = sinon.stub();
 
     widget.init({
@@ -169,8 +167,8 @@ describe('connectToggle', () => {
         {
           facets: {
             isShippingFree: {
-            'true': 45, // eslint-disable-line
-            'false': 40, // eslint-disable-line
+              true: 45, // eslint-disable-line
+              false: 40, // eslint-disable-line
             },
           },
           nbHits: 85,
@@ -214,7 +212,7 @@ describe('connectToggle', () => {
         {
           facets: {
             isShippingFree: {
-            'true': 45, // eslint-disable-line
+              true: 45, // eslint-disable-line
             },
           },
           nbHits: 85,
@@ -222,8 +220,8 @@ describe('connectToggle', () => {
         {
           facets: {
             isShippingFree: {
-            'true': 45, // eslint-disable-line
-            'false': 40, // eslint-disable-line
+              true: 45, // eslint-disable-line
+              false: 40, // eslint-disable-line
             },
           },
           nbHits: 85,
@@ -278,7 +276,7 @@ describe('connectToggle', () => {
       },
     });
 
-    const helper = jsHelper(fakeClient, '', widget.getConfiguration());
+    const helper = jsHelper({}, '', widget.getConfiguration());
     helper.search = sinon.stub();
 
     widget.init({
@@ -326,7 +324,7 @@ describe('connectToggle', () => {
         {
           facets: {
             isShippingFree: {
-            'false': 40, // eslint-disable-line
+              false: 40, // eslint-disable-line
             },
           },
           nbHits: 40,
@@ -334,8 +332,8 @@ describe('connectToggle', () => {
         {
           facets: {
             isShippingFree: {
-            'true': 45, // eslint-disable-line
-            'false': 40, // eslint-disable-line
+              true: 45, // eslint-disable-line
+              false: 40, // eslint-disable-line
             },
           },
           nbHits: 85,
@@ -380,7 +378,7 @@ describe('connectToggle', () => {
         {
           facets: {
             isShippingFree: {
-            'true': 45, // eslint-disable-line
+              true: 45, // eslint-disable-line
             },
           },
           nbHits: 85,
@@ -388,8 +386,8 @@ describe('connectToggle', () => {
         {
           facets: {
             isShippingFree: {
-            'true': 45, // eslint-disable-line
-            'false': 40, // eslint-disable-line
+              true: 45, // eslint-disable-line
+              false: 40, // eslint-disable-line
             },
           },
           nbHits: 85,
@@ -443,7 +441,7 @@ describe('connectToggle', () => {
       });
 
       const initialConfig = widget.getConfiguration({});
-      const helper = jsHelper(fakeClient, '', initialConfig);
+      const helper = jsHelper({}, '', initialConfig);
       helper.search = jest.fn();
 
       widget.init({

--- a/src/connectors/toggle/__tests__/connectToggle-test.js
+++ b/src/connectors/toggle/__tests__/connectToggle-test.js
@@ -71,8 +71,8 @@ describe('connectToggle', () => {
         {
           facets: {
             isShippingFree: {
-              true: 45, // eslint-disable-line
-              false: 40, // eslint-disable-line
+              true: 45,
+              false: 40,
             },
           },
           nbHits: 85,
@@ -167,8 +167,8 @@ describe('connectToggle', () => {
         {
           facets: {
             isShippingFree: {
-              true: 45, // eslint-disable-line
-              false: 40, // eslint-disable-line
+              true: 45,
+              false: 40,
             },
           },
           nbHits: 85,
@@ -212,7 +212,7 @@ describe('connectToggle', () => {
         {
           facets: {
             isShippingFree: {
-              true: 45, // eslint-disable-line
+              true: 45,
             },
           },
           nbHits: 85,
@@ -220,8 +220,8 @@ describe('connectToggle', () => {
         {
           facets: {
             isShippingFree: {
-              true: 45, // eslint-disable-line
-              false: 40, // eslint-disable-line
+              true: 45,
+              false: 40,
             },
           },
           nbHits: 85,
@@ -324,7 +324,7 @@ describe('connectToggle', () => {
         {
           facets: {
             isShippingFree: {
-              false: 40, // eslint-disable-line
+              false: 40,
             },
           },
           nbHits: 40,
@@ -332,8 +332,8 @@ describe('connectToggle', () => {
         {
           facets: {
             isShippingFree: {
-              true: 45, // eslint-disable-line
-              false: 40, // eslint-disable-line
+              true: 45,
+              false: 40,
             },
           },
           nbHits: 85,
@@ -378,7 +378,7 @@ describe('connectToggle', () => {
         {
           facets: {
             isShippingFree: {
-              true: 45, // eslint-disable-line
+              true: 45,
             },
           },
           nbHits: 85,
@@ -386,8 +386,8 @@ describe('connectToggle', () => {
         {
           facets: {
             isShippingFree: {
-              true: 45, // eslint-disable-line
-              false: 40, // eslint-disable-line
+              true: 45,
+              false: 40,
             },
           },
           nbHits: 85,

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -314,7 +314,6 @@ Usage: instantsearch({
       helper.search = () => {
         const helperSearchFunction = algoliasearchHelper(
           {
-            addAlgoliaAgent: () => {},
             search: () => Promise.resolve({ results: [{}] }),
           },
           helper.state.index,

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -312,7 +312,7 @@ Usage: instantsearch({
         const helperSearchFunction = algoliasearchHelper(
           {
             addAlgoliaAgent: () => {},
-            search: () => {},
+            search: () => Promise.resolve({ results: [{}] }),
           },
           helper.state.index,
           helper.state

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -65,7 +65,10 @@ Usage: instantsearch({
     }
 
     const client = createAlgoliaClient(algoliasearch, appId, apiKey);
-    client.addAlgoliaAgent(`instantsearch.js ${version}`);
+
+    if (typeof client.addAlgoliaAgent === 'function') {
+      client.addAlgoliaAgent(`instantsearch.js ${version}`);
+    }
 
     this.client = client;
     this.helper = null;

--- a/src/lib/RoutingManager.js
+++ b/src/lib/RoutingManager.js
@@ -27,7 +27,7 @@ export default class RoutingManager {
     // like hierarchicalFacet.rootPath are then triggering a default refinement that would
     // be not present if it was not going trough the SearchParameters constructor
     this.originalConfig = algoliasearchHelper(
-      { addAlgoliaAgent() {} },
+      {},
       currentConfiguration.index,
       currentConfiguration
     ).state;

--- a/src/lib/__tests__/InstantSearch-test-2.js
+++ b/src/lib/__tests__/InstantSearch-test-2.js
@@ -14,7 +14,7 @@ describe('InstantSearch life cycle', () => {
     });
 
     const fakeClient = {
-      search: jest.fn(),
+      search: jest.fn(() => Promise.resolve({ results: [{}] })),
       addAlgoliaAgent: () => {},
     };
 
@@ -54,16 +54,12 @@ describe('InstantSearch life cycle', () => {
   });
 
   it('triggers the stalled search rendering once if the search does not resolve in time', () => {
-    const searchResultsResolvers = [];
     const searchResultsPromises = [];
     const fakeClient = {
-      search: jest.fn((qs, cb) => {
-        const p = new Promise(resolve =>
-          searchResultsResolvers.push(resolve)
-        ).then(() => {
-          cb(null, fakeResults());
-        });
-        searchResultsPromises.push(p);
+      search: jest.fn(() => {
+        const results = Promise.resolve(fakeResults());
+        searchResultsPromises.push(results);
+        return results;
       }),
       addAlgoliaAgent: () => {},
     };
@@ -95,9 +91,6 @@ describe('InstantSearch life cycle', () => {
     expect(widget.init).toHaveBeenCalledTimes(1);
     expect(widget.render).not.toHaveBeenCalled();
 
-    // first results come back
-    searchResultsResolvers[0]();
-
     return searchResultsPromises[0].then(() => {
       // render has now been called
       expect(widget.render).toHaveBeenCalledTimes(1);
@@ -126,7 +119,6 @@ describe('InstantSearch life cycle', () => {
         })
       );
 
-      searchResultsResolvers[1]();
       return searchResultsPromises[1].then(() => {
         expect(widget.render).toHaveBeenCalledTimes(3);
         expect(widget.render).toHaveBeenLastCalledWith(
@@ -150,7 +142,7 @@ describe('InstantSearch life cycle', () => {
     });
 
     const fakeClient = {
-      search: jest.fn(),
+      search: jest.fn(() => Promise.resolve({ results: [{}] })),
       addAlgoliaAgent: () => {},
     };
 

--- a/src/lib/__tests__/InstantSearch-test-2.js
+++ b/src/lib/__tests__/InstantSearch-test-2.js
@@ -15,7 +15,6 @@ describe('InstantSearch life cycle', () => {
 
     const fakeClient = {
       search: jest.fn(() => Promise.resolve({ results: [{}] })),
-      addAlgoliaAgent: () => {},
     };
 
     const search = new InstantSearch({
@@ -61,7 +60,6 @@ describe('InstantSearch life cycle', () => {
         searchResultsPromises.push(results);
         return results;
       }),
-      addAlgoliaAgent: () => {},
     };
 
     const search = new InstantSearch({
@@ -143,7 +141,6 @@ describe('InstantSearch life cycle', () => {
 
     const fakeClient = {
       search: jest.fn(() => Promise.resolve({ results: [{}] })),
-      addAlgoliaAgent: () => {},
     };
 
     const search = new InstantSearch({

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -19,7 +19,7 @@ describe('InstantSearch lifecycle', () => {
   let urlSync;
 
   beforeEach(() => {
-    client = { algolia: 'client', addAlgoliaAgent: () => {} };
+    client = { algolia: 'client' };
     helper = algoliaSearchHelper(client);
 
     // when using searchFunction, we lose the reference to

--- a/src/lib/__tests__/RoutingManager-test.js
+++ b/src/lib/__tests__/RoutingManager-test.js
@@ -4,7 +4,7 @@ import simpleMapping from '../stateMappings/simple.js';
 
 const makeFakeAlgoliaClient = () => ({
   addAlgoliaAgent: () => {},
-  search: () => {},
+  search: () => Promise.resolve({ results: [{}] }),
 });
 
 describe('RoutingManager', () => {

--- a/src/lib/__tests__/RoutingManager-test.js
+++ b/src/lib/__tests__/RoutingManager-test.js
@@ -3,7 +3,6 @@ import RoutingManager from '../RoutingManager.js';
 import simpleMapping from '../stateMappings/simple.js';
 
 const makeFakeAlgoliaClient = () => ({
-  addAlgoliaAgent: () => {},
   search: () => Promise.resolve({ results: [{}] }),
 });
 

--- a/src/lib/__tests__/__snapshots__/InstantSearch-test.js.snap
+++ b/src/lib/__tests__/__snapshots__/InstantSearch-test.js.snap
@@ -15,7 +15,6 @@ Array [
       "_lastQueryIdReceived": -1,
       "_queryId": 0,
       "client": Object {
-        "addAlgoliaAgent": [Function],
         "algolia": "client",
       },
       "derivedHelpers": Array [],
@@ -88,7 +87,6 @@ Array [
       "_searchStalledTimer": null,
       "_stalledSearchDelay": 200,
       "client": Object {
-        "addAlgoliaAgent": [Function],
         "algolia": "client",
       },
       "domain": null,
@@ -103,7 +101,6 @@ Array [
         "_lastQueryIdReceived": -1,
         "_queryId": 0,
         "client": Object {
-          "addAlgoliaAgent": [Function],
           "algolia": "client",
         },
         "derivedHelpers": Array [],

--- a/src/lib/__tests__/url-sync-test.js
+++ b/src/lib/__tests__/url-sync-test.js
@@ -25,7 +25,7 @@ const makeTestUrlUtils = () => ({
 
 describe('urlSync mechanics', () => {
   test('Generates urls on change', () => {
-    const helper = jsHelper({ addAlgoliaAgent: () => {} });
+    const helper = jsHelper({});
     const urlUtils = makeTestUrlUtils();
     const urlSyncWidget = urlSync({ urlUtils, threshold: 0 });
     urlSyncWidget.init({ state: SearchParameters.make({}) });
@@ -40,7 +40,7 @@ describe('urlSync mechanics', () => {
     expect(urlUtils.lastQs).toMatchSnapshot();
   });
   test('Generated urls should not contain a version', () => {
-    const helper = jsHelper({ addAlgoliaAgent: () => {} });
+    const helper = jsHelper({});
     const urlUtils = makeTestUrlUtils();
     const urlSyncWidget = urlSync({ urlUtils, threshold: 0 });
     urlSyncWidget.init({ state: SearchParameters.make({}) });
@@ -52,7 +52,7 @@ describe('urlSync mechanics', () => {
     expect(urlUtils.lastQs).not.toEqual(expect.stringContaining('is_v'));
   });
   test('updates the URL during the first rendering if it has change since the initial configuration', () => {
-    const helper = jsHelper({ addAlgoliaAgent: () => {} });
+    const helper = jsHelper({});
     const urlUtils = makeTestUrlUtils();
     const urlSyncWidget = urlSync({ urlUtils, threshold: 0 });
     urlSyncWidget.init({ state: SearchParameters.make({}) });

--- a/src/lib/__tests__/utils-test.js
+++ b/src/lib/__tests__/utils-test.js
@@ -291,7 +291,7 @@ describe('utils.getRefinements', () => {
   let results;
 
   beforeEach(() => {
-    helper = algoliasearchHelper({ addAlgoliaAgent: () => {} }, 'my_index', {
+    helper = algoliasearchHelper({}, 'my_index', {
       facets: ['facet1', 'facet2', 'numericFacet1'],
       disjunctiveFacets: [
         'disjunctiveFacet1',
@@ -871,7 +871,7 @@ describe('utils.clearRefinementsFromState', () => {
   let state;
 
   beforeEach(() => {
-    helper = algoliasearchHelper({ addAlgoliaAgent: () => {} }, 'my_index', {
+    helper = algoliasearchHelper({}, 'my_index', {
       facets: ['facet1', 'facet2', 'numericFacet1', 'facetExclude1'],
       disjunctiveFacets: ['disjunctiveFacet1', 'numericDisjunctiveFacet'],
       hierarchicalFacets: [

--- a/src/lib/url-sync.js
+++ b/src/lib/url-sync.js
@@ -127,7 +127,7 @@ class URLSync {
     // like hierarchicalFacet.rootPath are then triggering a default refinement that would
     // be not present if it was not going trough the SearchParameters constructor
     this.originalConfig = algoliasearchHelper(
-      { addAlgoliaAgent() {} },
+      {},
       currentConfiguration.index,
       currentConfiguration
     ).state;

--- a/src/widgets/geo-search/__tests__/geo-search-test.js
+++ b/src/widgets/geo-search/__tests__/geo-search-test.js
@@ -97,9 +97,6 @@ describe('GeoSearch', () => {
         search() {
           return Promise.resolve({ results: [{}] });
         },
-        addAlgoliaAgent() {
-          return {};
-        },
       },
       'indexName'
     );

--- a/src/widgets/geo-search/__tests__/geo-search-test.js
+++ b/src/widgets/geo-search/__tests__/geo-search-test.js
@@ -94,7 +94,9 @@ describe('GeoSearch', () => {
   const createFakeHelper = () =>
     algoliasearchHelper(
       {
-        search() {},
+        search() {
+          return Promise.resolve({ results: [{}] });
+        },
         addAlgoliaAgent() {
           return {};
         },

--- a/src/widgets/infinite-hits/__tests__/infinite-hits-test.js
+++ b/src/widgets/infinite-hits/__tests__/infinite-hits-test.js
@@ -17,7 +17,7 @@ describe('infiniteHits()', () => {
   let helper;
 
   beforeEach(() => {
-    helper = algoliasearchHelper({ addAlgoliaAgent: () => {} });
+    helper = algoliasearchHelper({});
     helper.search = sinon.spy();
 
     ReactDOM = { render: sinon.spy() };

--- a/src/widgets/range-input/__tests__/range-input-test.js
+++ b/src/widgets/range-input/__tests__/range-input-test.js
@@ -17,7 +17,9 @@ describe('rangeInput', () => {
   const createHelper = () =>
     new AlgoliasearchHelper(
       {
-        search() {},
+        search() {
+          return Promise.resolve({ results: [{}] });
+        },
         addAlgoliaAgent() {
           return {};
         },

--- a/src/widgets/range-input/__tests__/range-input-test.js
+++ b/src/widgets/range-input/__tests__/range-input-test.js
@@ -20,9 +20,6 @@ describe('rangeInput', () => {
         search() {
           return Promise.resolve({ results: [{}] });
         },
-        addAlgoliaAgent() {
-          return {};
-        },
       },
       'indexName',
       { disjunctiveFacets: [attributeName] }

--- a/src/widgets/range-slider/__tests__/range-slider-test.js
+++ b/src/widgets/range-slider/__tests__/range-slider-test.js
@@ -30,7 +30,9 @@ describe('rangeSlider', () => {
       container = document.createElement('div');
       helper = new AlgoliasearchHelper(
         {
-          search() {},
+          search() {
+            return Promise.resolve({ results: [{}] });
+          },
           addAlgoliaAgent() {
             return {};
           },

--- a/src/widgets/range-slider/__tests__/range-slider-test.js
+++ b/src/widgets/range-slider/__tests__/range-slider-test.js
@@ -33,9 +33,6 @@ describe('rangeSlider', () => {
           search() {
             return Promise.resolve({ results: [{}] });
           },
-          addAlgoliaAgent() {
-            return {};
-          },
         },
         'indexName',
         { disjunctiveFacets: ['aNumAttr'] }

--- a/src/widgets/sort-by-selector/__tests__/sort-by-selector-test.js
+++ b/src/widgets/sort-by-selector/__tests__/sort-by-selector-test.js
@@ -5,8 +5,6 @@ import Selector from '../../../components/Selector';
 
 import instantSearch from '../../../lib/main.js';
 
-const fakeClient = { addAlgoliaAgent: () => {} };
-
 describe('sortBySelector call', () => {
   it('throws an exception when no options', () => {
     const container = document.createElement('div');
@@ -34,7 +32,7 @@ describe('sortBySelector()', () => {
       apiKey: '',
       appId: '',
       indexName: 'defaultIndex',
-      createAlgoliaClient: () => fakeClient,
+      createAlgoliaClient: () => ({}),
     });
     autoHideContainer = sinon.stub().returns(Selector);
     ReactDOM = { render: sinon.spy() };

--- a/src/widgets/star-rating/__tests__/star-rating-test.js
+++ b/src/widgets/star-rating/__tests__/star-rating-test.js
@@ -6,7 +6,6 @@ import jsHelper from 'algoliasearch-helper';
 import defaultLabels from '../../../widgets/star-rating/defaultLabels.js';
 import starRating from '../star-rating.js';
 
-const fakeClient = { addAlgoliaAgent: () => {} };
 const SearchResults = jsHelper.SearchResults;
 
 describe('starRating()', () => {
@@ -30,7 +29,7 @@ describe('starRating()', () => {
       attributeName,
       cssClasses: { body: ['body', 'cx'] },
     });
-    helper = jsHelper(fakeClient, '', widget.getConfiguration({}));
+    helper = jsHelper({}, '', widget.getConfiguration({}));
     sinon.spy(helper, 'clearRefinements');
     sinon.spy(helper, 'addDisjunctiveFacetRefinement');
     sinon.spy(helper, 'getRefinements');
@@ -155,7 +154,7 @@ describe('starRating()', () => {
       attributeName,
       cssClasses: { body: ['body', 'cx'] },
     });
-    const _helper = jsHelper(fakeClient, '', _widget.getConfiguration({}));
+    const _helper = jsHelper({}, '', _widget.getConfiguration({}));
     _helper.search = sinon.stub();
 
     _widget.init({

--- a/src/widgets/toggle/__tests__/currentToggle-test.js
+++ b/src/widgets/toggle/__tests__/currentToggle-test.js
@@ -230,7 +230,7 @@ describe('currentToggle()', () => {
         });
 
         const config = widget.getConfiguration();
-        const altHelper = jsHelper({ addAlgoliaAgent: () => {} }, '', config);
+        const altHelper = jsHelper({}, '', config);
         altHelper.search = () => {};
 
         widget.init({
@@ -471,7 +471,7 @@ describe('currentToggle()', () => {
           });
 
           const config = widget.getConfiguration();
-          const altHelper = jsHelper({ addAlgoliaAgent: () => {} }, '', config);
+          const altHelper = jsHelper({}, '', config);
           altHelper.search = () => {};
 
           const createURL = () => '#';
@@ -543,7 +543,7 @@ describe('currentToggle()', () => {
           values: userValues,
         });
         const config = widget.getConfiguration();
-        const helper = jsHelper({ addAlgoliaAgent: () => {} }, '', config);
+        const helper = jsHelper({}, '', config);
 
         // When
         widget.init({

--- a/yarn.lock
+++ b/yarn.lock
@@ -188,13 +188,13 @@ ajv@^6.1.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
 
-algoliasearch-helper@2.25.1:
-  version "2.25.1"
-  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-2.25.1.tgz#89828b83257df7e6cd0a9e42cfb4ab5dd35a7f4e"
+algoliasearch-helper@2.26.0:
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-2.26.0.tgz#cb784b692a5aacf17062493cb0b94f6d60d30d0f"
   dependencies:
-    events "^1.1.0"
-    lodash "^4.13.1"
-    qs "^6.2.1"
+    events "^1.1.1"
+    lodash "^4.17.5"
+    qs "^6.5.1"
     util "^0.10.3"
 
 algoliasearch@3.27.0:
@@ -8109,7 +8109,7 @@ q@^1.1.2, q@^1.4.1, q@^1.5.1, q@~1.5.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
 
-qs@6.5.1, qs@^6.2.1, qs@^6.4.0, qs@~6.5.1:
+qs@6.5.1, qs@^6.4.0, qs@^6.5.1, qs@~6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -188,16 +188,36 @@ ajv@^6.1.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
 
-algoliasearch-helper@2.24.0:
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-2.24.0.tgz#6ebf91683a82799bc4019ee1ad92d0ad0f41167b"
+algoliasearch-helper@2.25.1:
+  version "2.25.1"
+  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-2.25.1.tgz#89828b83257df7e6cd0a9e42cfb4ab5dd35a7f4e"
   dependencies:
     events "^1.1.0"
     lodash "^4.13.1"
     qs "^6.2.1"
     util "^0.10.3"
 
-algoliasearch@3.25.1, algoliasearch@^3.24.0:
+algoliasearch@3.27.0:
+  version "3.27.0"
+  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-3.27.0.tgz#675b7f2d186e5785a1553369b15d47b53d4efb31"
+  dependencies:
+    agentkeepalive "^2.2.0"
+    debug "^2.6.8"
+    envify "^4.0.0"
+    es6-promise "^4.1.0"
+    events "^1.1.0"
+    foreach "^2.0.5"
+    global "^4.3.2"
+    inherits "^2.0.1"
+    isarray "^2.0.1"
+    load-script "^1.0.0"
+    object-keys "^1.0.11"
+    querystring-es3 "^0.2.1"
+    reduce "^1.0.1"
+    semver "^5.1.0"
+    tunnel-agent "^0.6.0"
+
+algoliasearch@^3.24.0:
   version "3.25.1"
   resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-3.25.1.tgz#e543108b528e5c89338834473cb8fb082d13d11f"
   dependencies:


### PR DESCRIPTION
This PR updates to `algoliasearch@3.27.0` and `algoliasearch-helper@2.25.1`, using the promisified version of `client.search()`.

This update anticipates the integration of the next minor version of the helper making `addAlgoliaAgent()` and `clearCache()` optional (see algolia/algoliasearch-helper-js#577).