### PR TITLE
fix(numericselector): default value can be undefined

### DIFF
--- a/src/connectors/numeric-selector/connectNumericSelector.js
+++ b/src/connectors/numeric-selector/connectNumericSelector.js
@@ -202,9 +202,14 @@ export default function connectNumericSelector(renderFn, unmountFn) {
             .addNumericRefinement(attributeName, operator, value);
         }
 
-        return searchParameters
-          .clearRefinements(attributeName)
-          .addNumericRefinement(attributeName, operator, options[0].value);
+        const firstItemValue = options[0] && options[0].value;
+        if (typeof firstItemValue === 'number') {
+          return searchParameters
+            .clearRefinements(attributeName)
+            .addNumericRefinement(attributeName, operator, options[0].value);
+        }
+
+        return searchParameters;
       },
 
       _getRefinedValue(state) {


### PR DESCRIPTION
Waiting for the netlify build

Conditions of the bug:
 - routing
 - default undefined value (first one in the list)

Can be reproduced in the dev-novel.