### PR TITLE
docs(dev-novel): add tabs to switch between kinds of stories

### DIFF
--- a/dev/app/index.js
+++ b/dev/app/index.js
@@ -15,19 +15,36 @@ registerDisposer(() => {
 
 const q = window.location.search;
 
+let selectedTab = '';
 switch (true) {
   case q.includes('widgets=vanilla'):
     initVanillaWidgets();
+    selectedTab = 'vanilla';
     break;
   case q.includes('widgets=jquery'):
     initJqueryWidgets();
+    selectedTab = 'jquery';
     break;
   case q.includes('widgets=unmount'):
     initUnmountWidgets();
+    selectedTab = 'unmount';
     break;
   default:
     initBuiltInWidgets();
 }
+
+const selectStories = document.createElement('div');
+selectStories.className = 'story-selector';
+selectStories.innerHTML = `
+  <a href="?" class="tab ${selectedTab === '' ? 'active' : ''}">Built-in</a>
+  <a href="?widgets=jquery" class="tab ${
+    selectedTab === 'jquery' ? 'active' : ''
+  }">Connectors with jQuery</a>
+  <a href="?widgets=unmount" class="tab ${
+    selectedTab === 'unmount' ? 'active' : ''
+  }">Disposable widgets</a>
+`;
+document.body.appendChild(selectStories);
 
 start({
   projectName: 'instantsearch.js',

--- a/dev/style.css
+++ b/dev/style.css
@@ -123,3 +123,23 @@
 .my-custom-info-box__text {
   text-align: center;
 }
+
+.story-selector {
+  padding-left: 5px;
+  background: #333;
+}
+
+.tab {
+  height: 30px;
+  display: inline-block;
+  padding: 5px;
+  margin: 5px 2px 0 2px;
+  background: #d6d6d6;
+  color: #777;
+  text-decoration: none;
+}
+
+.tab.active {
+  background: #f7f7f7;
+  color: black;
+}


### PR DESCRIPTION
This PR adds tabs on top of dev-novel so that we can easily switch between the different kinds of stories: built-in widgets, connectors + jQuery, unmountable widgets. Those stories were there, but you had to know the URL in order to access them.

<img width="1440" alt="screen shot 2018-05-29 at 06 35 59" src="https://user-images.githubusercontent.com/393765/40638349-20fa2c88-630b-11e8-8c9c-0a82d744fe12.png">

It is [available on the preview](https://deploy-preview-2947--algolia-instantsearch.netlify.com/v2/dev-novel/?selectedStory=Analytics.default)