### PR TITLE
refactor(pagination): refactor widget

### DIFF
--- a/src/components/Pagination/Pagination.js
+++ b/src/components/Pagination/Pagination.js
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
 import React, { Component } from 'preact-compat';
+import PropTypes from 'prop-types';
 import defaultsDeep from 'lodash/defaultsDeep';
 import cx from 'classnames';
 
@@ -23,7 +23,7 @@ class Pagination extends Component {
   }) {
     const cssClasses = {
       item: cx(this.props.cssClasses.item, additionalClassName),
-      link: cx(this.props.cssClasses.link),
+      link: this.props.cssClasses.link,
     };
 
     if (isDisabled) {
@@ -122,7 +122,7 @@ class Pagination extends Component {
           [this.props.cssClasses.noRefinementRoot]: this.props.isFirstPage,
         })}
       >
-        <ul className={cx(this.props.cssClasses.list)}>
+        <ul className={this.props.cssClasses.list}>
           {this.props.showFirst && this.firstPageLink(this.props)}
           {this.props.showPrevious && this.previousPageLink(this.props)}
           {this.pages(this.props)}
@@ -137,26 +137,26 @@ class Pagination extends Component {
 Pagination.propTypes = {
   createURL: PropTypes.func,
   cssClasses: PropTypes.shape({
-    root: PropTypes.string,
-    noRefinementRoot: PropTypes.string,
-    list: PropTypes.string,
-    item: PropTypes.string,
-    firstPageItem: PropTypes.string,
-    lastPageItem: PropTypes.string,
-    previousPageItem: PropTypes.string,
-    nextPageItem: PropTypes.string,
-    pageItem: PropTypes.string,
-    selectedItem: PropTypes.string,
-    disabledItem: PropTypes.string,
-    link: PropTypes.string,
-  }),
+    root: PropTypes.string.isRequired,
+    noRefinementRoot: PropTypes.string.isRequired,
+    list: PropTypes.string.isRequired,
+    item: PropTypes.string.isRequired,
+    firstPageItem: PropTypes.string.isRequired,
+    lastPageItem: PropTypes.string.isRequired,
+    previousPageItem: PropTypes.string.isRequired,
+    nextPageItem: PropTypes.string.isRequired,
+    pageItem: PropTypes.string.isRequired,
+    selectedItem: PropTypes.string.isRequired,
+    disabledItem: PropTypes.string.isRequired,
+    link: PropTypes.string.isRequired,
+  }).isRequired,
   currentPage: PropTypes.number,
   labels: PropTypes.shape({
-    first: PropTypes.string,
-    last: PropTypes.string,
-    next: PropTypes.string,
-    previous: PropTypes.string,
-  }),
+    first: PropTypes.string.isRequired,
+    last: PropTypes.string.isRequired,
+    next: PropTypes.string.isRequired,
+    previous: PropTypes.string.isRequired,
+  }).isRequired,
   nbHits: PropTypes.number,
   nbPages: PropTypes.number,
   pages: PropTypes.arrayOf(PropTypes.number),

--- a/src/components/Pagination/PaginationLink.js
+++ b/src/components/Pagination/PaginationLink.js
@@ -1,6 +1,5 @@
-import PropTypes from 'prop-types';
 import React, { Component } from 'preact-compat';
-
+import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
 
 class PaginationLink extends Component {
@@ -48,9 +47,9 @@ PaginationLink.propTypes = {
   ariaLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
     .isRequired,
   cssClasses: PropTypes.shape({
-    item: PropTypes.string,
-    link: PropTypes.string,
-  }),
+    item: PropTypes.string.isRequired,
+    link: PropTypes.string.isRequired,
+  }).isRequired,
   handleClick: PropTypes.func.isRequired,
   isDisabled: PropTypes.bool,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,

--- a/src/components/Pagination/__tests__/Pagination-test.js
+++ b/src/components/Pagination/__tests__/Pagination-test.js
@@ -1,8 +1,7 @@
 import React from 'react';
-import sinon from 'sinon';
+import { mount } from 'enzyme';
 import Pagination from '../Pagination';
 import Paginator from '../../../connectors/pagination/Paginator';
