### PR TITLE
docs(contributing): fix dev-novel link on deploy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,8 +71,8 @@ On it you can find:
 1. The generated documentation: https://**deploy-url-netlify**/
     - for example: https://deploy-preview-2383--algolia-instantsearch.netlify.com/
     - source: https://github.com/algolia/instantsearch.js/tree/develop/docgen
-2. A playground for the widgets: https://**deploy-url-netlify**/dev-novel
-    - for example: https://deploy-preview-2383--algolia-instantsearch.netlify.com/dev-novel/
+2. A playground for the widgets: https://**deploy-url-netlify**/v2/dev-novel
+    - for example: https://deploy-preview-3102--algolia-instantsearch.netlify.com/v2/dev-novel
     - source: https://github.com/algolia/instantsearch.js/tree/develop/dev
 
 ## Commit conventions 🤓


### PR DESCRIPTION
Dev Novel is accessible at `/v2/dev-novel` for quite some time, not `/dev-novel`.