### PR TITLE
refactor(geo): implement static map [PART-6]

### DIFF
--- a/dev/app/builtin/stories/geo-search.stories.js
+++ b/dev/app/builtin/stories/geo-search.stories.js
@@ -150,7 +150,7 @@ export default () => {
 
   // Only UI
   Stories.add(
-    'with control & refine on map move',
+    'with refine disabled',
     wrapWithHitsAndConfiguration((container, start) =>
       injectGoogleMaps(() => {
         container.style.height = '600px';
@@ -167,8 +167,7 @@ export default () => {
             container,
             initialPosition,
             initialZoom,
-            enableRefineControl: true,
-            enableRefineOnMapMove: true,
+            enableRefine: false,
           })
         );
 
@@ -176,6 +175,33 @@ export default () => {
       })
     )
   )
+    .add(
+      'with control & refine on map move',
+      wrapWithHitsAndConfiguration((container, start) =>
+        injectGoogleMaps(() => {
+          container.style.height = '600px';
+
+          window.search.addWidget(
+            instantsearch.widgets.configure({
+              aroundLatLngViaIP: true,
+            })
+          );
+
+          window.search.addWidget(
+            instantsearch.widgets.geoSearch({
+              googleReference: window.google,
+              container,
+              initialPosition,
+              initialZoom,
+              enableRefineControl: true,
+              enableRefineOnMapMove: true,
+            })
+          );
+
+          start();
+        })
+      )
+    )
     .add(
       'with control & disable refine on map move',
       wrapWithHitsAndConfiguration((container, start) =>

--- a/src/components/GeoSearchControls/GeoSearchControls.js
+++ b/src/components/GeoSearchControls/GeoSearchControls.js
@@ -7,6 +7,7 @@ import GeoSearchToggle from './GeoSearchToggle';
 
 const GeoSearchControls = ({
   cssClasses,
+  enableRefine,
   enableRefineControl,
   enableClearMapRefinement,
   isRefineOnMapMove,
@@ -16,67 +17,72 @@ const GeoSearchControls = ({
   onRefineClick,
   onClearClick,
   templateProps,
-}) => (
-  <div>
-    {enableRefineControl && (
-      <div className={cssClasses.control}>
-        {isRefineOnMapMove || !hasMapMoveSinceLastRefine ? (
-          <GeoSearchToggle
-            classNameLabel={cx(
-              cssClasses.toggleLabel,
-              isRefineOnMapMove && cssClasses.toggleLabelActive
-            )}
-            classNameInput={cssClasses.toggleInput}
-            checked={isRefineOnMapMove}
-            onToggle={onRefineToggle}
-          >
+}) =>
+  enableRefine && (
+    <div>
+      {enableRefineControl && (
+        <div className={cssClasses.control}>
+          {isRefineOnMapMove || !hasMapMoveSinceLastRefine ? (
+            <GeoSearchToggle
+              classNameLabel={cx(
+                cssClasses.toggleLabel,
+                isRefineOnMapMove && cssClasses.toggleLabelActive
+              )}
+              classNameInput={cssClasses.toggleInput}
+              checked={isRefineOnMapMove}
+              onToggle={onRefineToggle}
+            >
+              <Template
+                {...templateProps}
+                templateKey="toggle"
+                rootTagName="span"
+              />
+            </GeoSearchToggle>
+          ) : (
+            <GeoSearchButton
+              className={cssClasses.redo}
+              disabled={!hasMapMoveSinceLastRefine}
+              onClick={onRefineClick}
+            >
+              <Template
+                {...templateProps}
+                templateKey="redo"
+                rootTagName="span"
+              />
+            </GeoSearchButton>
+          )}
+        </div>
+      )}
+
+      {!enableRefineControl &&
+        !isRefineOnMapMove && (
+          <div className={cssClasses.control}>
+            <GeoSearchButton
+              className={cssClasses.redo}
+              disabled={!hasMapMoveSinceLastRefine}
+              onClick={onRefineClick}
+            >
+              <Template
+                {...templateProps}
+                templateKey="redo"
+                rootTagName="span"
+              />
+            </GeoSearchButton>
+          </div>
+        )}
+
+      {enableClearMapRefinement &&
+        isRefinedWithMap && (
+          <GeoSearchButton className={cssClasses.clear} onClick={onClearClick}>
             <Template
               {...templateProps}
-              templateKey="toggle"
-              rootTagName="span"
-            />
-          </GeoSearchToggle>
-        ) : (
-          <GeoSearchButton
-            className={cssClasses.redo}
-            disabled={!hasMapMoveSinceLastRefine}
-            onClick={onRefineClick}
-          >
-            <Template
-              {...templateProps}
-              templateKey="redo"
+              templateKey="clear"
               rootTagName="span"
             />
           </GeoSearchButton>
         )}
-      </div>
-    )}
-
-    {!enableRefineControl &&
-      !isRefineOnMapMove && (
-        <div className={cssClasses.control}>
-          <GeoSearchButton
-            className={cssClasses.redo}
-            disabled={!hasMapMoveSinceLastRefine}
-            onClick={onRefineClick}
-          >
-            <Template
-              {...templateProps}
-              templateKey="redo"
-              rootTagName="span"
-            />
-          </GeoSearchButton>
-        </div>
-      )}
-
-    {enableClearMapRefinement &&
-      isRefinedWithMap && (
-        <GeoSearchButton className={cssClasses.clear} onClick={onClearClick}>
-          <Template {...templateProps} templateKey="clear" rootTagName="span" />
-        </GeoSearchButton>
-      )}
-  </div>
-);
+    </div>
+  );
 
 const CSSClassesPropTypes = PropTypes.shape({
   control: PropTypes.string.isRequired,
@@ -89,6 +95,7 @@ const CSSClassesPropTypes = PropTypes.shape({
 
 GeoSearchControls.propTypes = {
   cssClasses: CSSClassesPropTypes.isRequired,
+  enableRefine: PropTypes.bool.isRequired,
   enableRefineControl: PropTypes.bool.isRequired,
   enableClearMapRefinement: PropTypes.bool.isRequired,
   isRefineOnMapMove: PropTypes.bool.isRequired,

--- a/src/components/GeoSearchControls/__tests__/GeoSearchControls-test.js
+++ b/src/components/GeoSearchControls/__tests__/GeoSearchControls-test.js
@@ -16,6 +16,7 @@ describe('GeoSearchControls', () => {
     cssClasses: CSSClassesDefaultProps,
     enableRefineControl: true,
     enableClearMapRefinement: true,
+    enableRefine: true,
     isRefineOnMapMove: true,
     isRefinedWithMap: false,
     hasMapMoveSinceLastRefine: false,
@@ -24,6 +25,17 @@ describe('GeoSearchControls', () => {
     onClearClick: () => {},
     templateProps: {},
   };
+
+  it('expect to render nothing with refine dsiabled', () => {
+    const props = {
+      ...defaultProps,
+      enableRefine: false,
+    };
+
+    const wrapper = shallow(<GeoSearchControls {...props} />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
 
   describe('Control enabled', () => {
     it('expect to render the toggle checked when refine on map move is enabled', () => {

--- a/src/components/GeoSearchControls/__tests__/__snapshots__/GeoSearchControls-test.js.snap
+++ b/src/components/GeoSearchControls/__tests__/__snapshots__/GeoSearchControls-test.js.snap
@@ -137,3 +137,5 @@ exports[`GeoSearchControls Control enabled expect to render the toggle unchecked
   </div>
 </div>
 `;
+
+exports[`GeoSearchControls expect to render nothing with refine dsiabled 1`] = `""`;

--- a/src/widgets/geo-search/GeoSearchRenderer.js
+++ b/src/widgets/geo-search/GeoSearchRenderer.js
@@ -68,6 +68,7 @@ const renderer = (
     templates,
     initialZoom,
     initialPosition,
+    enableRefine,
     enableClearMapRefinement,
     enableRefineControl,
     mapOptions,
@@ -106,7 +107,7 @@ const renderer = (
 
     const setupListenersWhenMapIsReady = () => {
       const onChange = () => {
-        if (renderState.isUserInteraction) {
+        if (renderState.isUserInteraction && enableRefine) {
           setMapMoveSinceLastRefine();
 
           if (isRefineOnMapMove()) {
@@ -217,6 +218,7 @@ const renderer = (
   render(
     <GeoSearchControls
       cssClasses={cssClasses}
+      enableRefine={enableRefine}
       enableRefineControl={enableRefineControl}
       enableClearMapRefinement={enableClearMapRefinement}
       isRefineOnMapMove={isRefineOnMapMove()}

--- a/src/widgets/geo-search/__tests__/__snapshots__/geo-search-test.js.snap
+++ b/src/widgets/geo-search/__tests__/__snapshots__/geo-search-test.js.snap
@@ -1,52 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`GeoSearch expect to render with custom classNames 1`] = `"<div class=\\"ais-geo-search custom-root\\"><div class=\\"ais-geo-search--map custom-map\\"></div><div class=\\"ais-geo-search--controls custom-controls\\"></div></div>"`;
-
-exports[`GeoSearch expect to render with custom classNames 2`] = `
-Array [
-  <GeoSearchControls
-    cssClasses={
-      Object {
-        "clear": "ais-geo-search--clear custom-clear",
-        "control": "ais-geo-search--control custom-control",
-        "controls": "ais-geo-search--controls custom-controls",
-        "map": "ais-geo-search--map custom-map",
-        "redo": "ais-geo-search--redo custom-redo",
-        "root": "ais-geo-search custom-root",
-        "toggleInput": "ais-geo-search--toggle-input custom-toggleInput",
-        "toggleLabel": "ais-geo-search--toggle-label custom-toggleLabel",
-        "toggleLabelActive": "ais-geo-search--toggle-label-active",
-      }
-    }
-    enableClearMapRefinement={true}
-    enableRefineControl={true}
-    hasMapMoveSinceLastRefine={false}
-    isRefineOnMapMove={true}
-    isRefinedWithMap={false}
-    onClearClick={[Function]}
-    onRefineClick={[Function]}
-    onRefineToggle={[Function]}
-    templateProps={
-      Object {
-        "templates": Object {
-          "clear": "Clear the map refinement",
-          "redo": "Redo search here",
-          "toggle": "Search as I move the map",
-        },
-        "templatesConfig": undefined,
-        "transformData": undefined,
-        "useCustomCompileOptions": Object {
-          "clear": true,
-          "redo": true,
-          "toggle": true,
-        },
-      }
-    }
-  />,
-  null,
-]
-`;
-
 exports[`GeoSearch expect to render 1`] = `"<div class=\\"ais-geo-search\\"><div class=\\"ais-geo-search--map\\"></div><div class=\\"ais-geo-search--controls\\"></div></div>"`;
 
 exports[`GeoSearch expect to render 2`] = `
@@ -66,6 +19,7 @@ Array [
       }
     }
     enableClearMapRefinement={true}
+    enableRefine={true}
     enableRefineControl={true}
     hasMapMoveSinceLastRefine={false}
     isRefineOnMapMove={true}
@@ -93,5 +47,53 @@ Array [
   <div
     class="ais-geo-search--controls"
   />,
+]
+`;
+
+exports[`GeoSearch expect to render with custom classNames 1`] = `"<div class=\\"ais-geo-search custom-root\\"><div class=\\"ais-geo-search--map custom-map\\"></div><div class=\\"ais-geo-search--controls custom-controls\\"></div></div>"`;
+
+exports[`GeoSearch expect to render with custom classNames 2`] = `
+Array [
+  <GeoSearchControls
+    cssClasses={
+      Object {
+        "clear": "ais-geo-search--clear custom-clear",
+        "control": "ais-geo-search--control custom-control",
+        "controls": "ais-geo-search--controls custom-controls",
+        "map": "ais-geo-search--map custom-map",
+        "redo": "ais-geo-search--redo custom-redo",
+        "root": "ais-geo-search custom-root",
+        "toggleInput": "ais-geo-search--toggle-input custom-toggleInput",
+        "toggleLabel": "ais-geo-search--toggle-label custom-toggleLabel",
+        "toggleLabelActive": "ais-geo-search--toggle-label-active",
+      }
+    }
+    enableClearMapRefinement={true}
+    enableRefine={true}
+    enableRefineControl={true}
+    hasMapMoveSinceLastRefine={false}
+    isRefineOnMapMove={true}
+    isRefinedWithMap={false}
+    onClearClick={[Function]}
+    onRefineClick={[Function]}
+    onRefineToggle={[Function]}
+    templateProps={
+      Object {
+        "templates": Object {
+          "clear": "Clear the map refinement",
+          "redo": "Redo search here",
+          "toggle": "Search as I move the map",
+        },
+        "templatesConfig": undefined,
+        "transformData": undefined,
+        "useCustomCompileOptions": Object {
+          "clear": true,
+          "redo": true,
+          "toggle": true,
+        },
+      }
+    }
+  />,
+  null,
 ]
 `;

--- a/src/widgets/geo-search/__tests__/geo-search-test.js
+++ b/src/widgets/geo-search/__tests__/geo-search-test.js
@@ -660,6 +660,45 @@ describe('GeoSearch', () => {
         );
         expect(lastRenderState(renderer).isPendingRefine).toBe(false);
       });
+
+      it(`expect to listen for "${eventName}" and do not trigger when refine is disabled`, () => {
+        const container = createContainer();
+        const instantSearchInstance = createFakeInstantSearch();
+        const helper = createFakeHelper();
+        const mapInstance = createFakeMapInstance();
+        const googleReference = createFakeGoogleReference({ mapInstance });
+
+        const widget = geoSearch({
+          googleReference,
+          container,
+          enableRefine: false,
+        });
+
+        widget.init({
+          helper,
+          instantSearchInstance,
+          state: helper.state,
+        });
+
+        simulateMapReadyEvent(googleReference);
+
+        expect(mapInstance.addListener).toHaveBeenCalledWith(
+          eventName,
+          expect.any(Function)
+        );
+
+        expect(lastRenderArgs(renderer).hasMapMoveSinceLastRefine()).toBe(
+          false
+        );
+        expect(lastRenderState(renderer).isPendingRefine).toBe(false);
+
+        simulateEvent(mapInstance, eventName);
+
+        expect(lastRenderArgs(renderer).hasMapMoveSinceLastRefine()).toBe(
+          false
+        );
+        expect(lastRenderState(renderer).isPendingRefine).toBe(false);
+      });
     });
   });
 

--- a/src/widgets/geo-search/geo-search.js
+++ b/src/widgets/geo-search/geo-search.js
@@ -21,6 +21,7 @@ geoSearch({
   [ mapOptions ],
   [ builtInMarker ],
   [ customHTMLMarker = false ],
+  [ enableRefine = true ],
   [ enableClearMapRefinement = true ],
   [ enableRefineControl = true ],
   [ enableRefineOnMapMove = true ],
@@ -87,6 +88,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  * See [the documentation](https://developers.google.com/maps/documentation/javascript/reference/3/#MapOptions) for more information.
  * @property {BuiltInMarkerOptions} [builtInMarker] Options for customize the built-in Google Maps marker. This option is ignored when the `customHTMLMarker` is provided.
  * @property {CustomHTMLMarkerOptions|boolean} [customHTMLMarker=false] Options for customize the HTML marker. We provide an alternative to the built-in Google Maps marker in order to have a full control of the marker rendering. You can use plain HTML to build your marker.
+ * @property {boolean} [enableRefine=true] If true, the map is used to search - otherwise it's for display purposes only.
  * @property {boolean} [enableClearMapRefinement=true] If true, a button is displayed on the map when the refinement is coming from the map in order to remove it.
  * @property {boolean} [enableRefineControl=true] If true, the user can toggle the option `enableRefineOnMapMove` directly from the map.
  * @property {boolean} [enableRefineOnMapMove=true] If true, refine will be triggered as you move the map.

--- a/src/widgets/geo-search/geo-search.js
+++ b/src/widgets/geo-search/geo-search.js
@@ -124,6 +124,7 @@ const geoSearch = ({
   cssClasses: userCssClasses = {},
   builtInMarker: userBuiltInMarker = {},
   customHTMLMarker: userCustomHTMLMarker = false,
+  enableRefine = true,
   enableClearMapRefinement = true,
   enableRefineControl = true,
   container,
@@ -235,6 +236,7 @@ const geoSearch = ({
       cssClasses,
       createMarker,
       markerOptions,
+      enableRefine,
       enableClearMapRefinement,
       enableRefineControl,
     });


### PR DESCRIPTION
**Summary**

This PR implements the static map support for the geo-search widget. Previously it was not possible to use the widget for display purpose only. You were always force to use the refinement capabilities of the map. We now have the option `enableRefine` that disable the refinement from the map.

**Result**

![static](https://user-images.githubusercontent.com/6513513/46292586-99703e80-c591-11e8-83c9-29b610adb084.gif)

You can play with the live example in [DevNovel](https://deploy-preview-3160--algolia-instantsearch.netlify.com/v2/dev-novel/?selectedStory=GeoSearch.with%20refine%20disabled).