### PR TITLE
chore: unify and enforce import style to no extensions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,7 @@ module.exports = {
   rules: {
     "no-param-reassign": 0,
     "import/no-extraneous-dependencies": 0,
-    "react/no-string-refs": 1
+    "react/no-string-refs": 1,
+    "import/extensions": [2, "always", {js: "never"}]
   }
 }

--- a/dev/app/builtin/init-stories.js
+++ b/dev/app/builtin/init-stories.js
@@ -1,6 +1,6 @@
 import initAnalyticsStories from './stories/analytics.stories';
-import initBreadcrumbStories from './stories/breadcrumb.stories.js';
-import initClearRefinementsStories from './stories/clear-refinements.stories.js';
+import initBreadcrumbStories from './stories/breadcrumb.stories';
+import initClearRefinementsStories from './stories/clear-refinements.stories';
 import initCurrentRefinedValuesStories from './stories/current-refined-values.stories';
 import initGeoSearch from './stories/geo-search.stories';
 import initHierarchicalMenu from './stories/hierarchical-menu.stories';
@@ -13,7 +13,7 @@ import initNumericRefinementListStories from './stories/numeric-refinement-list.
 import initNumericSelectorStories from './stories/numeric-selector.stories';
 import initPaginationStories from './stories/pagination.stories';
 import initPriceRangesStories from './stories/price-ranges.stories';
-import initRangeInputStories from './stories/range-input.stories.js';
+import initRangeInputStories from './stories/range-input.stories';
 import initRangeSliderStories from './stories/range-slider.stories';
 import initRefinementListStories from './stories/refinement-list.stories';
 import initReloadStories from './stories/reload.stories';

--- a/dev/app/builtin/stories/analytics.stories.js
+++ b/dev/app/builtin/stories/analytics.stories.js
@@ -2,7 +2,7 @@
 
 import { action, storiesOf } from 'dev-novel';
 import instantsearch from '../../../../index';
-import { wrapWithHits } from '../../utils/wrap-with-hits.js';
+import { wrapWithHits } from '../../utils/wrap-with-hits';
 
 const stories = storiesOf('Analytics');
 

--- a/dev/app/builtin/stories/breadcrumb.stories.js
+++ b/dev/app/builtin/stories/breadcrumb.stories.js
@@ -2,7 +2,7 @@
 
 import { storiesOf } from 'dev-novel';
 import instantsearch from '../../../../index';
