### PR TITLE
fix(index.es6): avoid use of Object.assign for IE

### DIFF
--- a/index.es6.js
+++ b/index.es6.js
@@ -9,10 +9,11 @@ import version from './lib/version.js';
 
 // import instantsearch from 'instantsearch.js';
 // -> provides instantsearch object without connectors and widgets
-const instantSearchFactory = Object.assign(toFactory(InstantSearch), {
-  version,
-  createQueryString: algoliasearchHelper.url.getQueryStringFromState,
-});
+const instantSearchFactory = toFactory(InstantSearch);
+
+instantSearchFactory.version = version;
+instantSearchFactory.createQueryString =
+  algoliasearchHelper.url.getQueryStringFromState;
 
 Object.defineProperty(instantSearchFactory, 'widgets', {
   get() {


### PR DESCRIPTION
**Summary**

In a recent PR (https://github.com/algolia/instantsearch.js/pull/2885) we updated all references to `Object.assign` for IE. But we forgot to update the entry point of the `es` build. The lib breaks in IE when the it's bundled with Webpack & friends.

We don't need to use the spread operator because with the previous `Object.assign` call we already mutate the factory. So we can directly assign the two attribute on it.