### PR TITLE
feat(utils): add warn function

### DIFF
--- a/src/lib/__tests__/utils-test.js
+++ b/src/lib/__tests__/utils-test.js
@@ -899,6 +899,38 @@ describe('utils.deprecate', () => {
   });
 });
 
+describe('utils.warn', () => {
+  it('expect to print a warn message', () => {
+    const message = 'message';
+    const warn = jest.spyOn(global.console, 'warn');
+
+    utils.warn(message);
+
+    expect(warn).toHaveBeenCalled();
+
+    warn.mockReset();
+    warn.mockRestore();
+    utils.warn.cache = {};
+  });
+
+  it('expect to print the same message only once', () => {
+    const message = 'message';
+    const warn = jest.spyOn(global.console, 'warn');
+
+    utils.warn(message);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+
+    utils.warn(message);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+
+    warn.mockReset();
+    warn.mockRestore();
+    utils.warn.cache = {};
+  });
+});
+
 describe('utils.parseAroundLatLngFromString', () => {
   it('expect to return a LatLng object from string', () => {
     const samples = [

--- a/src/lib/__tests__/utils-test.js
+++ b/src/lib/__tests__/utils-test.js
@@ -876,7 +876,7 @@ describe('utils.deprecate', () => {
     const actual = 6;
 
     expect(actual).toBe(expectation);
-    expect(warn).toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith('[InstantSearch.js]: message');
 
     warn.mockReset();
     warn.mockRestore();
@@ -906,7 +906,7 @@ describe('utils.warn', () => {
 
     utils.warn(message);
 
-    expect(warn).toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith('[InstantSearch.js]: message');
 
     warn.mockReset();
     warn.mockRestore();

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -25,6 +25,7 @@ export {
   checkRendering,
   isReactElement,
   deprecate,
+  warn,
   parseAroundLatLngFromString,
 };
 
@@ -401,6 +402,11 @@ function isReactElement(object) {
   );
 }
 
+function logger(message) {
+  // eslint-disable-next-line no-console
+  console.warn(`[InstantSearch.js]: ${message.trim()}`);
+}
+
 function deprecate(fn, message) {
   let hasAlreadyPrint = false;
 
@@ -408,12 +414,22 @@ function deprecate(fn, message) {
     if (!hasAlreadyPrint) {
       hasAlreadyPrint = true;
 
-      // eslint-disable-next-line no-console
-      console.warn(`[InstantSearch.js]: ${message}`);
+      logger(message);
     }
 
     return fn(...args);
   };
+}
+
+warn.cache = {};
+function warn(message) {
+  const hasAlreadyPrint = warn.cache[message];
+
+  if (!hasAlreadyPrint) {
+    warn.cache[message] = true;
+
+    logger(message);
+  }
 }
 
 const latLngRegExp = /^(-?\d+(?:\.\d+)?),\s*(-?\d+(?:\.\d+)?)$/;


### PR DESCRIPTION
**Summary**

This PR introduces a function to display warnings on the page only once (cached by message). I didn't update all the usage of `console.warn` across the codebase to avoid conflict with the 3.0 branch. We can move on latter once the next version is released.