### PR TITLE
feat(stats): implement is.css

### DIFF
--- a/docgen/src/guides/migrate-instantsearchcss.md
+++ b/docgen/src/guides/migrate-instantsearchcss.md
@@ -95,8 +95,6 @@ search.addWidget(
   <button class="ais-ClearRefinements-button">
     Clear refinements
   </button>
-</div>
-```
 
 ### Options
 
@@ -130,7 +128,32 @@ CSS classes and templates for autohideContainer, header, footer and body have be
 
 The connector `connectClearAll` has been renamed into `connectClearRefinements`.
 
+## Widget - Stats
+
+### Markup
+
+The markup has been updated:
+
+```html
+<div class="ais-Stats">
+  <span class="ais-Stats-text">20,337 results found in 1ms.</span>
+</div>
+```
+
 ### Options
+The values for `cssClasses` have been updated to reflect the new markup:
+
+* `root`
+* `text`
+
+The widget is not able to autohide anymore. Use the panel wrapper instead.
+
+### CSS classe names
+
+| V2              | V3 equivalent  |
+| --------------- | -------------- |
+| ais-stats--body | ais-Stats-text |
+| ais-stats       | ais-Stats      |
 
 <!-- Template -->
 

--- a/src/components/Stats/Stats.js
+++ b/src/components/Stats/Stats.js
@@ -1,29 +1,16 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'preact-compat';
+import isEqual from 'lodash/isEqual';
 
 import Template from '../Template';
 
 export default class Stats extends Component {
   shouldComponentUpdate(nextProps) {
-    return (
-      this.props.nbHits !== nextProps.nbHits ||
-      this.props.processingTimeMS !== nextProps.processingTimeMS
-    );
+    return isEqual(this.props.data, nextProps.data);
   }
 
   render() {
-    const { cssClasses } = this.props;
-    const data = {
-      hasManyResults: this.props.nbHits > 1,
-      hasNoResults: this.props.nbHits === 0,
-      hasOneResult: this.props.nbHits === 1,
-      hitsPerPage: this.props.hitsPerPage,
-      nbHits: this.props.nbHits,
-      nbPages: this.props.nbPages,
-      page: this.props.page,
-      processingTimeMS: this.props.processingTimeMS,
-      query: this.props.query,
-    };
+    const { cssClasses, data } = this.props;
 
     return (
       <div className={cssClasses.root}>
@@ -46,11 +33,16 @@ Stats.propTypes = {
     root: PropTypes.string,
     text: PropTypes.string,
   }),
-  hitsPerPage: PropTypes.number,
-  nbHits: PropTypes.number,
-  nbPages: PropTypes.number,
-  page: PropTypes.number,
-  processingTimeMS: PropTypes.number,
-  query: PropTypes.string,
+  data: PropTypes.shape({
+    hasManyResults: PropTypes.bool,
+    hasNoResults: PropTypes.bool,
+    hasOneResult: PropTypes.bool,
+    hitsPerPage: PropTypes.number,
+    nbHits: PropTypes.number,
+    nbPages: PropTypes.number,
+    page: PropTypes.number,
+    processingTimeMS: PropTypes.number,
+    query: PropTypes.string,
+  }),
   templateProps: PropTypes.object.isRequired,
 };

--- a/src/components/Stats/Stats.js
+++ b/src/components/Stats/Stats.js
@@ -2,10 +2,8 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'preact-compat';
 
 import Template from '../Template';
-import autoHideContainerHOC from '../../decorators/autoHideContainer';
-import headerFooterHOC from '../../decorators/headerFooter';
 
-export class RawStats extends Component {
+export default class Stats extends Component {
   shouldComponentUpdate(nextProps) {
     return (
       this.props.nbHits !== nextProps.nbHits ||
@@ -14,6 +12,7 @@ export class RawStats extends Component {
   }
 
   render() {
+    const { cssClasses } = this.props;
     const data = {
       hasManyResults: this.props.nbHits > 1,
       hasNoResults: this.props.nbHits === 0,
@@ -24,18 +23,28 @@ export class RawStats extends Component {
       page: this.props.page,
       processingTimeMS: this.props.processingTimeMS,
       query: this.props.query,
-      cssClasses: this.props.cssClasses,
     };
 
     return (
-      <Template data={data} templateKey="body" {...this.props.templateProps} />
+      <div className={cssClasses.root}>
+        <Template
+          data={data}
+          templateKey="text"
+          rootProps={{
+            className: cssClasses.text,
+          }}
+          rootTagName="span"
+          {...this.props.templateProps}
+        />
+      </div>
     );
   }
 }
 
-RawStats.propTypes = {
+Stats.propTypes = {
   cssClasses: PropTypes.shape({
-    time: PropTypes.string,
+    root: PropTypes.string,
+    text: PropTypes.string,
   }),
   hitsPerPage: PropTypes.number,
   nbHits: PropTypes.number,
@@ -45,5 +54,3 @@ RawStats.propTypes = {
   query: PropTypes.string,
   templateProps: PropTypes.object.isRequired,
 };
-
-export default autoHideContainerHOC(headerFooterHOC(RawStats));

--- a/src/components/Stats/__tests__/Stats-test.js
+++ b/src/components/Stats/__tests__/Stats-test.js
@@ -1,18 +1,23 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { RawStats as Stats } from '../Stats';
+import Stats from '../Stats';
 
 describe('Stats', () => {
   it('should render <Template data= />', () => {
-    const out = shallow(<Stats {...getProps()} templateProps={{}} />);
+    const cssClasses = {
+      root: 'custom-root',
+      text: 'custom-text',
+    };
+    const out = shallow(
+      <Stats {...getProps()} cssClasses={cssClasses} templateProps={{}} />
+    );
 
     const defaultProps = {
-      cssClasses: {},
       hasManyResults: true,
       hasNoResults: false,
       hasOneResult: false,
     };
-    expect(out.props().data).toMatchObject(defaultProps);
+    expect(out.props().children.props.data).toMatchObject(defaultProps);
     expect(out).toMatchSnapshot();
   });
 

--- a/src/components/Stats/__tests__/Stats-test.js
+++ b/src/components/Stats/__tests__/Stats-test.js
@@ -8,28 +8,29 @@ describe('Stats', () => {
       root: 'custom-root',
       text: 'custom-text',
     };
+    const props = getProps();
     const out = shallow(
-      <Stats {...getProps()} cssClasses={cssClasses} templateProps={{}} />
+      <Stats {...props} cssClasses={cssClasses} templateProps={{}} />
     );
 
-    const defaultProps = {
-      hasManyResults: true,
-      hasNoResults: false,
-      hasOneResult: false,
-    };
-    expect(out.props().children.props.data).toMatchObject(defaultProps);
+    expect(out.props().children.props.data).toEqual(props.data);
     expect(out).toMatchSnapshot();
   });
 
   function getProps(extraProps = {}) {
     return {
       cssClasses: {},
-      hitsPerPage: 10,
-      nbHits: 1234,
-      nbPages: 124,
-      page: 0,
-      processingTimeMS: 42,
-      query: 'a query',
+      data: {
+        hasManyResults: true,
+        hasOneResult: false,
+        hasNoResults: false,
+        hitsPerPage: 10,
+        nbHits: 1234,
+        nbPages: 124,
+        page: 0,
+        processingTimeMS: 42,
+        query: 'a query',
+      },
       ...extraProps,
     };
   }

--- a/src/components/Stats/__tests__/__snapshots__/Stats-test.js.snap
+++ b/src/components/Stats/__tests__/__snapshots__/Stats-test.js.snap
@@ -1,21 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Stats should render <Template data= /> 1`] = `
-<Component
-  data={
-    Object {
-      "cssClasses": Object {},
-      "hasManyResults": true,
-      "hasNoResults": false,
-      "hasOneResult": false,
-      "hitsPerPage": 10,
-      "nbHits": 1234,
-      "nbPages": 124,
-      "page": 0,
-      "processingTimeMS": 42,
-      "query": "a query",
+<div
+  className="custom-root"
+>
+  <Component
+    data={
+      Object {
+        "hasManyResults": true,
+        "hasNoResults": false,
+        "hasOneResult": false,
+        "hitsPerPage": 10,
+        "nbHits": 1234,
+        "nbPages": 124,
+        "page": 0,
+        "processingTimeMS": 42,
+        "query": "a query",
+      }
     }
-  }
-  templateKey="body"
-/>
+    rootProps={
+      Object {
+        "className": "custom-text",
+      }
+    }
+    rootTagName="span"
+    templateKey="text"
+  />
+</div>
 `;

