### PR TITLE
fix attributeName for refinementList widget

### DIFF
--- a/docgen/src/getting-started.md.hbs
+++ b/docgen/src/getting-started.md.hbs
@@ -245,7 +245,7 @@ Since the dataset used here is an e-commerce one, let’s add a [RefinementList]
   search.addWidget(
     instantsearch.widgets.refinementList({
       container: '#refinement-list',
-      attributeName: 'category'
+      attributeName: 'categories'
     })
   );
 


### PR DESCRIPTION
**Documentation Typo Fix**

It seems that the attributeName for the refinementList widget with the given example is categories instead of category.

