### PR TITLE
refactor(geo): implement routing [PART-5]

### DIFF
--- a/dev/app/builtin/stories/geo-search.stories.js
+++ b/dev/app/builtin/stories/geo-search.stories.js
@@ -150,7 +150,7 @@ export default () => {
 
   // Only UI
   Stories.add(
-    'with control & refine on map move',
+    'with refine disabled',
     wrapWithHitsAndConfiguration((container, start) =>
       injectGoogleMaps(() => {
         container.style.height = '600px';
@@ -167,8 +167,7 @@ export default () => {
             container,
             initialPosition,
             initialZoom,
-            enableRefineControl: true,
-            enableRefineOnMapMove: true,
+            enableRefine: false,
           })
         );
 
@@ -176,6 +175,33 @@ export default () => {
       })
     )
   )
+    .add(
+      'with control & refine on map move',
+      wrapWithHitsAndConfiguration((container, start) =>
+        injectGoogleMaps(() => {
+          container.style.height = '600px';
+
+          window.search.addWidget(
+            instantsearch.widgets.configure({
+              aroundLatLngViaIP: true,
+            })
+          );
+
+          window.search.addWidget(
+            instantsearch.widgets.geoSearch({
+              googleReference: window.google,
+              container,
+              initialPosition,
+              initialZoom,
+              enableRefineControl: true,
+              enableRefineOnMapMove: true,
+            })
+          );
+
+          start();
+        })
+      )
+    )
     .add(
       'with control & disable refine on map move',
       wrapWithHitsAndConfiguration((container, start) =>

--- a/src/components/GeoSearchControls/GeoSearchControls.js
+++ b/src/components/GeoSearchControls/GeoSearchControls.js
@@ -7,6 +7,7 @@ import GeoSearchToggle from './GeoSearchToggle';
 
 const GeoSearchControls = ({
   cssClasses,
+  enableRefine,
   enableRefineControl,
   enableClearMapRefinement,
   isRefineOnMapMove,
@@ -16,67 +17,72 @@ const GeoSearchControls = ({
   onRefineClick,
   onClearClick,
   templateProps,
-}) => (
-  <div>
-    {enableRefineControl && (
-      <div className={cssClasses.control}>
-        {isRefineOnMapMove || !hasMapMoveSinceLastRefine ? (
-          <GeoSearchToggle
-            classNameLabel={cx(
-              cssClasses.toggleLabel,
-              isRefineOnMapMove && cssClasses.toggleLabelActive
-            )}
-            classNameInput={cssClasses.toggleInput}
-            checked={isRefineOnMapMove}
-            onToggle={onRefineToggle}
-          >
+}) =>
+  enableRefine && (
+    <div>
+      {enableRefineControl && (
+        <div className={cssClasses.control}>
+          {isRefineOnMapMove || !hasMapMoveSinceLastRefine ? (
+            <GeoSearchToggle
+              classNameLabel={cx(
+                cssClasses.toggleLabel,
+                isRefineOnMapMove && cssClasses.toggleLabelActive
+              )}
+              classNameInput={cssClasses.toggleInput}
+              checked={isRefineOnMapMove}
+              onToggle={onRefineToggle}
+            >
+              <Template
+                {...templateProps}
+                templateKey="toggle"
+                rootTagName="span"
+              />
+            </GeoSearchToggle>
+          ) : (
+            <GeoSearchButton
+              className={cssClasses.redo}
+              disabled={!hasMapMoveSinceLastRefine}
+              onClick={onRefineClick}
+            >
+              <Template
+                {...templateProps}
+                templateKey="redo"
+                rootTagName="span"
+              />
+            </GeoSearchButton>
+          )}
+        </div>
+      )}
+
+      {!enableRefineControl &&
+        !isRefineOnMapMove && (
+          <div className={cssClasses.control}>
+            <GeoSearchButton
+              className={cssClasses.redo}
+              disabled={!hasMapMoveSinceLastRefine}
+              onClick={onRefineClick}
+            >
+              <Template
+                {...templateProps}
+                templateKey="redo"
+                rootTagName="span"
+              />
+            </GeoSearchButton>
+          </div>
+        )}
+
+      {enableClearMapRefinement &&
+        isRefinedWithMap && (
+          <GeoSearchButton className={cssClasses.clear} onClick={onClearClick}>
             <Template
               {...templateProps}
-              templateKey="toggle"
-              rootTagName="span"
-            />
-          </GeoSearchToggle>
-        ) : (
-          <GeoSearchButton
-            className={cssClasses.redo}
-            disabled={!hasMapMoveSinceLastRefine}
-            onClick={onRefineClick}
-          >
-            <Template
-              {...templateProps}
-              templateKey="redo"
+              templateKey="clear"
               rootTagName="span"
             />
           </GeoSearchButton>
         )}
-      </div>
-    )}
-
-    {!enableRefineControl &&
-      !isRefineOnMapMove && (
-        <div className={cssClasses.control}>
-          <GeoSearchButton
-            className={cssClasses.redo}
-            disabled={!hasMapMoveSinceLastRefine}
-            onClick={onRefineClick}
-          >
-            <Template
-              {...templateProps}
-              templateKey="redo"
-              rootTagName="span"
-            />
-          </GeoSearchButton>
-        </div>
-      )}
-
-    {enableClearMapRefinement &&
-      isRefinedWithMap && (
-        <GeoSearchButton className={cssClasses.clear} onClick={onClearClick}>
-          <Template {...templateProps} templateKey="clear" rootTagName="span" />
-        </GeoSearchButton>
-      )}
-  </div>
-);
+    </div>
+  );
 
 const CSSClassesPropTypes = PropTypes.shape({
   control: PropTypes.string.isRequired,
@@ -89,6 +95,7 @@ const CSSClassesPropTypes = PropTypes.shape({
 
 GeoSearchControls.propTypes = {
   cssClasses: CSSClassesPropTypes.isRequired,
+  enableRefine: PropTypes.bool.isRequired,
   enableRefineControl: PropTypes.bool.isRequired,
   enableClearMapRefinement: PropTypes.bool.isRequired,
   isRefineOnMapMove: PropTypes.bool.isRequired,

--- a/src/components/GeoSearchControls/__tests__/GeoSearchControls-test.js
+++ b/src/components/GeoSearchControls/__tests__/GeoSearchControls-test.js
@@ -16,6 +16,7 @@ describe('GeoSearchControls', () => {
     cssClasses: CSSClassesDefaultProps,
     enableRefineControl: true,
     enableClearMapRefinement: true,
+    enableRefine: true,
     isRefineOnMapMove: true,
     isRefinedWithMap: false,
     hasMapMoveSinceLastRefine: false,
@@ -24,6 +25,17 @@ describe('GeoSearchControls', () => {
     onClearClick: () => {},
     templateProps: {},
   };
+
+  it('expect to render nothing with refine dsiabled', () => {
+    const props = {
+      ...defaultProps,
+      enableRefine: false,
+    };
+
+    const wrapper = shallow(<GeoSearchControls {...props} />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
 
   describe('Control enabled', () => {
     it('expect to render the toggle checked when refine on map move is enabled', () => {

--- a/src/components/GeoSearchControls/__tests__/__snapshots__/GeoSearchControls-test.js.snap
+++ b/src/components/GeoSearchControls/__tests__/__snapshots__/GeoSearchControls-test.js.snap
@@ -137,3 +137,5 @@ exports[`GeoSearchControls Control enabled expect to render the toggle unchecked
   </div>
 </div>
 `;
+
+exports[`GeoSearchControls expect to render nothing with refine dsiabled 1`] = `""`;

--- a/src/connectors/geo-search/__tests__/connectGeoSearch-test.js
+++ b/src/connectors/geo-search/__tests__/connectGeoSearch-test.js
@@ -50,6 +50,7 @@ describe('connectGeoSearch', () => {
       render: expect.any(Function),
       dispose: expect.any(Function),
       getWidgetState: expect.any(Function),
+      getWidgetSearchParameters: expect.any(Function),
     });
   });
 
@@ -1190,6 +1191,73 @@ describe('connectGeoSearch', () => {
       });
 
       expect(uiStateAfter).toBe(uiStateBefore);
+    });
+  });
+
+  describe('getWidgetSearchParameters', () => {
+    it('expect to return the same SearchParameters if the uiState is empty', () => {
+      const [widget, helper] = getInitializedWidget();
+
+      const uiState = {};
+      const searchParametersBefore = SearchParameters.make(helper.state);
+      const searchParametersAfter = widget.getWidgetSearchParameters(
+        searchParametersBefore,
+        { uiState }
+      );
+
+      expect(searchParametersAfter).toBe(searchParametersBefore);
+    });
+
+    it('expect to return the same SearchParameters if the geoSearch attribute is empty', () => {
+      const [widget, helper] = getInitializedWidget();
+
+      const uiState = {
+        geoSearch: {},
+      };
+
+      const searchParametersBefore = SearchParameters.make(helper.state);
+      const searchParametersAfter = widget.getWidgetSearchParameters(
+        searchParametersBefore,
+        { uiState }
+      );
+
+      expect(searchParametersAfter).toBe(searchParametersBefore);
+    });
+
+    it('expect to return the SearchParameters with the boundingBox value from the uiState', () => {
+      const [widget, helper] = getInitializedWidget();
+
+      const uiState = {
+        geoSearch: {
+          boundingBox: '10,12,12,14',
+        },
+      };
+
+      const searchParametersBefore = SearchParameters.make(helper.state);
+      const searchParametersAfter = widget.getWidgetSearchParameters(
+        searchParametersBefore,
+        { uiState }
+      );
+
+      expect(searchParametersAfter.insideBoundingBox).toBe('10,12,12,14');
+    });
+
+    it('expect to remove the boundingBox from the SearchParameters if the value is not in the uiState', () => {
+      const [widget, helper, refine] = getInitializedWidget();
+
+      refine({
+        northEast: { lat: 10, lng: 12 },
+        southWest: { lat: 12, lng: 14 },
+      });
+
+      const uiState = {};
+      const searchParametersBefore = SearchParameters.make(helper.state);
+      const searchParametersAfter = widget.getWidgetSearchParameters(
+        searchParametersBefore,
+        { uiState }
+      );
+
+      expect(searchParametersAfter.insideBoundingBox).toBeUndefined();
     });
   });
 });

--- a/src/connectors/geo-search/__tests__/connectGeoSearch-test.js
+++ b/src/connectors/geo-search/__tests__/connectGeoSearch-test.js
@@ -1,20 +1,43 @@
 import last from 'lodash/last';
 import first from 'lodash/first';
-import algoliasearchHelper, { SearchResults } from 'algoliasearch-helper';
+import algoliasearchHelper, {
+  SearchParameters,
+  SearchResults,
+} from 'algoliasearch-helper';
 import connectGeoSearch from '../connectGeoSearch';
 
-const createFakeHelper = client => {
-  const helper = algoliasearchHelper(client);
-
-  helper.search = jest.fn();
-
-  return helper;
-};
-
-const firstRenderArgs = fn => first(fn.mock.calls)[0];
-const lastRenderArgs = fn => last(fn.mock.calls)[0];
-
 describe('connectGeoSearch', () => {
+  const createFakeHelper = client => {
+    const helper = algoliasearchHelper(client);
+
+    helper.search = jest.fn();
+
+    return helper;
+  };
+
+  const getInitializedWidget = () => {
+    const render = jest.fn();
+    const makeWidget = connectGeoSearch(render);
+
+    const widget = makeWidget();
+
+    const helper = createFakeHelper({});
+
+    widget.init({
+      helper,
+      state: helper.state,
+      createURL: () => '#',
+      onHistoryChange: () => {},
+    });
+
+    const { refine } = render.mock.calls[0][0];
+
+    return [widget, helper, refine];
+  };
+
+  const firstRenderArgs = fn => first(fn.mock.calls)[0];
+  const lastRenderArgs = fn => last(fn.mock.calls)[0];
+
   it('expect to be a widget', () => {
     const render = jest.fn();
     const unmount = jest.fn();
@@ -26,6 +49,7 @@ describe('connectGeoSearch', () => {
       init: expect.any(Function),
       render: expect.any(Function),
       dispose: expect.any(Function),
+      getWidgetState: expect.any(Function),
     });
   });
 
@@ -1107,6 +1131,65 @@ describe('connectGeoSearch', () => {
 
       expect(unmount).toHaveBeenCalled();
       expect(actual).toMatchObject(expectation);
+    });
+  });
+
+  describe('getWidgetState', () => {
+    it('expect to return the uiState unmodified if no boundingBox is selected', () => {
+      const [widget, helper] = getInitializedWidget();
+
+      const uiStateBefore = {};
+      const uiStateAfter = widget.getWidgetState(uiStateBefore, {
+        searchParameters: helper.state,
+        helper,
+      });
+
+      expect(uiStateAfter).toBe(uiStateBefore);
+    });
+
+    it('expect to return the uiState with an entry equal to the boundingBox', () => {
+      const [widget, helper, refine] = getInitializedWidget();
+
+      refine({
+        northEast: { lat: 10, lng: 12 },
+        southWest: { lat: 12, lng: 14 },
+      });
+
+      const uiStateBefore = {};
+      const uiStateAfter = widget.getWidgetState(uiStateBefore, {
+        searchParameters: helper.state,
+        helper,
+      });
+
+      expect(uiStateAfter).toEqual({
+        geoSearch: {
+          boundingBox: '10,12,12,14',
+        },
+      });
+    });
+
+    it('expect to return the same uiState instance if the value is alreay there', () => {
+      const [widget, helper, refine] = getInitializedWidget();
+
+      refine({
+        northEast: { lat: 10, lng: 12 },
+        southWest: { lat: 12, lng: 14 },
+      });
+
+      const uiStateBefore = widget.getWidgetState(
+        {},
+        {
+          searchParameters: helper.state,
+          helper,
+        }
+      );
+
+      const uiStateAfter = widget.getWidgetState(uiStateBefore, {
+        searchParameters: helper.state,
+        helper,
+      });
+
+      expect(uiStateAfter).toBe(uiStateBefore);
     });
   });
 });

--- a/src/connectors/geo-search/connectGeoSearch.js
+++ b/src/connectors/geo-search/connectGeoSearch.js
@@ -356,6 +356,26 @@ http://community.algolia.com/instantsearch.js/migration-guide
 
         return state.setQueryParameter('insideBoundingBox');
       },
+
+      getWidgetState(uiState, { searchParameters }) {
+        const boundingBox = searchParameters.insideBoundingBox;
+
+        if (
+          !boundingBox ||
+          (uiState &&
+            uiState.geoSearch &&
+            uiState.geoSearch.boundingBox === boundingBox)
+        ) {
+          return uiState;
+        }
+
+        return {
+          ...uiState,
+          geoSearch: {
+            boundingBox,
+          },
+        };
+      },
     };
   };
 };

--- a/src/connectors/geo-search/connectGeoSearch.js
+++ b/src/connectors/geo-search/connectGeoSearch.js
@@ -376,6 +376,17 @@ http://community.algolia.com/instantsearch.js/migration-guide
           },
         };
       },
+
+      getWidgetSearchParameters(searchParameters, { uiState }) {
+        if (!uiState || !uiState.geoSearch) {
+          return searchParameters.setQueryParameter('insideBoundingBox');
+        }
+
+        return searchParameters.setQueryParameter(
+          'insideBoundingBox',
+          uiState.geoSearch.boundingBox
+        );
+      },
     };
   };
 };

