### PR TITLE
docs(readme): Fix license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Open positions:
 
 ## License
 
-InstantSearch.js is [MIT licensed](LICENSE.md).
+InstantSearch.js is [MIT licensed][license-url].
 
 <!-- Badges -->
 


### PR DESCRIPTION
The file is named `LICENSE` (I used [Markdown reference links](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#links)).

I detected many more broken links in our Markdown files and documentation website with a tool I'm building. I will try to automate this and take care of fixing them all.