### PR TITLE
fix(connectRefinementList): throw error with usage

### DIFF
--- a/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
+++ b/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
@@ -14,28 +14,28 @@ describe('connectRefinementList', () => {
   };
 
   it('throws on bad usage', () => {
-    expect(connectRefinementList).toThrow();
+    expect(connectRefinementList).toThrow(/Usage:/);
 
     expect(() =>
       connectRefinementList({
         operator: 'and',
       })
-    ).toThrow();
+    ).toThrow(/Usage:/);
 
-    expect(() => connectRefinementList(() => {})()).toThrow();
+    expect(() => connectRefinementList(() => {})()).toThrow(/Usage:/);
 
     expect(() =>
       connectRefinementList(() => {})({
         operator: 'and',
       })
-    ).toThrow();
+    ).toThrow(/Usage:/);
 
     expect(() =>
       connectRefinementList(() => {})({
         attributeName: 'company',
         operator: 'YUP',
       })
-    ).toThrow();
+    ).toThrow(/Usage:/);
   });
 
   describe('options configuring the helper', () => {

--- a/src/connectors/refinement-list/connectRefinementList.js
+++ b/src/connectors/refinement-list/connectRefinementList.js
@@ -33,9 +33,9 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
 export const checkUsage = ({
   attributeName,
   operator,
-  usageMessage,
   showMoreLimit,
   limit,
+  message,
 }) => {
   const noAttributeName = attributeName === undefined;
   const invalidOperator = !/^(and|or)$/.test(operator);
@@ -45,7 +45,7 @@ export const checkUsage = ({
       : false;
 
   if (noAttributeName || invalidOperator || invalidShowMoreLimit) {
-    throw new Error(usageMessage);
+    throw new Error(message);
   }
 };
 
@@ -159,7 +159,13 @@ export default function connectRefinementList(renderFn, unmountFn) {
       escapeFacetValues = false,
     } = widgetParams;
 
-    checkUsage({ attributeName, operator, usage, limit, showMoreLimit });
+    checkUsage({
+      message: usage,
+      attributeName,
+      operator,
+      showMoreLimit,
+      limit,
+    });
 
     const formatItems = ({ name: label, ...item }) => ({
       ...item,

--- a/src/connectors/refinement-list/connectRefinementList.js
+++ b/src/connectors/refinement-list/connectRefinementList.js
@@ -17,6 +17,7 @@ var customRefinementList = connectRefinementList(function render(params) {
   //   widgetParams,
   // }
 });
+
 search.addWidget(
   customRefinementList({
     attributeName,
@@ -27,6 +28,7 @@ search.addWidget(
     [ escapeFacetValues = false ]
   })
 );
+
 Full documentation available at https://community.algolia.com/instantsearch.js/v2/connectors/connectRefinementList.html
 `;
 


### PR DESCRIPTION
**Summary**

We correctly check display the usage in case of incorrect rendering but not when the provided parameters are wrong. The message is not correctly pass to the function that throw the error.

**Before**

![screen shot 2018-06-01 at 15 57 37](https://user-images.githubusercontent.com/6513513/40845123-050b58fa-65b6-11e8-8a42-e2958362fc09.png)

**After**

![screen shot 2018-06-01 at 16 10 07](https://user-images.githubusercontent.com/6513513/40845208-4f1f51c6-65b6-11e8-9294-cf709c18b77a.png)
