### PR TITLE
refactor(stats): refactor widget

### DIFF
--- a/src/components/Stats/Stats.js
+++ b/src/components/Stats/Stats.js
@@ -1,42 +1,44 @@
+import React from 'preact-compat';
 import PropTypes from 'prop-types';
-import React, { Component } from 'preact-compat';
-
 import Template from '../Template.js';
 
-class Stats extends Component {
-  render() {
-    const data = {
-      hasManyResults: this.props.nbHits > 1,
-      hasNoResults: this.props.nbHits === 0,
-      hasOneResult: this.props.nbHits === 1,
-      hitsPerPage: this.props.hitsPerPage,
-      nbHits: this.props.nbHits,
-      nbPages: this.props.nbPages,
-      page: this.props.page,
-      processingTimeMS: this.props.processingTimeMS,
-      query: this.props.query,
-      cssClasses: this.props.cssClasses,
-    };
-
-    return (
-      <div className={this.props.cssClasses.root}>
-        <Template
-          templateKey="text"
-          rootTagName="span"
-          rootProps={{ className: this.props.cssClasses.text }}
-          data={data}
-          {...this.props.templateProps}
-        />
-      </div>
-    );
-  }
-}
+const Stats = ({
+  nbHits,
+  hitsPerPage,
+  nbPages,
+  page,
+  processingTimeMS,
+  query,
+  templateProps,
+  cssClasses,
+}) => (
+  <div className={cssClasses.root}>
+    <Template
+      {...templateProps}
+      templateKey="text"
+      rootTagName="span"
+      rootProps={{ className: cssClasses.text }}
+      data={{
+        hasManyResults: nbHits > 1,
+        hasNoResults: nbHits === 0,
+        hasOneResult: nbHits === 1,
+        hitsPerPage,
+        nbHits,
+        nbPages,
+        page,
+        processingTimeMS,
+        query,
+        cssClasses,
+      }}
+    />
+  </div>
+);
 
 Stats.propTypes = {
   cssClasses: PropTypes.shape({
-    root: PropTypes.string,
-    text: PropTypes.string,
-  }),
+    root: PropTypes.string.isRequired,
+    text: PropTypes.string.isRequired,
+  }).isRequired,
   hitsPerPage: PropTypes.number,
   nbHits: PropTypes.number,
   nbPages: PropTypes.number,

