### PR TITLE
fix(sourcemap): provide good url

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,6 +7,10 @@ mkdir -p dist dist-es5-module es
 
 echo "➡️  Bundle instantsearch.js to UMD build './dist' via webpack"
 NODE_ENV=production BABEL_ENV=production webpack --config scripts/webpack.config.js --hide-modules
+
+# https://stackoverflow.com/questions/16745988/sed-command-with-i-option-in-place-editing-works-fine-on-ubuntu-but-not-mac
+sed -i.bak 's/sourceMappingURL=instantsearch\.min\.js\.map/sourceMappingURL=\/dist\/instantsearch\.min\.js\.map/g' dist/instantsearch.min.js && rm dist/instantsearch.min.js.bak
+
 csso dist/instantsearch.css dist/instantsearch.min.css --map file &
 csso dist/instantsearch-theme-algolia.css dist/instantsearch-theme-algolia.min.css --map file
 


### PR DESCRIPTION
When IS.js is inserted with     <script src="https://cdn.jsdelivr.net/npm/instantsearch.js@2"></script>

Then the sourcemap url is not the right one (it was
"instantsearch.min.js.map") now it will be
/dist/instantsearch.min.js.map which will work in every cases.

This will ease a lot debugging live websites.