### PR TITLE
chore(ci): don't do the commit messages check on a PR

### DIFF
--- a/scripts/ci/validate-commit-msgs.sh
+++ b/scripts/ci/validate-commit-msgs.sh
@@ -4,10 +4,10 @@ set -e # exit when error
 
 [ -z $TRAVIS_PULL_REQUEST ] && TRAVIS_PULL_REQUEST="false"
 
-# if [ $TRAVIS_PULL_REQUEST == "false" ]; then
-#   echo "No need to validate commit message when not in a pull request"
-#   exit 0
-# fi
+if [ $TRAVIS_PULL_REQUEST == "true" ]; then
+  echo "No need to validate commit messages in a pull request, we have conventional PRs"
+  exit 0
+fi
 
 # Checks the commits msgs in the range of commits travis is testing.
 # Based heavily on


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

We have the test with [semantic-pull-requests](https://github.com/probot/semantic-pull-requests) which takes care of the PR title as well. This test is still useful to see if `develop` has wrong commits for example

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
  
  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot): 
  
  1. the documentation site (/)
  2. a widget playground (/dev-novel)
-->

Don't run our own commit messages check on Travis on PRs

Another option is to remove it all together, but that would only be a good idea if develop is a protected branch (I don't think it is?) 
