### PR TITLE
fix(connectHitsPerPage): default value should not break the API 

### DIFF
--- a/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
+++ b/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
@@ -273,6 +273,49 @@ describe('connectHitsPerPage', () => {
     expect(helper.getQueryParameter('hitsPerPage')).not.toBeDefined();
   });
 
+  it('Should be able to unselect using an empty string', () => {
+    const rendering = sinon.stub();
+    const makeWidget = connectHitsPerPage(rendering);
+    const widget = makeWidget({
+      items: [
+        { value: 3, label: '3 items per page' },
+        { value: 10, label: '10 items per page' },
+      ],
+    });
+
+    const helper = jsHelper({}, '', {
+      hitsPerPage: 7,
+    });
+    helper.search = sinon.stub();
+
+    widget.init({
+      helper,
+      state: helper.state,
+      createURL: () => '#',
+      onHistoryChange: () => {},
+    });
+
+    const firstRenderingOptions = rendering.lastCall.args[0];
+    expect(firstRenderingOptions.items).toHaveLength(3);
+    firstRenderingOptions.refine('');
+    expect(helper.getQueryParameter('hitsPerPage')).not.toBeDefined();
+
+    // Reset the hitsPerPage to an actual value
+    helper.setQueryParameter('hitsPerPage', 7);
+
+    widget.render({
+      results: new SearchResults(helper.state, [{}]),
+      state: helper.state,
+      helper,
+      createURL: () => '#',
+    });
+
+    const secondRenderingOptions = rendering.lastCall.args[0];
+    expect(secondRenderingOptions.items).toHaveLength(3);
+    secondRenderingOptions.refine('');
+    expect(helper.getQueryParameter('hitsPerPage')).not.toBeDefined();
+  });
+
   describe('routing', () => {
     const getInitializedWidget = () => {
       const rendering = jest.fn();

--- a/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
+++ b/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
@@ -230,6 +230,49 @@ describe('connectHitsPerPage', () => {
     expect(helper.getQueryParameter('hitsPerPage')).not.toBeDefined();
   });
 
+  it('the option for unselecting values should work even if stringified', () => {
+    const rendering = sinon.stub();
+    const makeWidget = connectHitsPerPage(rendering);
+    const widget = makeWidget({
+      items: [
+        { value: 3, label: '3 items per page' },
+        { value: 10, label: '10 items per page' },
+      ],
+    });
+
+    const helper = jsHelper({}, '', {
+      hitsPerPage: 7,
+    });
+    helper.search = sinon.stub();
+
+    widget.init({
+      helper,
+      state: helper.state,
+      createURL: () => '#',
+      onHistoryChange: () => {},
+    });
+
+    const firstRenderingOptions = rendering.lastCall.args[0];
+    expect(firstRenderingOptions.items).toHaveLength(3);
+    firstRenderingOptions.refine(`${firstRenderingOptions.items[0].value}`);
+    expect(helper.getQueryParameter('hitsPerPage')).not.toBeDefined();
+
+    // Reset the hitsPerPage to an actual value
+    helper.setQueryParameter('hitsPerPage', 7);
+
+    widget.render({
+      results: new SearchResults(helper.state, [{}]),
+      state: helper.state,
+      helper,
+      createURL: () => '#',
+    });
+
+    const secondRenderingOptions = rendering.lastCall.args[0];
+    expect(secondRenderingOptions.items).toHaveLength(3);
+    secondRenderingOptions.refine(`${secondRenderingOptions.items[0].value}`);
+    expect(helper.getQueryParameter('hitsPerPage')).not.toBeDefined();
+  });
+
   describe('routing', () => {
     const getInitializedWidget = () => {
       const rendering = jest.fn();

--- a/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
+++ b/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
@@ -212,7 +212,7 @@ describe('connectHitsPerPage', () => {
     const firstRenderingOptions = rendering.lastCall.args[0];
     expect(firstRenderingOptions.items).toHaveLength(3);
     firstRenderingOptions.refine(firstRenderingOptions.items[0].value);
-    expect(helper.getQueryParameter('hitsPerPage')).toBe(undefined);
+    expect(helper.getQueryParameter('hitsPerPage')).not.toBeDefined();
 
     // Reset the hitsPerPage to an actual value
     helper.setQueryParameter('hitsPerPage', 7);
@@ -227,7 +227,7 @@ describe('connectHitsPerPage', () => {
     const secondRenderingOptions = rendering.lastCall.args[0];
     expect(secondRenderingOptions.items).toHaveLength(3);
     secondRenderingOptions.refine(secondRenderingOptions.items[0].value);
-    expect(helper.getQueryParameter('hitsPerPage')).toBe(undefined);
+    expect(helper.getQueryParameter('hitsPerPage')).not.toBeDefined();
   });
 
   describe('routing', () => {

--- a/src/connectors/hits-per-page/connectHitsPerPage.js
+++ b/src/connectors/hits-per-page/connectHitsPerPage.js
@@ -157,11 +157,11 @@ The first one will be picked, you should probably set only one default value`
             );
           }
 
-          items = [{ value: undefined, label: '' }, ...items];
+          items = [{ value: '', label: '' }, ...items];
         }
 
         this.setHitsPerPage = value =>
-          value === 'undefined' || value === ''
+          !value && value !== 0
             ? helper.setQueryParameter('hitsPerPage', undefined).search()
             : helper.setQueryParameter('hitsPerPage', value).search();
 

--- a/src/connectors/hits-per-page/connectHitsPerPage.js
+++ b/src/connectors/hits-per-page/connectHitsPerPage.js
@@ -161,7 +161,9 @@ The first one will be picked, you should probably set only one default value`
         }
 
         this.setHitsPerPage = value =>
-          helper.setQueryParameter('hitsPerPage', value).search();
+          value === 'undefined' || value === ''
+            ? helper.setQueryParameter('hitsPerPage', undefined).search()
+            : helper.setQueryParameter('hitsPerPage', value).search();
 
         renderFn(
           {


### PR DESCRIPTION
Fix #2732 

Reproducible here: https://codesandbox.io/s/8qo2m8n89
With the fix: http://splendid-discussion.surge.sh/

Test case:
 - select 3 hits per page
 - select the empty entry in the menu
 - use the searchbox: the search is broken

## Limitations

What you can notice is that the empty value doesn't fall back to the search parameters value. This is because the correct way to set a default value is to use the `default: true` option. We should maybe not support the empty choice (to be discussed)