### PR TITLE
ci(commit-msgs): correct the conditional detecting PRs

### DIFF
--- a/scripts/ci/validate-commit-msgs.sh
+++ b/scripts/ci/validate-commit-msgs.sh
@@ -4,7 +4,7 @@ set -e # exit when error
 
 [ -z $TRAVIS_PULL_REQUEST ] && TRAVIS_PULL_REQUEST="false"
 
-if [ $TRAVIS_PULL_REQUEST == "true" ]; then
+if [ $TRAVIS_PULL_REQUEST != "false" ]; then
   echo "No need to validate commit messages in a pull request, we have conventional PRs"
   exit 0
 fi


### PR DESCRIPTION
Travis puts the PR number, not `"true"` if it's a PR. See: https://docs.travis-ci.com/user/environment-variables/#convenience-variables
