### PR TITLE
feat(panel): provide panel as a widget wrapper

### DIFF
--- a/dev/app/builtin/init-stories.js
+++ b/dev/app/builtin/init-stories.js
@@ -12,6 +12,7 @@ import initMenuStories from './stories/menu.stories';
 import initNumericRefinementListStories from './stories/numeric-refinement-list.stories';
 import initNumericSelectorStories from './stories/numeric-selector.stories';
 import initPaginationStories from './stories/pagination.stories';
+import initPanel from './stories/panel.stories';
 import initPriceRangesStories from './stories/price-ranges.stories';
 import initRangeInputStories from './stories/range-input.stories.js';
 import initRangeSliderStories from './stories/range-slider.stories';
@@ -50,4 +51,5 @@ export default () => {
   initStarRatingStories();
   initToggleStories();
   initConfigureStories();
+  initPanel();
 };

--- a/dev/app/builtin/stories/panel.stories.js
+++ b/dev/app/builtin/stories/panel.stories.js
@@ -1,0 +1,41 @@
+/* eslint-disable import/default */
+
+import { storiesOf } from 'dev-novel';
+import instantsearch from '../../../../index';
+import { wrapWithHits } from '../../utils/wrap-with-hits.js';
+
+const stories = storiesOf('Panel');
+
+export default () => {
+  stories
+    .add(
+      'default',
+      wrapWithHits(container => {
+        window.search.addWidget(
+          instantsearch.wrappers.panel(instantsearch.widgets.stats)({
+            container,
+            templates: {
+              header: 'Header!',
+              footer: 'Footer',
+            },
+          })
+        );
+      })
+    )
+    .add(
+      'collapsible',
+      wrapWithHits(container => {
+        window.search.addWidget(
+          instantsearch.wrappers.panel(instantsearch.widgets.refinementList)({
+            container,
+            attributeName: 'brand',
+            templates: {
+              header: 'Header!',
+              footer: 'Footer',
+            },
+            collapsible: true,
+          })
+        );
+      })
+    );
+};

