### PR TITLE
feat(snippet): implement InstantSearch.css

### DIFF
--- a/dev/app/builtin/stories/hits.stories.js
+++ b/dev/app/builtin/stories/hits.stories.js
@@ -63,6 +63,57 @@ export default () => {
       })
     )
     .add(
+      'with snippet function',
+      wrapWithHits(container => {
+        window.search.addWidget(
+          instantsearch.widgets.configure({
+            attributesToSnippet: ['name', 'description'],
+          })
+        );
+
+        window.search.addWidget(
+          instantsearch.widgets.hits({
+            container,
+            templates: {
+              item(hit) {
+                return `
+                  <h4>${instantsearch.snippet({
+                    attribute: 'name',
+                    hit,
+                  })}</h4>
+                  <p>${instantsearch.snippet({
+                    attribute: 'description',
+                    hit,
+                  })}</p>
+                `;
+              },
+            },
+          })
+        );
+      })
+    )
+    .add(
+      'with snippet helper',
+      wrapWithHits(container => {
+        window.search.addWidget(
+          instantsearch.widgets.configure({
+            attributesToSnippet: ['name', 'description'],
+          })
+        );
+
+        window.search.addWidget(
+          instantsearch.widgets.hits({
+            container,
+            templates: {
+              item: `
+                <h4>{{#helpers.snippet}}{ "attribute": "name", "highlightedTagName": "mark" }{{/helpers.snippet}}</h4>
+                <p>{{#helpers.snippet}}{ "attribute": "description", "highlightedTagName": "mark" }{{/helpers.snippet}}</p>`,
+            },
+          })
+        );
+      })
+    )
+    .add(
       'with highlighted array',
       wrapWithHits(
         container => {

--- a/index.es6.js
+++ b/index.es6.js
@@ -5,6 +5,7 @@ import toFactory from 'to-factory';
 /* eslint-disable import/no-unresolved */
 import InstantSearch from './lib/InstantSearch.js';
 import version from './lib/version.js';
+import { snippet } from './helpers';
 /* eslint-enable import/no-unresolved */
 
 // import instantsearch from 'instantsearch.js';
@@ -14,6 +15,7 @@ const instantSearchFactory = toFactory(InstantSearch);
 instantSearchFactory.version = version;
 instantSearchFactory.createQueryString =
   algoliasearchHelper.url.getQueryStringFromState;
+instantSearchFactory.snippet = snippet;
 
 Object.defineProperty(instantSearchFactory, 'widgets', {
   get() {

--- a/src/helpers/__tests__/snippet-test.js
+++ b/src/helpers/__tests__/snippet-test.js
@@ -1,0 +1,112 @@
+import snippet from '../snippet';
+
+/* eslint-disable camelcase */
+const hit = {
+  name: 'Amazon - Fire TV Stick with Alexa Voice Remote - Black',
+  description:
+    'Enjoy smart access to videos, games and apps with this Amazon Fire TV stick. Its Alexa voice remote lets you deliver hands-free commands when you want to watch television or engage with other applications. With a quad-core processor, 1GB internal memory and 8GB of storage, this portable Amazon Fire TV stick works fast for buffer-free streaming.',
+  brand: 'Amazon',
+  categories: ['TV & Home Theater', 'Streaming Media Players'],
+  hierarchicalCategories: {
+    lvl0: 'TV & Home Theater',
+    lvl1: 'TV & Home Theater > Streaming Media Players',
+  },
+  type: 'Streaming media plyr',
+  price: 39.99,
+  price_range: '1 - 50',
+  image: 'https://cdn-demo.algolia.com/bestbuy-0118/5477500_sb.jpg',
+  url: 'https://api.bestbuy.com/click/-/5477500/pdp',
+  free_shipping: false,
+  rating: 4,
+  popularity: 21469,
+  objectID: '5477500',
+  _snippetResult: {
+    name: {
+      value: '<em>Amazon</em> - Fire TV Stick with Alexa Voice Remote - Black',
+      matchLevel: 'full',
+      fullyHighlighted: false,
+      matchedWords: ['amazon'],
+    },
+    description: {
+      value:
+        'Enjoy smart access to videos, games and apps with this <em>Amazon</em> Fire TV stick. Its Alexa voice remote lets you deliver hands-free commands when you want to watch television or engage with other applications. With a quad-core processor, 1GB internal memory and 8GB of storage, this portable <em>Amazon</em> Fire TV stick works fast for buffer-free streaming.',
+      matchLevel: 'full',
+      fullyHighlighted: false,
+      matchedWords: ['amazon'],
+    },
+    brand: {
+      value: '<em>Amazon</em>',
+      matchLevel: 'full',
+      fullyHighlighted: true,
+      matchedWords: ['amazon'],
+    },
+    categories: [
+      {
+        value: 'TV & Home Theater',
+        matchLevel: 'none',
+        matchedWords: [],
+      },
+      {
+        value: 'Streaming Media Players',
+        matchLevel: 'none',
+        matchedWords: [],
+      },
+    ],
+    type: {
+      value: 'Streaming media plyr',
+      matchLevel: 'none',
+      matchedWords: [],
+    },
+    meta: {
+      name: {
+        value: 'Nested <em>Amazon</em> name',
+      },
+    },
+  },
+};
+/* eslint-enable camelcase */
+
+describe('snippet', () => {
+  test('with default tag name', () => {
+    expect(
+      snippet({
+        attribute: 'name',
+        hit,
+      })
+    ).toMatchInlineSnapshot(
+      `"<mark class=\\"ais-Snippet-highlighted\\">Amazon</mark> - Fire TV Stick with Alexa Voice Remote - Black"`
+    );
+  });
+
+  test('with custom tag name', () => {
+    expect(
+      snippet({
+        attribute: 'description',
+        highlightedTagName: 'em',
+        hit,
+      })
+    ).toMatchInlineSnapshot(
+      `"Enjoy smart access to videos, games and apps with this <em class=\\"ais-Snippet-highlighted\\">Amazon</em> Fire TV stick. Its Alexa voice remote lets you deliver hands-free commands when you want to watch television or engage with other applications. With a quad-core processor, 1GB internal memory and 8GB of storage, this portable <em class=\\"ais-Snippet-highlighted\\">Amazon</em> Fire TV stick works fast for buffer-free streaming."`
+    );
+  });
+
+  test('with unknown attribute returns an empty string', () => {
+    expect(
+      snippet({
+        attribute: 'wrong-attribute',
+        hit,
+      })
+    ).toMatchInlineSnapshot(`""`);
+  });
+
+  test('with nested attribute', () => {
+    expect(
+      snippet({
+        attribute: 'meta.name',
+        hit,
+      })
+    ).toMatchInlineSnapshot(
+      `"Nested <mark class=\\"ais-Snippet-highlighted\\">Amazon</mark> name"`
+    );
+  });
+});

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,1 +1,2 @@
 export { default as highlight } from './highlight.js';
+export { default as snippet } from './snippet.js';

--- a/src/helpers/snippet.js
+++ b/src/helpers/snippet.js
@@ -3,7 +3,7 @@ import { component } from '../lib/suit';
 
 const suit = component('Snippet');
 
-export default function highlight({
+export default function snippet({
   attribute,
   highlightedTagName = 'mark',
   hit,

--- a/src/helpers/snippet.js
+++ b/src/helpers/snippet.js
@@ -1,0 +1,22 @@
+import { getPropertyByPath } from '../lib/utils';
+import { component } from '../lib/suit';
+
+const suit = component('Snippet');
+
+export default function highlight({
+  attribute,
+  highlightedTagName = 'mark',
+  hit,
+} = {}) {
+  const attributeValue =
+    getPropertyByPath(hit, `_snippetResult.${attribute}.value`) || '';
+
+  return attributeValue
+    .replace(
+      /<em>/g,
+      `<${highlightedTagName} class="${suit({
+        descendantName: 'highlighted',
+      })}">`
+    )
+    .replace(/<\/em>/g, `</${highlightedTagName}>`);
+}

--- a/src/lib/__tests__/__snapshots__/InstantSearch-test.js.snap
+++ b/src/lib/__tests__/__snapshots__/InstantSearch-test.js.snap
@@ -181,6 +181,7 @@ Array [
         "helpers": Object {
           "formatNumber": [Function],
           "highlight": [Function],
+          "snippet": [Function],
         },
       },
       "urlSync": Object {},
@@ -264,6 +265,7 @@ Array [
       "helpers": Object {
         "formatNumber": [Function],
         "highlight": [Function],
+        "snippet": [Function],
       },
     },
   },

--- a/src/lib/createHelpers.js
+++ b/src/lib/createHelpers.js
@@ -1,4 +1,4 @@
-import { highlight } from '../helpers';
+import { highlight, snippet } from '../helpers';
 
 export default function({ numberLocale }) {
   return {
@@ -18,6 +18,22 @@ export default function({ numberLocale }) {
       } catch (error) {
         throw new Error(`
 The highlight helper expects a JSON object of the format:
+{ "attribute": "name", "highlightedTagName": "mark" }`);
+      }
+    },
+    snippet(options, render) {
+      try {
+        const snippetOptions = JSON.parse(options);
+
+        return render(
+          snippet({
+            ...snippetOptions,
+            hit: this,
+          })
+        );
+      } catch (error) {
+        throw new Error(`
+The snippet helper expects a JSON object of the format:
 { "attribute": "name", "highlightedTagName": "mark" }`);
       }
     },

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -159,5 +159,6 @@ instantsearch.connectors = connectors;
 instantsearch.widgets = widgets;
 instantsearch.version = version;
 instantsearch.highlight = helpers.highlight;
+instantsearch.snippet = helpers.snippet;
 
 export default instantsearch;


### PR DESCRIPTION
This PR add functionalities to snippet hits without manipulating the Algolia response object (`_snippetResult`). It provides two ways to snippet a hit.

```js
instantsearch.snippet({ attribute, highlightedTagName, hit })
// => <mark class="ais-Snippet-highlighted">Amazon</mark> - Fire TV Stick with Alexa Voice Remote - Black
```

```js
{{#snippet}}{ "attribute": "name", "highlightedTagName": "mark" }{{/snippet}}
// => <mark class="ais-Snippet-highlighted">Amazon</mark> - Fire TV Stick with Alexa Voice Remote - Black
```

## Specs

[See specs →](https://instantsearch-css.netlify.com/widgets/snippet/)

## Stories

- [Function](https://deploy-preview-3134--algolia-instantsearch.netlify.com/v2/dev-novel/?selectedStory=Hits.with%20snippet%20function)
- [Helper](https://deploy-preview-3134--algolia-instantsearch.netlify.com/v2/dev-novel/?selectedStory=Hits.with%20snippet%20helper)

## Related

- #3132 