### PR TITLE
fix(searchFunction): Fix unresolved returned Promise

### DIFF
--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -314,7 +314,7 @@ Usage: instantsearch({
       helper.search = () => {
         const helperSearchFunction = algoliasearchHelper(
           {
-            search: () => Promise.resolve({ results: [{}] }),
+            search: () => new Promise(() => {}),
           },
           helper.state.index,
           helper.state


### PR DESCRIPTION
Since 01197db3fb98a73aae55c4fb5e888844ea5b95ce, we returned a resolved promise in the `search()` method of `searchFunction`. We instead need to return an unresolved promise to deal with multiple requests.

I noticed this bug when running [this story](https://github.com/algolia/angular-instantsearch/blob/master/examples/dev-novel/main.ts#L12) in Angular InstantSearch with the upgraded InstantSearch@2.8.0-beta.0.