### PR TITLE
fix(connectConfigure): ensure we do not extend `SearchParameters`

### DIFF
--- a/src/connectors/configure/connectConfigure.js
+++ b/src/connectors/configure/connectConfigure.js
@@ -71,9 +71,12 @@ export default function connectConfigure(renderFn, unmountFn) {
         return searchParameters => {
           // merge new `searchParameters` with the ones set from other widgets
           const actualState = this.removeSearchParameters(helper.getState());
-          const nextSearchParameters = enhanceConfiguration({})(actualState, {
-            getConfiguration: () => searchParameters,
-          });
+          const nextSearchParameters = enhanceConfiguration({})(
+            { ...actualState },
+            {
+              getConfiguration: () => searchParameters,
+            }
+          );
 
           // trigger a search with the new merged searchParameters
           helper.setState(nextSearchParameters).search();


### PR DESCRIPTION
Before we were merging the full SearchParameters object with the methods on it then firing a new request to Algolia, so the request was wrong.

Now we ensure we only merge the actual state of the search.

cc @Haroenv 