### PR TITLE
feat(hits-per-page-selector): implement panel (panel: part 5)

### DIFF
--- a/dev/app/builtin/stories/hits-per-page-selector.stories.js
+++ b/dev/app/builtin/stories/hits-per-page-selector.stories.js
@@ -24,6 +24,52 @@ export default () => {
       })
     )
     .add(
+      'with header and footer',
+      wrapWithHits(container => {
+        window.search.addWidget(
+          instantsearch.widgets.hitsPerPageSelector({
+            container,
+            items: [
+              { value: 3, label: '3 per page' },
+              { value: 5, label: '5 per page' },
+              { value: 10, label: '10 per page' },
+            ],
+            templates: {
+              panelHeader: 'Hits per page?',
+              panelFooter: 'Brought to you by Algolia',
+            },
+          })
+        );
+      })
+    )
+    .add(
+      'with custom css classes',
+      wrapWithHits(container => {
+        window.search.addWidget(
+          instantsearch.widgets.hitsPerPageSelector({
+            container,
+            items: [
+              { value: 3, label: '3 per page' },
+              { value: 5, label: '5 per page' },
+              { value: 10, label: '10 per page' },
+            ],
+            templates: {
+              panelHeader: 'Hits per page?',
+              panelFooter: 'Brought to you by Algolia',
+            },
+            cssClasses: {
+              panelRoot: 'root',
+              panelHeader: 'header',
+              panelBody: 'body',
+              panelFooter: 'footer',
+              select: 'select',
+              item: 'item',
+            }
+          })
+        );
+      })
+    )
+    .add(
       'with default hitPerPage to 5',
       wrapWithHits(container => {
         window.search.addWidget(

--- a/src/widgets/hits-per-page-selector/defaultTemplates.js
+++ b/src/widgets/hits-per-page-selector/defaultTemplates.js
@@ -1,0 +1,4 @@
+export default {
+  panelHeader: '',
+  panelFooter: '',
+};


### PR DESCRIPTION
This PR implements the panel options for the current refined values.

This is the fifth sub-part of the [panel stacked PR](https://github.com/algolia/instantsearch.js/pull/2961).

This widget didn't have support for templates, so this PR adds them. However this doesn't add support for transformData since we only add support for header and footer.