### PR TITLE
chore(release): fix release script

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -19,11 +19,13 @@ const {
 } = require('./conventionalChangelog.js');
 
 // check if user can publish new version to npm
-const { code: isNotOwner } = shell.exec('$(npm owner add `npm whoami`)', {
-  silent: true,
-});
+const ownersFound = parseFloat(
+  shell.exec('npm owner ls | grep "`npm whoami` " | wc -l', {
+    silent: true,
+  })
+);
 
-if (isNotOwner) {
+if (ownersFound !== 1) {
   shell.echo(
     colors.red(`
     You are not an owner of the npm repository,


### PR DESCRIPTION
NPM doesn't seem to responde to `npm owner add`, this implements
an alternative way to check if the currently logged NPM user is in
the list of contributors on NPM.