-import renderer from 'react-test-renderer';
 
 describe('Pagination', () => {
   const pager = new Paginator({
@@ -38,76 +37,70 @@ describe('Pagination', () => {
   };
 
   it('should render five elements', () => {
-    const tree = renderer.create(<Pagination {...defaultProps} />).toJSON();
-    expect(tree).toMatchSnapshot();
+    const wrapper = mount(<Pagination {...defaultProps} />);
+
+    expect(wrapper).toMatchSnapshot();
   });
 
   it('should display the first/last link', () => {
-    const tree = renderer
-      .create(<Pagination {...defaultProps} showFirst showLast />)
-      .toJSON();
-    expect(tree).toMatchSnapshot();
+    const wrapper = mount(<Pagination {...defaultProps} showFirst showLast />);
+
+    expect(wrapper).toMatchSnapshot();
   });
 
   it('should disable last page if already on it', () => {
-    const tree = renderer
-      .create(
-        <Pagination
-          {...defaultProps}
-          showFirst
-          showLast
-          showPrevious
-          showNext
-          pages={[13, 14, 15, 16, 17, 18, 19]}
-          currentPage={19}
-          isFirstPage={false}
-          isLastPage={true}
-        />
-      )
-      .toJSON();
-    expect(tree).toMatchSnapshot();
+    const wrapper = mount(
+      <Pagination
+        {...defaultProps}
+        showFirst
+        showLast
+        showPrevious
+        showNext
+        pages={[13, 14, 15, 16, 17, 18, 19]}
+        currentPage={19}
+        isFirstPage={false}
+        isLastPage={true}
+      />
+    );
+
+    expect(wrapper).toMatchSnapshot();
   });
 
   it('should handle special clicks', () => {
     const props = {
-      setCurrentPage: sinon.spy(),
+      setCurrentPage: jest.fn(),
     };
-    const preventDefault = sinon.spy();
+    const preventDefault = jest.fn();
     const component = new Pagination(props);
     ['ctrlKey', 'shiftKey', 'altKey', 'metaKey'].forEach(e => {
       const event = { preventDefault };
       event[e] = true;
       component.handleClick(42, event);
-      expect(props.setCurrentPage.called).toBe(
-        false,
-        'setCurrentPage never called'
-      );
-      expect(preventDefault.called).toBe(false, 'preventDefault never called');
+
+      expect(props.setCurrentPage).toHaveBeenCalledTimes(0);
+      expect(preventDefault).toHaveBeenCalledTimes(0);
     });
     component.handleClick(42, { preventDefault });
-    expect(props.setCurrentPage.calledOnce).toBe(
-      true,
-      'setCurrentPage called once'
-    );
-    expect(preventDefault.calledOnce).toBe(true, 'preventDefault called once');
+
+    expect(props.setCurrentPage).toHaveBeenCalledTimes(1);
+    expect(preventDefault).toHaveBeenCalledTimes(1);
   });
 
   it('should have all buttons disabled if there are no results', () => {
-    const tree = renderer
-      .create(
-        <Pagination
-          {...defaultProps}
-          showFirst
-          showLast
-          showPrevious
-          showNext
-          currentPage={0}
-          nbHits={0}
-          nbPages={0}
-          pages={[0]}
-        />
-      )
-      .toJSON();
-    expect(tree).toMatchSnapshot();
+    const wrapper = mount(
+      <Pagination
+        {...defaultProps}
+        showFirst
+        showLast
+        showPrevious
+        showNext
+        currentPage={0}
+        nbHits={0}
+        nbPages={0}
+        pages={[0]}
+      />
+    );
+
+    expect(wrapper).toMatchSnapshot();
   });
 });

--- a/src/connectors/pagination/__tests__/connectPagination-test.js
+++ b/src/connectors/pagination/__tests__/connectPagination-test.js
@@ -1,5 +1,3 @@
-import sinon from 'sinon';
-
 import jsHelper, {
   SearchResults,
   SearchParameters,
@@ -11,7 +9,7 @@ describe('connectPagination', () => {
   it('connectPagination - Renders during init and render', () => {
     // test that the dummyRendering is called with the isFirstRendering
     // flag set accordingly
-    const rendering = sinon.stub();
+    const rendering = jest.fn();
     const makeWidget = connectPagination(rendering);
     const widget = makeWidget({
       foo: 'bar', // dummy param for `widgetParams` test
@@ -21,7 +19,7 @@ describe('connectPagination', () => {
     expect(widget.getConfiguration).toBe(undefined);
 
     const helper = jsHelper({});
-    helper.search = sinon.stub();
+    helper.search = jest.fn();
 
     widget.init({
       helper,
@@ -32,12 +30,14 @@ describe('connectPagination', () => {
 
     {
       // should call the rendering once with isFirstRendering to true
-      expect(rendering.callCount).toBe(1);
-      const isFirstRendering = rendering.lastCall.args[1];
+      expect(rendering).toHaveBeenCalledTimes(1);
+      const isFirstRendering =
+        rendering.mock.calls[rendering.mock.calls.length - 1][1];
       expect(isFirstRendering).toBe(true);
 
       // should provide good values for the first rendering
-      const firstRenderingOptions = rendering.lastCall.args[0];
+      const firstRenderingOptions =
+        rendering.mock.calls[rendering.mock.calls.length - 1][0];
       expect(firstRenderingOptions.currentRefinement).toBe(0);
       expect(firstRenderingOptions.nbHits).toBe(0);
       expect(firstRenderingOptions.nbPages).toBe(0);
@@ -62,12 +62,14 @@ describe('connectPagination', () => {
 
     {
       // Should call the rendering a second time, with isFirstRendering to false
-      expect(rendering.callCount).toBe(2);
-      const isFirstRendering = rendering.lastCall.args[1];
+      expect(rendering).toHaveBeenCalledTimes(2);
+      const isFirstRendering =
+        rendering.mock.calls[rendering.mock.calls.length - 1][1];
       expect(isFirstRendering).toBe(false);
 
       // should call the rendering with values from the results
-      const secondRenderingOptions = rendering.lastCall.args[0];
+      const secondRenderingOptions =
+        rendering.mock.calls[rendering.mock.calls.length - 1][0];
       expect(secondRenderingOptions.currentRefinement).toBe(0);
       expect(secondRenderingOptions.nbHits).toBe(1);
       expect(secondRenderingOptions.nbPages).toBe(1);
@@ -75,13 +77,13 @@ describe('connectPagination', () => {
   });
 
   it('Provides a function to update the refinements at each step', () => {
-    const rendering = sinon.stub();
+    const rendering = jest.fn();
     const makeWidget = connectPagination(rendering);
 
     const widget = makeWidget();
 
     const helper = jsHelper({});
-    helper.search = sinon.stub();
+    helper.search = jest.fn();
 
     widget.init({
       helper,
@@ -92,11 +94,12 @@ describe('connectPagination', () => {
 
     {
       // first rendering
-      const renderOptions = rendering.lastCall.args[0];
+      const renderOptions =
+        rendering.mock.calls[rendering.mock.calls.length - 1][0];
       const { refine } = renderOptions;
       refine(2);
       expect(helper.getPage()).toBe(2);
-      expect(helper.search.callCount).toBe(1);
+      expect(helper.search).toHaveBeenCalledTimes(1);
     }
 
     widget.render({
@@ -108,11 +111,12 @@ describe('connectPagination', () => {
 
     {
       // Second rendering
-      const renderOptions = rendering.lastCall.args[0];
+      const renderOptions =
+        rendering.mock.calls[rendering.mock.calls.length - 1][0];
       const { refine } = renderOptions;
       refine(7);
       expect(helper.getPage()).toBe(7);
-      expect(helper.search.callCount).toBe(2);
+      expect(helper.search).toHaveBeenCalledTimes(2);
     }
   });
 

--- a/src/widgets/pagination/__tests__/pagination-test.js
+++ b/src/widgets/pagination/__tests__/pagination-test.js
@@ -1,5 +1,4 @@
 import expect from 'expect';
-import sinon from 'sinon';
 import pagination from '../pagination';
 
 describe('pagination call', () => {
@@ -16,7 +15,7 @@ describe('pagination()', () => {
   let cssClasses;
 
   beforeEach(() => {
-    ReactDOM = { render: sinon.spy() };
+    ReactDOM = { render: jest.fn() };
     pagination.__Rewire__('render', ReactDOM.render);
 
     container = document.createElement('div');
@@ -40,8 +39,8 @@ describe('pagination()', () => {
       nbPages: 20,
     };
     helper = {
-      setPage: sinon.spy(),
-      search: sinon.spy(),
+      setPage: jest.fn(),
+      search: jest.fn(),
       getPage: () => 0,
     };
     widget.init({ helper });
@@ -53,30 +52,27 @@ describe('pagination()', () => {
 
   it('sets the page', () => {
     widget.refine(helper, 42);
-    expect(helper.setPage.calledOnce).toBe(true);
-    expect(helper.search.calledOnce).toBe(true);
+    expect(helper.setPage).toHaveBeenCalledTimes(1);
+    expect(helper.search).toHaveBeenCalledTimes(1);
   });
 
   it('calls twice ReactDOM.render(<Pagination props />, container)', () => {
     widget.render({ results, helper, state: { page: 0 } });
     widget.render({ results, helper, state: { page: 0 } });
 
-    expect(ReactDOM.render.calledTwice).toBe(
-      true,
-      'ReactDOM.render called twice'
-    );
-    expect(ReactDOM.render.firstCall.args[0]).toMatchSnapshot();
-    expect(ReactDOM.render.firstCall.args[1]).toEqual(container);
-    expect(ReactDOM.render.secondCall.args[0]).toMatchSnapshot();
-    expect(ReactDOM.render.secondCall.args[1]).toEqual(container);
+    expect(ReactDOM.render).toHaveBeenCalledTimes(2);
+    expect(ReactDOM.render.mock.calls[0][0]).toMatchSnapshot();
+    expect(ReactDOM.render.mock.calls[0][1]).toEqual(container);
+    expect(ReactDOM.render.mock.calls[1][0]).toMatchSnapshot();
+    expect(ReactDOM.render.mock.calls[1][1]).toEqual(container);
   });
 
   describe('mocking getContainerNode', () => {
     let scrollIntoView;
 
     beforeEach(() => {
-      scrollIntoView = sinon.spy();
-      const getContainerNode = sinon.stub().returns({
+      scrollIntoView = jest.fn();
+      const getContainerNode = jest.fn().mockReturnValue({
         scrollIntoView,
       });
       pagination.__Rewire__('getContainerNode', getContainerNode);
@@ -86,22 +82,16 @@ describe('pagination()', () => {
       widget = pagination({ container, scrollTo: false });
       widget.init({ helper });
       widget.refine(helper, 2);
-      expect(scrollIntoView.calledOnce).toBe(
-        false,
-        'scrollIntoView never called'
-      );
+      expect(scrollIntoView).toHaveBeenCalledTimes(0);
     });
 
     it('should scroll to body', () => {
       widget = pagination({ container });
       widget.init({ helper });
       widget.render({ results, helper, state: { page: 0 } });
-      const { props: { setCurrentPage } } = ReactDOM.render.firstCall.args[0];
+      const { props: { setCurrentPage } } = ReactDOM.render.mock.calls[0][0];
       setCurrentPage(2);
-      expect(scrollIntoView.calledOnce).toBe(
-        true,
-        'scrollIntoView called once'
-      );
+      expect(scrollIntoView).toHaveBeenCalledTimes(1);
     });
 
     afterEach(() => {
@@ -124,7 +114,7 @@ describe('pagination MaxPage', () => {
   let paginationOptions;
 
   beforeEach(() => {
-    ReactDOM = { render: sinon.spy() };
+    ReactDOM = { render: jest.fn() };
     pagination.__Rewire__('render', ReactDOM.render);
 
     container = document.createElement('div');

--- a/src/widgets/pagination/pagination.js
+++ b/src/widgets/pagination/pagination.js
@@ -1,13 +1,9 @@
-import defaults from 'lodash/defaults';
-
 import React, { render, unmountComponentAtNode } from 'preact-compat';
 import cx from 'classnames';
-
+import defaults from 'lodash/defaults';
 import Pagination from '../../components/Pagination/Pagination.js';
 import connectPagination from '../../connectors/pagination/connectPagination.js';
-
 import { getContainerNode } from '../../lib/utils.js';
-
 import { component } from '../../lib/suit';
 
 const suit = component('Pagination');
@@ -77,7 +73,7 @@ const renderer = ({
 const usage = `Usage:
 pagination({
   container,
-  [ cssClasses.{root, noRefinementRoot, list, item, itemFirstPage, itemLastPage, itemPreviousPage, itemNextPage, itemPage, selectedItem, disabledItem, link}={} ],
+  [ cssClasses.{root, noRefinementRoot, list, item, itemFirstPage, itemLastPage, itemPreviousPage, itemNextPage, itemPage, selectedItem, disabledItem, link} ],
   [ labels.{previous,next,first,last} ],
   [ totalPages ],
   [ padding=3 ],
@@ -233,7 +229,7 @@ export default function pagination({
       unmountComponentAtNode(containerNode)
     );
     return makeWidget({ maxPages, padding });
-  } catch (e) {
+  } catch (error) {
     throw new Error(usage);
   }
 }


### PR DESCRIPTION
- Remove unused `cx()`
- Use functional functional components when possible
- Enforce prop types for class names
- Use Enzyme over React Test Renderer
- Convert Sinon to Jest