### PR TITLE
docs(routing): check refinement before joining

### DIFF
--- a/docgen/src/guides/routing.md
+++ b/docgen/src/guides/routing.md
@@ -58,7 +58,11 @@ const search = instantsearch({
         return {
           query: uiState.query,
           // we use the character ~ as it is one that is rarely present in data and renders well in urls
-          brands: uiState.refinementList && uiState.refinementList.brand.join('~'),
+          brands:
+            (uiState.refinementList &&
+            uiState.refinementList.brand &&
+              uiState.refinementList.brand.join('~')) ||
+            'all',
           page: uiState.page
         };
       },
@@ -127,7 +131,11 @@ const search = instantsearch({
       stateToRoute(uiState) {
         return {
           q: uiState.query || '',
-          brands: uiState.refinementList && uiState.refinementList.brand.join('~') || 'all',
+          brands:
+            (uiState.refinementList &&
+              uiState.refinementList.brand &&
+              uiState.refinementList.brand.join('~')) ||
+            'all',
           p: uiState.page || 1
         };
       },


### PR DESCRIPTION
This change makes the code a little bit more robust when having an undefined refinement list and using `.join()` on it.

See: https://discourse.algolia.com/t/custom-router-with-multiple-refinementlist/5999/4