### PR TITLE
docs(transformItems): add a section in prepare for v3

### DIFF
--- a/docgen/src/guides/prepare-for-v3.md
+++ b/docgen/src/guides/prepare-for-v3.md
@@ -22,9 +22,9 @@ InstantSearch has always worked with the [Algolia search client](https://github.
 
 ```javascript
 const search = instantsearch({
-  appId: 'appId',
-  apiKey: 'apiKey',
-  indexName: 'indexName',
+  appId: "appId",
+  apiKey: "apiKey",
+  indexName: "indexName"
 });
 
 search.start();
@@ -38,13 +38,72 @@ search.start();
 
 ```javascript
 const search = instantsearch({
-  indexName: 'indexName',
-  searchClient: algoliasearch('appId', 'apiKey'),
+  indexName: "indexName",
+  searchClient: algoliasearch("appId", "apiKey")
 });
 
 search.start();
 ```
 
+## transformData vs transformItems
+
+Since InstantSearch.js first public release, we have provided an option to customize the values used in the widgets. This method was letting you map 1-1 the values with other values. With react-instantsearch, we implemented a slightly different API that allowed for mapping but also completly change the content of the list of values. This API is way more powerful and therefore it will be the one that we want to push forward with.
+
+### Current usage
+
+```js
+search.addWidget(
+  instantsearch.widget.refinementList({
+    container: '#someDomNode',
+    attributeName: 'facet',
+    transformData: function(item) {
+      item.count = 0;
+      return item;
+    }
+  })
+);
+```
+
+Will update the counts of every item to 0.
+
+### New usage
+
+```js
+search.addWidget(
+  instantsearch.widget.refinementList({
+    container: '#someDomNode',
+    attributeName: 'facet',
+    transformItems: function(items) {
+      return items.map(function(item) {
+        item.count = 0;
+        return item;
+      });
+    }
+  })
+);
+```
+
+For just updating the values, it's more work but it also new operations on the items:
+
+```js
+search.addWidget(
+  instantsearch.widget.refinementList({
+    container: '#someDomNode',
+    attributeName: 'facet',
+    transformItems: function(items) {
+      items.push({
+        value: 'facetValue',
+        count: 100,
+      }); // injecting new values
+      items.splice(0,1); // removing items
+      items.sort((a, b) => b.count - a.count); // custom sort
+      return item;
+    }
+  })
+);
+```
+
 ## Deprecations
 
 * [`createAlgoliaClient`](https://community.algolia.com/instantsearch.js/v2/instantsearch.html#struct-InstantSearchOptions-createAlgoliaClient) becomes deprecated in favor of [`searchClient`](https://community.algolia.com/instantsearch.js/v2/instantsearch.html#struct-InstantSearchOptions-searchClient)
+* transformData becomes deprecated in favore of transformItems in all widgets

--- a/docgen/src/guides/prepare-for-v3.md
+++ b/docgen/src/guides/prepare-for-v3.md
@@ -106,4 +106,4 @@ search.addWidget(
 ## Deprecations
 
 * [`createAlgoliaClient`](https://community.algolia.com/instantsearch.js/v2/instantsearch.html#struct-InstantSearchOptions-createAlgoliaClient) becomes deprecated in favor of [`searchClient`](https://community.algolia.com/instantsearch.js/v2/instantsearch.html#struct-InstantSearchOptions-searchClient)
-* transformData becomes deprecated in favore of transformItems in all widgets
+* `transformData` becomes deprecated in favor of `transformItems` in all widgets

--- a/docgen/src/guides/prepare-for-v3.md
+++ b/docgen/src/guides/prepare-for-v3.md
@@ -22,9 +22,9 @@ InstantSearch has always worked with the [Algolia search client](https://github.
 
 ```javascript
 const search = instantsearch({
-  appId: "appId",
-  apiKey: "apiKey",
-  indexName: "indexName"
+  appId: 'appId',
+  apiKey: 'apiKey',
+  indexName: 'indexName',
 });
 
 search.start();
@@ -38,8 +38,8 @@ search.start();
 
 ```javascript
 const search = instantsearch({
-  indexName: "indexName",
-  searchClient: algoliasearch("appId", "apiKey")
+  indexName: 'indexName',
+  searchClient: algoliasearch('appId', 'apiKey'),
 });
 
 search.start();
@@ -59,7 +59,7 @@ search.addWidget(
     transformData: function(item) {
       item.count = 0;
       return item;
-    }
+    },
   })
 );
 ```
@@ -78,7 +78,7 @@ search.addWidget(
         item.count = 0;
         return item;
       });
-    }
+    },
   })
 );
 ```
@@ -95,10 +95,10 @@ search.addWidget(
         value: 'facetValue',
         count: 100,
       }); // injecting new values
-      items.splice(0,1); // removing items
+      items.splice(0, 1); // removing items
       items.sort((a, b) => b.count - a.count); // custom sort
-      return item;
-    }
+      return items;
+    },
   })
 );
 ```

--- a/docgen/src/guides/prepare-for-v3.md
+++ b/docgen/src/guides/prepare-for-v3.md
@@ -45,7 +45,7 @@ const search = instantsearch({
 search.start();
 ```
 
-## transformData vs transformItems
+## `transformData` vs `transformItems`
 
 Since InstantSearch.js first public release, we have provided an option to customize the values used in the widgets. This method was letting you map 1-1 the values with other values. With react-instantsearch, we implemented a slightly different API that allowed for mapping but also completly change the content of the list of values. This API is way more powerful and therefore it will be the one that we want to push forward with.
 
@@ -56,10 +56,10 @@ search.addWidget(
   instantsearch.widget.refinementList({
     container: '#someDomNode',
     attributeName: 'facet',
-    transformData: function(item) {
-      item.count = 0;
-      return item;
-    },
+    transformData: (item) => ({
+      ...item,
+      count: 0;
+    }),
   })
 );
 ```
@@ -73,11 +73,11 @@ search.addWidget(
   instantsearch.widget.refinementList({
     container: '#someDomNode',
     attributeName: 'facet',
-    transformItems: function(items) {
-      return items.map(function(item) {
-        item.count = 0;
-        return item;
-      });
+    transformItems: (items) => {
+      return items.map((item) => ({
+        ...item,
+        count: 0;
+      }));
     },
   })
 );
@@ -90,14 +90,17 @@ search.addWidget(
   instantsearch.widget.refinementList({
     container: '#someDomNode',
     attributeName: 'facet',
-    transformItems: function(items) {
-      items.push({
-        value: 'facetValue',
-        count: 100,
-      }); // injecting new values
-      items.splice(0, 1); // removing items
-      items.sort((a, b) => b.count - a.count); // custom sort
-      return items;
+    transformItems: items => {
+      const updatedItems = [
+        ...items,
+        {
+          value: 'facetValue',
+          count: 100,
+        }, // Adding new values
+      ];
+      updatedItems.splice(0, 1); // removing items
+      updatedItems.sort((a, b) => b.count - a.count); // custom sort
+      return updatedItems;
     },
   })
 );


### PR DESCRIPTION
This section documents the move to transformItems in "prepare for v3". It's also a good time to think if we want deprecate all transforrmData? And how?