### PR TITLE
refactor(geo): implement controlled map [PART-4]

### DIFF
--- a/dev/app/builtin/stories/geo-search.stories.js
+++ b/dev/app/builtin/stories/geo-search.stories.js
@@ -150,7 +150,7 @@ export default () => {
 
   // Only UI
   Stories.add(
-    'with control & refine on map move',
+    'with refine disabled',
     wrapWithHitsAndConfiguration((container, start) =>
       injectGoogleMaps(() => {
         container.style.height = '600px';
@@ -167,8 +167,7 @@ export default () => {
             container,
             initialPosition,
             initialZoom,
-            enableRefineControl: true,
-            enableRefineOnMapMove: true,
+            enableRefine: false,
           })
         );
 
@@ -176,6 +175,33 @@ export default () => {
       })
     )
   )
+    .add(
+      'with control & refine on map move',
+      wrapWithHitsAndConfiguration((container, start) =>
+        injectGoogleMaps(() => {
+          container.style.height = '600px';
+
+          window.search.addWidget(
+            instantsearch.widgets.configure({
+              aroundLatLngViaIP: true,
+            })
+          );
+
+          window.search.addWidget(
+            instantsearch.widgets.geoSearch({
+              googleReference: window.google,
+              container,
+              initialPosition,
+              initialZoom,
+              enableRefineControl: true,
+              enableRefineOnMapMove: true,
+            })
+          );
+
+          start();
+        })
+      )
+    )
     .add(
       'with control & disable refine on map move',
       wrapWithHitsAndConfiguration((container, start) =>

--- a/dev/app/builtin/stories/geo-search.stories.js
+++ b/dev/app/builtin/stories/geo-search.stories.js
@@ -20,7 +20,7 @@ const wrapWithHitsAndConfiguration = (story, searchParameters) =>
 
 const injectGoogleMaps = fn => {
   injectScript(
-    `https://maps.googleapis.com/maps/api/js?v=3.31&key=${API_KEY}`,
+    `https://maps.googleapis.com/maps/api/js?v=weekly&key=${API_KEY}`,
     fn
   );
 };

--- a/dev/app/builtin/stories/geo-search.stories.js
+++ b/dev/app/builtin/stories/geo-search.stories.js
@@ -13,7 +13,7 @@ const wrapWithHitsAndConfiguration = (story, searchParameters) =>
   wrapWithHits(story, {
     indexName: 'airbnb',
     searchParameters: {
-      hitsPerPage: 25,
+      hitsPerPage: 20,
       ...searchParameters,
     },
   });

--- a/src/components/GeoSearchControls/GeoSearchControls.js
+++ b/src/components/GeoSearchControls/GeoSearchControls.js
@@ -7,6 +7,7 @@ import GeoSearchToggle from './GeoSearchToggle';
 
 const GeoSearchControls = ({
   cssClasses,
+  enableRefine,
   enableRefineControl,
   enableClearMapRefinement,
   isRefineOnMapMove,
@@ -16,67 +17,72 @@ const GeoSearchControls = ({
   onRefineClick,
   onClearClick,
   templateProps,
-}) => (
-  <div>
-    {enableRefineControl && (
-      <div className={cssClasses.control}>
-        {isRefineOnMapMove || !hasMapMoveSinceLastRefine ? (
-          <GeoSearchToggle
-            classNameLabel={cx(
-              cssClasses.toggleLabel,
-              isRefineOnMapMove && cssClasses.toggleLabelActive
-            )}
-            classNameInput={cssClasses.toggleInput}
-            checked={isRefineOnMapMove}
-            onToggle={onRefineToggle}
-          >
+}) =>
+  enableRefine && (
+    <div>
+      {enableRefineControl && (
+        <div className={cssClasses.control}>
+          {isRefineOnMapMove || !hasMapMoveSinceLastRefine ? (
+            <GeoSearchToggle
+              classNameLabel={cx(
+                cssClasses.toggleLabel,
+                isRefineOnMapMove && cssClasses.toggleLabelActive
+              )}
+              classNameInput={cssClasses.toggleInput}
+              checked={isRefineOnMapMove}
+              onToggle={onRefineToggle}
+            >
+              <Template
+                {...templateProps}
+                templateKey="toggle"
+                rootTagName="span"
+              />
+            </GeoSearchToggle>
+          ) : (
+            <GeoSearchButton
+              className={cssClasses.redo}
+              disabled={!hasMapMoveSinceLastRefine}
+              onClick={onRefineClick}
+            >
+              <Template
+                {...templateProps}
+                templateKey="redo"
+                rootTagName="span"
+              />
+            </GeoSearchButton>
+          )}
+        </div>
+      )}
+
+      {!enableRefineControl &&
+        !isRefineOnMapMove && (
+          <div className={cssClasses.control}>
+            <GeoSearchButton
+              className={cssClasses.redo}
+              disabled={!hasMapMoveSinceLastRefine}
+              onClick={onRefineClick}
+            >
+              <Template
+                {...templateProps}
+                templateKey="redo"
+                rootTagName="span"
+              />
+            </GeoSearchButton>
+          </div>
+        )}
+
+      {enableClearMapRefinement &&
+        isRefinedWithMap && (
+          <GeoSearchButton className={cssClasses.clear} onClick={onClearClick}>
             <Template
               {...templateProps}
-              templateKey="toggle"
-              rootTagName="span"
-            />
-          </GeoSearchToggle>
-        ) : (
-          <GeoSearchButton
-            className={cssClasses.redo}
-            disabled={!hasMapMoveSinceLastRefine}
-            onClick={onRefineClick}
-          >
-            <Template
-              {...templateProps}
-              templateKey="redo"
+              templateKey="clear"
               rootTagName="span"
             />
           </GeoSearchButton>
         )}
-      </div>
-    )}
-
-    {!enableRefineControl &&
-      !isRefineOnMapMove && (
-        <div className={cssClasses.control}>
-          <GeoSearchButton
-            className={cssClasses.redo}
-            disabled={!hasMapMoveSinceLastRefine}
-            onClick={onRefineClick}
-          >
-            <Template
-              {...templateProps}
-              templateKey="redo"
-              rootTagName="span"
-            />
-          </GeoSearchButton>
-        </div>
-      )}
-
-    {enableClearMapRefinement &&
-      isRefinedWithMap && (
-        <GeoSearchButton className={cssClasses.clear} onClick={onClearClick}>
-          <Template {...templateProps} templateKey="clear" rootTagName="span" />
-        </GeoSearchButton>
-      )}
-  </div>
-);
+    </div>
+  );
 
 const CSSClassesPropTypes = PropTypes.shape({
   control: PropTypes.string.isRequired,
@@ -89,6 +95,7 @@ const CSSClassesPropTypes = PropTypes.shape({
 
 GeoSearchControls.propTypes = {
   cssClasses: CSSClassesPropTypes.isRequired,
+  enableRefine: PropTypes.bool.isRequired,
   enableRefineControl: PropTypes.bool.isRequired,
   enableClearMapRefinement: PropTypes.bool.isRequired,
   isRefineOnMapMove: PropTypes.bool.isRequired,

--- a/src/components/GeoSearchControls/__tests__/GeoSearchControls-test.js
+++ b/src/components/GeoSearchControls/__tests__/GeoSearchControls-test.js
@@ -16,6 +16,7 @@ describe('GeoSearchControls', () => {
     cssClasses: CSSClassesDefaultProps,
     enableRefineControl: true,
     enableClearMapRefinement: true,
+    enableRefine: true,
     isRefineOnMapMove: true,
     isRefinedWithMap: false,
     hasMapMoveSinceLastRefine: false,
@@ -24,6 +25,17 @@ describe('GeoSearchControls', () => {
     onClearClick: () => {},
     templateProps: {},
   };
+
+  it('expect to render nothing with refine dsiabled', () => {
+    const props = {
+      ...defaultProps,
+      enableRefine: false,
+    };
+
+    const wrapper = shallow(<GeoSearchControls {...props} />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
 
   describe('Control enabled', () => {
     it('expect to render the toggle checked when refine on map move is enabled', () => {

--- a/src/components/GeoSearchControls/__tests__/__snapshots__/GeoSearchControls-test.js.snap
+++ b/src/components/GeoSearchControls/__tests__/__snapshots__/GeoSearchControls-test.js.snap
@@ -137,3 +137,5 @@ exports[`GeoSearchControls Control enabled expect to render the toggle unchecked
   </div>
 </div>
 `;
+
+exports[`GeoSearchControls expect to render nothing with refine dsiabled 1`] = `""`;

--- a/src/connectors/geo-search/connectGeoSearch.js
+++ b/src/connectors/geo-search/connectGeoSearch.js
@@ -356,6 +356,37 @@ http://community.algolia.com/instantsearch.js/migration-guide
 
         return state.setQueryParameter('insideBoundingBox');
       },
+
+      getWidgetState(uiState, { searchParameters }) {
+        const boundingBox = searchParameters.insideBoundingBox;
+
+        if (
+          !boundingBox ||
+          (uiState &&
+            uiState.geoSearch &&
+            uiState.geoSearch.boundingBox === boundingBox)
+        ) {
+          return uiState;
+        }
+
+        return {
+          ...uiState,
+          geoSearch: {
+            boundingBox,
+          },
+        };
+      },
+
+      getWidgetSearchParameters(searchParameters, { uiState }) {
+        if (!uiState || !uiState.geoSearch) {
+          return searchParameters.setQueryParameter('insideBoundingBox');
+        }
+
+        return searchParameters.setQueryParameter(
+          'insideBoundingBox',
+          uiState.geoSearch.boundingBox
+        );
+      },
     };
   };
 };

--- a/src/widgets/geo-search/GeoSearchRenderer.js
+++ b/src/widgets/geo-search/GeoSearchRenderer.js
@@ -68,6 +68,7 @@ const renderer = (
     templates,
     initialZoom,
     initialPosition,
+    enableRefine,
     enableClearMapRefinement,
     enableRefineControl,
     mapOptions,
@@ -106,7 +107,7 @@ const renderer = (
 
     const setupListenersWhenMapIsReady = () => {
       const onChange = () => {
-        if (renderState.isUserInteraction) {
+        if (renderState.isUserInteraction && enableRefine) {
           setMapMoveSinceLastRefine();
 
           if (isRefineOnMapMove()) {
@@ -217,6 +218,7 @@ const renderer = (
   render(
     <GeoSearchControls
       cssClasses={cssClasses}
+      enableRefine={enableRefine}
       enableRefineControl={enableRefineControl}
       enableClearMapRefinement={enableClearMapRefinement}
       isRefineOnMapMove={isRefineOnMapMove()}

--- a/src/widgets/geo-search/GeoSearchRenderer.js
+++ b/src/widgets/geo-search/GeoSearchRenderer.js
@@ -38,6 +38,12 @@ const createBoundingBoxFromMarkers = (google, markers) => {
   };
 };
 
+const lockUserInteraction = (renderState, functionThatAltersTheMapPosition) => {
+  renderState.isUserInteraction = false;
+  functionThatAltersTheMapPosition();
+  renderState.isUserInteraction = true;
+};
+
 const renderer = (
   {
     items,
@@ -192,20 +198,20 @@ const renderer = (
       : currentRefinement;
 
   if (boundingBox && shouldUpdate) {
-    renderState.isUserInteraction = false;
-    renderState.mapInstance.fitBounds(
-      new googleReference.maps.LatLngBounds(
-        boundingBox.southWest,
-        boundingBox.northEast
-      ),
-      boundingBoxPadding
-    );
-    renderState.isUserInteraction = true;
+    lockUserInteraction(renderState, () => {
+      renderState.mapInstance.fitBounds(
+        new googleReference.maps.LatLngBounds(
+          boundingBox.southWest,
+          boundingBox.northEast
+        ),
+        boundingBoxPadding
+      );
+    });
   } else if (shouldUpdate) {
-    renderState.isUserInteraction = false;
-    renderState.mapInstance.setCenter(position || initialPosition);
-    renderState.mapInstance.setZoom(initialZoom);
-    renderState.isUserInteraction = true;
+    lockUserInteraction(renderState, () => {
+      renderState.mapInstance.setCenter(position || initialPosition);
+      renderState.mapInstance.setZoom(initialZoom);
+    });
   }
 
   render(

--- a/src/widgets/geo-search/__tests__/__snapshots__/geo-search-test.js.snap
+++ b/src/widgets/geo-search/__tests__/__snapshots__/geo-search-test.js.snap
@@ -1,52 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`GeoSearch expect to render with custom classNames 1`] = `"<div class=\\"ais-geo-search custom-root\\"><div class=\\"ais-geo-search--map custom-map\\"></div><div class=\\"ais-geo-search--controls custom-controls\\"></div></div>"`;
-
-exports[`GeoSearch expect to render with custom classNames 2`] = `
-Array [
-  <GeoSearchControls
-    cssClasses={
-      Object {
-        "clear": "ais-geo-search--clear custom-clear",
-        "control": "ais-geo-search--control custom-control",
-        "controls": "ais-geo-search--controls custom-controls",
-        "map": "ais-geo-search--map custom-map",
-        "redo": "ais-geo-search--redo custom-redo",
-        "root": "ais-geo-search custom-root",
-        "toggleInput": "ais-geo-search--toggle-input custom-toggleInput",
-        "toggleLabel": "ais-geo-search--toggle-label custom-toggleLabel",
-        "toggleLabelActive": "ais-geo-search--toggle-label-active",
-      }
-    }
-    enableClearMapRefinement={true}
-    enableRefineControl={true}
-    hasMapMoveSinceLastRefine={false}
-    isRefineOnMapMove={true}
-    isRefinedWithMap={false}
-    onClearClick={[Function]}
-    onRefineClick={[Function]}
-    onRefineToggle={[Function]}
-    templateProps={
-      Object {
-        "templates": Object {
-          "clear": "Clear the map refinement",
-          "redo": "Redo search here",
-          "toggle": "Search as I move the map",
-        },
-        "templatesConfig": undefined,
-        "transformData": undefined,
-        "useCustomCompileOptions": Object {
-          "clear": true,
-          "redo": true,
-          "toggle": true,
-        },
-      }
-    }
-  />,
-  null,
-]
-`;
-
 exports[`GeoSearch expect to render 1`] = `"<div class=\\"ais-geo-search\\"><div class=\\"ais-geo-search--map\\"></div><div class=\\"ais-geo-search--controls\\"></div></div>"`;
 
 exports[`GeoSearch expect to render 2`] = `
@@ -66,6 +19,7 @@ Array [
       }
     }
     enableClearMapRefinement={true}
+    enableRefine={true}
     enableRefineControl={true}
     hasMapMoveSinceLastRefine={false}
     isRefineOnMapMove={true}
@@ -93,5 +47,53 @@ Array [
   <div
     class="ais-geo-search--controls"
   />,
+]
+`;
+
+exports[`GeoSearch expect to render with custom classNames 1`] = `"<div class=\\"ais-geo-search custom-root\\"><div class=\\"ais-geo-search--map custom-map\\"></div><div class=\\"ais-geo-search--controls custom-controls\\"></div></div>"`;
+
+exports[`GeoSearch expect to render with custom classNames 2`] = `
+Array [
+  <GeoSearchControls
+    cssClasses={
+      Object {
+        "clear": "ais-geo-search--clear custom-clear",
+        "control": "ais-geo-search--control custom-control",
+        "controls": "ais-geo-search--controls custom-controls",
+        "map": "ais-geo-search--map custom-map",
+        "redo": "ais-geo-search--redo custom-redo",
+        "root": "ais-geo-search custom-root",
+        "toggleInput": "ais-geo-search--toggle-input custom-toggleInput",
+        "toggleLabel": "ais-geo-search--toggle-label custom-toggleLabel",
+        "toggleLabelActive": "ais-geo-search--toggle-label-active",
+      }
+    }
+    enableClearMapRefinement={true}
+    enableRefine={true}
+    enableRefineControl={true}
+    hasMapMoveSinceLastRefine={false}
+    isRefineOnMapMove={true}
+    isRefinedWithMap={false}
+    onClearClick={[Function]}
+    onRefineClick={[Function]}
+    onRefineToggle={[Function]}
+    templateProps={
+      Object {
+        "templates": Object {
+          "clear": "Clear the map refinement",
+          "redo": "Redo search here",
+          "toggle": "Search as I move the map",
+        },
+        "templatesConfig": undefined,
+        "transformData": undefined,
+        "useCustomCompileOptions": Object {
+          "clear": true,
+          "redo": true,
+          "toggle": true,
+        },
+      }
+    }
+  />,
+  null,
 ]
 `;

--- a/src/widgets/geo-search/__tests__/geo-search-test.js
+++ b/src/widgets/geo-search/__tests__/geo-search-test.js
@@ -58,8 +58,22 @@ describe('GeoSearch', () => {
   } = {}) => ({
     maps: {
       LatLng: jest.fn(),
-      LatLngBounds: jest.fn(() => ({
+      LatLngBounds: jest.fn((southWest, northEast) => ({
+        northEast,
+        southWest,
         extend: jest.fn().mockReturnThis(),
+        getNorthEast: jest.fn(() => ({
+          toJSON: jest.fn(() => ({
+            lat: 10,
+            lng: 12,
+          })),
+        })),
+        getSouthWest: jest.fn(() => ({
+          toJSON: jest.fn(() => ({
+            lat: 12,
+            lng: 14,
+          })),
+        })),
       })),
       Map: jest.fn(() => mapInstance),
       Marker: jest.fn(args => ({
@@ -649,232 +663,6 @@ describe('GeoSearch', () => {
     });
   });
 
-  describe('initial position', () => {
-    it('expect to init the position from "initialPosition"', () => {
-      const container = createContainer();
-      const instantSearchInstance = createFakeInstantSearch();
-      const helper = createFakeHelper();
-      const mapInstance = createFakeMapInstance();
-      const googleReference = createFakeGoogleReference({ mapInstance });
-
-      const widget = geoSearch({
-        googleReference,
-        container,
-        initialZoom: 8,
-        initialPosition: {
-          lat: 10,
-          lng: 12,
-        },
-      });
-
-      widget.init({
-        helper,
-        instantSearchInstance,
-        state: helper.state,
-      });
-
-      expect(mapInstance.setCenter).not.toHaveBeenCalled();
-      expect(mapInstance.setZoom).not.toHaveBeenCalled();
-
-      widget.render({
-        helper,
-        instantSearchInstance,
-        results: {
-          hits: [],
-        },
-      });
-
-      expect(mapInstance.setCenter).toHaveBeenCalledWith({ lat: 10, lng: 12 });
-      expect(mapInstance.setZoom).toHaveBeenCalledWith(8);
-    });
-
-    it('expect to init the position from "position"', () => {
-      const container = createContainer();
-      const instantSearchInstance = createFakeInstantSearch();
-      const helper = createFakeHelper();
-      const mapInstance = createFakeMapInstance();
-      const googleReference = createFakeGoogleReference({ mapInstance });
-
-      const widget = geoSearch({
-        googleReference,
-        container,
-        initialZoom: 8,
-        initialPosition: {
-          lat: 10,
-          lng: 12,
-        },
-      });
-
-      // Simulate the configuration for the position
-      helper.setState({ aroundLatLng: '12, 14' });
-
-      widget.init({
-        helper,
-        instantSearchInstance,
-        state: helper.state,
-      });
-
-      expect(mapInstance.setCenter).not.toHaveBeenCalled();
-      expect(mapInstance.setZoom).not.toHaveBeenCalled();
-
-      widget.render({
-        helper,
-        instantSearchInstance,
-        results: {
-          hits: [],
-        },
-      });
-
-      expect(mapInstance.setCenter).toHaveBeenCalledWith({ lat: 12, lng: 14 });
-      expect(mapInstance.setZoom).toHaveBeenCalledWith(8);
-    });
-
-    it('expect to not init the position when items are available', () => {
-      const container = createContainer();
-      const instantSearchInstance = createFakeInstantSearch();
-      const helper = createFakeHelper();
-      const mapInstance = createFakeMapInstance();
-      const googleReference = createFakeGoogleReference({ mapInstance });
-
-      const widget = geoSearch({
-        googleReference,
-        container,
-        initialZoom: 8,
-        initialPosition: {
-          lat: 10,
-          lng: 12,
-        },
-      });
-
-      widget.init({
-        helper,
-        instantSearchInstance,
-        state: helper.state,
-      });
-
-      expect(mapInstance.setCenter).not.toHaveBeenCalled();
-      expect(mapInstance.setZoom).not.toHaveBeenCalled();
-
-      widget.render({
-        helper,
-        instantSearchInstance,
-        results: {
-          hits: [{ objectID: 123, _geoloc: true }],
-        },
-      });
-
-      expect(mapInstance.setCenter).not.toHaveBeenCalled();
-      expect(mapInstance.setZoom).not.toHaveBeenCalled();
-    });
-
-    it('expect to not init the position when the refinement is from the map', () => {
-      const container = createContainer();
-      const instantSearchInstance = createFakeInstantSearch();
-      const helper = createFakeHelper();
-      const mapInstance = createFakeMapInstance();
-      const googleReference = createFakeGoogleReference({ mapInstance });
-
-      const widget = geoSearch({
-        googleReference,
-        container,
-        initialZoom: 8,
-        initialPosition: {
-          lat: 10,
-          lng: 12,
-        },
-      });
-
-      widget.init({
-        helper,
-        instantSearchInstance,
-        state: helper.state,
-      });
-
-      simulateMapReadyEvent(googleReference);
-
-      expect(mapInstance.setCenter).not.toHaveBeenCalled();
-      expect(mapInstance.setZoom).not.toHaveBeenCalled();
-
-      widget.render({
-        helper,
-        instantSearchInstance,
-        results: {
-          hits: [{ objectID: 123, _geoloc: true }],
-        },
-      });
-
-      // Simulate a refinement
-      simulateEvent(mapInstance, 'dragstart');
-      simulateEvent(mapInstance, 'center_changed');
-      simulateEvent(mapInstance, 'idle');
-
-      widget.render({
-        helper,
-        instantSearchInstance,
-        results: {
-          hits: [],
-        },
-      });
-
-      expect(mapInstance.setCenter).not.toHaveBeenCalled();
-      expect(mapInstance.setZoom).not.toHaveBeenCalled();
-    });
-
-    it('expect to not init the position when the map has moved', () => {
-      const container = createContainer();
-      const instantSearchInstance = createFakeInstantSearch();
-      const helper = createFakeHelper();
-      const mapInstance = createFakeMapInstance();
-      const googleReference = createFakeGoogleReference({ mapInstance });
-
-      const widget = geoSearch({
-        googleReference,
-        container,
-        enableRefineOnMapMove: false,
-        initialZoom: 8,
-        initialPosition: {
-          lat: 10,
-          lng: 12,
-        },
-      });
-
-      widget.init({
-        helper,
-        instantSearchInstance,
-        state: helper.state,
-      });
-
-      simulateMapReadyEvent(googleReference);
-
-      expect(mapInstance.setCenter).not.toHaveBeenCalled();
-      expect(mapInstance.setZoom).not.toHaveBeenCalled();
-
-      widget.render({
-        helper,
-        instantSearchInstance,
-        results: {
-          hits: [{ objectID: 123, _geoloc: true }],
-        },
-      });
-
-      // Simulate a refinement
-      simulateEvent(mapInstance, 'dragstart');
-      simulateEvent(mapInstance, 'center_changed');
-      simulateEvent(mapInstance, 'idle');
-
-      widget.render({
-        helper,
-        instantSearchInstance,
-        results: {
-          hits: [],
-        },
-      });
-
-      expect(mapInstance.setCenter).not.toHaveBeenCalled();
-      expect(mapInstance.setZoom).not.toHaveBeenCalled();
-    });
-  });
-
   describe('markers creation', () => {
     it('expect to render built-in markers with default options', () => {
       const container = createContainer();
@@ -1397,8 +1185,8 @@ describe('GeoSearch', () => {
     });
   });
 
-  describe('fit markers position', () => {
-    it('expect to set the position', () => {
+  describe('update map position', () => {
+    it('expect to update the map position from the markers boundingBox', () => {
       const container = createContainer();
       const instantSearchInstance = createFakeInstantSearch();
       const helper = createFakeHelper();
@@ -1425,6 +1213,13 @@ describe('GeoSearch', () => {
       });
 
       expect(mapInstance.fitBounds).toHaveBeenCalledTimes(1);
+      expect(mapInstance.fitBounds).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          northEast: { lat: 10, lng: 12 },
+          southWest: { lat: 12, lng: 14 },
+        }),
+        null
+      );
       expect(renderer).toHaveBeenCalledTimes(2);
 
       widget.render({
@@ -1439,30 +1234,129 @@ describe('GeoSearch', () => {
       });
 
       expect(mapInstance.fitBounds).toHaveBeenCalledTimes(2);
+      expect(mapInstance.fitBounds).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          northEast: { lat: 10, lng: 12 },
+          southWest: { lat: 12, lng: 14 },
+        }),
+        null
+      );
       expect(renderer).toHaveBeenCalledTimes(3);
     });
 
-    it("expect to set the position when it's refine with the map and the map is not render", () => {
+    it('expect to update the map position from a current refinement boundingBox', () => {
       const container = createContainer();
       const instantSearchInstance = createFakeInstantSearch();
       const helper = createFakeHelper();
       const mapInstance = createFakeMapInstance();
       const googleReference = createFakeGoogleReference({ mapInstance });
 
+      mapInstance.getBounds.mockImplementation(() => ({
+        getNorthEast: jest.fn(() => ({
+          toJSON: jest.fn(() => ({
+            lat: 12,
+            lng: 14,
+          })),
+        })),
+        getSouthWest: jest.fn(() => ({
+          toJSON: jest.fn(() => ({
+            lat: 14,
+            lng: 16,
+          })),
+        })),
+      }));
+
       const widget = geoSearch({
         googleReference,
         container,
       });
 
-      // Simulate external setter or URLSync
-      helper.setQueryParameter('insideBoundingBox', [
-        [
-          48.84174222399724,
-          2.367719162523599,
-          48.81614630305218,
-          2.284205902635904,
-        ],
-      ]);
+      widget.init({
+        helper,
+        instantSearchInstance,
+        state: helper.state,
+      });
+
+      simulateMapReadyEvent(googleReference);
+
+      widget.render({
+        helper,
+        instantSearchInstance,
+        results: {
+          hits: [{ objectID: 123, _geoloc: true }],
+        },
+      });
+
+      expect(lastRenderArgs(renderer).hasMapMoveSinceLastRefine()).toBe(false);
+      expect(lastRenderArgs(renderer).isRefinedWithMap()).toBe(false);
+      expect(mapInstance.fitBounds).toHaveBeenCalledTimes(1);
+      expect(mapInstance.fitBounds).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          northEast: { lat: 10, lng: 12 },
+          southWest: { lat: 12, lng: 14 },
+        }),
+        null
+      );
+      expect(renderer).toHaveBeenCalledTimes(2);
+
+      // Simulate user interactions
+      simulateEvent(mapInstance, 'dragstart');
+      simulateEvent(mapInstance, 'center_changed');
+
+      expect(lastRenderArgs(renderer).isRefinedWithMap()).toBe(false);
+      expect(mapInstance.fitBounds).toHaveBeenCalledTimes(1);
+      expect(mapInstance.fitBounds).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          northEast: { lat: 10, lng: 12 },
+          southWest: { lat: 12, lng: 14 },
+        }),
+        null
+      );
+      expect(renderer).toHaveBeenCalledTimes(3);
+
+      // Simulate refine
+      simulateEvent(mapInstance, 'idle');
+
+      widget.render({
+        helper,
+        instantSearchInstance,
+        results: {
+          hits: [
+            { objectID: 123, _geoloc: true },
+            { objectID: 456, _geoloc: true },
+          ],
+        },
+      });
+
+      expect(lastRenderArgs(renderer).isRefinedWithMap()).toBe(true);
+      expect(mapInstance.fitBounds).toHaveBeenCalledTimes(2);
+      expect(mapInstance.fitBounds).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          northEast: { lat: 12, lng: 14 },
+          southWest: { lat: 14, lng: 16 },
+        }),
+        0
+      );
+      expect(renderer).toHaveBeenCalledTimes(4);
+    });
+
+    it('expect to update the map position from the an initial current refinement boundingBox', () => {
+      const container = createContainer();
+      const instantSearchInstance = createFakeInstantSearch();
+      const helper = createFakeHelper();
+      const mapInstance = createFakeMapInstance();
+      const googleReference = createFakeGoogleReference({ mapInstance });
+
+      // Simulate the current refinement
+      helper.setQueryParameter(
+        'insideBoundingBox',
+        '48.84174222399724, 2.367719162523599, 48.81614630305218, 2.284205902635904'
+      );
+
+      const widget = geoSearch({
+        googleReference,
+        container,
+      });
 
       widget.init({
         helper,
@@ -1478,15 +1372,15 @@ describe('GeoSearch', () => {
         },
       });
 
-      // Simulate map setter
-      mapInstance.getZoom.mockImplementation(() => 12);
-      mapInstance.getCenter.mockImplementation(() => ({
-        lat: 10,
-        lng: 12,
-      }));
-
       expect(lastRenderArgs(renderer).isRefinedWithMap()).toBe(true);
       expect(mapInstance.fitBounds).toHaveBeenCalledTimes(1);
+      expect(mapInstance.fitBounds).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          northEast: { lat: 48.84174222399724, lng: 2.367719162523599 },
+          southWest: { lat: 48.81614630305218, lng: 2.284205902635904 },
+        }),
+        0
+      );
       expect(renderer).toHaveBeenCalledTimes(2);
 
       widget.render({
@@ -1501,11 +1395,18 @@ describe('GeoSearch', () => {
       });
 
       expect(lastRenderArgs(renderer).isRefinedWithMap()).toBe(true);
-      expect(mapInstance.fitBounds).toHaveBeenCalledTimes(1);
+      expect(mapInstance.fitBounds).toHaveBeenCalledTimes(2);
+      expect(mapInstance.fitBounds).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          northEast: { lat: 48.84174222399724, lng: 2.367719162523599 },
+          southWest: { lat: 48.81614630305218, lng: 2.284205902635904 },
+        }),
+        0
+      );
       expect(renderer).toHaveBeenCalledTimes(3);
     });
 
-    it('expect to not set the position when there is no markers', () => {
+    it('expect to update the map position from the initial position & zoom without a boundingBox', () => {
       const container = createContainer();
       const instantSearchInstance = createFakeInstantSearch();
       const helper = createFakeHelper();
@@ -1532,6 +1433,9 @@ describe('GeoSearch', () => {
       });
 
       expect(mapInstance.fitBounds).toHaveBeenCalledTimes(1);
+      expect(mapInstance.setZoom).toHaveBeenCalledTimes(0);
+      expect(mapInstance.setCenter).toHaveBeenCalledTimes(0);
+
       expect(renderer).toHaveBeenCalledTimes(2);
 
       widget.render({
@@ -1543,15 +1447,28 @@ describe('GeoSearch', () => {
       });
 
       expect(mapInstance.fitBounds).toHaveBeenCalledTimes(1);
+
+      expect(mapInstance.setZoom).toHaveBeenCalledTimes(1);
+      expect(mapInstance.setZoom).toHaveBeenLastCalledWith(1);
+
+      expect(mapInstance.setCenter).toHaveBeenCalledTimes(1);
+      expect(mapInstance.setCenter).toHaveBeenLastCalledWith({
+        lat: 0,
+        lng: 0,
+      });
+
       expect(renderer).toHaveBeenCalledTimes(3);
     });
 
-    it('expect to not set the position when the map has move since last refine', () => {
+    it('expect to update the map position from the position & zoom without a boundingBox', () => {
       const container = createContainer();
       const instantSearchInstance = createFakeInstantSearch();
       const helper = createFakeHelper();
       const mapInstance = createFakeMapInstance();
       const googleReference = createFakeGoogleReference({ mapInstance });
+
+      // Simulate the position
+      helper.setQueryParameter('aroundLatLng', '10, 12');
 
       const widget = geoSearch({
         googleReference,
@@ -1564,8 +1481,6 @@ describe('GeoSearch', () => {
         state: helper.state,
       });
 
-      simulateMapReadyEvent(googleReference);
-
       widget.render({
         helper,
         instantSearchInstance,
@@ -1574,79 +1489,76 @@ describe('GeoSearch', () => {
         },
       });
 
-      expect(lastRenderArgs(renderer).hasMapMoveSinceLastRefine()).toBe(false);
       expect(mapInstance.fitBounds).toHaveBeenCalledTimes(1);
+      expect(mapInstance.setZoom).toHaveBeenCalledTimes(0);
+      expect(mapInstance.setCenter).toHaveBeenCalledTimes(0);
       expect(renderer).toHaveBeenCalledTimes(2);
 
-      simulateEvent(mapInstance, 'center_changed');
-
-      expect(lastRenderArgs(renderer).hasMapMoveSinceLastRefine()).toBe(true);
-      expect(mapInstance.fitBounds).toHaveBeenCalledTimes(1);
-      expect(renderer).toHaveBeenCalledTimes(3);
-    });
-
-    it("expect to not set the position when it's refine with the map and the map is already render", () => {
-      const container = createContainer();
-      const instantSearchInstance = createFakeInstantSearch();
-      const helper = createFakeHelper();
-      const mapInstance = createFakeMapInstance();
-      const googleReference = createFakeGoogleReference({ mapInstance });
-
-      const widget = geoSearch({
-        googleReference,
-        container,
-      });
-
-      widget.init({
-        helper,
-        instantSearchInstance,
-        state: helper.state,
-      });
-
-      simulateMapReadyEvent(googleReference);
-
       widget.render({
         helper,
         instantSearchInstance,
         results: {
-          hits: [{ objectID: 123, _geoloc: true }],
+          hits: [],
         },
       });
 
-      // Simulate map setter
-      mapInstance.getZoom.mockImplementation(() => 12);
-      mapInstance.getCenter.mockImplementation(() => ({
+      expect(mapInstance.fitBounds).toHaveBeenCalledTimes(1);
+
+      expect(mapInstance.setZoom).toHaveBeenCalledTimes(1);
+      expect(mapInstance.setZoom).toHaveBeenLastCalledWith(1);
+
+      expect(mapInstance.setCenter).toHaveBeenCalledTimes(1);
+      expect(mapInstance.setCenter).toHaveBeenLastCalledWith({
         lat: 10,
         lng: 12,
-      }));
+      });
+
+      expect(renderer).toHaveBeenCalledTimes(3);
+    });
+
+    it('expect to not update the map when it has moved since last refine', () => {
+      const container = createContainer();
+      const instantSearchInstance = createFakeInstantSearch();
+      const helper = createFakeHelper();
+      const mapInstance = createFakeMapInstance();
+      const googleReference = createFakeGoogleReference({ mapInstance });
+
+      const widget = geoSearch({
+        googleReference,
+        container,
+      });
+
+      widget.init({
+        helper,
+        instantSearchInstance,
+        state: helper.state,
+      });
+
+      simulateMapReadyEvent(googleReference);
+
+      widget.render({
+        helper,
+        instantSearchInstance,
+        results: {
+          hits: [{ objectID: 123, _geoloc: true }],
+        },
+      });
 
       expect(lastRenderArgs(renderer).hasMapMoveSinceLastRefine()).toBe(false);
-      expect(lastRenderArgs(renderer).isRefinedWithMap()).toBe(false);
       expect(mapInstance.fitBounds).toHaveBeenCalledTimes(1);
+      expect(mapInstance.setZoom).not.toHaveBeenCalled();
+      expect(mapInstance.setCenter).not.toHaveBeenCalled();
       expect(renderer).toHaveBeenCalledTimes(2);
 
+      // Simulate user interaction
       simulateEvent(mapInstance, 'dragstart');
       simulateEvent(mapInstance, 'center_changed');
 
       expect(lastRenderArgs(renderer).hasMapMoveSinceLastRefine()).toBe(true);
-      expect(lastRenderArgs(renderer).isRefinedWithMap()).toBe(false);
       expect(mapInstance.fitBounds).toHaveBeenCalledTimes(1);
+      expect(mapInstance.setZoom).not.toHaveBeenCalled();
+      expect(mapInstance.setCenter).not.toHaveBeenCalled();
       expect(renderer).toHaveBeenCalledTimes(3);
-
-      simulateEvent(mapInstance, 'idle');
-
-      widget.render({
-        helper,
-        instantSearchInstance,
-        results: {
-          hits: [{ objectID: 123, _geoloc: true }],
-        },
-      });
-
-      expect(lastRenderArgs(renderer).hasMapMoveSinceLastRefine()).toBe(false);
-      expect(lastRenderArgs(renderer).isRefinedWithMap()).toBe(true);
-      expect(mapInstance.fitBounds).toHaveBeenCalledTimes(1);
-      expect(renderer).toHaveBeenCalledTimes(4);
     });
   });
 });

--- a/src/widgets/geo-search/__tests__/geo-search-test.js
+++ b/src/widgets/geo-search/__tests__/geo-search-test.js
@@ -660,6 +660,45 @@ describe('GeoSearch', () => {
         );
         expect(lastRenderState(renderer).isPendingRefine).toBe(false);
       });
+
+      it(`expect to listen for "${eventName}" and do not trigger when refine is disabled`, () => {
+        const container = createContainer();
+        const instantSearchInstance = createFakeInstantSearch();
+        const helper = createFakeHelper();
+        const mapInstance = createFakeMapInstance();
+        const googleReference = createFakeGoogleReference({ mapInstance });
+
+        const widget = geoSearch({
+          googleReference,
+          container,
+          enableRefine: false,
+        });
+
+        widget.init({
+          helper,
+          instantSearchInstance,
+          state: helper.state,
+        });
+
+        simulateMapReadyEvent(googleReference);
+
+        expect(mapInstance.addListener).toHaveBeenCalledWith(
+          eventName,
+          expect.any(Function)
+        );
+
+        expect(lastRenderArgs(renderer).hasMapMoveSinceLastRefine()).toBe(
+          false
+        );
+        expect(lastRenderState(renderer).isPendingRefine).toBe(false);
+
+        simulateEvent(mapInstance, eventName);
+
+        expect(lastRenderArgs(renderer).hasMapMoveSinceLastRefine()).toBe(
+          false
+        );
+        expect(lastRenderState(renderer).isPendingRefine).toBe(false);
+      });
     });
   });
 
@@ -1244,7 +1283,7 @@ describe('GeoSearch', () => {
       expect(renderer).toHaveBeenCalledTimes(3);
     });
 
-    it('expect to update the map position from a current refinement boundingBox', () => {
+    it('expect to update the map position from the current refinement boundingBox', () => {
       const container = createContainer();
       const instantSearchInstance = createFakeInstantSearch();
       const helper = createFakeHelper();
@@ -1340,7 +1379,7 @@ describe('GeoSearch', () => {
       expect(renderer).toHaveBeenCalledTimes(4);
     });
 
-    it('expect to update the map position from the an initial current refinement boundingBox', () => {
+    it('expect to update the map position from the initial current refinement boundingBox', () => {
       const container = createContainer();
       const instantSearchInstance = createFakeInstantSearch();
       const helper = createFakeHelper();

--- a/src/widgets/geo-search/geo-search.js
+++ b/src/widgets/geo-search/geo-search.js
@@ -21,6 +21,7 @@ geoSearch({
   [ mapOptions ],
   [ builtInMarker ],
   [ customHTMLMarker = false ],
+  [ enableRefine = true ],
   [ enableClearMapRefinement = true ],
   [ enableRefineControl = true ],
   [ enableRefineOnMapMove = true ],
@@ -87,6 +88,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  * See [the documentation](https://developers.google.com/maps/documentation/javascript/reference/3/#MapOptions) for more information.
  * @property {BuiltInMarkerOptions} [builtInMarker] Options for customize the built-in Google Maps marker. This option is ignored when the `customHTMLMarker` is provided.
  * @property {CustomHTMLMarkerOptions|boolean} [customHTMLMarker=false] Options for customize the HTML marker. We provide an alternative to the built-in Google Maps marker in order to have a full control of the marker rendering. You can use plain HTML to build your marker.
+ * @property {boolean} [enableRefine=true] If true, the map is used to search - otherwise it's for display purposes only.
  * @property {boolean} [enableClearMapRefinement=true] If true, a button is displayed on the map when the refinement is coming from the map in order to remove it.
  * @property {boolean} [enableRefineControl=true] If true, the user can toggle the option `enableRefineOnMapMove` directly from the map.
  * @property {boolean} [enableRefineOnMapMove=true] If true, refine will be triggered as you move the map.
@@ -124,6 +126,7 @@ const geoSearch = ({
   cssClasses: userCssClasses = {},
   builtInMarker: userBuiltInMarker = {},
   customHTMLMarker: userCustomHTMLMarker = false,
+  enableRefine = true,
   enableClearMapRefinement = true,
   enableRefineControl = true,
   container,
@@ -235,6 +238,7 @@ const geoSearch = ({
       cssClasses,
       createMarker,
       markerOptions,
+      enableRefine,
       enableClearMapRefinement,
       enableRefineControl,
     });


### PR DESCRIPTION
**Summary**

This PR revamp the GeoSearch renderer to use a "controlled" map. We leverage the provided `currentRefinement` to (almost) always render the map from a bounding box. It simplify a lot the workflow of the widget - we don't rely anymore on complicated conditions to init the position. This refactor also allow us to implement a proper support for the URLSync.