### PR TITLE
fix(infinite-hits): throw with allItems

### DIFF
--- a/src/widgets/infinite-hits/__tests__/infinite-hits-test.js
+++ b/src/widgets/infinite-hits/__tests__/infinite-hits-test.js
@@ -76,9 +76,17 @@ describe('infiniteHits()', () => {
     expect(ReactDOM.render.secondCall.args[1]).toEqual(container);
   });
 
-  it('does not accept both item and allItems templates', () => {
-    expect(
-      infiniteHits.bind({ container, templates: { item: '', allItems: '' } })
+  it('does not accept allItems templates', () => {
+    expect(() =>
+      infiniteHits({ container, templates: { allItems: '' } })
+    ).toThrow();
+
+    expect(() =>
+      infiniteHits({ container, templates: { allItems: 'not empty' } })
+    ).toThrow();
+
+    expect(() =>
+      infiniteHits({ container, templates: { allItems: () => 'template' } })
     ).toThrow();
   });
 

--- a/src/widgets/infinite-hits/infinite-hits.js
+++ b/src/widgets/infinite-hits/infinite-hits.js
@@ -124,6 +124,14 @@ export default function infiniteHits({
     throw new Error(`Must provide a container.${usage}`);
   }
 
+  // We have this specific check because unlike the hits, infiniteHits does not support this template.
+  // This can be misleading as they are very similar.
+  if (templates.allItems !== undefined) {
+    throw new Error(
+      'allItems is not a valid template for the infiniteHits widget'
+    );
+  }
+
   const containerNode = getContainerNode(container);
   const cssClasses = {
     root: cx(bem(null), userCssClasses.root),


### PR DESCRIPTION
The infinite hits widget is based internally on the hits widget which
accepts the `allItems` template. However this template is not usable for
the purpose of the infinite hits widget.

In order to prevent users from using this buggy and yet accepted option
this PR generates a exception if we detect this particular template.

Fix #2543