### PR TITLE
refactor(geo): remove support for paddingBoundingBox [PART-1]

### DIFF
--- a/dev/app/builtin/stories/geo-search.stories.js
+++ b/dev/app/builtin/stories/geo-search.stories.js
@@ -41,13 +41,6 @@ export default () => {
     lng: -74.01,
   };
 
-  const paddingBoundingBox = {
-    top: 41,
-    right: 13,
-    bottom: 5,
-    left: 13,
-  };
-
   Stories.add(
     'default',
     wrapWithHitsAndConfiguration((container, start) =>
@@ -103,7 +96,6 @@ export default () => {
             container,
             initialPosition,
             initialZoom,
-            paddingBoundingBox,
           })
         );
 
@@ -123,7 +115,6 @@ export default () => {
               container,
               initialPosition,
               initialZoom,
-              paddingBoundingBox,
               radius,
             })
           );
@@ -144,7 +135,6 @@ export default () => {
               container,
               initialPosition,
               initialZoom,
-              paddingBoundingBox,
               radius,
               precision,
             })
@@ -167,7 +157,6 @@ export default () => {
             googleReference: window.google,
             container,
             initialZoom,
-            paddingBoundingBox,
             position,
           })
         );
@@ -187,7 +176,6 @@ export default () => {
               googleReference: window.google,
               container,
               initialZoom,
-              paddingBoundingBox,
               radius,
               position,
             })
@@ -208,7 +196,6 @@ export default () => {
               googleReference: window.google,
               container,
               initialZoom,
-              paddingBoundingBox,
               radius,
               precision,
               position,
@@ -248,7 +235,6 @@ export default () => {
             enableGeolocationWithIP: false,
             enableClearMapRefinement: false,
             initialZoom,
-            paddingBoundingBox,
           })
         );
 
@@ -270,7 +256,6 @@ export default () => {
             container,
             initialPosition,
             initialZoom,
-            paddingBoundingBox,
             enableRefineControl: true,
             enableRefineOnMapMove: true,
           })
@@ -294,7 +279,6 @@ export default () => {
               container,
               initialPosition,
               initialZoom,
-              paddingBoundingBox,
             })
           );
 
@@ -316,7 +300,6 @@ export default () => {
               container,
               initialPosition,
               initialZoom,
-              paddingBoundingBox,
             })
           );
 
@@ -338,7 +321,6 @@ export default () => {
               container,
               initialPosition,
               initialZoom,
-              paddingBoundingBox,
             })
           );
 
@@ -363,7 +345,6 @@ export default () => {
               container,
               initialPosition,
               initialZoom,
-              paddingBoundingBox,
             })
           );
 
@@ -386,7 +367,6 @@ export default () => {
               container,
               initialPosition,
               initialZoom,
-              paddingBoundingBox,
             })
           );
 
@@ -419,7 +399,6 @@ export default () => {
               container,
               initialPosition,
               initialZoom,
-              paddingBoundingBox,
             })
           );
 
@@ -454,7 +433,6 @@ export default () => {
               container,
               initialPosition,
               initialZoom,
-              paddingBoundingBox,
             })
           );
 
@@ -505,7 +483,6 @@ export default () => {
               container,
               initialPosition,
               initialZoom,
-              paddingBoundingBox,
             })
           );
 
@@ -545,7 +522,6 @@ export default () => {
               container,
               initialPosition,
               initialZoom,
-              paddingBoundingBox,
             })
           );
 
@@ -593,7 +569,6 @@ export default () => {
               container,
               initialPosition,
               initialZoom,
-              paddingBoundingBox,
             })
           );
 
@@ -655,7 +630,6 @@ export default () => {
               container,
               initialPosition,
               initialZoom,
-              paddingBoundingBox,
             })
           );
 
@@ -738,7 +712,6 @@ export default () => {
               container,
               initialPosition,
               initialZoom,
-              paddingBoundingBox,
             })
           );
 
@@ -759,7 +732,6 @@ export default () => {
                 container,
                 initialPosition,
                 initialZoom,
-                paddingBoundingBox,
               })
             );
 
@@ -790,7 +762,6 @@ export default () => {
                 container,
                 initialPosition,
                 initialZoom,
-                paddingBoundingBox,
               })
             );
 

