### PR TITLE
docs(menuSelect): Change `limit` type to `number`

### DIFF
--- a/src/widgets/menu-select/menu-select.js
+++ b/src/widgets/menu-select/menu-select.js
@@ -91,7 +91,7 @@ menuSelect({
  *
  * You can also use a sort function that behaves like the standard Javascript [compareFunction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#Syntax).
  * @property {MenuSelectTemplates} [templates] Customize the output through templating.
- * @property {string} [limit=10] How many facets values to retrieve.
+ * @property {number} [limit=10] How many facets values to retrieve.
  * @property {MenuSelectTransforms} [transformData] Set of functions to update the data before passing them to the templates.
  * @property {boolean} [autoHideContainer=true] Hide the container when there are no items in the menu select.
  * @property {MenuSelectCSSClasses} [cssClasses] CSS classes to add to the wrapping elements.


### PR DESCRIPTION
The documentation considered the `limit` option of the `menuSelect` widget as a `string` although it should be a `number`.