### PR TITLE
refactor(breadcrumb): refactor widget

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.js
+++ b/src/components/Breadcrumb/Breadcrumb.js
@@ -32,10 +32,10 @@ const renderLink = ({ cssClasses, createURL, refine, templateProps }) => (
       })}
     >
       <Template
+        {...templateProps}
+        templateKey="separator"
         rootTagName="span"
         rootProps={{ className: cssClasses.separator, 'aria-hidden': true }}
-        templateKey="separator"
-        {...templateProps}
       />
       {link}
     </li>
@@ -48,47 +48,40 @@ const Breadcrumb = ({
   refine,
   cssClasses,
   templateProps,
-}) => {
-  const rootClassnames = cx(cssClasses.root, {
-    [cssClasses.noRefinement]: items.length > 0,
-  });
-  const homeClassnames = cx(cssClasses.item, {
-    [cssClasses.selectedItem]: items.length === 0,
-  });
+}) => (
+  <div
+    className={cx(cssClasses.root, {
+      [cssClasses.noRefinement]: items.length > 0,
+    })}
+  >
+    <ul className={cssClasses.list}>
+      <li
+        className={cx(cssClasses.item, {
+          [cssClasses.selectedItem]: items.length === 0,
+        })}
+      >
+        <Template
+          {...templateProps}
+          templateKey="home"
+          rootTagName="a"
+          rootProps={{
+            className: cssClasses.link,
+            href: createURL(null),
+            onClick: event => {
+              event.preventDefault();
+              refine(null);
+            },
+          }}
+        />
+      </li>
 
-  const homeOnClickHandler = event => {
-    event.preventDefault();
-    refine(null);
-  };
-
-  const homeUrl = createURL(null);
-  const breadcrumb = items.map(
-    renderLink({ cssClasses, createURL, refine, templateProps })
-  );
-
-  return (
-    <div className={rootClassnames}>
-      <ul className={cssClasses.list}>
-        <li className={homeClassnames}>
-          <Template
-            {...templateProps}
-            templateKey="home"
-            rootTagName="a"
-            rootProps={{
-              className: cssClasses.link,
-              href: homeUrl,
-              onClick: homeOnClickHandler,
-            }}
-          />
-        </li>
-        {breadcrumb}
-      </ul>
-    </div>
-  );
-};
+      {items.map(renderLink({ cssClasses, createURL, refine, templateProps }))}
+    </ul>
+  </div>
+);
 
 Breadcrumb.propTypes = {
-  createURL: PropTypes.func,
+  createURL: PropTypes.func.isRequired,
   cssClasses: PropTypes.shape({
     root: PropTypes.string.isRequired,
     noRefinement: PropTypes.string.isRequired,
@@ -100,14 +93,12 @@ Breadcrumb.propTypes = {
   }).isRequired,
   items: PropTypes.arrayOf(
     PropTypes.shape({
-      name: PropTypes.string,
+      name: PropTypes.string.isRequired,
       value: PropTypes.string,
     })
-  ),
+  ).isRequired,
   refine: PropTypes.func.isRequired,
-  separator: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   templateProps: PropTypes.object.isRequired,
-  translate: PropTypes.func,
 };
 
 export default Breadcrumb;

