### PR TITLE
fix(Stats): let the widget render on all values

### DIFF
--- a/src/components/Stats/Stats.js
+++ b/src/components/Stats/Stats.js
@@ -6,13 +6,6 @@ import autoHideContainerHOC from '../../decorators/autoHideContainer.js';
 import headerFooterHOC from '../../decorators/headerFooter.js';
 
 export class RawStats extends Component {
-  shouldComponentUpdate(nextProps) {
-    return (
-      this.props.nbHits !== nextProps.nbHits ||
-      this.props.processingTimeMS !== nextProps.processingTimeMS
-    );
-  }
-
   render() {
     const data = {
       hasManyResults: this.props.nbHits > 1,


### PR DESCRIPTION
This removes the implementation of shouldComponentUpdate. This can be seen as a regression but given that it's a pretty simple widget, the impact shouldn't be noticeable.

Fix #3056