### PR TITLE
docs(dev-novel): use the router for logging state

### DIFF
--- a/dev/app/utils/wrap-with-hits.js
+++ b/dev/app/utils/wrap-with-hits.js
@@ -17,7 +17,7 @@ export const wrapWithHits = (
     ...otherInstantSearchConfig
   } = instantSearchConfig;
 
-  const urlLogger = action('[URL sync] pushstate: query string');
+  const urlLogger = action('Routing state');
   window.search = instantsearch({
     appId,
     apiKey,
@@ -26,18 +26,14 @@ export const wrapWithHits = (
       hitsPerPage: 3,
       ...searchParameters,
     },
-    urlSync: {
-      urlUtils: {
-        onpopstate() {},
-        pushState(qs) {
-          urlLogger(this.createURL(qs));
+    routing: {
+      router: {
+        write: routeState => {
+          urlLogger(JSON.stringify(routeState, null, 2));
         },
-        createURL(qs) {
-          return qs;
-        },
-        readUrl() {
-          return '';
-        },
+        read: () => ({}),
+        createURL: () => '',
+        onUpdate: () => {},
       },
     },
     ...otherInstantSearchConfig,


### PR DESCRIPTION
This changes replace the current implementation of the state logger in the dev-novel with a new one using the router.

## Result

![2018-07-19 11 45 23](https://user-images.githubusercontent.com/393765/42935217-663c3014-8b49-11e8-84f9-60eca76ce695.gif)

There is a bug in the logger. This has to be fixed in dev-novel directly.