--- a/src/components/Breadcrumb/__tests__/Breadcrumb-test.js
+++ b/src/components/Breadcrumb/__tests__/Breadcrumb-test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Breadcrumb from '../Breadcrumb';
-import renderer from 'react-test-renderer';
+import { mount } from 'enzyme';
 
 describe('Breadcrumb', () => {
   it('should render <Breadcrumb />', () => {
@@ -12,7 +12,7 @@ describe('Breadcrumb', () => {
       items: [],
       cssClasses: {
         root: 'root',
-        noRefinement: 'no-refinement',
+        noRefinement: 'noRefinement',
         list: 'list',
         item: 'item',
         selectedItem: 'selectedItem',
@@ -27,9 +27,9 @@ describe('Breadcrumb', () => {
         },
       },
     };
-    const tree = renderer.create(<Breadcrumb {...props} />).toJSON();
+    const wrapper = mount(<Breadcrumb {...props} />);
 
-    expect(tree).toMatchSnapshot();
+    expect(wrapper).toMatchSnapshot();
   });
 
   it('should render <Breadcrumb /> with a single item', () => {
@@ -46,7 +46,7 @@ describe('Breadcrumb', () => {
       ],
       cssClasses: {
         root: 'root',
-        noRefinement: 'no-refinement',
+        noRefinement: 'noRefinement',
         list: 'list',
         item: 'item',
         selectedItem: 'selectedItem',
@@ -61,9 +61,9 @@ describe('Breadcrumb', () => {
         },
       },
     };
-    const tree = renderer.create(<Breadcrumb {...props} />).toJSON();
+    const wrapper = mount(<Breadcrumb {...props} />);
 
-    expect(tree).toMatchSnapshot();
+    expect(wrapper).toMatchSnapshot();
   });
 
   it('should render <Breadcrumb /> with items', () => {
@@ -84,7 +84,7 @@ describe('Breadcrumb', () => {
       ],
       cssClasses: {
         root: 'root',
-        noRefinement: 'no-refinement',
+        noRefinement: 'noRefinement',
         list: 'list',
         item: 'item',
         selectedItem: 'selectedItem',
@@ -99,8 +99,8 @@ describe('Breadcrumb', () => {
         },
       },
     };
-    const tree = renderer.create(<Breadcrumb {...props} />).toJSON();
+    const wrapper = mount(<Breadcrumb {...props} />);
 
-    expect(tree).toMatchSnapshot();
+    expect(wrapper).toMatchSnapshot();
   });
 });

--- a/src/components/Breadcrumb/__tests__/__snapshots__/Breadcrumb-test.js.snap
+++ b/src/components/Breadcrumb/__tests__/__snapshots__/Breadcrumb-test.js.snap
@@ -26,7 +26,7 @@ exports[`Breadcrumb should render <Breadcrumb /> 1`] = `
 
 exports[`Breadcrumb should render <Breadcrumb /> with a single item 1`] = `
 <div
-  className="root no-refinement"
+  className="root noRefinement"
 >
   <ul
     className="list"
@@ -46,9 +46,10 @@ exports[`Breadcrumb should render <Breadcrumb /> with a single item 1`] = `
     </li>
     <li
       className="item selectedItem"
+      key="name00"
     >
       <span
-        ariaHidden={true}
+        aria-hidden={true}
         className="separator"
         dangerouslySetInnerHTML={
           Object {
@@ -64,7 +65,7 @@ exports[`Breadcrumb should render <Breadcrumb /> with a single item 1`] = `
 
 exports[`Breadcrumb should render <Breadcrumb /> with items 1`] = `
 <div
-  className="root no-refinement"
+  className="root noRefinement"
 >
   <ul
     className="list"
@@ -84,9 +85,10 @@ exports[`Breadcrumb should render <Breadcrumb /> with items 1`] = `
     </li>
     <li
       className="item"
+      key="name00"
     >
       <span
-        ariaHidden={true}
+        aria-hidden={true}
         className="separator"
         dangerouslySetInnerHTML={
           Object {
@@ -103,9 +105,10 @@ exports[`Breadcrumb should render <Breadcrumb /> with items 1`] = `
     </li>
     <li
       className="item selectedItem"
+      key="name11"
     >
       <span
-        ariaHidden={true}
+        aria-hidden={true}
         className="separator"
         dangerouslySetInnerHTML={
           Object {

--- a/src/widgets/breadcrumb/__tests__/__snapshots__/breadcrumb-test.js.snap
+++ b/src/widgets/breadcrumb/__tests__/__snapshots__/breadcrumb-test.js.snap
@@ -30,12 +30,11 @@ exports[`breadcrumb() render renders transformed items correctly 1`] = `
     ]
   }
   refine={[Function]}
-  separator=" > "
   templateProps={
     Object {
       "templates": Object {
         "home": "Home",
-        "separator": "",
+        "separator": " > ",
       },
       "templatesConfig": undefined,
       "transformData": undefined,

--- a/src/widgets/breadcrumb/breadcrumb.js
+++ b/src/widgets/breadcrumb/breadcrumb.js
@@ -12,7 +12,6 @@ const renderer = ({
   containerNode,
   cssClasses,
   renderState,
-  separator,
   templates,
   transformData,
 }) => (
@@ -26,6 +25,7 @@ const renderer = ({
       templates,
       transformData,
     });
+
     return;
   }
 
@@ -36,7 +36,6 @@ const renderer = ({
       createURL={createURL}
       items={items}
       refine={refine}
-      separator={separator}
       templateProps={renderState.templateProps}
     />,
     containerNode
@@ -145,7 +144,6 @@ export default function breadcrumb({
   container,
   cssClasses: userCssClasses = {},
   rootPath = null,
-  separator = ' > ',
   templates = defaultTemplates,
   transformData,
   transformItems,
@@ -179,7 +177,6 @@ export default function breadcrumb({
     containerNode,
     cssClasses,
     renderState: {},
-    separator,
     templates,
     transformData,
   });

--- a/src/widgets/breadcrumb/breadcrumb.js
+++ b/src/widgets/breadcrumb/breadcrumb.js
@@ -1,12 +1,9 @@
 import React, { render, unmountComponentAtNode } from 'preact-compat';
 import cx from 'classnames';
-
 import Breadcrumb from '../../components/Breadcrumb/Breadcrumb';
 import connectBreadcrumb from '../../connectors/breadcrumb/connectBreadcrumb';
 import defaultTemplates from './defaultTemplates.js';
-
 import { getContainerNode, prepareTemplateProps } from '../../lib/utils';
-
 import { component } from '../../lib/suit';
 
 const suit = component('Breadcrumb');
@@ -50,7 +47,7 @@ const usage = `Usage:
 breadcrumb({
   container,
   attributes,
-  [ cssClasses.{root, noRefinement, list, item, selectedItem, separator, link}={} ],
+  [ cssClasses.{root, noRefinement, list, item, selectedItem, separator, link} ],
   [ templates.{home, separator}]
   [ transformData.{item} ],
   [ transformItems ],
@@ -192,7 +189,7 @@ export default function breadcrumb({
       unmountComponentAtNode(containerNode)
     );
     return makeBreadcrumb({ attributes, rootPath, transformItems });
-  } catch (e) {
+  } catch (error) {
     throw new Error(usage);
   }
 }

--- a/src/widgets/breadcrumb/defaultTemplates.js
+++ b/src/widgets/breadcrumb/defaultTemplates.js
@@ -1,4 +1,4 @@
 export default {
   home: 'Home',
-  separator: '',
+  separator: ' > ',
 };


### PR DESCRIPTION
- Remove unused `cx()`
- Use functional functional components when possible
- Enforce prop types for class names
- Use Enzyme over React Test Renderer
- Convert Sinon to Jest