--- a/docgen/src/guides/migrations-geo-search.md
+++ b/docgen/src/guides/migrations-geo-search.md
@@ -1,0 +1,32 @@
+---
+title: Migration v3 - GeoSearch
+mainTitle: Guides
+layout: main.pug
+category: guides
+withHeadings: true
+navWeight: 0
+editable: true
+githubSource: docgen/src/guides/migrations-geo-search.md
+---
+
+> TODO: move the content of the migration guide inside the v3 migration guide
+
+### GeoSearch
+
+#### Options
+
+| Before               | After    |
+| -------------------- | -------- |
+| `paddingBoundingBox` | Removed  |
+
+- `paddingBoundingBox` was in conflit with the `routing` option - so we removed it to support URLSync for the GeoSearch widget.
+
+### connectGeoSearch
+
+#### Options
+
+| Before               | After    |
+| -------------------- | -------- |
+| `paddingBoundingBox` | Removed  |
+
+- `paddingBoundingBox` was in conflit with the `routing` option - so we removed it to support URLSync for the GeoSearch widget.

--- a/src/widgets/geo-search/GeoSearchRenderer.js
+++ b/src/widgets/geo-search/GeoSearchRenderer.js
@@ -2,35 +2,17 @@ import React, { render } from 'preact-compat';
 import { prepareTemplateProps } from '../../lib/utils';
 import GeoSearchControls from '../../components/GeoSearchControls/GeoSearchControls';
 
-const refineWithMap = ({ refine, paddingBoundingBox, mapInstance }) => {
-  // Function for compute the projection of LatLng to Point (pixel)
-  // Builtin in Leaflet: myMapInstance.project(LatLng, zoom)
-  // http://krasimirtsonev.com/blog/article/google-maps-api-v3-convert-latlng-object-to-actual-pixels-point-object
-  // http://leafletjs.com/reference-1.2.0.html#map-project
-  const scale = Math.pow(2, mapInstance.getZoom());
-
-  const northEastPoint = mapInstance
-    .getProjection()
-    .fromLatLngToPoint(mapInstance.getBounds().getNorthEast());
-
-  northEastPoint.x = northEastPoint.x - paddingBoundingBox.right / scale;
-  northEastPoint.y = northEastPoint.y + paddingBoundingBox.top / scale;
-
-  const southWestPoint = mapInstance
-    .getProjection()
-    .fromLatLngToPoint(mapInstance.getBounds().getSouthWest());
-
-  southWestPoint.x = southWestPoint.x + paddingBoundingBox.right / scale;
-  southWestPoint.y = southWestPoint.y - paddingBoundingBox.bottom / scale;
-
-  const ne = mapInstance.getProjection().fromPointToLatLng(northEastPoint);
-  const sw = mapInstance.getProjection().fromPointToLatLng(southWestPoint);
-
+const refineWithMap = ({ refine, mapInstance }) =>
   refine({
-    northEast: { lat: ne.lat(), lng: ne.lng() },
-    southWest: { lat: sw.lat(), lng: sw.lng() },
+    northEast: mapInstance
+      .getBounds()
+      .getNorthEast()
+      .toJSON(),
+    southWest: mapInstance
+      .getBounds()
+      .getSouthWest()
+      .toJSON(),
   });
-};
 
 const collectMarkersForNextRender = (markers, nextIds) =>
   markers.reduce(
@@ -69,7 +51,6 @@ const renderer = (
     initialPosition,
     enableClearMapRefinement,
     enableRefineControl,
-    paddingBoundingBox,
     mapOptions,
     createMarker,
     markerOptions,
@@ -126,7 +107,6 @@ const renderer = (
           refineWithMap({
             mapInstance: renderState.mapInstance,
             refine,
-            paddingBoundingBox,
           });
         }
       });
@@ -227,7 +207,6 @@ const renderer = (
         refineWithMap({
           mapInstance: renderState.mapInstance,
           refine,
-          paddingBoundingBox,
         })
       }
       onClearClick={clearMapRefinement}

