### PR TITLE
feat(formatNumber): add formatNumber helper

### DIFF
--- a/index.es6.js
+++ b/index.es6.js
@@ -5,7 +5,7 @@ import toFactory from 'to-factory';
 /* eslint-disable import/no-unresolved */
 import InstantSearch from './lib/InstantSearch.js';
 import version from './lib/version.js';
-import { snippet, highlight } from './helpers';
+import { highlight, snippet, formatNumber } from './helpers';
 /* eslint-enable import/no-unresolved */
 
 // import instantsearch from 'instantsearch.js';
@@ -15,8 +15,9 @@ const instantSearchFactory = toFactory(InstantSearch);
 instantSearchFactory.version = version;
 instantSearchFactory.createQueryString =
   algoliasearchHelper.url.getQueryStringFromState;
-instantSearchFactory.snippet = snippet;
 instantSearchFactory.highlight = highlight;
+instantSearchFactory.snippet = snippet;
+instantSearchFactory.formatNumber = formatNumber;
 
 Object.defineProperty(instantSearchFactory, 'widgets', {
   get() {

--- a/src/helpers/formatNumber.js
+++ b/src/helpers/formatNumber.js
@@ -1,0 +1,3 @@
+export default function formatNumber({ number, numberLocale }) {
+  return Number(number).toLocaleString(numberLocale);
+}

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,2 +1,3 @@
 export { default as highlight } from './highlight.js';
 export { default as snippet } from './snippet.js';
+export { default as formatNumber } from './formatNumber.js';

--- a/src/lib/createHelpers.js
+++ b/src/lib/createHelpers.js
@@ -1,9 +1,9 @@
-import { highlight, snippet } from '../helpers';
+import { highlight, snippet, formatNumber } from '../helpers';
 
 export default function({ numberLocale }) {
   return {
     formatNumber(number, render) {
-      return Number(render(number)).toLocaleString(numberLocale);
+      return formatNumber({ number: render(number), numberLocale });
     },
     highlight(options, render) {
       try {

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -160,5 +160,6 @@ instantsearch.widgets = widgets;
 instantsearch.version = version;
 instantsearch.highlight = helpers.highlight;
 instantsearch.snippet = helpers.snippet;
+instantsearch.formatNumber = helpers.formatNumber;
 
 export default instantsearch;


### PR DESCRIPTION
This PR exposes the `formatNumber` Hogan helper to a global helper on `instantsearch.formatNumber()`.

Note that this is untested because not easily feasible in Node ([see issue](https://stackoverflow.com/questions/23199909/using-tolocalestring-in-node-js/23200062#23200062)).

You can see the Hogan helper work on the [Stats story](https://deploy-preview-3141--algolia-instantsearch.netlify.com/v2/dev-novel/?selectedStory=Stats.default).

I've locally added a story to make sure it works:

```js
stories.add(
  'with helper',
  wrapWithHits(container => {
    window.search.addWidget(
      instantsearch.widgets.stats({
        container,
        templates: {
          text: ({ nbHits }) =>
            `${instantsearch.formatNumber({ number: nbHits, numberLocale: 'fr-FR' })} results`,
        },
      })
    );
  })
);
```