### PR TITLE
fix(connectBreadcrumb): ensure that data is an array

### DIFF
--- a/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.js
+++ b/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.js
@@ -202,6 +202,49 @@ describe('connectBreadcrumb', () => {
     ]);
   });
 
+  it('provides items from an empty results', () => {
+    const rendering = jest.fn();
+    const makeWidget = connectBreadcrumb(rendering);
+    const widget = makeWidget({
+      attributes: ['category', 'sub_category'],
+    });
+
+    const config = widget.getConfiguration({});
+    const helper = jsHelper({}, '', config);
+
+    helper.search = jest.fn();
+
+    helper.toggleRefinement('category', 'Decoration');
+
+    widget.init({
+      helper,
+      state: helper.state,
+      createURL: () => '#',
+    });
+
+    const firstRenderingOptions = rendering.mock.calls[0][0];
+    expect(firstRenderingOptions.items).toEqual([]);
+
+    widget.render({
+      results: new SearchResults(helper.state, [
+        {
+          hits: [],
+          facets: {},
+        },
+        {
+          hits: [],
+          facets: {},
+        },
+      ]),
+      state: helper.state,
+      helper,
+      createURL: () => '#',
+    });
+
+    const secondRenderingOptions = rendering.mock.calls[1][0];
+    expect(secondRenderingOptions.items).toEqual([]);
+  });
+
   it('provides the correct facet values when transformed', () => {
     const rendering = jest.fn();
     const makeWidget = connectBreadcrumb(rendering);
@@ -551,6 +594,7 @@ describe('connectBreadcrumb', () => {
       ],
     });
   });
+
   it('Provides an additional configuration if the existing one is different', () => {
     const makeWidget = connectBreadcrumb(() => {});
     const widget = makeWidget({ attributes: ['category', 'sub_category'] });

--- a/src/connectors/breadcrumb/connectBreadcrumb.js
+++ b/src/connectors/breadcrumb/connectBreadcrumb.js
@@ -154,10 +154,9 @@ export default function connectBreadcrumb(renderFn, unmountFn) {
       render({ instantSearchInstance, results, state }) {
         const [{ name: facetName }] = state.hierarchicalFacets;
 
-        const facetsValues = results.getFacetValues(facetName);
-        const items = transformItems(
-          shiftItemsValues(prepareItems(facetsValues))
-        );
+        const facetValues = results.getFacetValues(facetName);
+        const data = Array.isArray(facetValues.data) ? facetValues.data : [];
+        const items = transformItems(shiftItemsValues(prepareItems(data)));
 
         renderFn(
           {
@@ -179,16 +178,15 @@ export default function connectBreadcrumb(renderFn, unmountFn) {
   };
 }
 
-function prepareItems(obj) {
-  return obj.data.reduce((result, currentItem) => {
+function prepareItems(data) {
+  return data.reduce((result, currentItem) => {
     if (currentItem.isRefined) {
       result.push({
         name: currentItem.name,
         value: currentItem.path,
       });
       if (Array.isArray(currentItem.data)) {
-        const children = prepareItems(currentItem);
-        result = result.concat(children);
+        result = result.concat(prepareItems(currentItem.data));
       }
     }
     return result;


### PR DESCRIPTION
**Summary**

The current implementation of `connectBreadcrumb` never checked that the `facetValues.data` attribute is an array. But it might happen that this value is `null` (in case of no results for example). Currently the connector throws an error, this PR fixes this issue.

**Before**

![before](https://user-images.githubusercontent.com/6513513/44264412-d1f6cb80-a222-11e8-81bd-c8b5373471de.gif)

**After**

![after](https://user-images.githubusercontent.com/6513513/44264417-da4f0680-a222-11e8-91b4-2a587fd5c598.gif)

You can test the widget in [DevNovel](https://deploy-preview-3067--algolia-instantsearch.netlify.com/v2/dev-novel/?selectedStory=Breadcrumb.default).