-import { wrapWithHits } from '../../utils/wrap-with-hits.js';
+import { wrapWithHits } from '../../utils/wrap-with-hits';
 
 const stories = storiesOf('Breadcrumb');
 export default () => {

--- a/dev/app/builtin/stories/clear-refinements.stories.js
+++ b/dev/app/builtin/stories/clear-refinements.stories.js
@@ -2,7 +2,7 @@
 
 import { storiesOf } from 'dev-novel';
 import instantsearch from '../../../../index';
-import { wrapWithHits } from '../../utils/wrap-with-hits.js';
+import { wrapWithHits } from '../../utils/wrap-with-hits';
 
 const stories = storiesOf('ClearRefinements');
 

--- a/dev/app/builtin/stories/configure.stories.js
+++ b/dev/app/builtin/stories/configure.stories.js
@@ -3,7 +3,7 @@
 import { storiesOf } from 'dev-novel';
 
 import instantsearch from '../../../../index';
-import { wrapWithHits } from '../../utils/wrap-with-hits.js';
+import { wrapWithHits } from '../../utils/wrap-with-hits';
 
 const stories = storiesOf('Configure');
 

--- a/dev/app/builtin/stories/current-refined-values.stories.js
+++ b/dev/app/builtin/stories/current-refined-values.stories.js
@@ -2,7 +2,7 @@
 
 import { storiesOf } from 'dev-novel';
 import instantsearch from '../../../../index';
-import { wrapWithHits } from '../../utils/wrap-with-hits.js';
+import { wrapWithHits } from '../../utils/wrap-with-hits';
 
 const stories = storiesOf('CurrentRefinedValues');
 

--- a/dev/app/builtin/stories/hierarchical-menu.stories.js
+++ b/dev/app/builtin/stories/hierarchical-menu.stories.js
@@ -2,7 +2,7 @@
 
 import { storiesOf } from 'dev-novel';
 import instantsearch from '../../../../index';
-import { wrapWithHits } from '../../utils/wrap-with-hits.js';
+import { wrapWithHits } from '../../utils/wrap-with-hits';
 
 const stories = storiesOf('HierarchicalMenu');
 

--- a/dev/app/builtin/stories/hits-per-page-selector.stories.js
+++ b/dev/app/builtin/stories/hits-per-page-selector.stories.js
@@ -2,7 +2,7 @@
 
 import { storiesOf } from 'dev-novel';
 import instantsearch from '../../../../index';
-import { wrapWithHits } from '../../utils/wrap-with-hits.js';
+import { wrapWithHits } from '../../utils/wrap-with-hits';
 
 const stories = storiesOf('HitsPerPageSelector');
 

--- a/dev/app/builtin/stories/hits.stories.js
+++ b/dev/app/builtin/stories/hits.stories.js
@@ -2,7 +2,7 @@
 
 import { storiesOf } from 'dev-novel';
 import instantsearch from '../../../../index';
-import { wrapWithHits } from '../../utils/wrap-with-hits.js';
+import { wrapWithHits } from '../../utils/wrap-with-hits';
 
 const stories = storiesOf('Hits');
 

--- a/dev/app/builtin/stories/infinite-hits.stories.js
+++ b/dev/app/builtin/stories/infinite-hits.stories.js
@@ -2,7 +2,7 @@
 
 import { storiesOf } from 'dev-novel';
 import instantsearch from '../../../../index';
-import { wrapWithHits } from '../../utils/wrap-with-hits.js';
+import { wrapWithHits } from '../../utils/wrap-with-hits';
 
 const stories = storiesOf('InfiniteHits');
 

--- a/dev/app/builtin/stories/instantsearch.stories.js
+++ b/dev/app/builtin/stories/instantsearch.stories.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/default */
 
 import { storiesOf } from 'dev-novel';
-import { wrapWithHits } from '../../utils/wrap-with-hits.js';
+import { wrapWithHits } from '../../utils/wrap-with-hits';
 
 const stories = storiesOf('Instantsearch');
 

--- a/dev/app/builtin/stories/menu.stories.js
+++ b/dev/app/builtin/stories/menu.stories.js
@@ -2,7 +2,7 @@
 
 import { storiesOf } from 'dev-novel';
 import instantsearch from '../../../../index';
-import { wrapWithHits } from '../../utils/wrap-with-hits.js';
+import { wrapWithHits } from '../../utils/wrap-with-hits';
 
 const stories = storiesOf('Menu');
 

--- a/dev/app/builtin/stories/numeric-refinement-list.stories.js
+++ b/dev/app/builtin/stories/numeric-refinement-list.stories.js
@@ -2,7 +2,7 @@
 
 import { storiesOf } from 'dev-novel';
 import instantsearch from '../../../../index';
-import { wrapWithHits } from '../../utils/wrap-with-hits.js';
+import { wrapWithHits } from '../../utils/wrap-with-hits';
 
 const stories = storiesOf('NumericRefinementList');
 

--- a/dev/app/builtin/stories/numeric-selector.stories.js
+++ b/dev/app/builtin/stories/numeric-selector.stories.js
@@ -2,7 +2,7 @@
 
 import { storiesOf } from 'dev-novel';
 import instantsearch from '../../../../index';
-import { wrapWithHits } from '../../utils/wrap-with-hits.js';
+import { wrapWithHits } from '../../utils/wrap-with-hits';
 
 const stories = storiesOf('NumericSelector');
 

--- a/dev/app/builtin/stories/pagination.stories.js
+++ b/dev/app/builtin/stories/pagination.stories.js
@@ -2,7 +2,7 @@
 
 import { storiesOf } from 'dev-novel';
 import instantsearch from '../../../../index';
-import { wrapWithHits } from '../../utils/wrap-with-hits.js';
+import { wrapWithHits } from '../../utils/wrap-with-hits';
 
 const stories = storiesOf('Pagination');
 

--- a/dev/app/builtin/stories/price-ranges.stories.js
+++ b/dev/app/builtin/stories/price-ranges.stories.js
@@ -2,7 +2,7 @@
 
 import { storiesOf } from 'dev-novel';
 import instantsearch from '../../../../index';
-import { wrapWithHits } from '../../utils/wrap-with-hits.js';
+import { wrapWithHits } from '../../utils/wrap-with-hits';
 
 const stories = storiesOf('PriceRanges');
 

--- a/dev/app/builtin/stories/range-input.stories.js
+++ b/dev/app/builtin/stories/range-input.stories.js
@@ -2,7 +2,7 @@
 
 import { storiesOf } from 'dev-novel';
 import instantsearch from '../../../../index';
-import { wrapWithHits } from '../../utils/wrap-with-hits.js';
+import { wrapWithHits } from '../../utils/wrap-with-hits';
 
 const stories = storiesOf('RangeInput');
 

--- a/dev/app/builtin/stories/range-slider.stories.js
+++ b/dev/app/builtin/stories/range-slider.stories.js
@@ -2,7 +2,7 @@
 
 import { storiesOf } from 'dev-novel';
 import instantsearch from '../../../../index';
-import { wrapWithHits } from '../../utils/wrap-with-hits.js';
+import { wrapWithHits } from '../../utils/wrap-with-hits';
 
 const stories = storiesOf('RangeSlider');
 

--- a/dev/app/builtin/stories/refinement-list.stories.js
+++ b/dev/app/builtin/stories/refinement-list.stories.js
@@ -2,7 +2,7 @@
 
 import { storiesOf } from 'dev-novel';
 import instantsearch from '../../../../index';
-import { wrapWithHits } from '../../utils/wrap-with-hits.js';
+import { wrapWithHits } from '../../utils/wrap-with-hits';
 
 const stories = storiesOf('RefinementList');
 

--- a/dev/app/builtin/stories/reload.stories.js
+++ b/dev/app/builtin/stories/reload.stories.js
@@ -2,7 +2,7 @@
 
 import { storiesOf } from 'dev-novel';
 import instantsearch from '../../../../index';
-import { wrapWithHits } from '../../utils/wrap-with-hits.js';
+import { wrapWithHits } from '../../utils/wrap-with-hits';
 
 const stories = storiesOf('Refresh');
 

--- a/dev/app/builtin/stories/search-box.stories.js
+++ b/dev/app/builtin/stories/search-box.stories.js
@@ -2,7 +2,7 @@
 
 import { storiesOf } from 'dev-novel';
 import instantsearch from '../../../../index';
-import { wrapWithHits } from '../../utils/wrap-with-hits.js';
+import { wrapWithHits } from '../../utils/wrap-with-hits';
 
 const stories = storiesOf('SearchBox');
 

--- a/dev/app/builtin/stories/sort-by-selector.stories.js
+++ b/dev/app/builtin/stories/sort-by-selector.stories.js
@@ -2,7 +2,7 @@
 
 import { storiesOf } from 'dev-novel';
 import instantsearch from '../../../../index';
-import { wrapWithHits } from '../../utils/wrap-with-hits.js';
+import { wrapWithHits } from '../../utils/wrap-with-hits';
 
 const stories = storiesOf('SortBySelector');
 

--- a/dev/app/builtin/stories/star-rating.stories.js
+++ b/dev/app/builtin/stories/star-rating.stories.js
@@ -2,7 +2,7 @@
 
 import { storiesOf } from 'dev-novel';
 import instantsearch from '../../../../index';
-import { wrapWithHits } from '../../utils/wrap-with-hits.js';
+import { wrapWithHits } from '../../utils/wrap-with-hits';
 
 const stories = storiesOf('StarRating');
 

--- a/dev/app/builtin/stories/stats.stories.js
+++ b/dev/app/builtin/stories/stats.stories.js
@@ -2,7 +2,7 @@
 
 import { storiesOf } from 'dev-novel';
 import instantsearch from '../../../../index';
-import { wrapWithHits } from '../../utils/wrap-with-hits.js';
+import { wrapWithHits } from '../../utils/wrap-with-hits';
 
 const stories = storiesOf('Stats');
 

--- a/dev/app/builtin/stories/toggle.stories.js
+++ b/dev/app/builtin/stories/toggle.stories.js
@@ -2,7 +2,7 @@
 
 import { storiesOf } from 'dev-novel';
 import instantsearch from '../../../../index';
-import { wrapWithHits } from '../../utils/wrap-with-hits.js';
+import { wrapWithHits } from '../../utils/wrap-with-hits';
 
 const stories = storiesOf('Toggle');
 

--- a/dev/app/index.js
+++ b/dev/app/index.js
@@ -2,7 +2,7 @@ import { registerDisposer, start } from 'dev-novel';
 import initBuiltInWidgets from './builtin/init-stories';
 import initJqueryWidgets from './jquery/init-stories';
 import initVanillaWidgets from './vanilla/init-stories';
-import initUnmountWidgets from './init-unmount-widgets.js';
+import initUnmountWidgets from './init-unmount-widgets';
 
 import '../style.css';
 

--- a/dev/app/init-unmount-widgets.js
+++ b/dev/app/init-unmount-widgets.js
@@ -1,8 +1,8 @@
 /* eslint-disable import/default */
 import { storiesOf } from 'dev-novel';
-import instantsearch from '../../index.js';
+import instantsearch from '../../index';
 
-import { wrapWithHits } from './utils/wrap-with-hits.js';
+import { wrapWithHits } from './utils/wrap-with-hits';
 
 function wrapWithUnmount(getWidget, params) {
   return wrapWithHits(container => {

--- a/dev/app/jquery/init-stories.js
+++ b/dev/app/jquery/init-stories.js
@@ -1,4 +1,4 @@
-import initClearRefinementsStories from './stories/clear-refinements.stories.js';
+import initClearRefinementsStories from './stories/clear-refinements.stories';
 import initCurrentRefinedValuesStories from './stories/current-refined-values.stories';
 import initHierarchicalMenuStories from './stories/hierarchical-menu.stories';
 import initHitsStories from './stories/hits.stories';

--- a/dev/app/jquery/stories/autocomplete.stories.js
+++ b/dev/app/jquery/stories/autocomplete.stories.js
@@ -2,8 +2,8 @@
 
 import { action, storiesOf } from 'dev-novel';
 
-import instantsearch from '../../../../index.js';
-import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits.js';
+import instantsearch from '../../../../index';
+import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits';
 
 const stories = storiesOf('Autocomplete');
 

--- a/dev/app/jquery/stories/clear-refinements.stories.js
+++ b/dev/app/jquery/stories/clear-refinements.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from 'dev-novel';
-import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits.js';
-import * as widgets from '../widgets/index.js';
+import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits';
+import * as widgets from '../widgets/index';
 
 const stories = storiesOf('ClearAll');
 

--- a/dev/app/jquery/stories/current-refined-values.stories.js
+++ b/dev/app/jquery/stories/current-refined-values.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from 'dev-novel';
-import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits.js';
-import * as widgets from '../widgets/index.js';
+import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits';
+import * as widgets from '../widgets/index';
 
 const stories = storiesOf('CurrentRefinedValues');
 

--- a/dev/app/jquery/stories/hierarchical-menu.stories.js
+++ b/dev/app/jquery/stories/hierarchical-menu.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from 'dev-novel';
-import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits.js';
-import * as widgets from '../widgets/index.js';
+import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits';
+import * as widgets from '../widgets/index';
 
 const stories = storiesOf('HierarchicalMenu');
 

--- a/dev/app/jquery/stories/hits-per-page-selector.stories.js
+++ b/dev/app/jquery/stories/hits-per-page-selector.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from 'dev-novel';
-import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits.js';
-import * as widgets from '../widgets/index.js';
+import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits';
+import * as widgets from '../widgets/index';
 
 const stories = storiesOf('HitsPerPageSelector');
 

--- a/dev/app/jquery/stories/hits.stories.js
+++ b/dev/app/jquery/stories/hits.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from 'dev-novel';
-import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits.js';
-import * as widgets from '../widgets/index.js';
+import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits';
+import * as widgets from '../widgets/index';
 
 const stories = storiesOf('Hits');
 

--- a/dev/app/jquery/stories/infinite-hits.stories.js
+++ b/dev/app/jquery/stories/infinite-hits.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from 'dev-novel';
-import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits.js';
-import * as widgets from '../widgets/index.js';
+import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits';
+import * as widgets from '../widgets/index';
 
 const stories = storiesOf('InfiniteHits');
 

--- a/dev/app/jquery/stories/menu.stories.js
+++ b/dev/app/jquery/stories/menu.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from 'dev-novel';
-import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits.js';
-import * as widgets from '../widgets/index.js';
+import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits';
+import * as widgets from '../widgets/index';
 
 const stories = storiesOf('Menu');
 

--- a/dev/app/jquery/stories/numeric-refinement-list.stories.js
+++ b/dev/app/jquery/stories/numeric-refinement-list.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from 'dev-novel';
-import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits.js';
-import * as widgets from '../widgets/index.js';
+import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits';
+import * as widgets from '../widgets/index';
 
 const stories = storiesOf('NumericRefinementList');
 

--- a/dev/app/jquery/stories/numeric-selector.stories.js
+++ b/dev/app/jquery/stories/numeric-selector.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from 'dev-novel';
-import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits.js';
-import * as widgets from '../widgets/index.js';
+import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits';
+import * as widgets from '../widgets/index';
 
 const stories = storiesOf('NumericSelector');
 

--- a/dev/app/jquery/stories/pagination.stories.js
+++ b/dev/app/jquery/stories/pagination.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from 'dev-novel';
-import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits.js';
-import * as widgets from '../widgets/index.js';
+import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits';
+import * as widgets from '../widgets/index';
 
 const stories = storiesOf('Pagination');
 

--- a/dev/app/jquery/stories/price-ranges.stories.js
+++ b/dev/app/jquery/stories/price-ranges.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from 'dev-novel';
-import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits.js';
-import * as widgets from '../widgets/index.js';
+import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits';
+import * as widgets from '../widgets/index';
 
 const stories = storiesOf('PriceRanges');
 

--- a/dev/app/jquery/stories/refinement-list.stories.js
+++ b/dev/app/jquery/stories/refinement-list.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from 'dev-novel';
-import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits.js';
-import * as widgets from '../widgets/index.js';
+import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits';
+import * as widgets from '../widgets/index';
 
 const stories = storiesOf('RefinementList');
 

--- a/dev/app/jquery/stories/search-box.stories.js
+++ b/dev/app/jquery/stories/search-box.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from 'dev-novel';
-import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits.js';
-import * as widgets from '../widgets/index.js';
+import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits';
+import * as widgets from '../widgets/index';
 
 const stories = storiesOf('SearchBox');
 

--- a/dev/app/jquery/stories/sort-by-selector.stories.js
+++ b/dev/app/jquery/stories/sort-by-selector.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from 'dev-novel';
-import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits.js';
-import * as widgets from '../widgets/index.js';
+import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits';
+import * as widgets from '../widgets/index';
 
 const stories = storiesOf('SortBySelector');
 

--- a/dev/app/jquery/stories/star-rating.stories.js
+++ b/dev/app/jquery/stories/star-rating.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from 'dev-novel';
-import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits.js';
-import * as widgets from '../widgets/index.js';
+import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits';
+import * as widgets from '../widgets/index';
 
 const stories = storiesOf('StarRating');
 

--- a/dev/app/jquery/stories/stats.stories.js
+++ b/dev/app/jquery/stories/stats.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from 'dev-novel';
-import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits.js';
-import * as widgets from '../widgets/index.js';
+import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits';
+import * as widgets from '../widgets/index';
 
 const stories = storiesOf('Stats');
 

--- a/dev/app/jquery/stories/toggle.stories.js
+++ b/dev/app/jquery/stories/toggle.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from 'dev-novel';
-import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits.js';
-import * as widgets from '../widgets/index.js';
+import { wrapWithHitsAndJquery } from '../../utils/wrap-with-hits';
+import * as widgets from '../widgets/index';
 
 const stories = storiesOf('Toggle');
 

--- a/dev/app/jquery/widgets/clearRefinements.js
+++ b/dev/app/jquery/widgets/clearRefinements.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/default */
-import instantsearch from '../../../../index.js';
+import instantsearch from '../../../../index';
 
 const renderFn = (
   { refine, hasRefinements, widgetParams: { containerNode } },

--- a/dev/app/jquery/widgets/currentRefinedValues.js
+++ b/dev/app/jquery/widgets/currentRefinedValues.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/default */
-import instantsearch from '../../../../index.js';
+import instantsearch from '../../../../index';
 
 const renderFn = (
   {

--- a/dev/app/jquery/widgets/hierarchicalMenu.js
+++ b/dev/app/jquery/widgets/hierarchicalMenu.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/default */
-import instantsearch from '../../../../index.js';
+import instantsearch from '../../../../index';
 
 const formatMenuEntry = (createURL, lvl = 0) => item => {
   const countHTML = `

--- a/dev/app/jquery/widgets/hits.js
+++ b/dev/app/jquery/widgets/hits.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/default */
-import instantsearch from '../../../../index.js';
+import instantsearch from '../../../../index';
 
 const renderFn = ({ hits, widgetParams: { containerNode } }) => {
   containerNode.html(

--- a/dev/app/jquery/widgets/hitsPerPageSelector.js
+++ b/dev/app/jquery/widgets/hitsPerPageSelector.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/default */
-import instantsearch from '../../../../index.js';
+import instantsearch from '../../../../index';
 
 const renderFn = (
   { items, refine, widgetParams: { containerNode } },

--- a/dev/app/jquery/widgets/index.js
+++ b/dev/app/jquery/widgets/index.js
@@ -1,4 +1,4 @@
-export { default as clearRefinements } from './clearRefinements.js';
+export { default as clearRefinements } from './clearRefinements';
 export { default as currentRefinedValues } from './currentRefinedValues';
 export { default as hierarchicalMenu } from './hierarchicalMenu';
 export { default as menu } from './menu';

--- a/dev/app/jquery/widgets/infiniteHits.js
+++ b/dev/app/jquery/widgets/infiniteHits.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/default */
-import instantsearch from '../../../../index.js';
+import instantsearch from '../../../../index';
 
 const renderFn = ({
   hits,

--- a/dev/app/jquery/widgets/menu.js
+++ b/dev/app/jquery/widgets/menu.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/default */
 /* global $ */
-import instantsearch from '../../../../index.js';
+import instantsearch from '../../../../index';
 
 export default instantsearch.connectors.connectMenu(customMenuRendering);
 function customMenuRendering(opts, isFirstRendering) {

--- a/dev/app/jquery/widgets/numericRefinementList.js
+++ b/dev/app/jquery/widgets/numericRefinementList.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/default */
-import instantsearch from '../../../../index.js';
+import instantsearch from '../../../../index';
 
 const renderFn = (
   {

--- a/dev/app/jquery/widgets/numericSelector.js
+++ b/dev/app/jquery/widgets/numericSelector.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/default */
-import instantsearch from '../../../../index.js';
+import instantsearch from '../../../../index';
 
 const renderFn = (
   { currentRefinement, options, refine, widgetParams: { containerNode } },

--- a/dev/app/jquery/widgets/pagination.js
+++ b/dev/app/jquery/widgets/pagination.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/default */
-import instantsearch from '../../../../index.js';
+import instantsearch from '../../../../index';
 
 const renderFn = (
   {

--- a/dev/app/jquery/widgets/priceRanges.js
+++ b/dev/app/jquery/widgets/priceRanges.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/default */
-import instantsearch from '../../../../index.js';
+import instantsearch from '../../../../index';
 
 const getLabel = ({ from, to } = {}) => {
   if (to === undefined) return `≥ $${from}`;

--- a/dev/app/jquery/widgets/refinementList.js
+++ b/dev/app/jquery/widgets/refinementList.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/default */
-import instantsearch from '../../../../index.js';
+import instantsearch from '../../../../index';
 
 const renderFn = (
   {

--- a/dev/app/jquery/widgets/searchBox.js
+++ b/dev/app/jquery/widgets/searchBox.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/default */
-import instantsearch from '../../../../index.js';
+import instantsearch from '../../../../index';
 
 const renderFn = (
   { query, refine, widgetParams: { inputNode } },

--- a/dev/app/jquery/widgets/showMoreMenu.js
+++ b/dev/app/jquery/widgets/showMoreMenu.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/default */
-import instantsearch from '../../../../index.js';
+import instantsearch from '../../../../index';
 
 const renderFn = (
   {

--- a/dev/app/jquery/widgets/sortBySelector.js
+++ b/dev/app/jquery/widgets/sortBySelector.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/default */
-import instantsearch from '../../../../index.js';
+import instantsearch from '../../../../index';
 
 const renderFn = (
   { options, refine, currentRefinement, widgetParams: { containerNode } },

--- a/dev/app/jquery/widgets/starRating.js
+++ b/dev/app/jquery/widgets/starRating.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/default */
-import instantsearch from '../../../../index.js';
+import instantsearch from '../../../../index';
 
 const renderFn = (
   {

--- a/dev/app/jquery/widgets/stats.js
+++ b/dev/app/jquery/widgets/stats.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/default */
-import instantsearch from '../../../../index.js';
+import instantsearch from '../../../../index';
 
 const renderFn = (
   { nbHits, processingTimeMS, widgetParams: { containerNode } },

--- a/dev/app/jquery/widgets/toggle.js
+++ b/dev/app/jquery/widgets/toggle.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/default */
-import instantsearch from '../../../../index.js';
+import instantsearch from '../../../../index';
 
 const renderFn = (
   {

--- a/dev/app/utils/wrap-with-hits.js
+++ b/dev/app/utils/wrap-with-hits.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/default */
 
 import { action } from 'dev-novel';
-import instantsearch from '../../../index.js';
+import instantsearch from '../../../index';
 import item from './item.html';
 import empty from './no-results.html';
 

--- a/dev/app/vanilla/init-stories.js
+++ b/dev/app/vanilla/init-stories.js
@@ -1,4 +1,4 @@
-import initClearRefinementsStories from './stories/clear-refinements.stories.js';
+import initClearRefinementsStories from './stories/clear-refinements.stories';
 import initHitsStories from './stories/hits.stories';
 import initMenuStories from './stories/menu.stories';
 import initRefinementListStories from './stories/refinement-list.stories';

--- a/dev/app/vanilla/stories/clear-refinements.stories.js
+++ b/dev/app/vanilla/stories/clear-refinements.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from 'dev-novel';
-import { wrapWithHits } from '../../utils/wrap-with-hits.js';
-import * as widgets from '../widgets/index.js';
+import { wrapWithHits } from '../../utils/wrap-with-hits';
+import * as widgets from '../widgets/index';
 
 const stories = storiesOf('ClearAll');
 

--- a/dev/app/vanilla/stories/hits.stories.js
+++ b/dev/app/vanilla/stories/hits.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from 'dev-novel';
-import { wrapWithHits } from '../../utils/wrap-with-hits.js';
-import * as widgets from '../widgets/index.js';
+import { wrapWithHits } from '../../utils/wrap-with-hits';
+import * as widgets from '../widgets/index';
 
 const stories = storiesOf('Hits');
 

--- a/dev/app/vanilla/stories/menu.stories.js
+++ b/dev/app/vanilla/stories/menu.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from 'dev-novel';
-import { wrapWithHits } from '../../utils/wrap-with-hits.js';
-import * as widgets from '../widgets/index.js';
+import { wrapWithHits } from '../../utils/wrap-with-hits';
+import * as widgets from '../widgets/index';
 
 const stories = storiesOf('Menu');
 

--- a/dev/app/vanilla/stories/refinement-list.stories.js
+++ b/dev/app/vanilla/stories/refinement-list.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from 'dev-novel';
-import { wrapWithHits } from '../../utils/wrap-with-hits.js';
-import * as widgets from '../widgets/index.js';
+import { wrapWithHits } from '../../utils/wrap-with-hits';
+import * as widgets from '../widgets/index';
 
 const stories = storiesOf('RefinementList');
 

--- a/dev/app/vanilla/stories/search-box.stories.js
+++ b/dev/app/vanilla/stories/search-box.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from 'dev-novel';
-import { wrapWithHits } from '../../utils/wrap-with-hits.js';
-import * as widgets from '../widgets/index.js';
+import { wrapWithHits } from '../../utils/wrap-with-hits';
+import * as widgets from '../widgets/index';
 
 const stories = storiesOf('SearchBox');
 

--- a/dev/app/vanilla/widgets/clearRefinements.js
+++ b/dev/app/vanilla/widgets/clearRefinements.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/default */
-import instantsearch from '../../../../index.js';
+import instantsearch from '../../../../index';
 
 export default instantsearch.connectors.connectClearRefinements(render);
 

--- a/dev/app/vanilla/widgets/hits.js
+++ b/dev/app/vanilla/widgets/hits.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/default */
-import instantsearch from '../../../../index.js';
+import instantsearch from '../../../../index';
 import bel from 'bel';
 
 function render({ hits, widgetParams: { containerNode } }) {

--- a/dev/app/vanilla/widgets/index.js
+++ b/dev/app/vanilla/widgets/index.js
@@ -1,4 +1,4 @@
-export { default as clearRefinements } from './clearRefinements.js';
+export { default as clearRefinements } from './clearRefinements';
 export { default as hits } from './hits';
 export { default as searchBox } from './searchBox';
 export { default as searchBoxReturn } from './searchBoxReturn';

--- a/dev/app/vanilla/widgets/refinementList.js
+++ b/dev/app/vanilla/widgets/refinementList.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/default */
-import instantsearch from '../../../../index.js';
+import instantsearch from '../../../../index';
 
 function render(
   { items, refine, widgetParams: { containerNode } },

--- a/dev/app/vanilla/widgets/searchBox.js
+++ b/dev/app/vanilla/widgets/searchBox.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/default */
-import instantsearch from '../../../../index.js';
+import instantsearch from '../../../../index';
 
 function render({ refine, widgetParams }, isFirstRendering) {
   const { node } = widgetParams;

--- a/dev/app/vanilla/widgets/searchBoxReturn.js
+++ b/dev/app/vanilla/widgets/searchBoxReturn.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/default */
-import instantsearch from '../../../../index.js';
+import instantsearch from '../../../../index';
 
 function render({ refine, widgetParams }, isFirstRendering) {
   const { node } = widgetParams;

--- a/dev/app/vanilla/widgets/selectMenu.js
+++ b/dev/app/vanilla/widgets/selectMenu.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/default */
-import instantsearch from '../../../../index.js';
+import instantsearch from '../../../../index';
 
 function render(
   { items, refine, widgetParams: { containerNode, title } },

--- a/docgen/assets/js/main.js
+++ b/docgen/assets/js/main.js
@@ -1,9 +1,9 @@
-import dropdowns from './dropdowns.js';
-import move from './mover.js';
-import activateClipboard from './activateClipboard.js';
-import bindRunExamples from './bindRunExamples.js';
+import dropdowns from './dropdowns';
+import move from './mover';
+import activateClipboard from './activateClipboard';
+import bindRunExamples from './bindRunExamples';
 
-import {fixSidebar, followSidebarNavigation} from './fix-sidebar.js';
+import {fixSidebar, followSidebarNavigation} from './fix-sidebar';
 
 import '../../../src/css/instantsearch.scss';
 import '../../../src/css/instantsearch-theme-algolia.scss';

--- a/docgen/build.js
+++ b/docgen/build.js
@@ -1,4 +1,4 @@
-import builder from './builder.js';
+import builder from './builder';
 import {build as middlewares} from './middlewares';
 
 builder({

--- a/docgen/builder.js
+++ b/docgen/builder.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import metalsmith from 'metalsmith';
-import config from './config.js';
+import config from './config';
 
 
 export default function builder({

--- a/docgen/devServer.js
+++ b/docgen/devServer.js
@@ -8,7 +8,7 @@ import webpackConfig from './webpack.config.start.babel';
 import webpackDevMiddleware from 'webpack-dev-middleware';
 import webpackHotMiddleware from 'webpack-hot-middleware';
 import compression from 'compression';
-import config from './config.js';
+import config from './config';
 
 export default function() {
   const compiler = webpack(webpackConfig);

--- a/docgen/mdRenderer.js
+++ b/docgen/mdRenderer.js
@@ -1,7 +1,7 @@
 import MarkdownIt from 'markdown-it';
 import markdownItAnchor from 'markdown-it-anchor';
 
-import highlight from './syntaxHighlighting.js';
+import highlight from './syntaxHighlighting';
 
 const md =
   new MarkdownIt('default', {

--- a/docgen/middlewares.js
+++ b/docgen/middlewares.js
@@ -2,28 +2,28 @@ import headings from 'metalsmith-headings';
 import layouts from 'metalsmith-layouts';
 import msWebpack from 'ms-webpack';
 import navigation from 'metalsmith-navigation';
-import nav from './plugins/navigation.js';
-import searchConfig from './plugins/searchConfig.js';
+import nav from './plugins/navigation';
+import searchConfig from './plugins/searchConfig';
 import sass from 'metalsmith-sass';
 import inPlace from 'metalsmith-in-place';
 import copy from 'metalsmith-copy';
 
-import assets from './plugins/assets.js';
-import helpers from './plugins/helpers.js';
-import ignore from './plugins/ignore.js';
-import markdown from './plugins/markdown.js';
-import onlyChanged from './plugins/onlyChanged.js';
-import webpackEntryMetadata from './plugins/webpackEntryMetadata.js';
-import autoprefixer from './plugins/autoprefixer.js';
-import documentationjs from './plugins/documentationjs-data.js';
+import assets from './plugins/assets';
+import helpers from './plugins/helpers';
+import ignore from './plugins/ignore';
+import markdown from './plugins/markdown';
+import onlyChanged from './plugins/onlyChanged';
+import webpackEntryMetadata from './plugins/webpackEntryMetadata';
+import autoprefixer from './plugins/autoprefixer';
+import documentationjs from './plugins/documentationjs-data';
 
 // performance and debug info for metalsmith, when needed see usage below
-// import {start as perfStart, stop as perfStop} from './plugins/perf.js';
+// import {start as perfStart, stop as perfStop} from './plugins/perf';
 
-import webpackStartConfig from './webpack.config.start.babel.js';
+import webpackStartConfig from './webpack.config.start.babel';
 import webpackBuildConfig from './webpack.config.build.babel';
 
-import {rootPath} from './path.js';
+import {rootPath} from './path';
 
 const common = [
   helpers,

--- a/docgen/plugins/helpers.js
+++ b/docgen/plugins/helpers.js
@@ -1,5 +1,5 @@
 import markdown from 'markdown-it';
-import highlight from '../syntaxHighlighting.js';
+import highlight from '../syntaxHighlighting';
 
 const md = markdown();
 

--- a/docgen/plugins/jsdoc-data.js
+++ b/docgen/plugins/jsdoc-data.js
@@ -1,7 +1,7 @@
 import collectJson from 'collect-json';
 import jsdocParse from 'jsdoc-parse';
 import {forEach, groupBy} from 'lodash';
-import {hasChanged} from './onlyChanged.js';
+import {hasChanged} from './onlyChanged';
 import {join} from 'path';
 
 let cachedFiles;

--- a/docgen/start.js
+++ b/docgen/start.js
@@ -1,9 +1,9 @@
 import {watch} from 'chokidar';
 
-import devServer from './devServer.js';
-import builder from './builder.js';
+import devServer from './devServer';
+import builder from './builder';
 import {start as middlewares} from './middlewares';
-import {rootPath} from './path.js';
+import {rootPath} from './path';
 
 // we build once at start
 builder({middlewares}, err => {

--- a/docgen/webpack.config.babel.js
+++ b/docgen/webpack.config.babel.js
@@ -1,7 +1,7 @@
 import webpack from 'webpack';
 import { join } from 'path';
 import autoprefixer from 'autoprefixer';
-import config from './config.js';
+import config from './config';
 
 export default {
   devtool: 'source-map',

--- a/docgen/webpack.config.build.babel.js
+++ b/docgen/webpack.config.build.babel.js
@@ -1,7 +1,7 @@
 // this is the webpack config when running `yarn run docs:build`
 
 import webpack from 'webpack';
-import webpackConfig from './webpack.config.babel.js';
+import webpackConfig from './webpack.config.babel';
 
 export default {
   ...webpackConfig,

--- a/docgen/webpack.config.start.babel.js
+++ b/docgen/webpack.config.start.babel.js
@@ -1,7 +1,7 @@
 // this is the webpack config when running `npm start`
 
 import webpack from 'webpack';
-import webpackConfig from './webpack.config.babel.js';
+import webpackConfig from './webpack.config.babel';
 
 export default {
   ...webpackConfig,

--- a/functional-tests/config.js
+++ b/functional-tests/config.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import { SaveScreenshot } from 'wdio-visual-regression-service/compare';
-import testServer from './testServer.js';
-import { clearAll, searchBox } from './utils.js';
+import testServer from './testServer';
+import { clearAll, searchBox } from './utils';
 const INDEX_PAGE = process.env.INDEX_PAGE || 'index';
 
 function screenshotName(context) {

--- a/functional-tests/test.js
+++ b/functional-tests/test.js
@@ -1,5 +1,5 @@
 import expect from 'expect';
-import { searchBox, prepareScreenshot } from './utils.js';
+import { searchBox, prepareScreenshot } from './utils';
 
 describe('searchBox', () => {
   describe('when there is no query', () => {

--- a/index.es6.js
+++ b/index.es6.js
@@ -2,12 +2,12 @@
 import algoliasearchHelper from 'algoliasearch-helper';
 import toFactory from 'to-factory';
 
-/* eslint-disable import/no-unresolved */
-import InstantSearch from './lib/InstantSearch.js';
-import version from './lib/version.js';
-/* eslint-enable import/no-unresolved */
+/* eslint-disable */
+import InstantSearch from './lib/InstantSearch';
+import version from './lib/version';
+/* eslint-enable */
 
-// import instantsearch from 'instantsearch.js';
+// import instantsearch from 'instantsearch';
 // -> provides instantsearch object without connectors and widgets
 const instantSearchFactory = toFactory(InstantSearch);
 

--- a/index.js
+++ b/index.js
@@ -3,6 +3,6 @@
 
 /* eslint-disable import/no-commonjs */
 
-import main from './src/lib/main.js';
+import main from './src/lib/main';
 
 module.exports = main;

--- a/scripts/bump-package-version.js
+++ b/scripts/bump-package-version.js
@@ -6,7 +6,7 @@ import path from 'path';
 import mversion from 'mversion';
 
 import semver from 'semver';
-import currentVersion from '../src/lib/version.js';
+import currentVersion from '../src/lib/version';
 
 if (!process.env.VERSION) {
   throw new Error(

--- a/scripts/dev-functional-tests-compile-watch.js
+++ b/scripts/dev-functional-tests-compile-watch.js
@@ -3,7 +3,7 @@
 import webpack from 'webpack';
 import watch from 'watch';
 import { join } from 'path';
-import config from './webpack.config.js';
+import config from './webpack.config';
 const compiler = webpack(config);
 
 export default cb => {

--- a/scripts/dev-functional-tests-debug-server.js
+++ b/scripts/dev-functional-tests-debug-server.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
-import testServer from '../functional-tests/testServer.js';
-import watch from './dev-functional-tests-compile-watch.js';
+import testServer from '../functional-tests/testServer';
+import watch from './dev-functional-tests-compile-watch';
 
 watch(() => {});
 

--- a/scripts/dev-functional-tests.js
+++ b/scripts/dev-functional-tests.js
@@ -2,7 +2,7 @@
 
 import { spawn } from 'child_process';
 import debounce from 'lodash/debounce';
-import watch from './dev-functional-tests-compile-watch.js';
+import watch from './dev-functional-tests-compile-watch';
 
 const REBUILD_TIMEOUT = 1500;
 let wdio;

--- a/src/components/Breadcrumb/Breadcrumb.js
+++ b/src/components/Breadcrumb/Breadcrumb.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'preact-compat';
 import PropTypes from 'prop-types';
-import Template from '../Template.js';
-import autoHideContainerHOC from '../../decorators/autoHideContainer.js';
+import Template from '../Template';
+import autoHideContainerHOC from '../../decorators/autoHideContainer';
 
 const renderLink = ({ cssClasses, createURL, refine, templateProps }) => (
   item,

--- a/src/components/ClearRefinements/ClearRefinements.js
+++ b/src/components/ClearRefinements/ClearRefinements.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'preact-compat';
-import Template from '../Template.js';
-import { isSpecialClick } from '../../lib/utils.js';
+import Template from '../Template';
+import { isSpecialClick } from '../../lib/utils';
 
 export default class RawClearRefinements extends Component {
   componentWillMount() {

--- a/src/components/CurrentRefinedValues/CurrentRefinedValues.js
+++ b/src/components/CurrentRefinedValues/CurrentRefinedValues.js
@@ -1,12 +1,12 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'preact-compat';
 
-import Template from '../Template.js';
+import Template from '../Template';
 
-import headerFooterHOC from '../../decorators/headerFooter.js';
+import headerFooterHOC from '../../decorators/headerFooter';
 import autoHideContainerHOC from '../../decorators/autoHideContainer';
 
-import { isSpecialClick } from '../../lib/utils.js';
+import { isSpecialClick } from '../../lib/utils';
 import map from 'lodash/map';
 import cloneDeep from 'lodash/cloneDeep';
 import isEqual from 'lodash/isEqual';

--- a/src/components/CurrentRefinedValues/__tests__/CurrentRefinedValues-test.js
+++ b/src/components/CurrentRefinedValues/__tests__/CurrentRefinedValues-test.js
@@ -1,6 +1,6 @@
 /* eslint react/no-multi-comp: 0 */
 import React from 'react';
-import { RawCurrentRefinedValues as CurrentRefinedValues } from '../CurrentRefinedValues.js';
+import { RawCurrentRefinedValues as CurrentRefinedValues } from '../CurrentRefinedValues';
 import renderer from 'react-test-renderer';
 
 describe('CurrentRefinedValues', () => {

--- a/src/components/Hits.js
+++ b/src/components/Hits.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'preact-compat';
 import map from 'lodash/map';
-import Template from './Template.js';
+import Template from './Template';
 import hasKey from 'lodash/has';
 import cx from 'classnames';
 

--- a/src/components/InfiniteHits.js
+++ b/src/components/InfiniteHits.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'preact-compat';
-import Hits from './Hits.js';
+import Hits from './Hits';
 
 class InfiniteHits extends Component {
   render() {

--- a/src/components/MenuSelect.js
+++ b/src/components/MenuSelect.js
@@ -2,8 +2,8 @@ import React, { Component } from 'preact-compat';
 import PropTypes from 'prop-types';
 
 import Template from './Template';
-import autoHideContainerHOC from '../decorators/autoHideContainer.js';
-import headerFooterHOC from '../decorators/headerFooter.js';
+import autoHideContainerHOC from '../decorators/autoHideContainer';
+import headerFooterHOC from '../decorators/headerFooter';
 
 class MenuSelect extends Component {
   static propTypes = {

--- a/src/components/Pagination/Pagination.js
+++ b/src/components/Pagination/Pagination.js
@@ -1,11 +1,11 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'preact-compat';
 import defaultsDeep from 'lodash/defaultsDeep';
-import { isSpecialClick } from '../../lib/utils.js';
+import { isSpecialClick } from '../../lib/utils';
 
-import autoHideContainerHOC from '../../decorators/autoHideContainer.js';
+import autoHideContainerHOC from '../../decorators/autoHideContainer';
 
-import PaginationLink from './PaginationLink.js';
+import PaginationLink from './PaginationLink';
 
 import cx from 'classnames';
 

--- a/src/components/PriceRanges/PriceRanges.js
+++ b/src/components/PriceRanges/PriceRanges.js
@@ -1,13 +1,13 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'preact-compat';
 
-import Template from '../Template.js';
-import PriceRangesForm from './PriceRangesForm.js';
+import Template from '../Template';
+import PriceRangesForm from './PriceRangesForm';
 import cx from 'classnames';
 import isEqual from 'lodash/isEqual';
 
-import autoHideContainerHOC from '../../decorators/autoHideContainer.js';
-import headerFooterHOC from '../../decorators/headerFooter.js';
+import autoHideContainerHOC from '../../decorators/autoHideContainer';
+import headerFooterHOC from '../../decorators/headerFooter';
 
 export class RawPriceRanges extends Component {
   componentWillMount() {

--- a/src/components/RangeInput/RangeInput.js
+++ b/src/components/RangeInput/RangeInput.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'preact-compat';
 import PropTypes from 'prop-types';
-import autoHideContainerHOC from '../../decorators/autoHideContainer.js';
-import headerFooterHOC from '../../decorators/headerFooter.js';
+import autoHideContainerHOC from '../../decorators/autoHideContainer';
+import headerFooterHOC from '../../decorators/headerFooter';
 
 export class RawRangeInput extends Component {
   constructor(props) {

--- a/src/components/RefinementList/RefinementList.js
+++ b/src/components/RefinementList/RefinementList.js
@@ -1,16 +1,16 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'preact-compat';
 import cx from 'classnames';
-import { isSpecialClick } from '../../lib/utils.js';
+import { isSpecialClick } from '../../lib/utils';
 
-import Template from '../Template.js';
-import RefinementListItem from './RefinementListItem.js';
+import Template from '../Template';
+import RefinementListItem from './RefinementListItem';
 import isEqual from 'lodash/isEqual';
 
 import SearchBox from '../SearchBox';
 
-import autoHideContainerHOC from '../../decorators/autoHideContainer.js';
-import headerFooterHOC from '../../decorators/headerFooter.js';
+import autoHideContainerHOC from '../../decorators/autoHideContainer';
+import headerFooterHOC from '../../decorators/headerFooter';
 
 export class RawRefinementList extends Component {
   constructor(props) {

--- a/src/components/RefinementList/RefinementListItem.js
+++ b/src/components/RefinementList/RefinementListItem.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'preact-compat';
 
-import Template from '../Template.js';
+import Template from '../Template';
 import isEqual from 'lodash/isEqual';
 
 class RefinementListItem extends Component {

--- a/src/components/Selector.js
+++ b/src/components/Selector.js
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'preact-compat';
 
-import autoHideContainer from '../decorators/autoHideContainer.js';
-import headerFooter from '../decorators/headerFooter.js';
+import autoHideContainer from '../decorators/autoHideContainer';
+import headerFooter from '../decorators/headerFooter';
 
 export class RawSelector extends Component {
   componentWillMount() {

--- a/src/components/Slider/Slider.js
+++ b/src/components/Slider/Slider.js
@@ -9,10 +9,10 @@ import React, { Component } from 'preact-compat';
 import Rheostat from 'preact-rheostat';
 import cx from 'classnames';
 
-import Pit from './Pit.js';
+import Pit from './Pit';
 
-import autoHideContainerHOC from '../../decorators/autoHideContainer.js';
-import headerFooterHOC from '../../decorators/headerFooter.js';
+import autoHideContainerHOC from '../../decorators/autoHideContainer';
+import headerFooterHOC from '../../decorators/headerFooter';
 
 export class RawSlider extends Component {
   static propTypes = {

--- a/src/components/Stats/Stats.js
+++ b/src/components/Stats/Stats.js
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'preact-compat';
 
-import Template from '../Template.js';
-import autoHideContainerHOC from '../../decorators/autoHideContainer.js';
-import headerFooterHOC from '../../decorators/headerFooter.js';
+import Template from '../Template';
+import autoHideContainerHOC from '../../decorators/autoHideContainer';
+import headerFooterHOC from '../../decorators/headerFooter';
 
 export class RawStats extends Component {
   shouldComponentUpdate(nextProps) {

--- a/src/connectors/autocomplete/__tests__/connectAutocomplete-test.js
+++ b/src/connectors/autocomplete/__tests__/connectAutocomplete-test.js
@@ -1,5 +1,5 @@
 import jsHelper from 'algoliasearch-helper';
-import connectAutocomplete from '../connectAutocomplete.js';
+import connectAutocomplete from '../connectAutocomplete';
 
 const fakeClient = { addAlgoliaAgent: () => {} };
 

--- a/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.js
+++ b/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.js
@@ -1,7 +1,7 @@
 import jsHelper from 'algoliasearch-helper';
 const SearchResults = jsHelper.SearchResults;
 
-import connectBreadcrumb from '../connectBreadcrumb.js';
+import connectBreadcrumb from '../connectBreadcrumb';
 
 describe('connectBreadcrumb', () => {
   it('It should compute getConfiguration() correctly', () => {

--- a/src/connectors/breadcrumb/connectBreadcrumb.js
+++ b/src/connectors/breadcrumb/connectBreadcrumb.js
@@ -1,6 +1,6 @@
 import find from 'lodash/find';
 import isEqual from 'lodash/isEqual';
-import { checkRendering } from '../../lib/utils.js';
+import { checkRendering } from '../../lib/utils';
 
 const usage = `Usage:
 var customBreadcrumb = connectBreadcrumb(function renderFn(params, isFirstRendering) {

--- a/src/connectors/clear-refinements/__tests__/connectClearRefinements-test.js
+++ b/src/connectors/clear-refinements/__tests__/connectClearRefinements-test.js
@@ -1,7 +1,7 @@
 import jsHelper from 'algoliasearch-helper';
 const SearchResults = jsHelper.SearchResults;
 
-import connectClearRefinements from '../connectClearRefinements.js';
+import connectClearRefinements from '../connectClearRefinements';
 
 describe('connectClearRefinements', () => {
   it('Renders during init and render', () => {
@@ -156,7 +156,7 @@ describe('connectClearRefinements', () => {
     helper.toggleRefinement('aFacet', 'some value');
     helper.search = () => {};
 
-    const rendering = jest.fn()
+    const rendering = jest.fn();
     const makeWidget = connectClearRefinements(rendering);
     const widget = makeWidget();
 

--- a/src/connectors/clear-refinements/connectClearRefinements.js
+++ b/src/connectors/clear-refinements/connectClearRefinements.js
@@ -2,7 +2,7 @@ import {
   checkRendering,
   clearRefinements,
   getAttributesToClear,
-} from '../../lib/utils.js';
+} from '../../lib/utils';
 
 const usage = `Usage:
 var customClearRefinements = connectClearRefinements(function render(params, isFirstRendering) {

--- a/src/connectors/configure/__tests__/connectConfigure-test.js
+++ b/src/connectors/configure/__tests__/connectConfigure-test.js
@@ -1,6 +1,6 @@
 import algoliasearchHelper, { SearchParameters } from 'algoliasearch-helper';
 
-import connectConfigure from '../connectConfigure.js';
+import connectConfigure from '../connectConfigure';
 
 const fakeClient = {
   search: jest.fn(() => Promise.resolve({ results: [{}] })),

--- a/src/connectors/configure/connectConfigure.js
+++ b/src/connectors/configure/connectConfigure.js
@@ -1,7 +1,7 @@
 import isFunction from 'lodash/isFunction';
 import isPlainObject from 'lodash/isPlainObject';
 
-import { enhanceConfiguration } from '../../lib/InstantSearch.js';
+import { enhanceConfiguration } from '../../lib/InstantSearch';
 
 const usage = `Usage:
 var customConfigureWidget = connectConfigure(

--- a/src/connectors/current-refined-values/__tests__/connectCurrentRefinedValues-test.js
+++ b/src/connectors/current-refined-values/__tests__/connectCurrentRefinedValues-test.js
@@ -1,6 +1,6 @@
 import jsHelper from 'algoliasearch-helper';
 const SearchResults = jsHelper.SearchResults;
-import connectCurrentRefinedValues from '../connectCurrentRefinedValues.js';
+import connectCurrentRefinedValues from '../connectCurrentRefinedValues';
 
 describe('connectCurrentRefinedValues', () => {
   it('Renders during init and render', () => {

--- a/src/connectors/current-refined-values/connectCurrentRefinedValues.js
+++ b/src/connectors/current-refined-values/connectCurrentRefinedValues.js
@@ -14,7 +14,7 @@ import {
   getRefinements,
   clearRefinements,
   checkRendering,
-} from '../../lib/utils.js';
+} from '../../lib/utils';
 
 const usage = `Usage:
 var customCurrentRefinedValues = connectCurrentRefinedValues(function renderFn(params, isFirstRendering) {

--- a/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.js
+++ b/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.js
@@ -4,7 +4,7 @@ import jsHelper from 'algoliasearch-helper';
 const SearchResults = jsHelper.SearchResults;
 const SearchParameters = jsHelper.SearchParameters;
 
-import connectHierarchicalMenu from '../connectHierarchicalMenu.js';
+import connectHierarchicalMenu from '../connectHierarchicalMenu';
 
 describe('connectHierarchicalMenu', () => {
   it('It should compute getConfiguration() correctly', () => {

--- a/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
+++ b/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
@@ -1,7 +1,7 @@
 import find from 'lodash/find';
 import isEqual from 'lodash/isEqual';
 
-import { checkRendering } from '../../lib/utils.js';
+import { checkRendering } from '../../lib/utils';
 
 const usage = `Usage:
 var customHierarchicalMenu = connectHierarchicalMenu(function renderFn(params, isFirstRendering) {

--- a/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
+++ b/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
@@ -3,7 +3,7 @@ import jsHelper from 'algoliasearch-helper';
 const SearchResults = jsHelper.SearchResults;
 const SearchParameters = jsHelper.SearchParameters;
 
-import connectHitsPerPage from '../connectHitsPerPage.js';
+import connectHitsPerPage from '../connectHitsPerPage';
 
 describe('connectHitsPerPage', () => {
   it('should throw when there is two default items defined', () => {

--- a/src/connectors/hits-per-page/connectHitsPerPage.js
+++ b/src/connectors/hits-per-page/connectHitsPerPage.js
@@ -1,7 +1,7 @@
 import some from 'lodash/some';
 import find from 'lodash/find';
 
-import { checkRendering } from '../../lib/utils.js';
+import { checkRendering } from '../../lib/utils';
 
 const usage = `Usage:
 var customHitsPerPage = connectHitsPerPage(function render(params, isFirstRendering) {

--- a/src/connectors/hits/__tests__/connectHits-test.js
+++ b/src/connectors/hits/__tests__/connectHits-test.js
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import jsHelper from 'algoliasearch-helper';
 const SearchResults = jsHelper.SearchResults;
 
-import connectHits from '../connectHits.js';
+import connectHits from '../connectHits';
 
 describe('connectHits', () => {
   it('Renders during init and render', () => {

--- a/src/connectors/hits/connectHits.js
+++ b/src/connectors/hits/connectHits.js
@@ -1,5 +1,5 @@
-import escapeHits, { tagConfig } from '../../lib/escape-highlight.js';
-import { checkRendering } from '../../lib/utils.js';
+import escapeHits, { tagConfig } from '../../lib/escape-highlight';
+import { checkRendering } from '../../lib/utils';
 
 const usage = `Usage:
 var customHits = connectHits(function render(params, isFirstRendering) {

--- a/src/connectors/index.js
+++ b/src/connectors/index.js
@@ -1,53 +1,47 @@
 export {
   default as connectClearRefinements,
-} from './clear-refinements/connectClearRefinements.js';
+} from './clear-refinements/connectClearRefinements';
 export {
   default as connectCurrentRefinedValues,
-} from './current-refined-values/connectCurrentRefinedValues.js';
+} from './current-refined-values/connectCurrentRefinedValues';
 export {
   default as connectHierarchicalMenu,
-} from './hierarchical-menu/connectHierarchicalMenu.js';
-export { default as connectHits } from './hits/connectHits.js';
+} from './hierarchical-menu/connectHierarchicalMenu';
+export { default as connectHits } from './hits/connectHits';
 export {
   default as connectHitsPerPage,
-} from './hits-per-page/connectHitsPerPage.js';
+} from './hits-per-page/connectHitsPerPage';
 export {
   default as connectInfiniteHits,
-} from './infinite-hits/connectInfiniteHits.js';
-export { default as connectMenu } from './menu/connectMenu.js';
+} from './infinite-hits/connectInfiniteHits';
+export { default as connectMenu } from './menu/connectMenu';
 export {
   default as connectNumericRefinementList,
-} from './numeric-refinement-list/connectNumericRefinementList.js';
+} from './numeric-refinement-list/connectNumericRefinementList';
 export {
   default as connectNumericSelector,
-} from './numeric-selector/connectNumericSelector.js';
-export {
-  default as connectPagination,
-} from './pagination/connectPagination.js';
+} from './numeric-selector/connectNumericSelector';
+export { default as connectPagination } from './pagination/connectPagination';
 export {
   default as connectPriceRanges,
-} from './price-ranges/connectPriceRanges.js';
+} from './price-ranges/connectPriceRanges';
 export {
   default as connectRangeSlider,
-} from './range-slider/connectRangeSlider.js';
-export { default as connectRange } from './range/connectRange.js';
+} from './range-slider/connectRangeSlider';
+export { default as connectRange } from './range/connectRange';
 export {
   default as connectRefinementList,
-} from './refinement-list/connectRefinementList.js';
-export { default as connectSearchBox } from './search-box/connectSearchBox.js';
+} from './refinement-list/connectRefinementList';
+export { default as connectSearchBox } from './search-box/connectSearchBox';
 export {
   default as connectSortBySelector,
-} from './sort-by-selector/connectSortBySelector.js';
-export {
-  default as connectStarRating,
-} from './star-rating/connectStarRating.js';
-export { default as connectStats } from './stats/connectStats.js';
-export { default as connectToggle } from './toggle/connectToggle.js';
-export {
-  default as connectBreadcrumb,
-} from './breadcrumb/connectBreadcrumb.js';
-export { default as connectGeoSearch } from './geo-search/connectGeoSearch.js';
-export { default as connectConfigure } from './configure/connectConfigure.js';
+} from './sort-by-selector/connectSortBySelector';
+export { default as connectStarRating } from './star-rating/connectStarRating';
+export { default as connectStats } from './stats/connectStats';
+export { default as connectToggle } from './toggle/connectToggle';
+export { default as connectBreadcrumb } from './breadcrumb/connectBreadcrumb';
+export { default as connectGeoSearch } from './geo-search/connectGeoSearch';
+export { default as connectConfigure } from './configure/connectConfigure';
 export {
   default as connectAutocomplete,
-} from './autocomplete/connectAutocomplete.js';
+} from './autocomplete/connectAutocomplete';

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.js
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.js
@@ -1,7 +1,7 @@
 import jsHelper from 'algoliasearch-helper';
 const SearchResults = jsHelper.SearchResults;
 
-import connectInfiniteHits from '../connectInfiniteHits.js';
+import connectInfiniteHits from '../connectInfiniteHits';
 
 describe('connectInfiniteHits', () => {
   it('Renders during init and render', () => {

--- a/src/connectors/infinite-hits/connectInfiniteHits.js
+++ b/src/connectors/infinite-hits/connectInfiniteHits.js
@@ -1,5 +1,5 @@
-import escapeHits, { tagConfig } from '../../lib/escape-highlight.js';
-import { checkRendering } from '../../lib/utils.js';
+import escapeHits, { tagConfig } from '../../lib/escape-highlight';
+import { checkRendering } from '../../lib/utils';
 
 const usage = `Usage:
 var customInfiniteHits = connectInfiniteHits(function render(params, isFirstRendering) {

--- a/src/connectors/menu/__tests__/connectMenu-test.js
+++ b/src/connectors/menu/__tests__/connectMenu-test.js
@@ -5,7 +5,7 @@ import jsHelper, {
   SearchParameters,
 } from 'algoliasearch-helper';
 
-import connectMenu from '../connectMenu.js';
+import connectMenu from '../connectMenu';
 
 describe('connectMenu', () => {
   let rendering;

--- a/src/connectors/menu/connectMenu.js
+++ b/src/connectors/menu/connectMenu.js
@@ -1,4 +1,4 @@
-import { checkRendering } from '../../lib/utils.js';
+import { checkRendering } from '../../lib/utils';
 
 const usage = `Usage:
 var customMenu = connectMenu(function render(params, isFirstRendering) {

--- a/src/connectors/numeric-refinement-list/__tests__/connectNumericRefinementList-test.js
+++ b/src/connectors/numeric-refinement-list/__tests__/connectNumericRefinementList-test.js
@@ -4,7 +4,7 @@ import jsHelper, {
   SearchParameters,
 } from 'algoliasearch-helper';
 
-import connectNumericRefinementList from '../connectNumericRefinementList.js';
+import connectNumericRefinementList from '../connectNumericRefinementList';
 
 const encodeValue = (start, end) =>
   window.encodeURI(JSON.stringify({ start, end }));

--- a/src/connectors/numeric-refinement-list/connectNumericRefinementList.js
+++ b/src/connectors/numeric-refinement-list/connectNumericRefinementList.js
@@ -1,7 +1,7 @@
 import includes from 'lodash/includes';
 import _isFinite from 'lodash/isFinite';
 
-import { checkRendering } from '../../lib/utils.js';
+import { checkRendering } from '../../lib/utils';
 
 const usage = `Usage:
 var customNumericRefinementList = connectNumericRefinementList(function renderFn(params, isFirstRendering) {

--- a/src/connectors/numeric-selector/__tests__/connectNumericSelector-test.js
+++ b/src/connectors/numeric-selector/__tests__/connectNumericSelector-test.js
@@ -3,7 +3,7 @@ import jsHelper, {
   SearchParameters,
 } from 'algoliasearch-helper';
 
-import connectNumericSelector from '../connectNumericSelector.js';
+import connectNumericSelector from '../connectNumericSelector';
 
 describe('connectNumericSelector', () => {
   it('Renders during init and render', () => {

--- a/src/connectors/numeric-selector/connectNumericSelector.js
+++ b/src/connectors/numeric-selector/connectNumericSelector.js
@@ -1,4 +1,4 @@
-import { checkRendering } from '../../lib/utils.js';
+import { checkRendering } from '../../lib/utils';
 
 const usage = `Usage:
 var customNumericSelector = connectNumericSelector(function renderFn(params, isFirstRendering) {

--- a/src/connectors/pagination/__tests__/connectPagination-test.js
+++ b/src/connectors/pagination/__tests__/connectPagination-test.js
@@ -5,7 +5,7 @@ import jsHelper, {
   SearchParameters,
 } from 'algoliasearch-helper';
 
-import connectPagination from '../connectPagination.js';
+import connectPagination from '../connectPagination';
 
 describe('connectPagination', () => {
   it('connectPagination - Renders during init and render', () => {

--- a/src/connectors/pagination/connectPagination.js
+++ b/src/connectors/pagination/connectPagination.js
@@ -1,4 +1,4 @@
-import { checkRendering } from '../../lib/utils.js';
+import { checkRendering } from '../../lib/utils';
 import Paginator from './Paginator';
 
 const usage = `Usage:

--- a/src/connectors/price-ranges/__tests__/connectPriceRanges-test.js
+++ b/src/connectors/price-ranges/__tests__/connectPriceRanges-test.js
@@ -5,7 +5,7 @@ import jsHelper, {
   SearchParameters,
 } from 'algoliasearch-helper';
 
-import connectPriceRanges from '../connectPriceRanges.js';
+import connectPriceRanges from '../connectPriceRanges';
 
 describe('connectPriceRanges', () => {
   it('Renders during init and render', () => {

--- a/src/connectors/price-ranges/connectPriceRanges.js
+++ b/src/connectors/price-ranges/connectPriceRanges.js
@@ -1,5 +1,5 @@
-import { checkRendering } from '../../lib/utils.js';
-import generateRanges from './generate-ranges.js';
+import { checkRendering } from '../../lib/utils';
+import generateRanges from './generate-ranges';
 
 import isFinite from 'lodash/isFinite';
 

--- a/src/connectors/range/__tests__/connectRange-test.js
+++ b/src/connectors/range/__tests__/connectRange-test.js
@@ -5,7 +5,7 @@ import jsHelper, {
   SearchParameters,
 } from 'algoliasearch-helper';
 
-import connectRange from '../connectRange.js';
+import connectRange from '../connectRange';
 
 describe('connectRange', () => {
   it('Renders during init and render', () => {

--- a/src/connectors/range/connectRange.js
+++ b/src/connectors/range/connectRange.js
@@ -1,7 +1,7 @@
 import find from 'lodash/find';
 import _isFinite from 'lodash/isFinite';
 
-import { checkRendering } from '../../lib/utils.js';
+import { checkRendering } from '../../lib/utils';
 
 const usage = `Usage:
 var customRange = connectRange(function render(params, isFirstRendering) {

--- a/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
+++ b/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
@@ -2,9 +2,9 @@ import jsHelper, {
   SearchResults,
   SearchParameters,
 } from 'algoliasearch-helper';
-import { tagConfig } from '../../../lib/escape-highlight.js';
+import { tagConfig } from '../../../lib/escape-highlight';
 
-import connectRefinementList from '../connectRefinementList.js';
+import connectRefinementList from '../connectRefinementList';
 
 describe('connectRefinementList', () => {
   const createWidgetFactory = () => {

--- a/src/connectors/refinement-list/connectRefinementList.js
+++ b/src/connectors/refinement-list/connectRefinementList.js
@@ -1,5 +1,5 @@
-import { checkRendering } from '../../lib/utils.js';
-import { tagConfig, escapeFacets } from '../../lib/escape-highlight.js';
+import { checkRendering } from '../../lib/utils';
+import { tagConfig, escapeFacets } from '../../lib/escape-highlight';
 import isEqual from 'lodash/isEqual';
 
 const usage = `Usage:

--- a/src/connectors/search-box/__tests__/connectSearchBox-test.js
+++ b/src/connectors/search-box/__tests__/connectSearchBox-test.js
@@ -3,7 +3,7 @@ import jsHelper, {
   SearchParameters,
 } from 'algoliasearch-helper';
 
-import connectSearchBox from '../connectSearchBox.js';
+import connectSearchBox from '../connectSearchBox';
 
 describe('connectSearchBox', () => {
   it('Renders during init and render', () => {

--- a/src/connectors/search-box/connectSearchBox.js
+++ b/src/connectors/search-box/connectSearchBox.js
@@ -1,4 +1,4 @@
-import { checkRendering } from '../../lib/utils.js';
+import { checkRendering } from '../../lib/utils';
 
 const usage = `Usage:
 var customSearchBox = connectSearchBox(function render(params, isFirstRendering) {

--- a/src/connectors/sort-by-selector/__tests__/connectSortBySelector-test.js
+++ b/src/connectors/sort-by-selector/__tests__/connectSortBySelector-test.js
@@ -5,8 +5,8 @@ import jsHelper, {
   SearchParameters,
 } from 'algoliasearch-helper';
 
-import connectSortBySelector from '../connectSortBySelector.js';
-import instantSearch from '../../../lib/main.js';
+import connectSortBySelector from '../connectSortBySelector';
+import instantSearch from '../../../lib/main';
 
 describe('connectSortBySelector', () => {
   it('Renders during init and render', () => {

--- a/src/connectors/sort-by-selector/connectSortBySelector.js
+++ b/src/connectors/sort-by-selector/connectSortBySelector.js
@@ -1,5 +1,5 @@
 import find from 'lodash/find';
-import { checkRendering } from '../../lib/utils.js';
+import { checkRendering } from '../../lib/utils';
 
 const usage = `Usage:
 var customSortBySelector = connectSortBySelector(function render(params, isFirstRendering) {

--- a/src/connectors/star-rating/__tests__/connectStarRating-test.js
+++ b/src/connectors/star-rating/__tests__/connectStarRating-test.js
@@ -5,7 +5,7 @@ import jsHelper, {
   SearchParameters,
 } from 'algoliasearch-helper';
 
-import connectStarRating from '../connectStarRating.js';
+import connectStarRating from '../connectStarRating';
 
 describe('connectStarRating', () => {
   it('Renders during init and render', () => {

--- a/src/connectors/star-rating/connectStarRating.js
+++ b/src/connectors/star-rating/connectStarRating.js
@@ -1,4 +1,4 @@
-import { checkRendering } from '../../lib/utils.js';
+import { checkRendering } from '../../lib/utils';
 
 const usage = `Usage:
 var customStarRating = connectStarRating(function render(params, isFirstRendering) {

--- a/src/connectors/stats/__tests__/connectStats-test.js
+++ b/src/connectors/stats/__tests__/connectStats-test.js
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import jsHelper from 'algoliasearch-helper';
 const SearchResults = jsHelper.SearchResults;
 
-import connectStats from '../connectStats.js';
+import connectStats from '../connectStats';
 
 describe('connectStats', () => {
   it('Renders during init and render', () => {

--- a/src/connectors/stats/connectStats.js
+++ b/src/connectors/stats/connectStats.js
@@ -1,4 +1,4 @@
-import { checkRendering } from '../../lib/utils.js';
+import { checkRendering } from '../../lib/utils';
 
 const usage = `Usage:
 var customStats = connectStats(function render(params, isFirstRendering) {

--- a/src/connectors/toggle/__tests__/connectToggle-test.js
+++ b/src/connectors/toggle/__tests__/connectToggle-test.js
@@ -5,7 +5,7 @@ import jsHelper, {
   SearchParameters,
 } from 'algoliasearch-helper';
 
-import connectToggle from '../connectToggle.js';
+import connectToggle from '../connectToggle';
 
 describe('connectToggle', () => {
   it('Renders during init and render', () => {

--- a/src/connectors/toggle/connectToggle.js
+++ b/src/connectors/toggle/connectToggle.js
@@ -2,7 +2,7 @@ import {
   checkRendering,
   escapeRefinement,
   unescapeRefinement,
-} from '../../lib/utils.js';
+} from '../../lib/utils';
 
 import find from 'lodash/find';
 

--- a/src/decorators/headerFooter.js
+++ b/src/decorators/headerFooter.js
@@ -7,7 +7,7 @@ import React, { Component } from 'preact-compat';
 import cx from 'classnames';
 import getKey from 'lodash/get';
 
-import Template from '../components/Template.js';
+import Template from '../components/Template';
 
 function headerFooter(ComposedComponent) {
   class HeaderFooter extends Component {

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -1,18 +1,18 @@
 // we use the full path to the lite build to solve a meteor.js issue:
 // https://github.com/algolia/instantsearch.js/issues/1024#issuecomment-221618284
-import algoliasearch from 'algoliasearch/src/browser/builds/algoliasearchLite.js';
+import algoliasearch from 'algoliasearch/src/browser/builds/algoliasearchLite';
 import algoliasearchHelper from 'algoliasearch-helper';
 import forEach from 'lodash/forEach';
 import mergeWith from 'lodash/mergeWith';
 import union from 'lodash/union';
 import isPlainObject from 'lodash/isPlainObject';
 import EventEmitter from 'events';
-import urlSyncWidget from './url-sync.js';
-import RoutingManager from './RoutingManager.js';
-import simpleMapping from './stateMappings/simple.js';
-import historyRouter from './routers/history.js';
-import version from './version.js';
-import createHelpers from './createHelpers.js';
+import urlSyncWidget from './url-sync';
+import RoutingManager from './RoutingManager';
+import simpleMapping from './stateMappings/simple';
+import historyRouter from './routers/history';
+import version from './version';
+import createHelpers from './createHelpers';
 
 const ROUTING_DEFAULT_OPTIONS = {
   stateMapping: simpleMapping(),

--- a/src/lib/__tests__/RoutingManager-test.js
+++ b/src/lib/__tests__/RoutingManager-test.js
@@ -1,6 +1,6 @@
-import instantsearch from '../main.js';
-import RoutingManager from '../RoutingManager.js';
-import simpleMapping from '../stateMappings/simple.js';
+import instantsearch from '../main';
+import RoutingManager from '../RoutingManager';
+import simpleMapping from '../stateMappings/simple';
 
 const makeFakeAlgoliaClient = () => ({
   search: () => Promise.resolve({ results: [{}] }),

--- a/src/lib/__tests__/main-test.js
+++ b/src/lib/__tests__/main-test.js
@@ -1,4 +1,4 @@
-import instantsearch from '../main.js';
+import instantsearch from '../main';
 import forEach from 'lodash/forEach';
 import expect from 'expect';
 

--- a/src/lib/__tests__/suits-test.js
+++ b/src/lib/__tests__/suits-test.js
@@ -1,4 +1,4 @@
-import { component } from '../suit.js';
+import { component } from '../suit';
 
 describe('suit - component classname generation', () => {
   test('generates a name with the component name, modifier and descendant', () => {

--- a/src/lib/__tests__/url-sync-test.js
+++ b/src/lib/__tests__/url-sync-test.js
@@ -1,4 +1,4 @@
-import urlSync from '../url-sync.js';
+import urlSync from '../url-sync';
 import jsHelper from 'algoliasearch-helper';
 const SearchParameters = jsHelper.SearchParameters;
 

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -3,14 +3,14 @@
 import toFactory from 'to-factory';
 import algoliasearchHelper from 'algoliasearch-helper';
 
-import InstantSearch from './InstantSearch.js';
-import version from './version.js';
+import InstantSearch from './InstantSearch';
+import version from './version';
 
-import * as connectors from '../connectors/index.js';
-import * as widgets from '../widgets/index.js';
+import * as connectors from '../connectors/index';
+import * as widgets from '../widgets/index';
 
-import * as routers from './routers/index.js';
-import * as stateMappings from './stateMappings/index.js';
+import * as routers from './routers/index';
+import * as stateMappings from './stateMappings/index';
 
 /**
  * @external SearchParameters

--- a/src/lib/routers/index.js
+++ b/src/lib/routers/index.js
@@ -1,1 +1,1 @@
-export { default as history } from './history.js';
+export { default as history } from './history';

--- a/src/lib/show-more/getShowMoreConfig.js
+++ b/src/lib/show-more/getShowMoreConfig.js
@@ -1,4 +1,4 @@
-import templates from './defaultShowMoreTemplates.js';
+import templates from './defaultShowMoreTemplates';
 
 const defaultShowMoreConfig = {
   templates,

--- a/src/lib/stateMappings/index.js
+++ b/src/lib/stateMappings/index.js
@@ -1,1 +1,1 @@
-export { default as simple } from './simple.js';
+export { default as simple } from './simple';

--- a/src/widgets/breadcrumb/breadcrumb.js
+++ b/src/widgets/breadcrumb/breadcrumb.js
@@ -3,11 +3,11 @@ import cx from 'classnames';
 
 import Breadcrumb from '../../components/Breadcrumb/Breadcrumb';
 import connectBreadcrumb from '../../connectors/breadcrumb/connectBreadcrumb';
-import defaultTemplates from './defaultTemplates.js';
+import defaultTemplates from './defaultTemplates';
 
 import { getContainerNode, prepareTemplateProps } from '../../lib/utils';
 
-import { component } from '../../lib/suit.js';
+import { component } from '../../lib/suit';
 
 const suit = component('Breadcrumb');
 

--- a/src/widgets/clear-refinements/__tests__/clear-refinements-test.js
+++ b/src/widgets/clear-refinements/__tests__/clear-refinements-test.js
@@ -1,7 +1,7 @@
 import expect from 'expect';
 import sinon from 'sinon';
-import clearRefinements from '../clear-refinements.js';
-import defaultTemplates from '../defaultTemplates.js';
+import clearRefinements from '../clear-refinements';
+import defaultTemplates from '../defaultTemplates';
 
 describe('clearRefinements()', () => {
   let ReactDOM;

--- a/src/widgets/clear-refinements/clear-refinements.js
+++ b/src/widgets/clear-refinements/clear-refinements.js
@@ -1,14 +1,14 @@
 import React, { render, unmountComponentAtNode } from 'preact-compat';
-import ClearRefinementsWithHOCs from '../../components/ClearRefinements/ClearRefinements.js';
+import ClearRefinementsWithHOCs from '../../components/ClearRefinements/ClearRefinements';
 import cx from 'classnames';
 
-import { getContainerNode, prepareTemplateProps } from '../../lib/utils.js';
+import { getContainerNode, prepareTemplateProps } from '../../lib/utils';
 
-import { component } from '../../lib/suit.js';
+import { component } from '../../lib/suit';
 
-import connectClearRefinements from '../../connectors/clear-refinements/connectClearRefinements.js';
+import connectClearRefinements from '../../connectors/clear-refinements/connectClearRefinements';
 
-import defaultTemplates from './defaultTemplates.js';
+import defaultTemplates from './defaultTemplates';
 
 const suit = component('ClearRefinements');
 

--- a/src/widgets/configure/configure.js
+++ b/src/widgets/configure/configure.js
@@ -1,4 +1,4 @@
-import connectConfigure from '../../connectors/configure/connectConfigure.js';
+import connectConfigure from '../../connectors/configure/connectConfigure';
 
 const usage = `Usage:
 search.addWidget(

--- a/src/widgets/current-refined-values/current-refined-values.js
+++ b/src/widgets/current-refined-values/current-refined-values.js
@@ -9,8 +9,8 @@ import isPlainObject from 'lodash/isPlainObject';
 import isFunction from 'lodash/isFunction';
 import reduce from 'lodash/reduce';
 
-import CurrentRefinedValuesWithHOCs from '../../components/CurrentRefinedValues/CurrentRefinedValues.js';
-import connectCurrentRefinedValues from '../../connectors/current-refined-values/connectCurrentRefinedValues.js';
+import CurrentRefinedValuesWithHOCs from '../../components/CurrentRefinedValues/CurrentRefinedValues';
+import connectCurrentRefinedValues from '../../connectors/current-refined-values/connectCurrentRefinedValues';
 import defaultTemplates from './defaultTemplates';
 
 import {
@@ -18,7 +18,7 @@ import {
   bemHelper,
   getContainerNode,
   prepareTemplateProps,
-} from '../../lib/utils.js';
+} from '../../lib/utils';
 
 const bem = bemHelper('ais-current-refined-values');
 

--- a/src/widgets/hierarchical-menu/hierarchical-menu.js
+++ b/src/widgets/hierarchical-menu/hierarchical-menu.js
@@ -2,14 +2,14 @@ import React, { render, unmountComponentAtNode } from 'preact-compat';
 import cx from 'classnames';
 
 import connectHierarchicalMenu from '../../connectors/hierarchical-menu/connectHierarchicalMenu';
-import RefinementList from '../../components/RefinementList/RefinementList.js';
-import defaultTemplates from './defaultTemplates.js';
+import RefinementList from '../../components/RefinementList/RefinementList';
+import defaultTemplates from './defaultTemplates';
 
 import {
   bemHelper,
   prepareTemplateProps,
   getContainerNode,
-} from '../../lib/utils.js';
+} from '../../lib/utils';
 
 const bem = bemHelper('ais-hierarchical-menu');
 

--- a/src/widgets/hits-per-page-selector/hits-per-page-selector.js
+++ b/src/widgets/hits-per-page-selector/hits-per-page-selector.js
@@ -3,10 +3,10 @@ import cx from 'classnames';
 
 import find from 'lodash/find';
 
-import Selector from '../../components/Selector.js';
-import connectHitsPerPage from '../../connectors/hits-per-page/connectHitsPerPage.js';
+import Selector from '../../components/Selector';
+import connectHitsPerPage from '../../connectors/hits-per-page/connectHitsPerPage';
 
-import { bemHelper, getContainerNode } from '../../lib/utils.js';
+import { bemHelper, getContainerNode } from '../../lib/utils';
 
 const bem = bemHelper('ais-hits-per-page-selector');
 

--- a/src/widgets/hits/__tests__/defaultTemplates-test.js
+++ b/src/widgets/hits/__tests__/defaultTemplates-test.js
@@ -1,4 +1,4 @@
-import defaultTemplates from '../defaultTemplates.js';
+import defaultTemplates from '../defaultTemplates';
 
 describe('hits defaultTemplates', () => {
   it('has a `empty` default template', () => {

--- a/src/widgets/hits/__tests__/hits-test.js
+++ b/src/widgets/hits/__tests__/hits-test.js
@@ -1,7 +1,7 @@
 import expect from 'expect';
 import sinon from 'sinon';
-import hits from '../hits.js';
-import defaultTemplates from '../defaultTemplates.js';
+import hits from '../hits';
+import defaultTemplates from '../defaultTemplates';
 
 describe('hits call', () => {
   it('throws an exception when no container', () => {

--- a/src/widgets/hits/hits.js
+++ b/src/widgets/hits/hits.js
@@ -1,15 +1,15 @@
 import React, { render, unmountComponentAtNode } from 'preact-compat';
 import cx from 'classnames';
 
-import Hits from '../../components/Hits.js';
-import connectHits from '../../connectors/hits/connectHits.js';
-import defaultTemplates from './defaultTemplates.js';
+import Hits from '../../components/Hits';
+import connectHits from '../../connectors/hits/connectHits';
+import defaultTemplates from './defaultTemplates';
 
 import {
   bemHelper,
   prepareTemplateProps,
   getContainerNode,
-} from '../../lib/utils.js';
+} from '../../lib/utils';
 
 const bem = bemHelper('ais-hits');
 

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -7,47 +7,43 @@
 
 export {
   default as clearRefinements,
-} from '../widgets/clear-refinements/clear-refinements.js';
-export { default as configure } from '../widgets/configure/configure.js';
+} from '../widgets/clear-refinements/clear-refinements';
+export { default as configure } from '../widgets/configure/configure';
 export {
   default as currentRefinedValues,
-} from '../widgets/current-refined-values/current-refined-values.js';
-export { default as geoSearch } from '../widgets/geo-search/geo-search.js';
+} from '../widgets/current-refined-values/current-refined-values';
+export { default as geoSearch } from '../widgets/geo-search/geo-search';
 export {
   default as hierarchicalMenu,
-} from '../widgets/hierarchical-menu/hierarchical-menu.js';
-export { default as hits } from '../widgets/hits/hits.js';
+} from '../widgets/hierarchical-menu/hierarchical-menu';
+export { default as hits } from '../widgets/hits/hits';
 export {
   default as hitsPerPageSelector,
-} from '../widgets/hits-per-page-selector/hits-per-page-selector.js';
+} from '../widgets/hits-per-page-selector/hits-per-page-selector';
 export {
   default as infiniteHits,
-} from '../widgets/infinite-hits/infinite-hits.js';
-export { default as menu } from '../widgets/menu/menu.js';
+} from '../widgets/infinite-hits/infinite-hits';
+export { default as menu } from '../widgets/menu/menu';
 export {
   default as refinementList,
-} from '../widgets/refinement-list/refinement-list.js';
+} from '../widgets/refinement-list/refinement-list';
 export {
   default as numericRefinementList,
-} from '../widgets/numeric-refinement-list/numeric-refinement-list.js';
+} from '../widgets/numeric-refinement-list/numeric-refinement-list';
 export {
   default as numericSelector,
-} from '../widgets/numeric-selector/numeric-selector.js';
-export { default as pagination } from '../widgets/pagination/pagination.js';
-export {
-  default as priceRanges,
-} from '../widgets/price-ranges/price-ranges.js';
-export { default as rangeInput } from '../widgets/range-input/range-input.js';
-export { default as searchBox } from '../widgets/search-box/search-box.js';
-export {
-  default as rangeSlider,
-} from '../widgets/range-slider/range-slider.js';
+} from '../widgets/numeric-selector/numeric-selector';
+export { default as pagination } from '../widgets/pagination/pagination';
+export { default as priceRanges } from '../widgets/price-ranges/price-ranges';
+export { default as rangeInput } from '../widgets/range-input/range-input';
+export { default as searchBox } from '../widgets/search-box/search-box';
+export { default as rangeSlider } from '../widgets/range-slider/range-slider';
 export {
   default as sortBySelector,
-} from '../widgets/sort-by-selector/sort-by-selector.js';
-export { default as starRating } from '../widgets/star-rating/star-rating.js';
-export { default as stats } from '../widgets/stats/stats.js';
-export { default as toggle } from '../widgets/toggle/toggle.js';
-export { default as analytics } from '../widgets/analytics/analytics.js';
-export { default as breadcrumb } from '../widgets/breadcrumb/breadcrumb.js';
-export { default as menuSelect } from '../widgets/menu-select/menu-select.js';
+} from '../widgets/sort-by-selector/sort-by-selector';
+export { default as starRating } from '../widgets/star-rating/star-rating';
+export { default as stats } from '../widgets/stats/stats';
+export { default as toggle } from '../widgets/toggle/toggle';
+export { default as analytics } from '../widgets/analytics/analytics';
+export { default as breadcrumb } from '../widgets/breadcrumb/breadcrumb';
+export { default as menuSelect } from '../widgets/menu-select/menu-select';

--- a/src/widgets/infinite-hits/__tests__/defaultTemplates-test.js
+++ b/src/widgets/infinite-hits/__tests__/defaultTemplates-test.js
@@ -1,4 +1,4 @@
-import defaultTemplates from '../defaultTemplates.js';
+import defaultTemplates from '../defaultTemplates';
 
 describe('hits defaultTemplates', () => {
   it('has a `empty` default template', () => {

--- a/src/widgets/infinite-hits/infinite-hits.js
+++ b/src/widgets/infinite-hits/infinite-hits.js
@@ -1,15 +1,15 @@
 import React, { render, unmountComponentAtNode } from 'preact-compat';
 import cx from 'classnames';
 
-import InfiniteHits from '../../components/InfiniteHits.js';
-import defaultTemplates from './defaultTemplates.js';
-import connectInfiniteHits from '../../connectors/infinite-hits/connectInfiniteHits.js';
+import InfiniteHits from '../../components/InfiniteHits';
+import defaultTemplates from './defaultTemplates';
+import connectInfiniteHits from '../../connectors/infinite-hits/connectInfiniteHits';
 
 import {
   bemHelper,
   prepareTemplateProps,
   getContainerNode,
-} from '../../lib/utils.js';
+} from '../../lib/utils';
 
 const bem = bemHelper('ais-infinite-hits');
 

--- a/src/widgets/menu/menu.js
+++ b/src/widgets/menu/menu.js
@@ -1,17 +1,17 @@
 import React, { render, unmountComponentAtNode } from 'preact-compat';
 import cx from 'classnames';
 
-import defaultTemplates from './defaultTemplates.js';
-import getShowMoreConfig from '../../lib/show-more/getShowMoreConfig.js';
-import connectMenu from '../../connectors/menu/connectMenu.js';
-import RefinementList from '../../components/RefinementList/RefinementList.js';
+import defaultTemplates from './defaultTemplates';
+import getShowMoreConfig from '../../lib/show-more/getShowMoreConfig';
+import connectMenu from '../../connectors/menu/connectMenu';
+import RefinementList from '../../components/RefinementList/RefinementList';
 
 import {
   bemHelper,
   prepareTemplateProps,
   getContainerNode,
   prefixKeys,
-} from '../../lib/utils.js';
+} from '../../lib/utils';
 
 const bem = bemHelper('ais-menu');
 

--- a/src/widgets/numeric-refinement-list/__tests__/numeric-refinement-list-test.js
+++ b/src/widgets/numeric-refinement-list/__tests__/numeric-refinement-list-test.js
@@ -1,7 +1,7 @@
 import expect from 'expect';
 import sinon from 'sinon';
 import cloneDeep from 'lodash/cloneDeep';
-import numericRefinementList from '../numeric-refinement-list.js';
+import numericRefinementList from '../numeric-refinement-list';
 
 const encodeValue = (start, end) =>
   window.encodeURI(JSON.stringify({ start, end }));

--- a/src/widgets/numeric-refinement-list/numeric-refinement-list.js
+++ b/src/widgets/numeric-refinement-list/numeric-refinement-list.js
@@ -1,15 +1,15 @@
 import React, { render, unmountComponentAtNode } from 'preact-compat';
 import cx from 'classnames';
 
-import RefinementList from '../../components/RefinementList/RefinementList.js';
-import connectNumericRefinementList from '../../connectors/numeric-refinement-list/connectNumericRefinementList.js';
-import defaultTemplates from './defaultTemplates.js';
+import RefinementList from '../../components/RefinementList/RefinementList';
+import connectNumericRefinementList from '../../connectors/numeric-refinement-list/connectNumericRefinementList';
+import defaultTemplates from './defaultTemplates';
 
 import {
   bemHelper,
   prepareTemplateProps,
   getContainerNode,
-} from '../../lib/utils.js';
+} from '../../lib/utils';
 
 const bem = bemHelper('ais-refinement-list');
 

--- a/src/widgets/numeric-selector/numeric-selector.js
+++ b/src/widgets/numeric-selector/numeric-selector.js
@@ -1,10 +1,10 @@
 import React, { render, unmountComponentAtNode } from 'preact-compat';
 import cx from 'classnames';
 
-import Selector from '../../components/Selector.js';
-import connectNumericSelector from '../../connectors/numeric-selector/connectNumericSelector.js';
+import Selector from '../../components/Selector';
+import connectNumericSelector from '../../connectors/numeric-selector/connectNumericSelector';
 
-import { bemHelper, getContainerNode } from '../../lib/utils.js';
+import { bemHelper, getContainerNode } from '../../lib/utils';
 
 const bem = bemHelper('ais-numeric-selector');
 

--- a/src/widgets/pagination/pagination.js
+++ b/src/widgets/pagination/pagination.js
@@ -3,10 +3,10 @@ import defaults from 'lodash/defaults';
 import React, { render, unmountComponentAtNode } from 'preact-compat';
 import cx from 'classnames';
 
-import Pagination from '../../components/Pagination/Pagination.js';
-import connectPagination from '../../connectors/pagination/connectPagination.js';
+import Pagination from '../../components/Pagination/Pagination';
+import connectPagination from '../../connectors/pagination/connectPagination';
 
-import { bemHelper, getContainerNode } from '../../lib/utils.js';
+import { bemHelper, getContainerNode } from '../../lib/utils';
 
 const defaultLabels = {
   previous: '‹',

--- a/src/widgets/price-ranges/__tests__/price-ranges-test.js
+++ b/src/widgets/price-ranges/__tests__/price-ranges-test.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
 import sinon from 'sinon';
-import priceRanges from '../price-ranges.js';
+import priceRanges from '../price-ranges';
 
 const instantSearchInstance = { templatesConfig: undefined };
 

--- a/src/widgets/price-ranges/price-ranges.js
+++ b/src/widgets/price-ranges/price-ranges.js
@@ -1,15 +1,15 @@
 import React, { render, unmountComponentAtNode } from 'preact-compat';
 import cx from 'classnames';
 
-import PriceRanges from '../../components/PriceRanges/PriceRanges.js';
-import connectPriceRanges from '../../connectors/price-ranges/connectPriceRanges.js';
-import defaultTemplates from './defaultTemplates.js';
+import PriceRanges from '../../components/PriceRanges/PriceRanges';
+import connectPriceRanges from '../../connectors/price-ranges/connectPriceRanges';
+import defaultTemplates from './defaultTemplates';
 
 import {
   bemHelper,
   prepareTemplateProps,
   getContainerNode,
-} from '../../lib/utils.js';
+} from '../../lib/utils';
 
 const bem = bemHelper('ais-price-ranges');
 

--- a/src/widgets/range-input/__tests__/range-input-test.js
+++ b/src/widgets/range-input/__tests__/range-input-test.js
@@ -1,6 +1,6 @@
 import ReactDOM from 'preact-compat';
 import AlgoliasearchHelper from 'algoliasearch-helper';
-import rangeInput from '../range-input.js';
+import rangeInput from '../range-input';
 
 jest.mock('preact-compat', () => {
   const module = require.requireActual('preact-compat');

--- a/src/widgets/range-input/range-input.js
+++ b/src/widgets/range-input/range-input.js
@@ -1,13 +1,13 @@
 import React, { render } from 'preact-compat';
 import cx from 'classnames';
-import RangeInput from '../../components/RangeInput/RangeInput.js';
-import connectRange from '../../connectors/range/connectRange.js';
+import RangeInput from '../../components/RangeInput/RangeInput';
+import connectRange from '../../connectors/range/connectRange';
 import {
   bemHelper,
   prepareTemplateProps,
   getContainerNode,
-} from '../../lib/utils.js';
-import defaultTemplates from './defaultTemplates.js';
+} from '../../lib/utils';
+import defaultTemplates from './defaultTemplates';
 
 const bem = bemHelper('ais-range-input');
 

--- a/src/widgets/range-slider/__tests__/range-slider-test.js
+++ b/src/widgets/range-slider/__tests__/range-slider-test.js
@@ -1,6 +1,6 @@
 import AlgoliasearchHelper from 'algoliasearch-helper';
 
-import rangeSlider from '../range-slider.js';
+import rangeSlider from '../range-slider';
 
 const instantSearchInstance = { templatesConfig: undefined };
 

--- a/src/widgets/range-slider/range-slider.js
+++ b/src/widgets/range-slider/range-slider.js
@@ -1,14 +1,14 @@
 import React, { render, unmountComponentAtNode } from 'preact-compat';
 import cx from 'classnames';
 
-import Slider from '../../components/Slider/Slider.js';
-import connectRange from '../../connectors/range/connectRange.js';
+import Slider from '../../components/Slider/Slider';
+import connectRange from '../../connectors/range/connectRange';
 
 import {
   bemHelper,
   prepareTemplateProps,
   getContainerNode,
-} from '../../lib/utils.js';
+} from '../../lib/utils';
 
 const defaultTemplates = {
   header: '',

--- a/src/widgets/refinement-list/__tests__/refinement-list-test.js
+++ b/src/widgets/refinement-list/__tests__/refinement-list-test.js
@@ -2,7 +2,7 @@ import sinon from 'sinon';
 
 import algoliasearchHelper from 'algoliasearch-helper';
 const SearchParameters = algoliasearchHelper.SearchParameters;
-import refinementList from '../refinement-list.js';
+import refinementList from '../refinement-list';
 const instantSearchInstance = { templatesConfig: {} };
 
 describe('refinementList()', () => {

--- a/src/widgets/refinement-list/refinement-list.js
+++ b/src/widgets/refinement-list/refinement-list.js
@@ -2,18 +2,18 @@ import React, { render, unmountComponentAtNode } from 'preact-compat';
 import cx from 'classnames';
 import filter from 'lodash/filter';
 
-import RefinementList from '../../components/RefinementList/RefinementList.js';
-import connectRefinementList from '../../connectors/refinement-list/connectRefinementList.js';
-import defaultTemplates from './defaultTemplates.js';
-import sffvDefaultTemplates from './defaultTemplates.searchForFacetValue.js';
-import getShowMoreConfig from '../../lib/show-more/getShowMoreConfig.js';
+import RefinementList from '../../components/RefinementList/RefinementList';
+import connectRefinementList from '../../connectors/refinement-list/connectRefinementList';
+import defaultTemplates from './defaultTemplates';
+import sffvDefaultTemplates from './defaultTemplates.searchForFacetValue';
+import getShowMoreConfig from '../../lib/show-more/getShowMoreConfig';
 
 import {
   bemHelper,
   prepareTemplateProps,
   getContainerNode,
   prefixKeys,
-} from '../../lib/utils.js';
+} from '../../lib/utils';
 
 const bem = bemHelper('ais-refinement-list');
 

--- a/src/widgets/sort-by-selector/__tests__/sort-by-selector-test.js
+++ b/src/widgets/sort-by-selector/__tests__/sort-by-selector-test.js
@@ -3,7 +3,7 @@ import expect from 'expect';
 import sortBySelector from '../sort-by-selector';
 import Selector from '../../../components/Selector';
 
-import instantSearch from '../../../lib/main.js';
+import instantSearch from '../../../lib/main';
 
 describe('sortBySelector call', () => {
   it('throws an exception when no options', () => {

--- a/src/widgets/sort-by-selector/sort-by-selector.js
+++ b/src/widgets/sort-by-selector/sort-by-selector.js
@@ -1,9 +1,9 @@
 import React, { render, unmountComponentAtNode } from 'preact-compat';
 import cx from 'classnames';
 
-import Selector from '../../components/Selector.js';
-import connectSortBySelector from '../../connectors/sort-by-selector/connectSortBySelector.js';
-import { bemHelper, getContainerNode } from '../../lib/utils.js';
+import Selector from '../../components/Selector';
+import connectSortBySelector from '../../connectors/sort-by-selector/connectSortBySelector';
+import { bemHelper, getContainerNode } from '../../lib/utils';
 
 const bem = bemHelper('ais-sort-by-selector');
 

--- a/src/widgets/star-rating/__tests__/star-rating-test.js
+++ b/src/widgets/star-rating/__tests__/star-rating-test.js
@@ -3,8 +3,8 @@ import expect from 'expect';
 
 import jsHelper from 'algoliasearch-helper';
 
-import defaultLabels from '../../../widgets/star-rating/defaultLabels.js';
-import starRating from '../star-rating.js';
+import defaultLabels from '../../../widgets/star-rating/defaultLabels';
+import starRating from '../star-rating';
 
 const SearchResults = jsHelper.SearchResults;
 

--- a/src/widgets/star-rating/star-rating.js
+++ b/src/widgets/star-rating/star-rating.js
@@ -1,16 +1,16 @@
 import React, { render, unmountComponentAtNode } from 'preact-compat';
 import cx from 'classnames';
 
-import RefinementList from '../../components/RefinementList/RefinementList.js';
-import connectStarRating from '../../connectors/star-rating/connectStarRating.js';
-import defaultTemplates from './defaultTemplates.js';
-import defaultLabels from './defaultLabels.js';
+import RefinementList from '../../components/RefinementList/RefinementList';
+import connectStarRating from '../../connectors/star-rating/connectStarRating';
+import defaultTemplates from './defaultTemplates';
+import defaultLabels from './defaultLabels';
 
 import {
   bemHelper,
   prepareTemplateProps,
   getContainerNode,
-} from '../../lib/utils.js';
+} from '../../lib/utils';
 
 const bem = bemHelper('ais-star-rating');
 

--- a/src/widgets/stats/stats.js
+++ b/src/widgets/stats/stats.js
@@ -1,15 +1,15 @@
 import React, { render, unmountComponentAtNode } from 'preact-compat';
 import cx from 'classnames';
 
-import Stats from '../../components/Stats/Stats.js';
-import connectStats from '../../connectors/stats/connectStats.js';
-import defaultTemplates from './defaultTemplates.js';
+import Stats from '../../components/Stats/Stats';
+import connectStats from '../../connectors/stats/connectStats';
+import defaultTemplates from './defaultTemplates';
 
 import {
   bemHelper,
   prepareTemplateProps,
   getContainerNode,
-} from '../../lib/utils.js';
+} from '../../lib/utils';
 
 const bem = bemHelper('ais-stats');
 

--- a/src/widgets/toggle/__tests__/currentToggle-test.js
+++ b/src/widgets/toggle/__tests__/currentToggle-test.js
@@ -1,8 +1,8 @@
 import expect from 'expect';
 import sinon from 'sinon';
-import currentToggle from '../toggle.js';
-import defaultTemplates from '../defaultTemplates.js';
-import RefinementList from '../../../components/RefinementList/RefinementList.js';
+import currentToggle from '../toggle';
+import defaultTemplates from '../defaultTemplates';
+import RefinementList from '../../../components/RefinementList/RefinementList';
 
 import jsHelper from 'algoliasearch-helper';
 

--- a/src/widgets/toggle/toggle.js
+++ b/src/widgets/toggle/toggle.js
@@ -1,15 +1,15 @@
 import React, { render, unmountComponentAtNode } from 'preact-compat';
 import cx from 'classnames';
 
-import defaultTemplates from './defaultTemplates.js';
-import RefinementList from '../../components/RefinementList/RefinementList.js';
-import connectToggle from '../../connectors/toggle/connectToggle.js';
+import defaultTemplates from './defaultTemplates';
+import RefinementList from '../../components/RefinementList/RefinementList';
+import connectToggle from '../../connectors/toggle/connectToggle';
 
 import {
   bemHelper,
   getContainerNode,
   prepareTemplateProps,
-} from '../../lib/utils.js';
+} from '../../lib/utils';
 
 const bem = bemHelper('ais-toggle');
 


### PR DESCRIPTION
Following up on [@samouss comment](https://github.com/algolia/instantsearch.js/pull/3017#discussion_r199545330), this PR activates import/extensions and configures to not accepts extensions for JS files.