### PR TITLE
chore: add .prettierrc

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "proseWrap": "never",
+  "trailingComma": "es5"
+}


### PR DESCRIPTION
We rely on ESLint for our Prettier configuration but when using Jest's `expect().toMatchInlineSnapshot()`, the Prettier configuration is not used (the file gets overwritten with the default Prettier config).

With `.prettierrc`, we ensure that we all work with the same Prettier configuration, including this Jest functionality.