### PR TITLE
refactor(geo): implement currentRefinement [PART-3]

### DIFF
--- a/dev/app/builtin/stories/geo-search.stories.js
+++ b/dev/app/builtin/stories/geo-search.stories.js
@@ -13,14 +13,14 @@ const wrapWithHitsAndConfiguration = (story, searchParameters) =>
   wrapWithHits(story, {
     indexName: 'airbnb',
     searchParameters: {
-      hitsPerPage: 25,
+      hitsPerPage: 20,
       ...searchParameters,
     },
   });
 
 const injectGoogleMaps = fn => {
   injectScript(
-    `https://maps.googleapis.com/maps/api/js?v=3.31&key=${API_KEY}`,
+    `https://maps.googleapis.com/maps/api/js?v=weekly&key=${API_KEY}`,
     fn
   );
 };
@@ -150,7 +150,7 @@ export default () => {
 
   // Only UI
   Stories.add(
-    'with control & refine on map move',
+    'with refine disabled',
     wrapWithHitsAndConfiguration((container, start) =>
       injectGoogleMaps(() => {
         container.style.height = '600px';
@@ -167,8 +167,7 @@ export default () => {
             container,
             initialPosition,
             initialZoom,
-            enableRefineControl: true,
-            enableRefineOnMapMove: true,
+            enableRefine: false,
           })
         );
 
@@ -176,6 +175,33 @@ export default () => {
       })
     )
   )