--- a/dev/webpack.config.js
+++ b/dev/webpack.config.js
@@ -13,7 +13,7 @@ const __DEV__ = process.env.NODE_ENV === 'development';
 const clean = arr => arr.filter(item => item !== false);
 
 module.exports = {
-  devtool: __DEV__ ? 'cheap-module-source-map' : 'source-map',
+  devtool: 'source-map',
 
   entry: __DEV__
     ? {

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -9,6 +9,8 @@ import version from './version.js';
 import * as connectors from '../connectors/index.js';
 import * as widgets from '../widgets/index.js';
 
+import * as wrappers from '../wrappers/index.js';
+
 import * as routers from './routers/index.js';
 import * as stateMappings from './stateMappings/index.js';
 
@@ -178,6 +180,7 @@ instantsearch.createQueryString =
   algoliasearchHelper.url.getQueryStringFromState;
 instantsearch.connectors = connectors;
 instantsearch.widgets = widgets;
+instantsearch.wrappers = wrappers;
 instantsearch.version = version;
 
 export default instantsearch;

--- a/src/lib/suit.js
+++ b/src/lib/suit.js
@@ -3,7 +3,7 @@ const NAMESPACE = 'ais';
 export const component = componentName => ({
   modifierName,
   descendantName,
-}) => {
+} = {}) => {
   const d = descendantName ? `-${descendantName}` : '';
   const m = modifierName ? `--${modifierName}` : '';
   return `${NAMESPACE}-${componentName}${d}${m}`;

--- a/src/wrappers/defaultTemplates.js
+++ b/src/wrappers/defaultTemplates.js
@@ -1,0 +1,4 @@
+export default {
+  collapseButton:
+    '{{#collapsed}}➕{{/collapsed}}{{^collapsed}}➖{{/collapsed}}',
+};

--- a/src/wrappers/index.js
+++ b/src/wrappers/index.js
@@ -1,0 +1,1 @@
+export { default as panel } from './panel.js';

--- a/src/wrappers/panel.js
+++ b/src/wrappers/panel.js
@@ -41,7 +41,11 @@ export default widgetFactory => optionsWithPanelOpts => {
       widget.init(opts);
     },
     render: opts => {
-      // update DOM
+      updatePanel({
+        panel,
+        renderOpts: opts,
+        constructorOpts: optionsWithPanelOpts,
+      });
       widget.render(opts);
     },
     // forward routing specific methods
@@ -135,4 +139,29 @@ function renderPanel({
     header,
     footer,
   };
+}
+
+function updatePanel({
+  panel: { header, footer },
+  renderOpts: { results },
+  constructorOpts: { templates },
+}) {
+  if (header) {
+    header.innerHTML = renderTemplate({
+      templateKey: 'header',
+      templates,
+      data: {
+        results,
+      },
+    });
+  }
+  if (footer) {
+    footer.innerHTML = renderTemplate({
+      templateKey: 'footer',
+      templates,
+      data: {
+        results,
+      },
+    });
+  }
 }

--- a/src/wrappers/panel.js
+++ b/src/wrappers/panel.js
@@ -1,0 +1,120 @@
+import { getContainerNode, renderTemplate } from '../lib/utils';
+import { component } from '../lib/suit.js';
+import cx from 'classnames';
+import defaultTemplates from './defaultTemplates';
+
+export default widgetFactory => optionsWithPanelOpts => {
+  const {
+    container,
+    cssClasses,
+    templates = {},
+    collapsible,
+  } = optionsWithPanelOpts;
+
+  const allTemplates = {
+    ...defaultTemplates,
+    ...templates,
+  };
+
+  const panelBodyContainer = renderPanel({
+    container: getContainerNode(container),
+    cssClasses,
+    templates: allTemplates,
+    collapsible,
+  });
+
+  const widget = widgetFactory({
+    ...optionsWithPanelOpts,
+    container: panelBodyContainer,
+    templates: {
+      ...optionsWithPanelOpts.templates,
+      header: undefined,
+      footer: undefined,
+      collapseButton: undefined,
+    },
+  });
+
+  return {
+    getConfiguration: opts =>
+      widget.getConfiguration ? widget.getConfiguration(opts) : {},
+    init: opts => {
+      widget.init(opts);
+    },
+    render: opts => {
+      // update DOM
+      widget.render(opts);
+    },
+    // forward routing specific methods
+  };
+};
+
+const suitPanel = component('Panel');
+
+function renderPanel({
+  container,
+  cssClasses = {},
+  templates = {},
+  collapsible,
+}) {
+  const rootClassnames = cx(suitPanel(), cssClasses.panelRoot, {
+    [suitPanel({ modifierName: 'collapsible' })]: collapsible,
+  });
+
+  const bodyClassnames = cx(
+    suitPanel({ descendantName: 'body' }),
+    cssClasses.panelBody
+  );
+
+  const root = document.createElement('div');
+  root.classList = rootClassnames;
+
+  if (templates.header) {
+    const headerClassnames = cx(
+      suitPanel({ descendantName: 'header' }),
+      cssClasses.panelRoot
+    );
+    const header = document.createElement('div');
+    header.innerHTML = renderTemplate({
+      templateKey: 'header',
+      templates,
+    });
+    header.classList = headerClassnames;
+    root.appendChild(header);
+  }
+
+  if (collapsible) {
+    const buttonClassnames = cx(
+      suitPanel({ descendantName: 'collapseButton' }),
+      cssClasses.collapseButton
+    );
+    const button = document.createElement('button');
+    button.innerHTML = renderTemplate({
+      templateKey: 'collapseButton',
+      templates,
+    });
+    button.classList = buttonClassnames;
+    root.appendChild(button);
+  }
+
+  const body = document.createElement('div');
+  body.classList = bodyClassnames;
+  root.appendChild(body);
+
+  if (templates.footer) {
+    const footerClassnames = cx(
+      suitPanel({ descendantName: 'footer' }),
+      cssClasses.panelRoot
+    );
+    const footer = document.createElement('div');
+    footer.innerHTML = renderTemplate({
+      templateKey: 'footer',
+      templates,
+    });
+    footer.classList = footerClassnames;
+    root.appendChild(footer);
+  }
+
+  container.appendChild(root);
+
+  return body;
+}

--- a/src/wrappers/panel.js
+++ b/src/wrappers/panel.js
@@ -16,7 +16,7 @@ export default widgetFactory => optionsWithPanelOpts => {
     ...templates,
   };
 
-  const panelBodyContainer = renderPanel({
+  const panel = renderPanel({
     container: getContainerNode(container),
     cssClasses,
     templates: allTemplates,
@@ -25,7 +25,7 @@ export default widgetFactory => optionsWithPanelOpts => {
 
   const widget = widgetFactory({
     ...optionsWithPanelOpts,
-    container: panelBodyContainer,
+    container: panel.body,
     templates: {
       ...optionsWithPanelOpts.templates,
       header: undefined,
@@ -68,12 +68,13 @@ function renderPanel({
   const root = document.createElement('div');
   root.classList = rootClassnames;
 
+  let header;
   if (templates.header) {
     const headerClassnames = cx(
       suitPanel({ descendantName: 'header' }),
       cssClasses.panelRoot
     );
-    const header = document.createElement('div');
+    header = document.createElement('div');
     header.innerHTML = renderTemplate({
       templateKey: 'header',
       templates,
@@ -93,6 +94,17 @@ function renderPanel({
       templates,
     });
     button.classList = buttonClassnames;
+
+    let collapsed = false;
+    button.addEventListener('click', () => {
+      collapsed = !collapsed;
+      root.classList.toggle(suitPanel({ modifierName: 'collapsed' }));
+      button.innerHTML = renderTemplate({
+        templateKey: 'collapseButton',
+        templates,
+        data: { collapsed },
+      });
+    });
     root.appendChild(button);
   }
 
@@ -100,12 +112,13 @@ function renderPanel({
   body.classList = bodyClassnames;
   root.appendChild(body);
 
+  let footer;
   if (templates.footer) {
     const footerClassnames = cx(
       suitPanel({ descendantName: 'footer' }),
       cssClasses.panelRoot
     );
-    const footer = document.createElement('div');
+    footer = document.createElement('div');
     footer.innerHTML = renderTemplate({
       templateKey: 'footer',
       templates,
@@ -116,5 +129,10 @@ function renderPanel({
 
   container.appendChild(root);
 
-  return body;
+  return {
+    root,
+    body,
+    header,
+    footer,
+  };
 }


### PR DESCRIPTION
Following up on the [panel RFC](https://github.com/algolia/instantsearch-rfcs/pull/1), this PR is a PoC of it.

Summary of the experiment so far. 

TLDR: it looks doable

**The good parts** ✅:
 - yes it's possible to use a wrapper
 - the pattern used here for the wrapper allow an almost seamless transition:

```js
// now
search.addWidget(
  refinementList({
    templates: {
      header: "",
      footer: ""
    },
    collapsible: true
  })
);

// new API

// composing with the panel, creates a widget factory
const refinementListWithPanel = panel(refinementList);

search.addWidget(
  refinementListWithPanel({
    templates: {
      header: "",
      footer: ""
    },
    collapsible: true
  })
);

// or
search.addWidget(
  panel(refinementList)({
    templates: {
      header: "",
      footer: ""
    },
    collapsible: true
  })
);
```

**The less good parts** 🛑:
 - we need infos from the widget to provide better templating for the header and footer and be on par with the features already provided (refinement list provides the number of selected items, for example)

**The questions** 🤔:
 - we have autohide and collapsible panels, can we merge them?
 - the wrapper rendering has to be done out of the widget lifecycle so we can provide the container to the internal widget factory. Not sure if it's a problem.

Next steps (in this PR):
 - [ ] freeze the features and implement them (see questions)
 - [ ] tests