### PR TITLE
fix(community): fix search config

### DIFF
--- a/docgen/assets/js/bindRunExamples.js
+++ b/docgen/assets/js/bindRunExamples.js
@@ -6,8 +6,7 @@ const {
   appId = "latency",
   apiKey = "6be0576ff61c053d5f9a3225e2a90f76",
   ...searchConfig
-} =
-  window.searchConfig || {};
+} = window.searchConfig || {};
 
 window.instantsearch = instantsearch;
 window.search = instantsearch({

--- a/docgen/assets/js/bindRunExamples.js
+++ b/docgen/assets/js/bindRunExamples.js
@@ -2,16 +2,21 @@ import instantsearch from "../../../src/lib/main.js";
 import algoliasearch from "algoliasearch/lite";
 import capitalize from "lodash/capitalize";
 
+const {
+  appId = "latency",
+  apiKey = "6be0576ff61c053d5f9a3225e2a90f76",
+  ...searchConfig
+} =
+  window.searchConfig || {};
+
 window.instantsearch = instantsearch;
 window.search = instantsearch({
-  indexName: window.searchConfig.indexName || "instant_search",
-  searchClient: algoliasearch(
-    window.searchConfig.appId || "latency",
-    window.searchConfig.apiKey || "6be0576ff61c053d5f9a3225e2a90f76"
-  ),
+  indexName: "instant_search",
+  searchClient: algoliasearch(appId, apiKey),
   searchParameters: {
     hitsPerPage: 3,
-  }
+  },
+  ...searchConfig
 });
 
 const el = html => {


### PR DESCRIPTION
This PR fixes the `searchConfig` object on the community website when it is `undefined`.

I also took the opportunity to refactor the way we extract the search configuration and made it possible to override the whole object (as it was before).