### PR TITLE
docs(autocomplete): indices is an object array, not a string array

### DIFF
--- a/src/connectors/autocomplete/connectAutocomplete.js
+++ b/src/connectors/autocomplete/connectAutocomplete.js
@@ -34,7 +34,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/c
 
 /**
  * @typedef {Object} CustomAutocompleteWidgetOptions
- * @property {{value: String, label: String}[]} [indices = []] Name of the others indices to search into.
+ * @property {{value: string, label: string}[]} [indices = []] Name of the others indices to search into.
  * @property {boolean} [escapeHits = false] If true, escape HTML tags from `hits[i]._highlightResult`.
  */
 

--- a/src/connectors/autocomplete/connectAutocomplete.js
+++ b/src/connectors/autocomplete/connectAutocomplete.js
@@ -34,7 +34,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/c
 
 /**
  * @typedef {Object} CustomAutocompleteWidgetOptions
- * @property {string[]} [indices = []] Name of the others indices to search into.
+ * @property {{value: String, label: String}[]} [indices = []] Name of the others indices to search into.
  * @property {boolean} [escapeHits = false] If true, escape HTML tags from `hits[i]._highlightResult`.
  */
 


### PR DESCRIPTION
Not sure if jsdoc will take this in account, but can be changed if necessary once I see the deploy preview

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

`indices` on `connectAutoComplete` expects an array of label/value and not a string

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->



<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
  
  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot): 
  
  1. the documentation site (/)
  2. a widget playground (/dev-novel)
-->