--- a/src/widgets/stats/__tests__/__snapshots__/stats-test.js.snap
+++ b/src/widgets/stats/__tests__/__snapshots__/stats-test.js.snap
@@ -1,15 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`stats() calls twice ReactDOM.render(<Stats props />, container) 1`] = `
-<HeaderFooter-AutoHide
+<Stats
   collapsible={false}
   cssClasses={
     Object {
-      "body": "ais-stats--body body cx",
-      "footer": "ais-stats--footer",
-      "header": "ais-stats--header",
-      "root": "ais-stats",
-      "time": "ais-stats--time",
+      "root": "ais-Stats",
+      "text": "ais-Stats-text",
     }
   }
   hitsPerPage={2}
@@ -18,23 +15,18 @@ exports[`stats() calls twice ReactDOM.render(<Stats props />, container) 1`] = `
   page={0}
   processingTimeMS={42}
   query="a query"
-  shouldAutoHideContainer={false}
   templateProps={
     Object {
       "templates": Object {
-        "body": "{{#hasNoResults}}No results{{/hasNoResults}}
+        "text": "{{#hasNoResults}}No results{{/hasNoResults}}
   {{#hasOneResult}}1 result{{/hasOneResult}}
   {{#hasManyResults}}{{#helpers.formatNumber}}{{nbHits}}{{/helpers.formatNumber}} results{{/hasManyResults}}
   <span class=\\"{{cssClasses.time}}\\">found in {{processingTimeMS}}ms</span>",
-        "footer": "",
-        "header": "",
       },
       "templatesConfig": undefined,
       "transformData": undefined,
       "useCustomCompileOptions": Object {
-        "body": false,
-        "footer": false,
-        "header": false,
+        "text": false,
       },
     }
   }
@@ -42,15 +34,12 @@ exports[`stats() calls twice ReactDOM.render(<Stats props />, container) 1`] = `
 `;
 
 exports[`stats() calls twice ReactDOM.render(<Stats props />, container) 2`] = `
-<HeaderFooter-AutoHide
+<Stats
   collapsible={false}
   cssClasses={
     Object {
-      "body": "ais-stats--body body cx",
-      "footer": "ais-stats--footer",
-      "header": "ais-stats--header",
-      "root": "ais-stats",
-      "time": "ais-stats--time",
+      "root": "ais-Stats",
+      "text": "ais-Stats-text",
     }
   }
   hitsPerPage={2}
@@ -59,23 +48,18 @@ exports[`stats() calls twice ReactDOM.render(<Stats props />, container) 2`] = `
   page={0}
   processingTimeMS={42}
   query="a query"
-  shouldAutoHideContainer={false}
   templateProps={
     Object {
       "templates": Object {
-        "body": "{{#hasNoResults}}No results{{/hasNoResults}}
+        "text": "{{#hasNoResults}}No results{{/hasNoResults}}
   {{#hasOneResult}}1 result{{/hasOneResult}}
   {{#hasManyResults}}{{#helpers.formatNumber}}{{nbHits}}{{/helpers.formatNumber}} results{{/hasManyResults}}
   <span class=\\"{{cssClasses.time}}\\">found in {{processingTimeMS}}ms</span>",
-        "footer": "",
-        "header": "",
       },
       "templatesConfig": undefined,
       "transformData": undefined,
       "useCustomCompileOptions": Object {
-        "body": false,
-        "footer": false,
-        "header": false,
+        "text": false,
       },
     }
   }

--- a/src/widgets/stats/__tests__/__snapshots__/stats-test.js.snap
+++ b/src/widgets/stats/__tests__/__snapshots__/stats-test.js.snap
@@ -9,12 +9,19 @@ exports[`stats() calls twice ReactDOM.render(<Stats props />, container) 1`] = `
       "text": "ais-Stats-text",
     }
   }
-  hitsPerPage={2}
-  nbHits={20}
-  nbPages={10}
-  page={0}
-  processingTimeMS={42}
-  query="a query"
+  data={
+    Object {
+      "hasManyResults": true,
+      "hasNoResults": false,
+      "hasOneResult": false,
+      "hitsPerPage": 2,
+      "nbHits": 20,
+      "nbPages": 10,
+      "page": 0,
+      "processingTimeMS": 42,
+      "query": "a query",
+    }
+  }
   templateProps={
     Object {
       "templates": Object {
@@ -42,12 +49,19 @@ exports[`stats() calls twice ReactDOM.render(<Stats props />, container) 2`] = `
       "text": "ais-Stats-text",
     }
   }
-  hitsPerPage={2}
-  nbHits={20}
-  nbPages={10}
-  page={0}
-  processingTimeMS={42}
-  query="a query"
+  data={
+    Object {
+      "hasManyResults": true,
+      "hasNoResults": false,
+      "hasOneResult": false,
+      "hitsPerPage": 2,
+      "nbHits": 20,
+      "nbPages": 10,
+      "page": 0,
+      "processingTimeMS": 42,
+      "query": "a query",
+    }
+  }
   templateProps={
     Object {
       "templates": Object {

--- a/src/widgets/stats/defaultTemplates.js
+++ b/src/widgets/stats/defaultTemplates.js
@@ -2,5 +2,5 @@ export default {
   text: `{{#hasNoResults}}No results{{/hasNoResults}}
   {{#hasOneResult}}1 result{{/hasOneResult}}
   {{#hasManyResults}}{{#helpers.formatNumber}}{{nbHits}}{{/helpers.formatNumber}} results{{/hasManyResults}}
-  <span class="{{cssClasses.time}}">found in {{processingTimeMS}}ms</span>`,
+  found in {{processingTimeMS}}ms`,
 };

--- a/src/widgets/stats/defaultTemplates.js
+++ b/src/widgets/stats/defaultTemplates.js
@@ -1,8 +1,6 @@
 export default {
-  header: '',
-  body: `{{#hasNoResults}}No results{{/hasNoResults}}
+  text: `{{#hasNoResults}}No results{{/hasNoResults}}
   {{#hasOneResult}}1 result{{/hasOneResult}}
   {{#hasManyResults}}{{#helpers.formatNumber}}{{nbHits}}{{/helpers.formatNumber}} results{{/hasManyResults}}
   <span class="{{cssClasses.time}}">found in {{processingTimeMS}}ms</span>`,
-  footer: '',
 };

--- a/src/widgets/stats/stats.js
+++ b/src/widgets/stats/stats.js
@@ -40,16 +40,23 @@ const renderer = ({
     return;
   }
 
+  const statsData = {
+    hitsPerPage,
+    nbHits,
+    nbPages,
+    page,
+    processingTimeMS,
+    query,
+    hasManyResults: nbHits > 1,
+    hasNoResults: nbHits === 0,
+    hasOneResult: nbHits === 1,
+  };
+
   render(
     <Stats
       collapsible={collapsible}
       cssClasses={cssClasses}
-      hitsPerPage={hitsPerPage}
-      nbHits={nbHits}
-      nbPages={nbPages}
-      page={page}
-      processingTimeMS={processingTimeMS}
-      query={query}
+      data={statsData}
       templateProps={renderState.templateProps}
     />,
     containerNode

--- a/src/widgets/stats/stats.js
+++ b/src/widgets/stats/stats.js
@@ -5,19 +5,16 @@ import Stats from '../../components/Stats/Stats';
 import connectStats from '../../connectors/stats/connectStats';
 import defaultTemplates from './defaultTemplates';
 
-import {
-  bemHelper,
-  prepareTemplateProps,
-  getContainerNode,
-} from '../../lib/utils';
+import { prepareTemplateProps, getContainerNode } from '../../lib/utils';
 
-const bem = bemHelper('ais-stats');
+import { component } from '../../lib/suit';
+
+const suit = component('Stats');
 
 const renderer = ({
   containerNode,
   cssClasses,
   collapsible,
-  autoHideContainer,
   renderState,
   templates,
   transformData,
@@ -43,8 +40,6 @@ const renderer = ({
     return;
   }
 
-  const shouldAutoHideContainer = autoHideContainer && nbHits === 0;
-
   render(
     <Stats
       collapsible={collapsible}
@@ -55,7 +50,6 @@ const renderer = ({
       page={page}
       processingTimeMS={processingTimeMS}
       query={query}
-      shouldAutoHideContainer={shouldAutoHideContainer}
       templateProps={renderState.templateProps}
     />,
     containerNode
@@ -65,36 +59,29 @@ const renderer = ({
 const usage = `Usage:
 stats({
   container,
-  [ templates.{header, body, footer} ],
-  [ transformData.{body} ],
-  [ autoHideContainer=true ],
-  [ cssClasses.{root, header, body, footer, time} ],
+  [ templates.{text} ],
+  [ transformData.{text} ],
+  [ cssClasses.{root, text} ],
 })`;
 
 /**
  * @typedef {Object} StatsWidgetTemplates
- * @property {string|function} [header=''] Header template.
- * @property {string|function} [body] Body template, provided with `hasManyResults`,
- * `hasNoResults`, `hasOneResult`, `hitsPerPage`, `nbHits`, `nbPages`, `page`, `processingTimeMS`, `query`.
- * @property {string|function} [footer=''] Footer template.
+ * @property {string|function(StatsData):string} [text] text of the widget.
  */
 
 /**
  * @typedef {Object} StatsWidgetCssClasses
- * @property {string|string[]} [root] CSS class to add to the root element.
- * @property {string|string[]} [header] CSS class to add to the header element.
- * @property {string|string[]} [body] CSS class to add to the body element.
- * @property {string|string[]} [footer] CSS class to add to the footer element.
- * @property {string|string[]} [time] CSS class to add to the element wrapping the time processingTimeMs.
+ * @property {string|string[]} [root] CSS class to add to the root element of the widget.
+ * @property {string|string[]} [text] CSS class to add to the element wrapping the text content of the widget.
  */
 
 /**
  * @typedef {Object} StatsWidgetTransforms
- * @property {function(StatsBodyData):object} [body] Updates the content of object passed to the `body` template.
+ * @property {function(StatsData):object} [text] Updates the content of object passed to the `text` template.
  */
 
 /**
- * @typedef {Object} StatsBodyData
+ * @typedef {Object} StatsData
  * @property {boolean} hasManyResults True if the result set has more than one result.
  * @property {boolean} hasNoResults True if the result set has no result.
  * @property {boolean} hasOneResult True if the result set has exactly one result.
@@ -111,7 +98,6 @@ stats({
  * @property {string|HTMLElement} container Place where to insert the widget in your webpage.
  * @property {StatsWidgetTemplates} [templates] Templates to use for the widget.
  * @property {StatsWidgetTransforms} [transformData] Object that contains the functions to be applied on the data * before being used for templating. Valid keys are `body` for the body template.
- * @property {boolean} [autoHideContainer=true] Make the widget hides itself when there is no results matching.
  * @property {StatsWidgetCssClasses} [cssClasses] CSS classes to add.
  */
 
@@ -135,7 +121,6 @@ stats({
 export default function stats({
   container,
   cssClasses: userCssClasses = {},
-  autoHideContainer = true,
   collapsible = false,
   transformData,
   templates = defaultTemplates,
@@ -147,18 +132,14 @@ export default function stats({
   const containerNode = getContainerNode(container);
 
   const cssClasses = {
-    body: cx(bem('body'), userCssClasses.body),
-    footer: cx(bem('footer'), userCssClasses.footer),
-    header: cx(bem('header'), userCssClasses.header),
-    root: cx(bem(null), userCssClasses.root),
-    time: cx(bem('time'), userCssClasses.time),
+    root: cx(suit(), userCssClasses.root),
+    text: cx(suit({ descendantName: 'text' }), userCssClasses.text),
   };
 
   const specializedRenderer = renderer({
     containerNode,
     cssClasses,
     collapsible,
-    autoHideContainer,
     renderState: {},
     templates,
     transformData,


### PR DESCRIPTION
## Summary

This PR implements:
 - [x] is.css for the widget stats.
 - [x] removes the panel from the widget.
 - [x] move the data computation into the widget.

[Specification](https://instantsearch-css.netlify.com/widgets/stats/)
## Result

[Story](https://deploy-preview-3023--algolia-instantsearch.netlify.com/v2/dev-novel/?selectedStory=Stats.default)