### PR TITLE
test(InstantSearch): use two results for disjunctive requests

### DIFF
--- a/src/lib/__tests__/InstantSearch-test-2.js
+++ b/src/lib/__tests__/InstantSearch-test-2.js
@@ -154,7 +154,7 @@ describe('InstantSearch life cycle', () => {
 
   it('does not break when providing searchFunction with multiple resquests', () => {
     const fakeClient = {
-      search: jest.fn(() => Promise.resolve({ results: [{}] })),
+      search: jest.fn(() => Promise.resolve({ results: [{}, {}] })),
     };
 
     const search = new InstantSearch({


### PR DESCRIPTION
**Summary**

For disjunctive requests we need to have two results.

**Before**

![screen shot 2018-09-24 at 15 56 30](https://user-images.githubusercontent.com/6513513/45956400-b1384780-c012-11e8-8a06-646d20c8553e.png)

**After**

![screen shot 2018-09-24 at 15 56 46](https://user-images.githubusercontent.com/6513513/45956405-b39aa180-c012-11e8-8f9c-e1f444bb7390.png)