+    .add(
+      'with control & refine on map move',
+      wrapWithHitsAndConfiguration((container, start) =>
+        injectGoogleMaps(() => {
+          container.style.height = '600px';
+
+          window.search.addWidget(
+            instantsearch.widgets.configure({
+              aroundLatLngViaIP: true,
+            })
+          );
+
+          window.search.addWidget(
+            instantsearch.widgets.geoSearch({
+              googleReference: window.google,
+              container,
+              initialPosition,
+              initialZoom,
+              enableRefineControl: true,
+              enableRefineOnMapMove: true,
+            })
+          );
+
+          start();
+        })
+      )
+    )
     .add(
       'with control & disable refine on map move',
       wrapWithHitsAndConfiguration((container, start) =>

--- a/src/components/GeoSearchControls/GeoSearchControls.js
+++ b/src/components/GeoSearchControls/GeoSearchControls.js
@@ -7,6 +7,7 @@ import GeoSearchToggle from './GeoSearchToggle';
 
 const GeoSearchControls = ({
   cssClasses,
+  enableRefine,
   enableRefineControl,
   enableClearMapRefinement,
   isRefineOnMapMove,
@@ -16,67 +17,72 @@ const GeoSearchControls = ({
   onRefineClick,
   onClearClick,
   templateProps,
-}) => (
-  <div>
-    {enableRefineControl && (
-      <div className={cssClasses.control}>
-        {isRefineOnMapMove || !hasMapMoveSinceLastRefine ? (
-          <GeoSearchToggle
-            classNameLabel={cx(
-              cssClasses.toggleLabel,
-              isRefineOnMapMove && cssClasses.toggleLabelActive
-            )}
-            classNameInput={cssClasses.toggleInput}
-            checked={isRefineOnMapMove}
-            onToggle={onRefineToggle}
-          >
+}) =>
+  enableRefine && (
+    <div>
+      {enableRefineControl && (
+        <div className={cssClasses.control}>
+          {isRefineOnMapMove || !hasMapMoveSinceLastRefine ? (
+            <GeoSearchToggle
+              classNameLabel={cx(
+                cssClasses.toggleLabel,
+                isRefineOnMapMove && cssClasses.toggleLabelActive
+              )}
+              classNameInput={cssClasses.toggleInput}
+              checked={isRefineOnMapMove}
+              onToggle={onRefineToggle}
+            >
+              <Template
+                {...templateProps}
+                templateKey="toggle"
+                rootTagName="span"
+              />
+            </GeoSearchToggle>
+          ) : (
+            <GeoSearchButton
+              className={cssClasses.redo}
+              disabled={!hasMapMoveSinceLastRefine}
+              onClick={onRefineClick}
+            >
+              <Template
+                {...templateProps}
+                templateKey="redo"
+                rootTagName="span"
+              />
+            </GeoSearchButton>
+          )}
+        </div>
+      )}
+
+      {!enableRefineControl &&
+        !isRefineOnMapMove && (
+          <div className={cssClasses.control}>
+            <GeoSearchButton
+              className={cssClasses.redo}
+              disabled={!hasMapMoveSinceLastRefine}
+              onClick={onRefineClick}
+            >
+              <Template
+                {...templateProps}
+                templateKey="redo"
+                rootTagName="span"
+              />
+            </GeoSearchButton>
+          </div>
+        )}
+
+      {enableClearMapRefinement &&
+        isRefinedWithMap && (
+          <GeoSearchButton className={cssClasses.clear} onClick={onClearClick}>
             <Template
               {...templateProps}
-              templateKey="toggle"
-              rootTagName="span"
-            />
-          </GeoSearchToggle>
-        ) : (
-          <GeoSearchButton
-            className={cssClasses.redo}
-            disabled={!hasMapMoveSinceLastRefine}
-            onClick={onRefineClick}
-          >
-            <Template
-              {...templateProps}
-              templateKey="redo"
+              templateKey="clear"
               rootTagName="span"
             />
           </GeoSearchButton>
         )}
-      </div>
-    )}
-
-    {!enableRefineControl &&
-      !isRefineOnMapMove && (
-        <div className={cssClasses.control}>
-          <GeoSearchButton
-            className={cssClasses.redo}
-            disabled={!hasMapMoveSinceLastRefine}
-            onClick={onRefineClick}
-          >
-            <Template
-              {...templateProps}
-              templateKey="redo"
-              rootTagName="span"
-            />
-          </GeoSearchButton>
-        </div>
-      )}
-
-    {enableClearMapRefinement &&
-      isRefinedWithMap && (
-        <GeoSearchButton className={cssClasses.clear} onClick={onClearClick}>
-          <Template {...templateProps} templateKey="clear" rootTagName="span" />
-        </GeoSearchButton>
-      )}
-  </div>
-);
+    </div>
+  );
 
 const CSSClassesPropTypes = PropTypes.shape({
   control: PropTypes.string.isRequired,
@@ -89,6 +95,7 @@ const CSSClassesPropTypes = PropTypes.shape({
 
 GeoSearchControls.propTypes = {
   cssClasses: CSSClassesPropTypes.isRequired,
+  enableRefine: PropTypes.bool.isRequired,
   enableRefineControl: PropTypes.bool.isRequired,
   enableClearMapRefinement: PropTypes.bool.isRequired,
   isRefineOnMapMove: PropTypes.bool.isRequired,

--- a/src/components/GeoSearchControls/__tests__/GeoSearchControls-test.js
+++ b/src/components/GeoSearchControls/__tests__/GeoSearchControls-test.js
@@ -16,6 +16,7 @@ describe('GeoSearchControls', () => {
     cssClasses: CSSClassesDefaultProps,
     enableRefineControl: true,
     enableClearMapRefinement: true,
+    enableRefine: true,
     isRefineOnMapMove: true,
     isRefinedWithMap: false,
     hasMapMoveSinceLastRefine: false,
@@ -24,6 +25,17 @@ describe('GeoSearchControls', () => {
     onClearClick: () => {},
     templateProps: {},
   };
+
+  it('expect to render nothing with refine dsiabled', () => {
+    const props = {
+      ...defaultProps,
+      enableRefine: false,
+    };
+
+    const wrapper = shallow(<GeoSearchControls {...props} />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
 
   describe('Control enabled', () => {
     it('expect to render the toggle checked when refine on map move is enabled', () => {

--- a/src/components/GeoSearchControls/__tests__/__snapshots__/GeoSearchControls-test.js.snap
+++ b/src/components/GeoSearchControls/__tests__/__snapshots__/GeoSearchControls-test.js.snap
@@ -137,3 +137,5 @@ exports[`GeoSearchControls Control enabled expect to render the toggle unchecked
   </div>
 </div>
 `;
+
+exports[`GeoSearchControls expect to render nothing with refine dsiabled 1`] = `""`;

--- a/src/connectors/geo-search/__tests__/connectGeoSearch-test.js
+++ b/src/connectors/geo-search/__tests__/connectGeoSearch-test.js
@@ -213,7 +213,7 @@ describe('connectGeoSearch', () => {
     );
   });
 
-  it('expect to render with position from the state', () => {
+  it('expect to render with position', () => {
     const render = jest.fn();
     const unmount = jest.fn();
 
@@ -282,60 +282,6 @@ describe('connectGeoSearch', () => {
       }),
       false
     );
-  });
-
-  it('expect to render with insideBoundingBox from the state', () => {
-    const render = jest.fn();
-    const unmount = jest.fn();
-
-    const customGeoSearch = connectGeoSearch(render, unmount);
-    const widget = customGeoSearch();
-    const helper = createFakeHelper({});
-
-    // Simulate the configuration or external setter
-    helper.setQueryParameter('insideBoundingBox', [
-      [
-        48.84174222399724,
-        2.367719162523599,
-        48.81614630305218,
-        2.284205902635904,
-      ],
-    ]);
-
-    widget.init({
-      helper,
-      state: helper.state,
-    });
-
-    expect(render).toHaveBeenCalledTimes(1);
-    expect(lastRenderArgs(render).isRefinedWithMap()).toBe(true);
-
-    widget.render({
-      results: new SearchResults(helper.getState(), [
-        {
-          hits: [],
-        },
-      ]),
-      helper,
-    });
-
-    expect(render).toHaveBeenCalledTimes(2);
-    expect(lastRenderArgs(render).isRefinedWithMap()).toBe(true);
-
-    // Simulate the configuration or external setter
-    helper.setQueryParameter('insideBoundingBox');
-
-    widget.render({
-      results: new SearchResults(helper.getState(), [
-        {
-          hits: [],
-        },
-      ]),
-      helper,
-    });
-
-    expect(render).toHaveBeenCalledTimes(3);
-    expect(lastRenderArgs(render).isRefinedWithMap()).toBe(false);
   });
 
   it('expect to reset the map state when position changed', () => {
@@ -596,6 +542,141 @@ describe('connectGeoSearch', () => {
     expect(render).toHaveBeenCalledTimes(4);
     expect(lastRenderArgs(render).hasMapMoveSinceLastRefine()).toBe(true);
     expect(lastRenderArgs(render).isRefinedWithMap()).toBe(true);
+  });
+
+  describe('currentRefinement', () => {
+    it('expect to render with currentRefinement from a string', () => {
+      const render = jest.fn();
+      const unmount = jest.fn();
+
+      const customGeoSearch = connectGeoSearch(render, unmount);
+      const widget = customGeoSearch();
+      const helper = createFakeHelper({});
+
+      // Simulate the configuration or external setter (like URLSync)
+      helper.setQueryParameter('insideBoundingBox', '10,12,12,14');
+
+      widget.init({
+        helper,
+        state: helper.state,
+      });
+
+      expect(render).toHaveBeenCalledTimes(1);
+      expect(lastRenderArgs(render).isRefinedWithMap()).toBe(true);
+      expect(lastRenderArgs(render).currentRefinement).toEqual({
+        northEast: {
+          lat: 10,
+          lng: 12,
+        },
+        southWest: {
+          lat: 12,
+          lng: 14,
+        },
+      });
+
+      widget.render({
+        results: new SearchResults(helper.getState(), [
+          {
+            hits: [],
+          },
+        ]),
+        helper,
+      });
+
+      expect(render).toHaveBeenCalledTimes(2);
+      expect(lastRenderArgs(render).isRefinedWithMap()).toBe(true);
+      expect(lastRenderArgs(render).currentRefinement).toEqual({
+        northEast: {
+          lat: 10,
+          lng: 12,
+        },
+        southWest: {
+          lat: 12,
+          lng: 14,
+        },
+      });
+
+      // Simulate the configuration or external setter (like URLSync)
+      helper.setQueryParameter('insideBoundingBox');
+
+      widget.render({
+        results: new SearchResults(helper.getState(), [
+          {
+            hits: [],
+          },
+        ]),
+        helper,
+      });
+
+      expect(render).toHaveBeenCalledTimes(3);
+      expect(lastRenderArgs(render).currentRefinement).toBeUndefined();
+    });
+
+    it('expect to render with currentRefinement from an array', () => {
+      const render = jest.fn();
+      const unmount = jest.fn();
+
+      const customGeoSearch = connectGeoSearch(render, unmount);
+      const widget = customGeoSearch();
+      const helper = createFakeHelper({});
+
+      helper.setQueryParameter('insideBoundingBox', [[10, 12, 12, 14]]);
+
+      widget.init({
+        helper,
+        state: helper.state,
+      });
+
+      expect(render).toHaveBeenCalledTimes(1);
+      expect(lastRenderArgs(render).isRefinedWithMap()).toBe(true);
+      expect(lastRenderArgs(render).currentRefinement).toEqual({
+        northEast: {
+          lat: 10,
+          lng: 12,
+        },
+        southWest: {
+          lat: 12,
+          lng: 14,
+        },
+      });
+
+      widget.render({
+        results: new SearchResults(helper.getState(), [
+          {
+            hits: [],
+          },
+        ]),
+        helper,
+      });
+
+      expect(render).toHaveBeenCalledTimes(2);
+      expect(lastRenderArgs(render).isRefinedWithMap()).toBe(true);
+      expect(lastRenderArgs(render).currentRefinement).toEqual({
+        northEast: {
+          lat: 10,
+          lng: 12,
+        },
+        southWest: {
+          lat: 12,
+          lng: 14,
+        },
+      });
+
+      // Simulate the configuration or external setter (like URLSync)
+      helper.setQueryParameter('insideBoundingBox');
+
+      widget.render({
+        results: new SearchResults(helper.getState(), [
+          {
+            hits: [],
+          },
+        ]),
+        helper,
+      });
+
+      expect(render).toHaveBeenCalledTimes(3);
+      expect(lastRenderArgs(render).currentRefinement).toBeUndefined();
+    });
   });
 
   describe('refine', () => {

--- a/src/connectors/geo-search/connectGeoSearch.js
+++ b/src/connectors/geo-search/connectGeoSearch.js
@@ -356,6 +356,37 @@ http://community.algolia.com/instantsearch.js/migration-guide
 
         return state.setQueryParameter('insideBoundingBox');
       },
+
+      getWidgetState(uiState, { searchParameters }) {
+        const boundingBox = searchParameters.insideBoundingBox;
+
+        if (
+          !boundingBox ||
+          (uiState &&
+            uiState.geoSearch &&
+            uiState.geoSearch.boundingBox === boundingBox)
+        ) {
+          return uiState;
+        }
+
+        return {
+          ...uiState,
+          geoSearch: {
+            boundingBox,
+          },
+        };
+      },
+
+      getWidgetSearchParameters(searchParameters, { uiState }) {
+        if (!uiState || !uiState.geoSearch) {
+          return searchParameters.setQueryParameter('insideBoundingBox');
+        }
+
+        return searchParameters.setQueryParameter(
+          'insideBoundingBox',
+          uiState.geoSearch.boundingBox
+        );
+      },
     };
   };
 };

--- a/src/connectors/geo-search/connectGeoSearch.js
+++ b/src/connectors/geo-search/connectGeoSearch.js
@@ -1,9 +1,5 @@
 import noop from 'lodash/noop';
-import {
-  checkRendering,
-  warn,
-  parseAroundLatLngFromString,
-} from '../../lib/utils';
+import { checkRendering, warn, aroundLatLngToPosition } from '../../lib/utils';
 
 const usage = `Usage:
 
@@ -208,7 +204,7 @@ http://community.algolia.com/instantsearch.js/migration-guide
     };
 
     const getPositionFromState = state =>
-      state.aroundLatLng && parseAroundLatLngFromString(state.aroundLatLng);
+      state.aroundLatLng && aroundLatLngToPosition(state.aroundLatLng);
 
     const refine = helper => ({ northEast: ne, southWest: sw }) => {
       const boundingBox = [ne.lat, ne.lng, sw.lat, sw.lng].join();

--- a/src/connectors/geo-search/connectGeoSearch.js
+++ b/src/connectors/geo-search/connectGeoSearch.js
@@ -1,5 +1,10 @@
 import noop from 'lodash/noop';
-import { checkRendering, warn, aroundLatLngToPosition } from '../../lib/utils';
+import {
+  checkRendering,
+  warn,
+  aroundLatLngToPosition,
+  insideBoundingBoxToBoundingBox,
+} from '../../lib/utils';
 
 const usage = `Usage:
 
@@ -7,6 +12,7 @@ var customGeoSearch = connectGeoSearch(function render(params, isFirstRendering)
   // params = {
   //   items,
   //   position,
+  //   currentRefinement,
   //   refine,
   //   clearMapRefinement,
   //   isRefinedWithMap,
@@ -51,6 +57,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
 /**
  * @typedef {Object} GeoSearchRenderingOptions
  * @property {Object[]} items The matched hits from Algolia API.
+ * @property {Bounds} currentRefinement The current bounding box of the search.
  * @property {function(Bounds)} refine Sets a bounding box to filter the results from the given map bounds.
  * @property {function()} clearMapRefinement Reset the current bounding box refinement.
  * @property {function(): boolean} isRefinedWithMap Return true if the current refinement is set with the map bounds.
@@ -206,6 +213,10 @@ http://community.algolia.com/instantsearch.js/migration-guide
     const getPositionFromState = state =>
       state.aroundLatLng && aroundLatLngToPosition(state.aroundLatLng);
 
+    const getCurrentRefinementFromState = state =>
+      state.insideBoundingBox &&
+      insideBoundingBoxToBoundingBox(state.insideBoundingBox);
+
     const refine = helper => ({ northEast: ne, southWest: sw }) => {
       const boundingBox = [ne.lat, ne.lng, sw.lat, sw.lng].join();
 
@@ -265,6 +276,7 @@ http://community.algolia.com/instantsearch.js/migration-guide
         {
           items: [],
           position: getPositionFromState(state),
+          currentRefinement: getCurrentRefinementFromState(state),
           refine: refine(helper),
           clearMapRefinement: clearMapRefinement(helper),
           isRefinedWithMap: isRefinedWithMap(state),
@@ -319,6 +331,7 @@ http://community.algolia.com/instantsearch.js/migration-guide
         {
           items,
           position: getPositionFromState(state),
+          currentRefinement: getCurrentRefinementFromState(state),
           refine: refine(helper),
           clearMapRefinement: clearMapRefinement(helper),
           isRefinedWithMap: isRefinedWithMap(state),

--- a/src/connectors/geo-search/connectGeoSearch.js
+++ b/src/connectors/geo-search/connectGeoSearch.js
@@ -57,6 +57,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
 /**
  * @typedef {Object} GeoSearchRenderingOptions
  * @property {Object[]} items The matched hits from Algolia API.
+ * @property {LatLng} position The current position of the search.
  * @property {Bounds} currentRefinement The current bounding box of the search.
  * @property {function(Bounds)} refine Sets a bounding box to filter the results from the given map bounds.
  * @property {function()} clearMapRefinement Reset the current bounding box refinement.

--- a/src/lib/__tests__/utils-test.js
+++ b/src/lib/__tests__/utils-test.js
@@ -931,7 +931,7 @@ describe('utils.warn', () => {
   });
 });
 
-describe('utils.parseAroundLatLngFromString', () => {
+describe('utils.aroundLatLngToPosition', () => {
   it('expect to return a LatLng object from string', () => {
     const samples = [
       { input: '10,12', expectation: { lat: 10, lng: 12 } },
@@ -941,7 +941,7 @@ describe('utils.parseAroundLatLngFromString', () => {
     ];
 
     samples.forEach(({ input, expectation }) => {
-      expect(utils.parseAroundLatLngFromString(input)).toEqual(expectation);
+      expect(utils.aroundLatLngToPosition(input)).toEqual(expectation);
     });
   });
 
@@ -949,7 +949,7 @@ describe('utils.parseAroundLatLngFromString', () => {
     const samples = [{ input: '10a,12' }, { input: '10.    12' }];
 
     samples.forEach(({ input }) => {
-      expect(() => utils.parseAroundLatLngFromString(input)).toThrow();
+      expect(() => utils.aroundLatLngToPosition(input)).toThrow();
     });
   });
 });

--- a/src/lib/__tests__/utils-test.js
+++ b/src/lib/__tests__/utils-test.js
@@ -954,6 +954,71 @@ describe('utils.aroundLatLngToPosition', () => {
   });
 });
 
+describe('utils.insideBoundingBoxToBoundingBox', () => {
+  it.each([
+    [
+      '10,12,12,14',
+      {
+        northEast: { lat: 10, lng: 12 },
+        southWest: { lat: 12, lng: 14 },
+      },
+    ],
+    [
+      '10,   12    ,12      ,    14',
+      {
+        northEast: { lat: 10, lng: 12 },
+        southWest: { lat: 12, lng: 14 },
+      },
+    ],
+    [
+      '10.15,12.15,12.15,14.15',
+      {
+        northEast: { lat: 10.15, lng: 12.15 },
+        southWest: { lat: 12.15, lng: 14.15 },
+      },
+    ],
+  ])(
+    'expect to return a BoundingBox from a string: %j',
+    (input, expectation) => {
+      expect(utils.insideBoundingBoxToBoundingBox(input)).toEqual(expectation);
+    }
+  );
+
+  it.each([
+    [
+      [[10, 12, 12, 14]],
+      {
+        northEast: { lat: 10, lng: 12 },
+        southWest: { lat: 12, lng: 14 },
+      },
+    ],
+    [
+      [[10.15, 12.15, 12.15, 14.15]],
+      {
+        northEast: { lat: 10.15, lng: 12.15 },
+        southWest: { lat: 12.15, lng: 14.15 },
+      },
+    ],
+  ])(
+    'expect to return a BoundingBox from an array: %j',
+    (input, expectation) => {
+      expect(utils.insideBoundingBoxToBoundingBox(input)).toEqual(expectation);
+    }
+  );
+
+  it.each([
+    [''],
+    ['10'],
+    ['10,12'],
+    ['10,12,12'],
+    ['10.  15,12,12'],
+    [[[]]],
+    [[]],
+  ])('expect to throw an error with: %j', input => {
+    expect(() => utils.insideBoundingBoxToBoundingBox(input)).toThrow();
+  });
+});
+
 describe('utils.clearRefinements', () => {
   const initHelperWithRefinements = () => {
     const helper = algoliasearchHelper({}, 'index', {

--- a/src/lib/__tests__/utils-test.js
+++ b/src/lib/__tests__/utils-test.js
@@ -932,26 +932,21 @@ describe('utils.warn', () => {
 });
 
 describe('utils.aroundLatLngToPosition', () => {
-  it('expect to return a LatLng object from string', () => {
-    const samples = [
-      { input: '10,12', expectation: { lat: 10, lng: 12 } },
-      { input: '10,    12', expectation: { lat: 10, lng: 12 } },
-      { input: '10.15,12', expectation: { lat: 10.15, lng: 12 } },
-      { input: '10,12.15', expectation: { lat: 10, lng: 12.15 } },
-    ];
-
-    samples.forEach(({ input, expectation }) => {
-      expect(utils.aroundLatLngToPosition(input)).toEqual(expectation);
-    });
+  it.each([
+    ['10,12', { lat: 10, lng: 12 }],
+    ['10,    12', { lat: 10, lng: 12 }],
+    ['10.15,12', { lat: 10.15, lng: 12 }],
+    ['10,12.15', { lat: 10, lng: 12.15 }],
+  ])('expect to return a Position from a string: %j', (input, expectation) => {
+    expect(utils.aroundLatLngToPosition(input)).toEqual(expectation);
   });
 
-  it('expect to throw an error when the parsing fail', () => {
-    const samples = [{ input: '10a,12' }, { input: '10.    12' }];
-
-    samples.forEach(({ input }) => {
+  it.each([['10a,12'], ['10.    12']])(
+    'expect to throw an error with: %j',
+    input => {
       expect(() => utils.aroundLatLngToPosition(input)).toThrow();
-    });
-  });
+    }
+  );
 });
 
 describe('utils.insideBoundingBoxToBoundingBox', () => {

--- a/src/lib/__tests__/utils-test.js
+++ b/src/lib/__tests__/utils-test.js
@@ -944,7 +944,9 @@ describe('utils.aroundLatLngToPosition', () => {
   it.each([['10a,12'], ['10.    12']])(
     'expect to throw an error with: %j',
     input => {
-      expect(() => utils.aroundLatLngToPosition(input)).toThrow();
+      expect(() => utils.aroundLatLngToPosition(input)).toThrowError(
+        `Invalid value for "aroundLatLng" parameter: "${input}"`
+      );
     }
   );
 });
@@ -1001,16 +1003,19 @@ describe('utils.insideBoundingBoxToBoundingBox', () => {
     }
   );
 
-  it.each([
-    [''],
-    ['10'],
-    ['10,12'],
-    ['10,12,12'],
-    ['10.  15,12,12'],
-    [[[]]],
-    [[]],
-  ])('expect to throw an error with: %j', input => {
-    expect(() => utils.insideBoundingBoxToBoundingBox(input)).toThrow();
+  it.each([[''], ['10'], ['10,12'], ['10,12,12'], ['10.  15,12,12']])(
+    'expect to throw an error with: %j',
+    input => {
+      expect(() => utils.insideBoundingBoxToBoundingBox(input)).toThrowError(
+        `Invalid value for "insideBoundingBox" parameter: "${input}"`
+      );
+    }
+  );
+
+  it.each([[[]], [[[]]]])('expect to throw an error with: %j', input => {
+    expect(() => utils.insideBoundingBoxToBoundingBox(input)).toThrowError(
+      `Invalid value for "insideBoundingBox" parameter: [${input}]`
+    );
   });
 });
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -26,7 +26,7 @@ export {
   isReactElement,
   deprecate,
   warn,
-  parseAroundLatLngFromString,
+  aroundLatLngToPosition,
 };
 
 /**
@@ -433,7 +433,7 @@ function warn(message) {
 }
 
 const latLngRegExp = /^(-?\d+(?:\.\d+)?),\s*(-?\d+(?:\.\d+)?)$/;
-function parseAroundLatLngFromString(value) {
+function aroundLatLngToPosition(value) {
   const pattern = value.match(latLngRegExp);
 
   // Since the value provided is the one send with the query, the API should

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -437,8 +437,8 @@ const latLngRegExp = /^(-?\d+(?:\.\d+)?),\s*(-?\d+(?:\.\d+)?)$/;
 function aroundLatLngToPosition(value) {
   const pattern = value.match(latLngRegExp);
 
-  // Since the value provided is the one send with the query, the API should
-  // throw an error due to the wrong format. So throw an error should be safe..
+  // Since the value provided is the one send with the request, the API should
+  // throw an error due to the wrong format. So throw an error should be safe.
   if (!pattern) {
     throw new Error(`Invalid value for "aroundLatLng" parameter: "${value}"`);
   }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -27,6 +27,7 @@ export {
   deprecate,
   warn,
   aroundLatLngToPosition,
+  insideBoundingBoxToBoundingBox,
 };
 
 /**
@@ -446,4 +447,58 @@ function aroundLatLngToPosition(value) {
     lat: parseFloat(pattern[1]),
     lng: parseFloat(pattern[2]),
   };
+}
+
+function insideBoundingBoxArrayToBoundingBox(value) {
+  const [[neLat, neLng, swLat, swLng] = []] = value;
+
+  // Since the value provided is the one send with the request, the API should
+  // throw an error due to the wrong format. So throw an error should be safe.
+  if (!neLat || !neLng || !swLat || !swLng) {
+    throw new Error(
+      `Invalid value for "insideBoundingBox" parameter: [${value}]`
+    );
+  }
+
+  return {
+    northEast: {
+      lat: neLat,
+      lng: neLng,
+    },
+    southWest: {
+      lat: swLat,
+      lng: swLng,
+    },
+  };
+}
+
+function insideBoundingBoxStringToBoundingBox(value) {
+  const [neLat, neLng, swLat, swLng] = value.split(',').map(parseFloat);
+
+  // Since the value provided is the one send with the request, the API should
+  // throw an error due to the wrong format. So throw an error should be safe.
+  if (!neLat || !neLng || !swLat || !swLng) {
+    throw new Error(
+      `Invalid value for "insideBoundingBox" parameter: "${value}"`
+    );
+  }
+
+  return {
+    northEast: {
+      lat: neLat,
+      lng: neLng,
+    },
+    southWest: {
+      lat: swLat,
+      lng: swLng,
+    },
+  };
+}
+
+function insideBoundingBoxToBoundingBox(value) {
+  if (Array.isArray(value)) {
+    return insideBoundingBoxArrayToBoundingBox(value);
+  }
+
+  return insideBoundingBoxStringToBoundingBox(value);
 }

--- a/src/widgets/geo-search/GeoSearchRenderer.js
+++ b/src/widgets/geo-search/GeoSearchRenderer.js
@@ -26,10 +26,29 @@ const collectMarkersForNextRender = (markers, nextIds) =>
     [[], []]
   );
 
+const createBoundingBoxFromMarkers = (google, markers) => {
+  const latLngBounds = markers.reduce(
+    (acc, marker) => acc.extend(marker.getPosition()),
+    new google.maps.LatLngBounds()
+  );
+
+  return {
+    northEast: latLngBounds.getNorthEast().toJSON(),
+    southWest: latLngBounds.getSouthWest().toJSON(),
+  };
+};
+
+const lockUserInteraction = (renderState, functionThatAltersTheMapPosition) => {
+  renderState.isUserInteraction = false;
+  functionThatAltersTheMapPosition();
+  renderState.isUserInteraction = true;
+};
+
 const renderer = (
   {
     items,
     position,
+    currentRefinement,
     refine,
     clearMapRefinement,
     toggleRefineOnMapMove,
@@ -49,6 +68,7 @@ const renderer = (
     templates,
     initialZoom,
     initialPosition,
+    enableRefine,
     enableClearMapRefinement,
     enableRefineControl,
     mapOptions,
@@ -87,7 +107,7 @@ const renderer = (
 
     const setupListenersWhenMapIsReady = () => {
       const onChange = () => {
-        if (renderState.isUserInteraction) {
+        if (renderState.isUserInteraction && enableRefine) {
           setMapMoveSinceLastRefine();
 
           if (isRefineOnMapMove()) {
@@ -124,15 +144,6 @@ const renderer = (
     });
 
     return;
-  }
-
-  if (!items.length && !isRefinedWithMap() && !hasMapMoveSinceLastRefine()) {
-    const initialMapPosition = position || initialPosition;
-
-    renderState.isUserInteraction = false;
-    renderState.mapInstance.setCenter(initialMapPosition);
-    renderState.mapInstance.setZoom(initialZoom);
-    renderState.isUserInteraction = true;
   }
 
   // Collect markers that need to be updated or removed
@@ -174,29 +185,40 @@ const renderer = (
     })
   );
 
-  // Fit the map to the markers when needed
-  const hasMarkers = renderState.markers.length;
-  const center = renderState.mapInstance.getCenter();
-  const zoom = renderState.mapInstance.getZoom();
-  const isPositionInitialize = center !== undefined && zoom !== undefined;
-  const enableFitBounds =
-    !hasMapMoveSinceLastRefine() &&
-    (!isRefinedWithMap() || (isRefinedWithMap() && !isPositionInitialize));
+  const shouldUpdate = !hasMapMoveSinceLastRefine();
 
-  if (hasMarkers && enableFitBounds) {
-    const bounds = renderState.markers.reduce(
-      (acc, marker) => acc.extend(marker.getPosition()),
-      new googleReference.maps.LatLngBounds()
-    );
+  // We use this value for differentiate the padding to apply during
+  // fitBounds. When we don't have a currenRefinement (boundingBox)
+  // we let Google Maps compute the automatic padding. But when we
+  // provide the currentRefinement we explicitly set the padding
+  // to `0` otherwise the map will decrease the zoom on each refine.
+  const boundingBoxPadding = currentRefinement ? 0 : null;
+  const boundingBox =
+    !currentRefinement && Boolean(renderState.markers.length)
+      ? createBoundingBoxFromMarkers(googleReference, renderState.markers)
+      : currentRefinement;
 
-    renderState.isUserInteraction = false;
-    renderState.mapInstance.fitBounds(bounds);
-    renderState.isUserInteraction = true;
+  if (boundingBox && shouldUpdate) {
+    lockUserInteraction(renderState, () => {
+      renderState.mapInstance.fitBounds(
+        new googleReference.maps.LatLngBounds(
+          boundingBox.southWest,
+          boundingBox.northEast
+        ),
+        boundingBoxPadding
+      );
+    });
+  } else if (shouldUpdate) {
+    lockUserInteraction(renderState, () => {
+      renderState.mapInstance.setCenter(position || initialPosition);
+      renderState.mapInstance.setZoom(initialZoom);
+    });
   }
 
   render(
     <GeoSearchControls
       cssClasses={cssClasses}
+      enableRefine={enableRefine}
       enableRefineControl={enableRefineControl}
       enableClearMapRefinement={enableClearMapRefinement}
       isRefineOnMapMove={isRefineOnMapMove()}

--- a/src/widgets/geo-search/__tests__/__snapshots__/geo-search-test.js.snap
+++ b/src/widgets/geo-search/__tests__/__snapshots__/geo-search-test.js.snap
@@ -1,52 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`GeoSearch expect to render with custom classNames 1`] = `"<div class=\\"ais-geo-search custom-root\\"><div class=\\"ais-geo-search--map custom-map\\"></div><div class=\\"ais-geo-search--controls custom-controls\\"></div></div>"`;
-
-exports[`GeoSearch expect to render with custom classNames 2`] = `
-Array [
-  <GeoSearchControls
-    cssClasses={
-      Object {
-        "clear": "ais-geo-search--clear custom-clear",
-        "control": "ais-geo-search--control custom-control",
-        "controls": "ais-geo-search--controls custom-controls",
-        "map": "ais-geo-search--map custom-map",
-        "redo": "ais-geo-search--redo custom-redo",
-        "root": "ais-geo-search custom-root",
-        "toggleInput": "ais-geo-search--toggle-input custom-toggleInput",
-        "toggleLabel": "ais-geo-search--toggle-label custom-toggleLabel",
-        "toggleLabelActive": "ais-geo-search--toggle-label-active",
-      }
-    }
-    enableClearMapRefinement={true}
-    enableRefineControl={true}
-    hasMapMoveSinceLastRefine={false}
-    isRefineOnMapMove={true}
-    isRefinedWithMap={false}
-    onClearClick={[Function]}
-    onRefineClick={[Function]}
-    onRefineToggle={[Function]}
-    templateProps={
-      Object {
-        "templates": Object {
-          "clear": "Clear the map refinement",
-          "redo": "Redo search here",
-          "toggle": "Search as I move the map",
-        },
-        "templatesConfig": undefined,
-        "transformData": undefined,
-        "useCustomCompileOptions": Object {
-          "clear": true,
-          "redo": true,
-          "toggle": true,
-        },
-      }
-    }
-  />,
-  null,
-]
-`;
-
 exports[`GeoSearch expect to render 1`] = `"<div class=\\"ais-geo-search\\"><div class=\\"ais-geo-search--map\\"></div><div class=\\"ais-geo-search--controls\\"></div></div>"`;
 
 exports[`GeoSearch expect to render 2`] = `
@@ -66,6 +19,7 @@ Array [
       }
     }
     enableClearMapRefinement={true}
+    enableRefine={true}
     enableRefineControl={true}
     hasMapMoveSinceLastRefine={false}
     isRefineOnMapMove={true}
@@ -93,5 +47,53 @@ Array [
   <div
     class="ais-geo-search--controls"
   />,
+]
+`;
+
+exports[`GeoSearch expect to render with custom classNames 1`] = `"<div class=\\"ais-geo-search custom-root\\"><div class=\\"ais-geo-search--map custom-map\\"></div><div class=\\"ais-geo-search--controls custom-controls\\"></div></div>"`;
+
+exports[`GeoSearch expect to render with custom classNames 2`] = `
+Array [
+  <GeoSearchControls
+    cssClasses={
+      Object {
+        "clear": "ais-geo-search--clear custom-clear",
+        "control": "ais-geo-search--control custom-control",
+        "controls": "ais-geo-search--controls custom-controls",
+        "map": "ais-geo-search--map custom-map",
+        "redo": "ais-geo-search--redo custom-redo",
+        "root": "ais-geo-search custom-root",
+        "toggleInput": "ais-geo-search--toggle-input custom-toggleInput",
+        "toggleLabel": "ais-geo-search--toggle-label custom-toggleLabel",
+        "toggleLabelActive": "ais-geo-search--toggle-label-active",
+      }
+    }
+    enableClearMapRefinement={true}
+    enableRefine={true}
+    enableRefineControl={true}
+    hasMapMoveSinceLastRefine={false}
+    isRefineOnMapMove={true}
+    isRefinedWithMap={false}
+    onClearClick={[Function]}
+    onRefineClick={[Function]}
+    onRefineToggle={[Function]}
+    templateProps={
+      Object {
+        "templates": Object {
+          "clear": "Clear the map refinement",
+          "redo": "Redo search here",
+          "toggle": "Search as I move the map",
+        },
+        "templatesConfig": undefined,
+        "transformData": undefined,
+        "useCustomCompileOptions": Object {
+          "clear": true,
+          "redo": true,
+          "toggle": true,
+        },
+      }
+    }
+  />,
+  null,
 ]
 `;

--- a/src/widgets/geo-search/__tests__/geo-search-test.js
+++ b/src/widgets/geo-search/__tests__/geo-search-test.js
@@ -58,8 +58,22 @@ describe('GeoSearch', () => {
   } = {}) => ({
     maps: {
       LatLng: jest.fn(),
-      LatLngBounds: jest.fn(() => ({
+      LatLngBounds: jest.fn((southWest, northEast) => ({
+        northEast,
+        southWest,
         extend: jest.fn().mockReturnThis(),
+        getNorthEast: jest.fn(() => ({
+          toJSON: jest.fn(() => ({
+            lat: 10,
+            lng: 12,
+          })),
+        })),
+        getSouthWest: jest.fn(() => ({
+          toJSON: jest.fn(() => ({
+            lat: 12,
+            lng: 14,
+          })),
+        })),
       })),
       Map: jest.fn(() => mapInstance),
       Marker: jest.fn(args => ({
@@ -646,232 +660,45 @@ describe('GeoSearch', () => {
         );
         expect(lastRenderState(renderer).isPendingRefine).toBe(false);
       });
-    });
-  });
 
-  describe('initial position', () => {
-    it('expect to init the position from "initialPosition"', () => {
-      const container = createContainer();
-      const instantSearchInstance = createFakeInstantSearch();
-      const helper = createFakeHelper();
-      const mapInstance = createFakeMapInstance();
-      const googleReference = createFakeGoogleReference({ mapInstance });
+      it(`expect to listen for "${eventName}" and do not trigger when refine is disabled`, () => {
+        const container = createContainer();
+        const instantSearchInstance = createFakeInstantSearch();
+        const helper = createFakeHelper();
+        const mapInstance = createFakeMapInstance();
+        const googleReference = createFakeGoogleReference({ mapInstance });
 
-      const widget = geoSearch({
-        googleReference,
-        container,
-        initialZoom: 8,
-        initialPosition: {
-          lat: 10,
-          lng: 12,
-        },
+        const widget = geoSearch({
+          googleReference,
+          container,
+          enableRefine: false,
+        });
+
+        widget.init({
+          helper,
+          instantSearchInstance,
+          state: helper.state,
+        });
+
+        simulateMapReadyEvent(googleReference);
+
+        expect(mapInstance.addListener).toHaveBeenCalledWith(
+          eventName,
+          expect.any(Function)
+        );
+
+        expect(lastRenderArgs(renderer).hasMapMoveSinceLastRefine()).toBe(
+          false
+        );
+        expect(lastRenderState(renderer).isPendingRefine).toBe(false);
+
+        simulateEvent(mapInstance, eventName);
+
+        expect(lastRenderArgs(renderer).hasMapMoveSinceLastRefine()).toBe(
+          false
+        );
+        expect(lastRenderState(renderer).isPendingRefine).toBe(false);
       });
-
-      widget.init({
-        helper,
-        instantSearchInstance,
-        state: helper.state,
-      });
-
-      expect(mapInstance.setCenter).not.toHaveBeenCalled();
-      expect(mapInstance.setZoom).not.toHaveBeenCalled();
-
-      widget.render({
-        helper,
-        instantSearchInstance,
-        results: {
-          hits: [],
-        },
-      });
-
-      expect(mapInstance.setCenter).toHaveBeenCalledWith({ lat: 10, lng: 12 });
-      expect(mapInstance.setZoom).toHaveBeenCalledWith(8);
-    });
-
-    it('expect to init the position from "position"', () => {
-      const container = createContainer();
-      const instantSearchInstance = createFakeInstantSearch();
-      const helper = createFakeHelper();
-      const mapInstance = createFakeMapInstance();
-      const googleReference = createFakeGoogleReference({ mapInstance });
-
-      const widget = geoSearch({
-        googleReference,
-        container,
-        initialZoom: 8,
-        initialPosition: {
-          lat: 10,
-          lng: 12,
-        },
-      });
-
-      // Simulate the configuration for the position
-      helper.setState({ aroundLatLng: '12, 14' });
-
-      widget.init({
-        helper,
-        instantSearchInstance,
-        state: helper.state,
-      });
-
-      expect(mapInstance.setCenter).not.toHaveBeenCalled();
-      expect(mapInstance.setZoom).not.toHaveBeenCalled();
-
-      widget.render({
-        helper,
-        instantSearchInstance,
-        results: {
-          hits: [],
-        },
-      });
-
-      expect(mapInstance.setCenter).toHaveBeenCalledWith({ lat: 12, lng: 14 });
-      expect(mapInstance.setZoom).toHaveBeenCalledWith(8);
-    });
-
-    it('expect to not init the position when items are available', () => {
-      const container = createContainer();
-      const instantSearchInstance = createFakeInstantSearch();
-      const helper = createFakeHelper();
-      const mapInstance = createFakeMapInstance();
-      const googleReference = createFakeGoogleReference({ mapInstance });
-
-      const widget = geoSearch({
-        googleReference,
-        container,
-        initialZoom: 8,
-        initialPosition: {
-          lat: 10,
-          lng: 12,
-        },
-      });
-
-      widget.init({
-        helper,
-        instantSearchInstance,
-        state: helper.state,
-      });
-
-      expect(mapInstance.setCenter).not.toHaveBeenCalled();
-      expect(mapInstance.setZoom).not.toHaveBeenCalled();
-
-      widget.render({
-        helper,
-        instantSearchInstance,
-        results: {
-          hits: [{ objectID: 123, _geoloc: true }],
-        },
-      });
-
-      expect(mapInstance.setCenter).not.toHaveBeenCalled();
-      expect(mapInstance.setZoom).not.toHaveBeenCalled();
-    });
-
-    it('expect to not init the position when the refinement is from the map', () => {
-      const container = createContainer();
-      const instantSearchInstance = createFakeInstantSearch();
-      const helper = createFakeHelper();
-      const mapInstance = createFakeMapInstance();
-      const googleReference = createFakeGoogleReference({ mapInstance });
-
-      const widget = geoSearch({
-        googleReference,
-        container,
-        initialZoom: 8,
-        initialPosition: {
-          lat: 10,
-          lng: 12,
-        },
-      });
-
-      widget.init({
-        helper,
-        instantSearchInstance,
-        state: helper.state,
-      });
-
-      simulateMapReadyEvent(googleReference);
-
-      expect(mapInstance.setCenter).not.toHaveBeenCalled();
-      expect(mapInstance.setZoom).not.toHaveBeenCalled();
-
-      widget.render({
-        helper,
-        instantSearchInstance,
-        results: {
-          hits: [{ objectID: 123, _geoloc: true }],
-        },
-      });
-
-      // Simulate a refinement
-      simulateEvent(mapInstance, 'dragstart');
-      simulateEvent(mapInstance, 'center_changed');
-      simulateEvent(mapInstance, 'idle');
-
-      widget.render({
-        helper,
-        instantSearchInstance,
-        results: {
-          hits: [],
-        },
-      });
-
-      expect(mapInstance.setCenter).not.toHaveBeenCalled();
-      expect(mapInstance.setZoom).not.toHaveBeenCalled();
-    });
-
-    it('expect to not init the position when the map has moved', () => {
-      const container = createContainer();
-      const instantSearchInstance = createFakeInstantSearch();
-      const helper = createFakeHelper();
-      const mapInstance = createFakeMapInstance();
-      const googleReference = createFakeGoogleReference({ mapInstance });
-
-      const widget = geoSearch({
-        googleReference,
-        container,
-        enableRefineOnMapMove: false,
-        initialZoom: 8,
-        initialPosition: {
-          lat: 10,
-          lng: 12,
-        },
-      });
-
-      widget.init({
-        helper,
-        instantSearchInstance,
-        state: helper.state,
-      });
-
-      simulateMapReadyEvent(googleReference);
-
-      expect(mapInstance.setCenter).not.toHaveBeenCalled();
-      expect(mapInstance.setZoom).not.toHaveBeenCalled();
-
-      widget.render({
-        helper,
-        instantSearchInstance,
-        results: {
-          hits: [{ objectID: 123, _geoloc: true }],
-        },
-      });
-
-      // Simulate a refinement
-      simulateEvent(mapInstance, 'dragstart');
-      simulateEvent(mapInstance, 'center_changed');
-      simulateEvent(mapInstance, 'idle');
-
-      widget.render({
-        helper,
-        instantSearchInstance,
-        results: {
-          hits: [],
-        },
-      });
-
-      expect(mapInstance.setCenter).not.toHaveBeenCalled();
-      expect(mapInstance.setZoom).not.toHaveBeenCalled();
     });
   });
 
@@ -1397,8 +1224,8 @@ describe('GeoSearch', () => {
     });
   });
 
-  describe('fit markers position', () => {
-    it('expect to set the position', () => {
+  describe('update map position', () => {
+    it('expect to update the map position from the markers boundingBox', () => {
       const container = createContainer();
       const instantSearchInstance = createFakeInstantSearch();
       const helper = createFakeHelper();
@@ -1425,6 +1252,13 @@ describe('GeoSearch', () => {
       });
 
       expect(mapInstance.fitBounds).toHaveBeenCalledTimes(1);
+      expect(mapInstance.fitBounds).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          northEast: { lat: 10, lng: 12 },
+          southWest: { lat: 12, lng: 14 },
+        }),
+        null
+      );
       expect(renderer).toHaveBeenCalledTimes(2);
 
       widget.render({
@@ -1439,30 +1273,129 @@ describe('GeoSearch', () => {
       });
 
       expect(mapInstance.fitBounds).toHaveBeenCalledTimes(2);
+      expect(mapInstance.fitBounds).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          northEast: { lat: 10, lng: 12 },
+          southWest: { lat: 12, lng: 14 },
+        }),
+        null
+      );
       expect(renderer).toHaveBeenCalledTimes(3);
     });
 
-    it("expect to set the position when it's refine with the map and the map is not render", () => {
+    it('expect to update the map position from the current refinement boundingBox', () => {
       const container = createContainer();
       const instantSearchInstance = createFakeInstantSearch();
       const helper = createFakeHelper();
       const mapInstance = createFakeMapInstance();
       const googleReference = createFakeGoogleReference({ mapInstance });
 
+      mapInstance.getBounds.mockImplementation(() => ({
+        getNorthEast: jest.fn(() => ({
+          toJSON: jest.fn(() => ({
+            lat: 12,
+            lng: 14,
+          })),
+        })),
+        getSouthWest: jest.fn(() => ({
+          toJSON: jest.fn(() => ({
+            lat: 14,
+            lng: 16,
+          })),
+        })),
+      }));
+
       const widget = geoSearch({
         googleReference,
         container,
       });
 
-      // Simulate external setter or URLSync
-      helper.setQueryParameter('insideBoundingBox', [
-        [
-          48.84174222399724,
-          2.367719162523599,
-          48.81614630305218,
-          2.284205902635904,
-        ],
-      ]);
+      widget.init({
+        helper,
+        instantSearchInstance,
+        state: helper.state,
+      });
+
+      simulateMapReadyEvent(googleReference);
+
+      widget.render({
+        helper,
+        instantSearchInstance,
+        results: {
+          hits: [{ objectID: 123, _geoloc: true }],
+        },
+      });
+
+      expect(lastRenderArgs(renderer).hasMapMoveSinceLastRefine()).toBe(false);
+      expect(lastRenderArgs(renderer).isRefinedWithMap()).toBe(false);
+      expect(mapInstance.fitBounds).toHaveBeenCalledTimes(1);
+      expect(mapInstance.fitBounds).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          northEast: { lat: 10, lng: 12 },
+          southWest: { lat: 12, lng: 14 },
+        }),
+        null
+      );
+      expect(renderer).toHaveBeenCalledTimes(2);
+
+      // Simulate user interactions
+      simulateEvent(mapInstance, 'dragstart');
+      simulateEvent(mapInstance, 'center_changed');
+
+      expect(lastRenderArgs(renderer).isRefinedWithMap()).toBe(false);
+      expect(mapInstance.fitBounds).toHaveBeenCalledTimes(1);
+      expect(mapInstance.fitBounds).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          northEast: { lat: 10, lng: 12 },
+          southWest: { lat: 12, lng: 14 },
+        }),
+        null
+      );
+      expect(renderer).toHaveBeenCalledTimes(3);
+
+      // Simulate refine
+      simulateEvent(mapInstance, 'idle');
+
+      widget.render({
+        helper,
+        instantSearchInstance,
+        results: {
+          hits: [
+            { objectID: 123, _geoloc: true },
+            { objectID: 456, _geoloc: true },
+          ],
+        },
+      });
+
+      expect(lastRenderArgs(renderer).isRefinedWithMap()).toBe(true);
+      expect(mapInstance.fitBounds).toHaveBeenCalledTimes(2);
+      expect(mapInstance.fitBounds).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          northEast: { lat: 12, lng: 14 },
+          southWest: { lat: 14, lng: 16 },
+        }),
+        0
+      );
+      expect(renderer).toHaveBeenCalledTimes(4);
+    });
+
+    it('expect to update the map position from the initial current refinement boundingBox', () => {
+      const container = createContainer();
+      const instantSearchInstance = createFakeInstantSearch();
+      const helper = createFakeHelper();
+      const mapInstance = createFakeMapInstance();
+      const googleReference = createFakeGoogleReference({ mapInstance });
+
+      // Simulate the current refinement
+      helper.setQueryParameter(
+        'insideBoundingBox',
+        '48.84174222399724, 2.367719162523599, 48.81614630305218, 2.284205902635904'
+      );
+
+      const widget = geoSearch({
+        googleReference,
+        container,
+      });
 
       widget.init({
         helper,
@@ -1478,15 +1411,15 @@ describe('GeoSearch', () => {
         },
       });
 
-      // Simulate map setter
-      mapInstance.getZoom.mockImplementation(() => 12);
-      mapInstance.getCenter.mockImplementation(() => ({
-        lat: 10,
-        lng: 12,
-      }));
-
       expect(lastRenderArgs(renderer).isRefinedWithMap()).toBe(true);
       expect(mapInstance.fitBounds).toHaveBeenCalledTimes(1);
+      expect(mapInstance.fitBounds).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          northEast: { lat: 48.84174222399724, lng: 2.367719162523599 },
+          southWest: { lat: 48.81614630305218, lng: 2.284205902635904 },
+        }),
+        0
+      );
       expect(renderer).toHaveBeenCalledTimes(2);
 
       widget.render({
@@ -1501,11 +1434,18 @@ describe('GeoSearch', () => {
       });
 
       expect(lastRenderArgs(renderer).isRefinedWithMap()).toBe(true);
-      expect(mapInstance.fitBounds).toHaveBeenCalledTimes(1);
+      expect(mapInstance.fitBounds).toHaveBeenCalledTimes(2);
+      expect(mapInstance.fitBounds).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          northEast: { lat: 48.84174222399724, lng: 2.367719162523599 },
+          southWest: { lat: 48.81614630305218, lng: 2.284205902635904 },
+        }),
+        0
+      );
       expect(renderer).toHaveBeenCalledTimes(3);
     });
 
-    it('expect to not set the position when there is no markers', () => {
+    it('expect to update the map position from the initial position & zoom without a boundingBox', () => {
       const container = createContainer();
       const instantSearchInstance = createFakeInstantSearch();
       const helper = createFakeHelper();
@@ -1532,6 +1472,9 @@ describe('GeoSearch', () => {
       });
 
       expect(mapInstance.fitBounds).toHaveBeenCalledTimes(1);
+      expect(mapInstance.setZoom).toHaveBeenCalledTimes(0);
+      expect(mapInstance.setCenter).toHaveBeenCalledTimes(0);
+
       expect(renderer).toHaveBeenCalledTimes(2);
 
       widget.render({
@@ -1543,15 +1486,28 @@ describe('GeoSearch', () => {
       });
 
       expect(mapInstance.fitBounds).toHaveBeenCalledTimes(1);
+
+      expect(mapInstance.setZoom).toHaveBeenCalledTimes(1);
+      expect(mapInstance.setZoom).toHaveBeenLastCalledWith(1);
+
+      expect(mapInstance.setCenter).toHaveBeenCalledTimes(1);
+      expect(mapInstance.setCenter).toHaveBeenLastCalledWith({
+        lat: 0,
+        lng: 0,
+      });
+
       expect(renderer).toHaveBeenCalledTimes(3);
     });
 
-    it('expect to not set the position when the map has move since last refine', () => {
+    it('expect to update the map position from the position & zoom without a boundingBox', () => {
       const container = createContainer();
       const instantSearchInstance = createFakeInstantSearch();
       const helper = createFakeHelper();
       const mapInstance = createFakeMapInstance();
       const googleReference = createFakeGoogleReference({ mapInstance });
+
+      // Simulate the position
+      helper.setQueryParameter('aroundLatLng', '10, 12');
 
       const widget = geoSearch({
         googleReference,
@@ -1564,8 +1520,6 @@ describe('GeoSearch', () => {
         state: helper.state,
       });
 
-      simulateMapReadyEvent(googleReference);
-
       widget.render({
         helper,
         instantSearchInstance,
@@ -1574,79 +1528,76 @@ describe('GeoSearch', () => {
         },
       });
 
-      expect(lastRenderArgs(renderer).hasMapMoveSinceLastRefine()).toBe(false);
       expect(mapInstance.fitBounds).toHaveBeenCalledTimes(1);
+      expect(mapInstance.setZoom).toHaveBeenCalledTimes(0);
+      expect(mapInstance.setCenter).toHaveBeenCalledTimes(0);
       expect(renderer).toHaveBeenCalledTimes(2);
 
-      simulateEvent(mapInstance, 'center_changed');
-
-      expect(lastRenderArgs(renderer).hasMapMoveSinceLastRefine()).toBe(true);
-      expect(mapInstance.fitBounds).toHaveBeenCalledTimes(1);
-      expect(renderer).toHaveBeenCalledTimes(3);
-    });
-
-    it("expect to not set the position when it's refine with the map and the map is already render", () => {
-      const container = createContainer();
-      const instantSearchInstance = createFakeInstantSearch();
-      const helper = createFakeHelper();
-      const mapInstance = createFakeMapInstance();
-      const googleReference = createFakeGoogleReference({ mapInstance });
-
-      const widget = geoSearch({
-        googleReference,
-        container,
-      });
-
-      widget.init({
-        helper,
-        instantSearchInstance,
-        state: helper.state,
-      });
-
-      simulateMapReadyEvent(googleReference);
-
       widget.render({
         helper,
         instantSearchInstance,
         results: {
-          hits: [{ objectID: 123, _geoloc: true }],
+          hits: [],
         },
       });
 
-      // Simulate map setter
-      mapInstance.getZoom.mockImplementation(() => 12);
-      mapInstance.getCenter.mockImplementation(() => ({
+      expect(mapInstance.fitBounds).toHaveBeenCalledTimes(1);
+
+      expect(mapInstance.setZoom).toHaveBeenCalledTimes(1);
+      expect(mapInstance.setZoom).toHaveBeenLastCalledWith(1);
+
+      expect(mapInstance.setCenter).toHaveBeenCalledTimes(1);
+      expect(mapInstance.setCenter).toHaveBeenLastCalledWith({
         lat: 10,
         lng: 12,
-      }));
+      });
+
+      expect(renderer).toHaveBeenCalledTimes(3);
+    });
+
+    it('expect to not update the map when it has moved since last refine', () => {
+      const container = createContainer();
+      const instantSearchInstance = createFakeInstantSearch();
+      const helper = createFakeHelper();
+      const mapInstance = createFakeMapInstance();
+      const googleReference = createFakeGoogleReference({ mapInstance });
+
+      const widget = geoSearch({
+        googleReference,
+        container,
+      });
+
+      widget.init({
+        helper,
+        instantSearchInstance,
+        state: helper.state,
+      });
+
+      simulateMapReadyEvent(googleReference);
+
+      widget.render({
+        helper,
+        instantSearchInstance,
+        results: {
+          hits: [{ objectID: 123, _geoloc: true }],
+        },
+      });
 
       expect(lastRenderArgs(renderer).hasMapMoveSinceLastRefine()).toBe(false);
-      expect(lastRenderArgs(renderer).isRefinedWithMap()).toBe(false);
       expect(mapInstance.fitBounds).toHaveBeenCalledTimes(1);
+      expect(mapInstance.setZoom).not.toHaveBeenCalled();
+      expect(mapInstance.setCenter).not.toHaveBeenCalled();
       expect(renderer).toHaveBeenCalledTimes(2);
 
+      // Simulate user interaction
       simulateEvent(mapInstance, 'dragstart');
       simulateEvent(mapInstance, 'center_changed');
 
       expect(lastRenderArgs(renderer).hasMapMoveSinceLastRefine()).toBe(true);
-      expect(lastRenderArgs(renderer).isRefinedWithMap()).toBe(false);
       expect(mapInstance.fitBounds).toHaveBeenCalledTimes(1);
+      expect(mapInstance.setZoom).not.toHaveBeenCalled();
+      expect(mapInstance.setCenter).not.toHaveBeenCalled();
       expect(renderer).toHaveBeenCalledTimes(3);
-
-      simulateEvent(mapInstance, 'idle');
-
-      widget.render({
-        helper,
-        instantSearchInstance,
-        results: {
-          hits: [{ objectID: 123, _geoloc: true }],
-        },
-      });
-
-      expect(lastRenderArgs(renderer).hasMapMoveSinceLastRefine()).toBe(false);
-      expect(lastRenderArgs(renderer).isRefinedWithMap()).toBe(true);
-      expect(mapInstance.fitBounds).toHaveBeenCalledTimes(1);
-      expect(renderer).toHaveBeenCalledTimes(4);
     });
   });
 });

--- a/src/widgets/geo-search/__tests__/geo-search-test.js
+++ b/src/widgets/geo-search/__tests__/geo-search-test.js
@@ -31,10 +31,16 @@ describe('GeoSearch', () => {
     setZoom: jest.fn(),
     getBounds: jest.fn(() => ({
       getNorthEast: jest.fn(() => ({
-        toJSON: jest.fn(() => ({})),
+        toJSON: jest.fn(() => ({
+          lat: 10,
+          lng: 12,
+        })),
       })),
       getSouthWest: jest.fn(() => ({
-        toJSON: jest.fn(() => ({})),
+        toJSON: jest.fn(() => ({
+          lat: 12,
+          lng: 14,
+        })),
       })),
     })),
     fitBounds: jest.fn(),

--- a/src/widgets/geo-search/geo-search.js
+++ b/src/widgets/geo-search/geo-search.js
@@ -21,6 +21,7 @@ geoSearch({
   [ mapOptions ],
   [ builtInMarker ],
   [ customHTMLMarker = false ],
+  [ enableRefine = true ],
   [ enableClearMapRefinement = true ],
   [ enableRefineControl = true ],
   [ enableRefineOnMapMove = true ],
@@ -87,6 +88,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  * See [the documentation](https://developers.google.com/maps/documentation/javascript/reference/3/#MapOptions) for more information.
  * @property {BuiltInMarkerOptions} [builtInMarker] Options for customize the built-in Google Maps marker. This option is ignored when the `customHTMLMarker` is provided.
  * @property {CustomHTMLMarkerOptions|boolean} [customHTMLMarker=false] Options for customize the HTML marker. We provide an alternative to the built-in Google Maps marker in order to have a full control of the marker rendering. You can use plain HTML to build your marker.
+ * @property {boolean} [enableRefine=true] If true, the map is used to search - otherwise it's for display purposes only.
  * @property {boolean} [enableClearMapRefinement=true] If true, a button is displayed on the map when the refinement is coming from the map in order to remove it.
  * @property {boolean} [enableRefineControl=true] If true, the user can toggle the option `enableRefineOnMapMove` directly from the map.
  * @property {boolean} [enableRefineOnMapMove=true] If true, refine will be triggered as you move the map.
@@ -124,6 +126,7 @@ const geoSearch = ({
   cssClasses: userCssClasses = {},
   builtInMarker: userBuiltInMarker = {},
   customHTMLMarker: userCustomHTMLMarker = false,
+  enableRefine = true,
   enableClearMapRefinement = true,
   enableRefineControl = true,
   container,
@@ -235,6 +238,7 @@ const geoSearch = ({
       cssClasses,
       createMarker,
       markerOptions,
+      enableRefine,
       enableClearMapRefinement,
       enableRefineControl,
     });


### PR DESCRIPTION
**Summary**

This PR implement the support of `currentRefinement` in the geo-search connector. We now provide the current bounding box to the render function. We can leverage this information to implement a map widget that is "controlled" (i.e. almost always rely on the bounding box to set the map position).