### PR TITLE
docs(connectNumericRefinementList): update docs

### DIFF
--- a/src/connectors/numeric-refinement-list/connectNumericRefinementList.js
+++ b/src/connectors/numeric-refinement-list/connectNumericRefinementList.js
@@ -35,7 +35,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
 /**
  * @typedef {Object} NumericRefinementListItem
  * @property {string} label Name of the option.
- * @property {string} value URL encoded value of the form `min:max`
+ * @property {string} value URL encoded of the bounds object with the form `{start, end}`. This value can be used verbatim in the webpage and can be read by `refine` directly. If you want to inspect the value, you can do `JSON.parse(window.decodeURI(value))` to get the object.
  * @property {boolean} isRefined True if the value is selected.
  */
 

--- a/src/connectors/numeric-refinement-list/connectNumericRefinementList.js
+++ b/src/connectors/numeric-refinement-list/connectNumericRefinementList.js
@@ -35,8 +35,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
 /**
  * @typedef {Object} NumericRefinementListItem
  * @property {string} label Name of the option.
- * @property {number} start Lower bound of the option (>=).
- * @property {number} end Higher bound of the option (<=).
+ * @property {string} value URL encoded value of the form `min:max`
  * @property {boolean} isRefined True if the value is selected.
  */
 

--- a/src/connectors/numeric-refinement-list/connectNumericRefinementList.js
+++ b/src/connectors/numeric-refinement-list/connectNumericRefinementList.js
@@ -13,13 +13,15 @@ var customNumericRefinementList = connectNumericRefinementList(function renderFn
   //   widgetParams,
   //  }
 });
+
 search.addWidget(
   customNumericRefinementList({
     attributeName,
     options,
-    transformItems,
+    [ transformItems ],
   })
 );
+
 Full documentation available at https://community.algolia.com/instantsearch.js/v2/connectors/connectNumericRefinementList.html
 `;
 


### PR DESCRIPTION
**Summary**

This PR updates the error message that list the `transformItems` prop as required. The other change update the type of the provided items. The item contains a `value` attribute not `start` & `end`.

https://github.com/algolia/instantsearch.js/blob/2c5bfdd2844041226a911cd4f5174387ba3c1405/src/connectors/numeric-refinement-list/connectNumericRefinementList.js#L143-L148

