### PR TITLE
docs(guide): Add guide "Prepare for v3"

### DIFF
--- a/docgen/src/data/communityHeader.json
+++ b/docgen/src/data/communityHeader.json
@@ -91,6 +91,10 @@
       {
         "name": "Integrate with Angular (2+)",
         "url": "guides/angular-integration.html"
+      },
+      {
+        "name": "Prepare for v3",
+        "url": "guides/prepare-for-v3.html"
       }
     ]
   },
@@ -143,6 +147,10 @@
   {
     "name": "Migrate from V1",
     "url": "guides/migration.html"
+  },
+  {
+    "name": "Prepare for v3",
+    "url": "guides/prepare-for-v3.html"
   },
   {
     "name": "instantsearch()",

--- a/docgen/src/guides/prepare-for-v3.md
+++ b/docgen/src/guides/prepare-for-v3.md
@@ -44,3 +44,7 @@ const search = instantsearch({
 
 search.start();
 ```
+
+## Deprecations
+
+* [`createAlgoliaClient`](https://community.algolia.com/instantsearch.js/v2/instantsearch.html#struct-InstantSearchOptions-createAlgoliaClient) becomes deprecated in favor of [`searchClient`](https://community.algolia.com/instantsearch.js/v2/instantsearch.html#struct-InstantSearchOptions-searchClient)

--- a/docgen/src/guides/prepare-for-v3.md
+++ b/docgen/src/guides/prepare-for-v3.md
@@ -9,9 +9,7 @@ editable: true
 githubSource: docgen/src/guides/prepare-for-v3.md
 ---
 
-> Starting with 2.8.0, we are introducing changes and deprecations to prepare for the upcoming InstantSearch.js 3.
-
-InstantSearch has always worked with the [Algolia search client](https://github.com/algolia/algoliasearch-client-javascript) behind the scenes. This will no longer be true for InstantSearch.js 3. To ease the migration to version 3, we recommend applying the changes from this guide now.
+Starting with 2.8.0, we are introducing changes and deprecations to prepare for the upcoming InstantSearch.js 3. InstantSearch has always worked with the [Algolia search client](https://github.com/algolia/algoliasearch-client-javascript) behind the scenes. This will no longer be the default for InstantSearch.js 3. To ease that migration, we recommend applying the changes from this guide now.
 
 ## Initializing InstantSearch
 

--- a/docgen/src/guides/prepare-for-v3.md
+++ b/docgen/src/guides/prepare-for-v3.md
@@ -9,9 +9,11 @@ editable: true
 githubSource: docgen/src/guides/prepare-for-v3.md
 ---
 
-Starting with 2.8.0, we are introducing changes and deprecations to prepare for the upcoming InstantSearch.js 3. InstantSearch has always worked with the [Algolia search client](https://github.com/algolia/algoliasearch-client-javascript) behind the scenes. This will no longer be the default for InstantSearch.js 3. To ease that migration, we recommend applying the changes from this guide now.
+Starting with 2.8.0, we are introducing changes and deprecations to prepare for the upcoming release of InstantSearch.js 3.
 
 ## Initializing InstantSearch
+
+InstantSearch has always worked with the [Algolia search client](https://github.com/algolia/algoliasearch-client-javascript) behind the scenes. This will no longer be the default for InstantSearch.js 3. To prepare this future migration, you can start using the new options now.
 
 ### Current usage
 

--- a/docgen/src/guides/prepare-for-v3.md
+++ b/docgen/src/guides/prepare-for-v3.md
@@ -1,0 +1,42 @@
+---
+title: Prepare for v3
+mainTitle: Guides
+layout: main.pug
+category: guides
+withHeadings: true
+navWeight: 0
+editable: true
+githubSource: docgen/src/guides/prepare-for-v3.md
+---
+
+InstantSearch has always worked with the [Algolia search client](https://github.com/algolia/algoliasearch-client-javascript) behind the scenes. This will no longer be true for InstantSearch 3. To ease the migration from 2.8.x to 3.x.x, we recommend applying the changes from this guide now.
+
+## Current usage
+
+1.  [Import `InstantSearch.js`](https://community.algolia.com/instantsearch.js/v2/getting-started.html#install-instantsearchjs)
+2.  Initialize InstantSearch
+
+```javascript
+const search = instantsearch({
+  appId: 'appId',
+  apiKey: 'apiKey',
+  indexName: 'indexName',
+});
+
+search.start();
+```
+
+## New usage
+
+1.  [Import `algoliasearch`](https://github.com/algolia/algoliasearch-client-javascript)
+2.  [Import `InstantSearch.js`](https://community.algolia.com/instantsearch.js/v2/getting-started.html#install-instantsearchjs)
+3.  Initialize InstantSearch with the `searchClient` option
+
+```javascript
+const search = instantsearch({
+  indexName: 'indexName',
+  searchClient: algoliasearch('appId', 'apiKey'),
+});
+
+search.start();
+```

--- a/docgen/src/guides/prepare-for-v3.md
+++ b/docgen/src/guides/prepare-for-v3.md
@@ -9,9 +9,13 @@ editable: true
 githubSource: docgen/src/guides/prepare-for-v3.md
 ---
 
-InstantSearch has always worked with the [Algolia search client](https://github.com/algolia/algoliasearch-client-javascript) behind the scenes. This will no longer be true for InstantSearch 3. To ease the migration from 2.8.x to 3.x.x, we recommend applying the changes from this guide now.
+> Starting with 2.8.0, we are introducing changes and deprecations to prepare for the upcoming InstantSearch.js 3.
 
-## Current usage
+InstantSearch has always worked with the [Algolia search client](https://github.com/algolia/algoliasearch-client-javascript) behind the scenes. This will no longer be true for InstantSearch.js 3. To ease the migration to version 3, we recommend applying the changes from this guide now.
+
+## Initializing InstantSearch
+
+### Current usage
 
 1.  [Import `InstantSearch.js`](https://community.algolia.com/instantsearch.js/v2/getting-started.html#install-instantsearchjs)
 2.  Initialize InstantSearch
@@ -26,7 +30,7 @@ const search = instantsearch({
 search.start();
 ```
 
-## New usage
+### New usage
 
 1.  [Import `algoliasearch`](https://github.com/algolia/algoliasearch-client-javascript)
 2.  [Import `InstantSearch.js`](https://community.algolia.com/instantsearch.js/v2/getting-started.html#install-instantsearchjs)

--- a/docgen/src/guides/routing.md
+++ b/docgen/src/guides/routing.md
@@ -4,6 +4,7 @@ mainTitle: Guides
 layout: main.pug
 category: guides
 name: routing
+navWeight: 5
 withHeadings: true
 editable: true
 githubSource: docgen/src/guides/routing.md


### PR DESCRIPTION
This PR adds the guide "[Prepare for v3](https://deploy-preview-2905--algolia-instantsearch.netlify.com/v2/guides/prepare-for-v3.html)" to ease the migration towards InstantSearch 3 with search clients.