### PR TITLE
 fix(connectInfiniteHits): fix #2928 

### DIFF
--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.js
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.js
@@ -11,7 +11,6 @@ describe('connectInfiniteHits', () => {
     const makeWidget = connectInfiniteHits(rendering);
     const widget = makeWidget({
       escapeHits: true,
-      hitsPerPage: 10,
     });
 
     expect(widget.getConfiguration()).toEqual({
@@ -44,7 +43,6 @@ describe('connectInfiniteHits', () => {
         instantSearchInstance: undefined,
         widgetParams: {
           escapeHits: true,
-          hitsPerPage: 10,
         },
       }),
       true
@@ -70,7 +68,6 @@ describe('connectInfiniteHits', () => {
         instantSearchInstance: undefined,
         widgetParams: {
           escapeHits: true,
-          hitsPerPage: 10,
         },
       }),
       false
@@ -207,9 +204,7 @@ describe('connectInfiniteHits', () => {
   it('does not render the same page twice', () => {
     const rendering = jest.fn();
     const makeWidget = connectInfiniteHits(rendering);
-    const widget = makeWidget({
-      hitsPerPage: 1,
-    });
+    const widget = makeWidget({});
 
     const helper = jsHelper({}, '');
     helper.search = jest.fn();

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.js
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.js
@@ -59,6 +59,7 @@ describe('connectInfiniteHits', () => {
       createURL: () => '#',
     });
 
+    expect(rendering).toHaveBeenCalledTimes(2);
     expect(rendering).toHaveBeenLastCalledWith(
       expect.objectContaining({
         hits: [],
@@ -248,7 +249,6 @@ describe('connectInfiniteHits', () => {
     expect(rendering).toHaveBeenLastCalledWith(
       expect.objectContaining({
         hits: [{ objectID: 'a' }, { objectID: 'b' }],
-        results: expect.any(Object),
       }),
       false
     );
@@ -267,10 +267,11 @@ describe('connectInfiniteHits', () => {
     });
 
     expect(rendering).toHaveBeenCalledTimes(4);
-    const renderingOptions = rendering.mock.calls[3][0];
-    expect(renderingOptions.hits).toEqual([
-      { objectID: 'a' },
-      { objectID: 'b' },
-    ]);
+    expect(rendering).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        hits: [{ objectID: 'a' }, { objectID: 'b' }],
+      }),
+      false
+    );
   });
 });

--- a/src/connectors/infinite-hits/connectInfiniteHits.js
+++ b/src/connectors/infinite-hits/connectInfiniteHits.js
@@ -79,6 +79,8 @@ export default function connectInfiniteHits(renderFn, unmountFn) {
 
   return (widgetParams = {}) => {
     let hitsCache = [];
+    let lastReceivedPage = -1;
+
     const getShowMore = helper => () => helper.nextPage().search();
 
     return {
@@ -105,6 +107,7 @@ export default function connectInfiniteHits(renderFn, unmountFn) {
       render({ results, state, instantSearchInstance }) {
         if (state.page === 0) {
           hitsCache = [];
+          lastReceivedPage = -1;
         }
 
         if (
@@ -115,7 +118,10 @@ export default function connectInfiniteHits(renderFn, unmountFn) {
           results.hits = escapeHits(results.hits);
         }
 
-        hitsCache = [...hitsCache, ...results.hits];
+        if (lastReceivedPage < state.page) {
+          hitsCache = [...hitsCache, ...results.hits];
+          lastReceivedPage = state.page;
+        }
 
         const isLastPage = results.nbPages <= results.page + 1;
 


### PR DESCRIPTION
When there is a slow network, the stalled search mechanics will trigger a new render with the same content. This has generally no impact. However the infinite builds up a list of all the results, and there was no mechanics in place to check if the same page has been already received.

To test, you can use dev-novel and with the performance set to slow 3g, you can see that there are no duplicates.

Fix #2928 

Might also be a patch for #2938 (need confirmation)