--- a/src/widgets/geo-search/__tests__/geo-search-test.js
+++ b/src/widgets/geo-search/__tests__/geo-search-test.js
@@ -30,17 +30,11 @@ describe('GeoSearch', () => {
     getZoom: jest.fn(),
     setZoom: jest.fn(),
     getBounds: jest.fn(() => ({
-      getNorthEast: jest.fn(),
-      getSouthWest: jest.fn(),
-    })),
-    getProjection: jest.fn(() => ({
-      fromPointToLatLng: jest.fn(() => ({
-        lat: jest.fn(),
-        lng: jest.fn(),
+      getNorthEast: jest.fn(() => ({
+        toJSON: jest.fn(() => ({})),
       })),
-      fromLatLngToPoint: jest.fn(() => ({
-        x: 0,
-        y: 0,
+      getSouthWest: jest.fn(() => ({
+        toJSON: jest.fn(() => ({})),
       })),
     })),
     fitBounds: jest.fn(),
@@ -220,46 +214,6 @@ describe('GeoSearch', () => {
       clear: 'Clear the map refinement',
       toggle: 'Search when the map move',
       redo: 'Redo search here',
-    };
-
-    expect(actual).toEqual(expectation);
-  });
-
-  it('expect to render with custom paddingBoundingBoc', () => {
-    const container = createContainer();
-    const instantSearchInstance = createFakeInstantSearch();
-    const helper = createFakeHelper();
-    const googleReference = createFakeGoogleReference();
-
-    const widget = geoSearch({
-      googleReference,
-      container,
-      paddingBoundingBox: {
-        top: 10,
-      },
-    });
-
-    widget.init({
-      helper,
-      instantSearchInstance,
-      state: helper.state,
-    });
-
-    widget.render({
-      helper,
-      instantSearchInstance,
-      results: {
-        hits: [],
-      },
-    });
-
-    const actual = renderer.mock.calls[0][0].widgetParams.paddingBoundingBox;
-
-    const expectation = {
-      top: 10,
-      right: 0,
-      bottom: 0,
-      left: 0,
     };
 
     expect(actual).toEqual(expectation);

--- a/src/widgets/geo-search/geo-search.js
+++ b/src/widgets/geo-search/geo-search.js
@@ -16,7 +16,6 @@ geoSearch({
   googleReference,
   [ initialZoom = 1 ],
   [ initialPosition = { lat: 0, lng: 0 } ],
-  [ paddingBoundingBox = { top: 0, right: 0, bottom: 0, right: 0 } ],
   [ cssClasses.{root,map,controls,clear,control,toggleLabel,toggleLabelActive,toggleInput,redo} = {} ],
   [ templates.{clear,toggle,redo} ],
   [ mapOptions ],
@@ -74,14 +73,6 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  */
 
 /**
- * @typedef {object} Padding
- * @property {number} top The top padding in pixels.
- * @property {number} right The right padding in pixels.
- * @property {number} bottom The bottom padding in pixels.
- * @property {number} left The left padding in pixels.
- */
-
-/**
  * @typedef {object} LatLng
  * @property {number} lat The latitude in degrees.
  * @property {number} lng The longitude in degrees.
@@ -94,7 +85,6 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  * See [the documentation](https://developers.google.com/maps/documentation/javascript/tutorial) for more information.
  * @property {number} [initialZoom=1] By default the map will set the zoom accordingly to the markers displayed on it. When we refine it may happen that the results are empty. For those situations we need to provide a zoom to render the map.
  * @property {LatLng} [initialPosition={ lat: 0, lng: 0 }] By default the map will set the position accordingly to the markers displayed on it. When we refine it may happen that the results are empty. For those situations we need to provide a position to render the map. This option is ignored when the `position` is provided.
- * @property {Padding} [paddingBoundingBox={ top:0, right: 0, bottom:0, left: 0 }] Add an inner padding on the map when you refine.
  * @property {GeoSearchTemplates} [templates] Templates to use for the widget.
  * @property {GeoSearchCSSClasses} [cssClasses] CSS classes to add to the wrapping elements.
  * @property {object} [mapOptions] Option forwarded to the Google Maps constructor. <br />
@@ -143,7 +133,6 @@ const geoSearch = ({
   initialPosition = { lat: 0, lng: 0 },
   templates: userTemplates = {},
   cssClasses: userCssClasses = {},
-  paddingBoundingBox: userPaddingBoundingBox = {},
   builtInMarker: userBuiltInMarker = {},
   customHTMLMarker: userCustomHTMLMarker = false,
   enableClearMapRefinement = true,
@@ -161,13 +150,6 @@ const geoSearch = ({
     template: '<p>Your custom HTML Marker</p>',
     createOptions: noop,
     events: {},
-  };
-
-  const defaultPaddingBoundingBox = {
-    top: 0,
-    right: 0,
-    bottom: 0,
-    left: 0,
   };
 
   if (!container) {
@@ -208,11 +190,6 @@ const geoSearch = ({
   const customHTMLMarker = Boolean(userCustomHTMLMarker) && {
     ...defaultCustomHTMLMarker,
     ...userCustomHTMLMarker,
-  };
-
-  const paddingBoundingBox = {
-    ...defaultPaddingBoundingBox,
-    ...userPaddingBoundingBox,
   };
 
   const createBuiltInMarker = ({ item, ...rest }) =>
@@ -267,7 +244,6 @@ const geoSearch = ({
       initialPosition,
       templates,
       cssClasses,
-      paddingBoundingBox,
       createMarker,
       markerOptions,
       enableClearMapRefinement,


### PR DESCRIPTION
**Summary**

This PR removes the support of `paddingBoundingBox`. This option doesn't play nicely with the URLSync - mainly because we are not able to determine the exact same position for the bounding box with a computed padding. For this reason we choose to drop the support of the option to be able to implement a proper URLSync - option that is more valuable.