--- a/src/components/Stats/__tests__/Stats-test.js
+++ b/src/components/Stats/__tests__/Stats-test.js
@@ -1,43 +1,45 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import Stats from '../Stats';
-import renderer from 'react-test-renderer';
 import defaultTemplates from '../../../widgets/stats/defaultTemplates';
 
 describe('Stats', () => {
+  const cssClasses = {
+    root: 'root',
+    text: 'text',
+  };
+
   it('should render <Template data= />', () => {
-    const out = shallow(<Stats {...getProps()} templateProps={{}} />);
+    const wrapper = shallow(<Stats {...getProps()} templateProps={{}} />);
 
     const defaultProps = {
-      cssClasses: {},
+      cssClasses,
       hasManyResults: true,
       hasNoResults: false,
       hasOneResult: false,
     };
 
-    expect(out.props().children.props.data).toMatchObject(defaultProps);
-    expect(out).toMatchSnapshot();
+    expect(wrapper.props().children.props.data).toMatchObject(defaultProps);
+    expect(wrapper).toMatchSnapshot();
   });
 
   it('should render <Stats /> with custom CSS classes', () => {
-    const tree = renderer
-      .create(
-        <Stats
-          templateProps={{
-            templates: defaultTemplates,
-          }}
-          nbHits={1}
-          cssClasses={{ root: 'my-root', text: 'my-text' }}
-        />
-      )
-      .toJSON();
+    const wrapper = mount(
+      <Stats
+        templateProps={{
+          templates: defaultTemplates,
+        }}
+        nbHits={1}
+        cssClasses={cssClasses}
+      />
+    );
 
-    expect(tree).toMatchSnapshot();
+    expect(wrapper).toMatchSnapshot();
   });
 
   function getProps(extraProps = {}) {
     return {
-      cssClasses: {},
+      cssClasses,
       hitsPerPage: 10,
       nbHits: 1234,
       nbPages: 124,

--- a/src/components/Stats/__tests__/__snapshots__/Stats-test.js.snap
+++ b/src/components/Stats/__tests__/__snapshots__/Stats-test.js.snap
@@ -2,10 +2,10 @@
 
 exports[`Stats should render <Stats /> with custom CSS classes 1`] = `
 <div
-  className="my-root"
+  className="root"
 >
   <span
-    className="my-text"
+    className="text"
     dangerouslySetInnerHTML={
       Object {
         "__html": "
@@ -18,11 +18,16 @@ exports[`Stats should render <Stats /> with custom CSS classes 1`] = `
 `;
 
 exports[`Stats should render <Template data= /> 1`] = `
-<div>
+<div
+  className="root"
+>
   <Component
     data={
       Object {
-        "cssClasses": Object {},
+        "cssClasses": Object {
+          "root": "root",
+          "text": "text",
+        },
         "hasManyResults": true,
         "hasNoResults": false,
         "hasOneResult": false,
@@ -36,7 +41,7 @@ exports[`Stats should render <Template data= /> 1`] = `
     }
     rootProps={
       Object {
-        "className": undefined,
+        "className": "text",
       }
     }
     rootTagName="span"

--- a/src/connectors/stats/__tests__/connectStats-test.js
+++ b/src/connectors/stats/__tests__/connectStats-test.js
@@ -1,5 +1,3 @@
-import sinon from 'sinon';
-
 import jsHelper from 'algoliasearch-helper';
 const SearchResults = jsHelper.SearchResults;
 
@@ -9,7 +7,7 @@ describe('connectStats', () => {
   it('Renders during init and render', () => {
     // test that the dummyRendering is called with the isFirstRendering
     // flag set accordingly
-    const rendering = sinon.stub();
+    const rendering = jest.fn();
     const makeWidget = connectStats(rendering);
 
     const widget = makeWidget({
@@ -19,7 +17,7 @@ describe('connectStats', () => {
     expect(widget.getConfiguration).toEqual(undefined);
 
     const helper = jsHelper({});
-    helper.search = sinon.stub();
+    helper.search = jest.fn();
 
     widget.init({
       helper,
@@ -30,8 +28,9 @@ describe('connectStats', () => {
 
     {
       // should call the rendering once with isFirstRendering to true
-      expect(rendering.callCount).toBe(1);
-      const isFirstRendering = rendering.lastCall.args[1];
+      expect(rendering).toHaveBeenCalledTimes(1);
+      const isFirstRendering =
+        rendering.mock.calls[rendering.mock.calls.length - 1][1];
       expect(isFirstRendering).toBe(true);
 
       // should provide good values for the first rendering
@@ -43,7 +42,7 @@ describe('connectStats', () => {
         processingTimeMS,
         query,
         widgetParams,
-      } = rendering.lastCall.args[0];
+      } = rendering.mock.calls[rendering.mock.calls.length - 1][0];
       expect(hitsPerPage).toBe(helper.state.hitsPerPage);
       expect(nbHits).toBe(0);
       expect(nbPages).toBe(0);
@@ -72,8 +71,9 @@ describe('connectStats', () => {
 
     {
       // Should call the rendering a second time, with isFirstRendering to false
-      expect(rendering.callCount).toBe(2);
-      const isFirstRendering = rendering.lastCall.args[1];
+      expect(rendering).toHaveBeenCalledTimes(2);
+      const isFirstRendering =
+        rendering.mock.calls[rendering.mock.calls.length - 1][1];
       expect(isFirstRendering).toBe(false);
 
       // should provide good values after the first search
@@ -84,7 +84,7 @@ describe('connectStats', () => {
         page,
         processingTimeMS,
         query,
-      } = rendering.lastCall.args[0];
+      } = rendering.mock.calls[rendering.mock.calls.length - 1][0];
       expect(hitsPerPage).toBe(helper.state.hitsPerPage);
       expect(nbHits).toBe(1);
       expect(nbPages).toBe(1);

--- a/src/widgets/stats/__tests__/stats-test.js
+++ b/src/widgets/stats/__tests__/stats-test.js
@@ -1,5 +1,4 @@
 import expect from 'expect';
-import sinon from 'sinon';
 import stats from '../stats';
 
 const instantSearchInstance = { templatesConfig: undefined };
@@ -17,7 +16,7 @@ describe('stats()', () => {
   let results;
 
   beforeEach(() => {
-    ReactDOM = { render: sinon.spy() };
+    ReactDOM = { render: jest.fn() };
     stats.__Rewire__('render', ReactDOM.render);
 
     container = document.createElement('div');
@@ -45,19 +44,14 @@ describe('stats()', () => {
   it('calls twice ReactDOM.render(<Stats props />, container)', () => {
     widget.render({ results, instantSearchInstance });
     widget.render({ results, instantSearchInstance });
-    expect(ReactDOM.render.calledTwice).toBe(
-      true,
-      'ReactDOM.render called twice'
-    );
-    expect(ReactDOM.render.firstCall.args[0]).toMatchSnapshot();
-    expect(ReactDOM.render.firstCall.args[1]).toEqual(container);
-    expect(ReactDOM.render.secondCall.args[0]).toMatchSnapshot();
-    expect(ReactDOM.render.secondCall.args[1]).toEqual(container);
+    expect(ReactDOM.render).toHaveBeenCalledTimes(2);
+    expect(ReactDOM.render.mock.calls[0][0]).toMatchSnapshot();
+    expect(ReactDOM.render.mock.calls[0][1]).toEqual(container);
+    expect(ReactDOM.render.mock.calls[1][0]).toMatchSnapshot();
+    expect(ReactDOM.render.mock.calls[1][1]).toEqual(container);
   });
 
   afterEach(() => {
     stats.__ResetDependency__('render');
-    stats.__ResetDependency__('autoHideContainerHOC');
-    stats.__ResetDependency__('headerFooterHOC');
   });
 });

--- a/src/widgets/stats/stats.js
+++ b/src/widgets/stats/stats.js
@@ -1,12 +1,9 @@
 import React, { render, unmountComponentAtNode } from 'preact-compat';
 import cx from 'classnames';
-
 import Stats from '../../components/Stats/Stats.js';
 import connectStats from '../../connectors/stats/connectStats.js';
 import defaultTemplates from './defaultTemplates.js';
-
 import { prepareTemplateProps, getContainerNode } from '../../lib/utils.js';
-
 import { component } from '../../lib/suit';
 
 const suit = component('Stats');
@@ -37,6 +34,7 @@ const renderer = ({
       templatesConfig: instantSearchInstance.templatesConfig,
       templates,
     });
+
     return;
   }
 
@@ -151,7 +149,7 @@ export default function stats({
       unmountComponentAtNode(containerNode)
     );
     return makeWidget();
-  } catch (e) {
+  } catch (error) {
     throw new Error(usage);
   }
 }


### PR DESCRIPTION
- Remove unused `cx()`
- Use functional functional components when possible
- Enforce prop types for class names
- Use Enzyme over React Test Renderer
- Convert Sinon to Jest