### PR TITLE
docs(routing): Replace urlSync with routing

### DIFF
--- a/docgen/src/getting-started.md.hbs
+++ b/docgen/src/getting-started.md.hbs
@@ -89,7 +89,7 @@ const search = instantsearch({
   appId: 'latency',
   apiKey: '6be0576ff61c053d5f9a3225e2a90f76',
   indexName: 'instant_search',
-  urlSync: true
+  routing: true
 });
 
 search.start();
@@ -102,7 +102,7 @@ You can synchronise the current search with the browser url. It provides two ben
   * Working back/next browser buttons
   * Copy and share the current search url
 
-To configure this feature, pass `urlSync: true` option to `instantsearch()`. The `urlSync` option has more parameters ([see InstantSearch.js API documentation](instantsearch.html)).
+To configure this feature, pass `routing: true` option to `instantsearch()`. The `routing` option has [more parameters](https://community.algolia.com/instantsearch.js/v2/instantsearch.html#struct-RoutingOptions).
 
 Congrats 🎉 ! Your website is now connected to Algolia.
 

--- a/docgen/src/getting-started.md.hbs
+++ b/docgen/src/getting-started.md.hbs
@@ -102,7 +102,7 @@ You can synchronise the current search with the browser url. It provides two ben
   * Working back/next browser buttons
   * Copy and share the current search url
 
-To configure this feature, pass `routing: true` option to `instantsearch()`. The `routing` option has [more parameters](https://community.algolia.com/instantsearch.js/v2/instantsearch.html#struct-RoutingOptions).
+To configure this feature, pass `routing: true` option to `instantsearch()`. The `routing` option has [more parameters](v2/instantsearch.html#struct-RoutingOptions).
 
 Congrats 🎉 ! Your website is now connected to Algolia.
 


### PR DESCRIPTION
The current getting started example will throw a warning about `urlSync` being deprecated in favor of `routing`. This will update the doc to use the `routing` in the examples instead.