--- a/src/widgets/geo-search/GeoSearchRenderer.js
+++ b/src/widgets/geo-search/GeoSearchRenderer.js
@@ -68,6 +68,7 @@ const renderer = (
     templates,
     initialZoom,
     initialPosition,
+    enableRefine,
     enableClearMapRefinement,
     enableRefineControl,
     mapOptions,
@@ -106,7 +107,7 @@ const renderer = (
 
     const setupListenersWhenMapIsReady = () => {
       const onChange = () => {
-        if (renderState.isUserInteraction) {
+        if (renderState.isUserInteraction && enableRefine) {
           setMapMoveSinceLastRefine();
 
           if (isRefineOnMapMove()) {
@@ -217,6 +218,7 @@ const renderer = (
   render(
     <GeoSearchControls
       cssClasses={cssClasses}
+      enableRefine={enableRefine}
       enableRefineControl={enableRefineControl}
       enableClearMapRefinement={enableClearMapRefinement}
       isRefineOnMapMove={isRefineOnMapMove()}

--- a/src/widgets/geo-search/__tests__/__snapshots__/geo-search-test.js.snap
+++ b/src/widgets/geo-search/__tests__/__snapshots__/geo-search-test.js.snap
@@ -1,52 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`GeoSearch expect to render with custom classNames 1`] = `"<div class=\\"ais-geo-search custom-root\\"><div class=\\"ais-geo-search--map custom-map\\"></div><div class=\\"ais-geo-search--controls custom-controls\\"></div></div>"`;
-
-exports[`GeoSearch expect to render with custom classNames 2`] = `
-Array [
-  <GeoSearchControls
-    cssClasses={
-      Object {
-        "clear": "ais-geo-search--clear custom-clear",
-        "control": "ais-geo-search--control custom-control",
-        "controls": "ais-geo-search--controls custom-controls",
-        "map": "ais-geo-search--map custom-map",
-        "redo": "ais-geo-search--redo custom-redo",
-        "root": "ais-geo-search custom-root",
-        "toggleInput": "ais-geo-search--toggle-input custom-toggleInput",
-        "toggleLabel": "ais-geo-search--toggle-label custom-toggleLabel",
-        "toggleLabelActive": "ais-geo-search--toggle-label-active",
-      }
-    }
-    enableClearMapRefinement={true}
-    enableRefineControl={true}
-    hasMapMoveSinceLastRefine={false}
-    isRefineOnMapMove={true}
-    isRefinedWithMap={false}
-    onClearClick={[Function]}
-    onRefineClick={[Function]}
-    onRefineToggle={[Function]}
-    templateProps={
-      Object {
-        "templates": Object {
-          "clear": "Clear the map refinement",
-          "redo": "Redo search here",
-          "toggle": "Search as I move the map",
-        },
-        "templatesConfig": undefined,
-        "transformData": undefined,
-        "useCustomCompileOptions": Object {
-          "clear": true,
-          "redo": true,
-          "toggle": true,
-        },
-      }
-    }
-  />,
-  null,
-]
-`;
-
 exports[`GeoSearch expect to render 1`] = `"<div class=\\"ais-geo-search\\"><div class=\\"ais-geo-search--map\\"></div><div class=\\"ais-geo-search--controls\\"></div></div>"`;
 
 exports[`GeoSearch expect to render 2`] = `
@@ -66,6 +19,7 @@ Array [
       }
     }
     enableClearMapRefinement={true}
+    enableRefine={true}
     enableRefineControl={true}
     hasMapMoveSinceLastRefine={false}
     isRefineOnMapMove={true}
@@ -93,5 +47,53 @@ Array [
   <div
     class="ais-geo-search--controls"
   />,
+]
+`;
+
+exports[`GeoSearch expect to render with custom classNames 1`] = `"<div class=\\"ais-geo-search custom-root\\"><div class=\\"ais-geo-search--map custom-map\\"></div><div class=\\"ais-geo-search--controls custom-controls\\"></div></div>"`;
+
+exports[`GeoSearch expect to render with custom classNames 2`] = `
+Array [
+  <GeoSearchControls
+    cssClasses={
+      Object {
+        "clear": "ais-geo-search--clear custom-clear",
+        "control": "ais-geo-search--control custom-control",
+        "controls": "ais-geo-search--controls custom-controls",
+        "map": "ais-geo-search--map custom-map",
+        "redo": "ais-geo-search--redo custom-redo",
+        "root": "ais-geo-search custom-root",
+        "toggleInput": "ais-geo-search--toggle-input custom-toggleInput",
+        "toggleLabel": "ais-geo-search--toggle-label custom-toggleLabel",
+        "toggleLabelActive": "ais-geo-search--toggle-label-active",
+      }
+    }
+    enableClearMapRefinement={true}
+    enableRefine={true}
+    enableRefineControl={true}
+    hasMapMoveSinceLastRefine={false}
+    isRefineOnMapMove={true}
+    isRefinedWithMap={false}
+    onClearClick={[Function]}
+    onRefineClick={[Function]}
+    onRefineToggle={[Function]}
+    templateProps={
+      Object {
+        "templates": Object {
+          "clear": "Clear the map refinement",
+          "redo": "Redo search here",
+          "toggle": "Search as I move the map",
+        },
+        "templatesConfig": undefined,
+        "transformData": undefined,
+        "useCustomCompileOptions": Object {
+          "clear": true,
+          "redo": true,
+          "toggle": true,
+        },
+      }
+    }
+  />,
+  null,
 ]
 `;

--- a/src/widgets/geo-search/__tests__/geo-search-test.js
+++ b/src/widgets/geo-search/__tests__/geo-search-test.js
@@ -1244,7 +1244,7 @@ describe('GeoSearch', () => {
       expect(renderer).toHaveBeenCalledTimes(3);
     });
 
-    it('expect to update the map position from a current refinement boundingBox', () => {
+    it('expect to update the map position from the current refinement boundingBox', () => {
       const container = createContainer();
       const instantSearchInstance = createFakeInstantSearch();
       const helper = createFakeHelper();
@@ -1340,7 +1340,7 @@ describe('GeoSearch', () => {
       expect(renderer).toHaveBeenCalledTimes(4);
     });
 
-    it('expect to update the map position from the an initial current refinement boundingBox', () => {
+    it('expect to update the map position from the initial current refinement boundingBox', () => {
       const container = createContainer();
       const instantSearchInstance = createFakeInstantSearch();
       const helper = createFakeHelper();

--- a/src/widgets/geo-search/__tests__/geo-search-test.js
+++ b/src/widgets/geo-search/__tests__/geo-search-test.js
@@ -660,6 +660,45 @@ describe('GeoSearch', () => {
         );
         expect(lastRenderState(renderer).isPendingRefine).toBe(false);
       });
+
+      it(`expect to listen for "${eventName}" and do not trigger when refine is disabled`, () => {
+        const container = createContainer();
+        const instantSearchInstance = createFakeInstantSearch();
+        const helper = createFakeHelper();
+        const mapInstance = createFakeMapInstance();
+        const googleReference = createFakeGoogleReference({ mapInstance });
+
+        const widget = geoSearch({
+          googleReference,
+          container,
+          enableRefine: false,
+        });
+
+        widget.init({
+          helper,
+          instantSearchInstance,
+          state: helper.state,
+        });
+
+        simulateMapReadyEvent(googleReference);
+
+        expect(mapInstance.addListener).toHaveBeenCalledWith(
+          eventName,
+          expect.any(Function)
+        );
+
+        expect(lastRenderArgs(renderer).hasMapMoveSinceLastRefine()).toBe(
+          false
+        );
+        expect(lastRenderState(renderer).isPendingRefine).toBe(false);
+
+        simulateEvent(mapInstance, eventName);
+
+        expect(lastRenderArgs(renderer).hasMapMoveSinceLastRefine()).toBe(
+          false
+        );
+        expect(lastRenderState(renderer).isPendingRefine).toBe(false);
+      });
     });
   });
 

--- a/src/widgets/geo-search/geo-search.js
+++ b/src/widgets/geo-search/geo-search.js
@@ -21,6 +21,7 @@ geoSearch({
   [ mapOptions ],
   [ builtInMarker ],
   [ customHTMLMarker = false ],
+  [ enableRefine = true ],
   [ enableClearMapRefinement = true ],
   [ enableRefineControl = true ],
   [ enableRefineOnMapMove = true ],
@@ -87,6 +88,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  * See [the documentation](https://developers.google.com/maps/documentation/javascript/reference/3/#MapOptions) for more information.
  * @property {BuiltInMarkerOptions} [builtInMarker] Options for customize the built-in Google Maps marker. This option is ignored when the `customHTMLMarker` is provided.
  * @property {CustomHTMLMarkerOptions|boolean} [customHTMLMarker=false] Options for customize the HTML marker. We provide an alternative to the built-in Google Maps marker in order to have a full control of the marker rendering. You can use plain HTML to build your marker.
+ * @property {boolean} [enableRefine=true] If true, the map is used to search - otherwise it's for display purposes only.
  * @property {boolean} [enableClearMapRefinement=true] If true, a button is displayed on the map when the refinement is coming from the map in order to remove it.
  * @property {boolean} [enableRefineControl=true] If true, the user can toggle the option `enableRefineOnMapMove` directly from the map.
  * @property {boolean} [enableRefineOnMapMove=true] If true, refine will be triggered as you move the map.
@@ -124,6 +126,7 @@ const geoSearch = ({
   cssClasses: userCssClasses = {},
   builtInMarker: userBuiltInMarker = {},
   customHTMLMarker: userCustomHTMLMarker = false,
+  enableRefine = true,
   enableClearMapRefinement = true,
   enableRefineControl = true,
   container,
@@ -235,6 +238,7 @@ const geoSearch = ({
       cssClasses,
       createMarker,
       markerOptions,
+      enableRefine,
       enableClearMapRefinement,
       enableRefineControl,
     });


### PR DESCRIPTION
**Summary**

This PR implements the routing for the geo-search connector. Here is the shape for the uiState:

```js
const uiState = {
  query: 'studio',
  geoSearch: {
    boundingBox: '10, 12, 12, 14',
  },
};
```

We use an object `geoSearch` rather than a direct attribute on the uiState because we may want to persist more information in the future (e.g. `enableRefineOnMapMove`). It's not implemented because it can be inconsistent. The sync with the URL is trigger each time the helper trigger a change event. The click on the Control component doesn't trigger this event. At the end it means that the URL state will be outdated at some point.

**Result**

![routing](https://user-images.githubusercontent.com/6513513/46291885-e3582500-c58f-11e8-8f7c-6e44d595e6d2.gif)
