### PR TITLE
refactor: update widgets

### DIFF
--- a/src/components/ClearRefinements/ClearRefinements.js
+++ b/src/components/ClearRefinements/ClearRefinements.js
@@ -1,44 +1,38 @@
+import React from 'preact-compat';
 import PropTypes from 'prop-types';
-import React, { Component } from 'preact-compat';
 import cx from 'classnames';
-
 import Template from '../Template.js';
 
-class ClearRefinements extends Component {
-  render() {
-    const { hasRefinements, cssClasses } = this.props;
-    const data = { hasRefinements };
-
-    const rootClassNames = cx(cssClasses.root);
-    const buttonClassNames = cx(cssClasses.button, {
-      [cssClasses.disabledButton]: !hasRefinements,
-    });
-
-    return (
-      <div className={rootClassNames}>
-        <Template
-          data={data}
-          templateKey="resetLabel"
-          rootTagName="button"
-          rootProps={{
-            className: buttonClassNames,
-            onClick: this.props.refine,
-            disabled: !hasRefinements,
-          }}
-          {...this.props.templateProps}
-        />
-      </div>
-    );
-  }
-}
+const ClearRefinements = ({
+  hasRefinements,
+  refine,
+  cssClasses,
+  templateProps,
+}) => (
+  <div className={cssClasses.root}>
+    <Template
+      {...templateProps}
+      templateKey="resetLabel"
+      rootTagName="button"
+      rootProps={{
+        className: cx(cssClasses.button, {
+          [cssClasses.disabledButton]: !hasRefinements,
+        }),
+        onClick: refine,
+        disabled: !hasRefinements,
+      }}
+      data={{ hasRefinements }}
+    />
+  </div>
+);
 
 ClearRefinements.propTypes = {
   refine: PropTypes.func.isRequired,
   cssClasses: PropTypes.shape({
-    root: PropTypes.string,
-    button: PropTypes.string,
-    disabledButton: PropTypes.string,
-  }),
+    root: PropTypes.string.isRequired,
+    button: PropTypes.string.isRequired,
+    disabledButton: PropTypes.string.isRequired,
+  }).isRequired,
   hasRefinements: PropTypes.bool.isRequired,
   templateProps: PropTypes.object.isRequired,
 };

--- a/src/components/ClearRefinements/__tests__/ClearRefinements-test.js
+++ b/src/components/ClearRefinements/__tests__/ClearRefinements-test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ClearRefinements from '../ClearRefinements';
-import renderer from 'react-test-renderer';
+import { mount } from 'enzyme';
 
 describe('ClearRefinements', () => {
   const defaultProps = {
@@ -20,16 +20,16 @@ describe('ClearRefinements', () => {
   };
 
   it('should render <ClearRefinements />', () => {
-    const tree = renderer
-      .create(<ClearRefinements {...defaultProps} />)
-      .toJSON();
-    expect(tree).toMatchSnapshot();
+    const wrapper = mount(<ClearRefinements {...defaultProps} />);
+
+    expect(wrapper).toMatchSnapshot();
   });
 
   it('should render <ClearRefinements /> with a specific class when no refinements', () => {
-    const tree = renderer
-      .create(<ClearRefinements {...defaultProps} hasRefinements={false} />)
-      .toJSON();
-    expect(tree).toMatchSnapshot();
+    const wrapper = mount(
+      <ClearRefinements {...defaultProps} hasRefinements={false} />
+    );
+
+    expect(wrapper).toMatchSnapshot();
   });
 });

--- a/src/components/MenuSelect.js
+++ b/src/components/MenuSelect.js
@@ -7,10 +7,10 @@ import Template from './Template';
 class MenuSelect extends Component {
   static propTypes = {
     cssClasses: PropTypes.shape({
-      root: PropTypes.string,
-      select: PropTypes.string,
-      option: PropTypes.string,
-    }),
+      root: PropTypes.string.isRequired,
+      select: PropTypes.string.isRequired,
+      option: PropTypes.string.isRequired,
+    }).isRequired,
     items: PropTypes.array.isRequired,
     refine: PropTypes.func.isRequired,
     templateProps: PropTypes.object.isRequired,
@@ -26,42 +26,38 @@ class MenuSelect extends Component {
       value: '',
     };
 
-    const noRefinements = items.length === 0;
-
     const rootClassNames = cx(cssClasses.root, {
-      [cssClasses.noRefinementRoot]: noRefinements,
+      [cssClasses.noRefinementRoot]: items.length === 0,
     });
-    const selectClassNames = cx(cssClasses.select);
-    const optionClassNames = cx(cssClasses.option);
 
     return (
       <div className={rootClassNames}>
         <select
-          className={selectClassNames}
+          className={cssClasses.select}
           value={selectedValue}
           onChange={this.handleSelectChange}
         >
           <Template
+            {...templateProps}
             templateKey="seeAllOptions"
             rootTagName="option"
             rootProps={{
               value: '',
-              className: optionClassNames,
+              className: cssClasses.option,
             }}
-            {...templateProps}
           />
 
           {items.map(item => (
             <Template
-              data={item}
+              {...templateProps}
               templateKey="item"
               rootTagName="option"
-              key={item.value}
               rootProps={{
                 value: item.value,
-                className: optionClassNames,
+                className: cssClasses.option,
               }}
-              {...templateProps}
+              key={item.value}
+              data={item}
             />
           ))}
         </select>

--- a/src/components/__tests__/MenuSelect-test.js
+++ b/src/components/__tests__/MenuSelect-test.js
@@ -1,25 +1,29 @@
 import React from 'react';
 import MenuSelect from '../MenuSelect';
-import renderer from 'react-test-renderer';
+import { mount } from 'enzyme';
 
 import defaultTemplates from '../../widgets/menu-select/defaultTemplates';
 
 describe('MenuSelect', () => {
+  const cssClasses = {
+    root: 'root',
+    noRefinementRoot: 'noRefinementRoot',
+    select: 'select',
+    option: 'option',
+  };
+
   it('should render <MenuSelect /> with items', () => {
     const props = {
       items: [{ value: 'foo', label: 'foo' }, { value: 'bar', label: 'bar' }],
       refine: () => {},
       templateProps: { templates: defaultTemplates },
       shouldAutoHideContainer: false,
-      cssClasses: {
-        root: 'root',
-        noRefinementRoot: 'noRefinementRoot',
-        select: 'select',
-        option: 'option',
-      },
+      cssClasses,
     };
-    const tree = renderer.create(<MenuSelect {...props} />).toJSON();
-    expect(tree).toMatchSnapshot();
+
+    const wrapper = mount(<MenuSelect {...props} />);
+
+    expect(wrapper).toMatchSnapshot();
   });
 
   it('should render <MenuSelect /> with no items', () => {
@@ -28,14 +32,11 @@ describe('MenuSelect', () => {
       refine: () => {},
       templateProps: { templates: defaultTemplates },
       shouldAutoHideContainer: false,
-      cssClasses: {
-        root: 'root',
-        noRefinementRoot: 'noRefinementRoot',
-        select: 'select',
-        option: 'option',
-      },
+      cssClasses,
     };
-    const tree = renderer.create(<MenuSelect {...props} />).toJSON();
-    expect(tree).toMatchSnapshot();
+
+    const wrapper = mount(<MenuSelect {...props} />);
+
+    expect(wrapper).toMatchSnapshot();
   });
 });

--- a/src/components/__tests__/Template-test.js
+++ b/src/components/__tests__/Template-test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import TemplateWithTransformData, { PureTemplate } from '../Template';
-import sinon from 'sinon';
 import renderer from 'react-test-renderer';
 
 describe('Template', () => {
@@ -172,37 +171,37 @@ describe('Template', () => {
         rootProps: { className: 'myCssClass' },
       });
       component = ReactDOM.render(<PureTemplate {...props} />, container);
-      sinon.spy(component, 'render');
+      jest.spyOn(component, 'render');
     });
 
     it('does not call render when no change in data', () => {
       ReactDOM.render(<PureTemplate {...props} />, container);
-      expect(component.render.called).toBe(false);
+      expect(component.render).not.toHaveBeenCalled();
     });
 
     it('calls render when data changes', () => {
       props.data = { hello: 'dad' };
       ReactDOM.render(<PureTemplate {...props} />, container);
-      expect(component.render.called).toBe(true);
+      expect(component.render).toHaveBeenCalled();
     });
 
     it('calls render when templateKey changes', () => {
       props.templateKey += '-rerender';
       props.templates = { [props.templateKey]: '' };
       ReactDOM.render(<PureTemplate {...props} />, container);
-      expect(component.render.called).toBe(true);
+      expect(component.render).toHaveBeenCalled();
     });
 
     it('calls render when rootProps changes', () => {
       props.rootProps = { className: 'myCssClass mySecondCssClass' };
       ReactDOM.render(<PureTemplate {...props} />, container);
-      expect(component.render.called).toBe(true);
+      expect(component.render).toHaveBeenCalled();
     });
 
     it('does not call render when rootProps remain unchanged', () => {
       props.rootProps = { className: 'myCssClass' };
       ReactDOM.render(<PureTemplate {...props} />, container);
-      expect(component.render.called).toBe(false);
+      expect(component.render).not.toHaveBeenCalled();
     });
   });
 

--- a/src/connectors/range/__tests__/connectRange-test.js
+++ b/src/connectors/range/__tests__/connectRange-test.js
@@ -1,5 +1,3 @@
-import sinon from 'sinon';
-
 import jsHelper, {
   SearchResults,
   SearchParameters,
@@ -11,7 +9,7 @@ describe('connectRange', () => {
   it('Renders during init and render', () => {
     // test that the dummyRendering is called with the isFirstRendering
     // flag set accordingly
-    const rendering = sinon.stub();
+    const rendering = jest.fn();
     const makeWidget = connectRange(rendering);
 
     const attribute = 'price';
@@ -25,7 +23,7 @@ describe('connectRange', () => {
     });
 
     const helper = jsHelper({}, '', config);
-    helper.search = sinon.stub();
+    helper.search = jest.fn();
 
     widget.init({
       helper,
@@ -36,12 +34,15 @@ describe('connectRange', () => {
 
     {
       // should call the rendering once with isFirstRendering to true
-      expect(rendering.callCount).toBe(1);
-      const isFirstRendering = rendering.lastCall.args[1];
+      expect(rendering).toHaveBeenCalledTimes(1);
+      const isFirstRendering =
+        rendering.mock.calls[rendering.mock.calls.length - 1][1];
       expect(isFirstRendering).toBe(true);
 
       // should provide good values for the first rendering
-      const { range, start, widgetParams } = rendering.lastCall.args[0];
+      const { range, start, widgetParams } = rendering.mock.calls[
+        rendering.mock.calls.length - 1
+      ][0];
       expect(range).toEqual({ min: 0, max: 0 });
       expect(start).toEqual([-Infinity, Infinity]);
       expect(widgetParams).toEqual({
@@ -76,12 +77,15 @@ describe('connectRange', () => {
 
     {
       // Should call the rendering a second time, with isFirstRendering to false
-      expect(rendering.callCount).toBe(2);
-      const isFirstRendering = rendering.lastCall.args[1];
+      expect(rendering).toHaveBeenCalledTimes(2);
+      const isFirstRendering =
+        rendering.mock.calls[rendering.mock.calls.length - 1][1];
       expect(isFirstRendering).toBe(false);
 
       // should provide good values for the first rendering
-      const { range, start, widgetParams } = rendering.lastCall.args[0];
+      const { range, start, widgetParams } = rendering.mock.calls[
+        rendering.mock.calls.length - 1
+      ][0];
       expect(range).toEqual({ min: 10, max: 30 });
       expect(start).toEqual([-Infinity, Infinity]);
       expect(widgetParams).toEqual({
@@ -124,7 +128,7 @@ describe('connectRange', () => {
   });
 
   it('Provides a function to update the refinements at each step', () => {
-    const rendering = sinon.stub();
+    const rendering = jest.fn();
     const makeWidget = connectRange(rendering);
 
     const attribute = 'price';
@@ -133,7 +137,7 @@ describe('connectRange', () => {
     });
 
     const helper = jsHelper({}, '', widget.getConfiguration());
-    helper.search = sinon.stub();
+    helper.search = jest.fn();
 
     widget.init({
       helper,
@@ -146,12 +150,13 @@ describe('connectRange', () => {
       // first rendering
       expect(helper.getNumericRefinement('price', '>=')).toEqual(undefined);
       expect(helper.getNumericRefinement('price', '<=')).toEqual(undefined);
-      const renderOptions = rendering.lastCall.args[0];
+      const renderOptions =
+        rendering.mock.calls[rendering.mock.calls.length - 1][0];
       const { refine } = renderOptions;
       refine([10, 30]);
       expect(helper.getNumericRefinement('price', '>=')).toEqual([10]);
       expect(helper.getNumericRefinement('price', '<=')).toEqual([30]);
-      expect(helper.search.callCount).toBe(1);
+      expect(helper.search).toHaveBeenCalledTimes(1);
     }
 
     widget.render({
@@ -183,24 +188,25 @@ describe('connectRange', () => {
       // Second rendering
       expect(helper.getNumericRefinement('price', '>=')).toEqual([10]);
       expect(helper.getNumericRefinement('price', '<=')).toEqual([30]);
-      const renderOptions = rendering.lastCall.args[0];
+      const renderOptions =
+        rendering.mock.calls[rendering.mock.calls.length - 1][0];
       const { refine } = renderOptions;
       refine([23, 27]);
       expect(helper.getNumericRefinement('price', '>=')).toEqual([23]);
       expect(helper.getNumericRefinement('price', '<=')).toEqual([27]);
-      expect(helper.search.callCount).toBe(2);
+      expect(helper.search).toHaveBeenCalledTimes(2);
     }
   });
 
   it('should add numeric refinement when refining min boundary without previous configuration', () => {
-    const rendering = sinon.stub();
+    const rendering = jest.fn();
     const makeWidget = connectRange(rendering);
 
     const attribute = 'price';
     const widget = makeWidget({ attribute, min: 0, max: 500 });
 
     const helper = jsHelper({}, '', widget.getConfiguration());
-    helper.search = sinon.stub();
+    helper.search = jest.fn();
 
     widget.init({
       helper,
@@ -214,13 +220,14 @@ describe('connectRange', () => {
       expect(helper.getNumericRefinement('price', '>=')).toEqual([0]);
       expect(helper.getNumericRefinement('price', '<=')).toEqual([500]);
 
-      const renderOptions = rendering.lastCall.args[0];
+      const renderOptions =
+        rendering.mock.calls[rendering.mock.calls.length - 1][0];
       const { refine } = renderOptions;
       refine([10, 30]);
 
       expect(helper.getNumericRefinement('price', '>=')).toEqual([10]);
       expect(helper.getNumericRefinement('price', '<=')).toEqual([30]);
-      expect(helper.search.callCount).toBe(1);
+      expect(helper.search).toHaveBeenCalledTimes(1);
 
       refine([0, undefined]);
       expect(helper.getNumericRefinement('price', '>=')).toEqual([0]);
@@ -229,7 +236,7 @@ describe('connectRange', () => {
   });
 
   it('should add numeric refinement when refining min boundary with previous configuration', () => {
-    const rendering = sinon.stub();
+    const rendering = jest.fn();
     const makeWidget = connectRange(rendering);
 
     const attribute = 'price';
@@ -239,7 +246,7 @@ describe('connectRange', () => {
     });
 
     const helper = jsHelper({}, '', configuration);
-    helper.search = sinon.stub();
+    helper.search = jest.fn();
 
     widget.init({
       helper,
@@ -253,13 +260,14 @@ describe('connectRange', () => {
       expect(helper.getNumericRefinement('price', '>=')).toEqual([0]);
       expect(helper.getNumericRefinement('price', '<=')).toEqual([500]);
 
-      const renderOptions = rendering.lastCall.args[0];
+      const renderOptions =
+        rendering.mock.calls[rendering.mock.calls.length - 1][0];
       const { refine } = renderOptions;
       refine([10, 30]);
 
       expect(helper.getNumericRefinement('price', '>=')).toEqual([10]);
       expect(helper.getNumericRefinement('price', '<=')).toEqual([30]);
-      expect(helper.search.callCount).toBe(1);
+      expect(helper.search).toHaveBeenCalledTimes(1);
 
       refine([0, undefined]);
       expect(helper.getNumericRefinement('price', '>=')).toEqual([0]);
@@ -268,14 +276,14 @@ describe('connectRange', () => {
   });
 
   it('should refine on boundaries when no min/max defined', () => {
-    const rendering = sinon.stub();
+    const rendering = jest.fn();
     const makeWidget = connectRange(rendering);
 
     const attribute = 'price';
     const widget = makeWidget({ attribute });
 
     const helper = jsHelper({}, '', widget.getConfiguration());
-    helper.search = sinon.stub();
+    helper.search = jest.fn();
 
     widget.init({
       helper,
@@ -288,23 +296,24 @@ describe('connectRange', () => {
       expect(helper.getNumericRefinement('price', '>=')).toEqual(undefined);
       expect(helper.getNumericRefinement('price', '<=')).toEqual(undefined);
 
-      const renderOptions = rendering.lastCall.args[0];
+      const renderOptions =
+        rendering.mock.calls[rendering.mock.calls.length - 1][0];
       const { refine } = renderOptions;
 
       refine([undefined, 100]);
       expect(helper.getNumericRefinement('price', '>=')).toEqual(undefined);
       expect(helper.getNumericRefinement('price', '<=')).toEqual([100]);
-      expect(helper.search.callCount).toBe(1);
+      expect(helper.search).toHaveBeenCalledTimes(1);
 
       refine([0, undefined]);
       expect(helper.getNumericRefinement('price', '>=')).toEqual([0]);
       expect(helper.getNumericRefinement('price', '<=')).toEqual(undefined);
-      expect(helper.search.callCount).toBe(2);
+      expect(helper.search).toHaveBeenCalledTimes(2);
 
       refine([0, 100]);
       expect(helper.getNumericRefinement('price', '>=')).toEqual([0]);
       expect(helper.getNumericRefinement('price', '<=')).toEqual([100]);
-      expect(helper.search.callCount).toBe(3);
+      expect(helper.search).toHaveBeenCalledTimes(3);
     }
   });
 

--- a/src/widgets/clear-refinements/__tests__/clear-refinements-test.js
+++ b/src/widgets/clear-refinements/__tests__/clear-refinements-test.js
@@ -1,5 +1,4 @@
 import expect from 'expect';
-import sinon from 'sinon';
 import clearRefinements from '../clear-refinements';
 
 describe('clearRefinements()', () => {
@@ -11,8 +10,8 @@ describe('clearRefinements()', () => {
   let createURL;
 
   beforeEach(() => {
-    ReactDOM = { render: sinon.spy() };
-    createURL = sinon.stub().returns('#all-cleared');
+    ReactDOM = { render: jest.fn() };
+    createURL = jest.fn().mockReturnValue('#all-cleared');
 
     clearRefinements.__Rewire__('render', ReactDOM.render);
 
@@ -29,10 +28,10 @@ describe('clearRefinements()', () => {
     results = {};
     helper = {
       state: {
-        clearRefinements: sinon.stub().returnsThis(),
-        clearTags: sinon.stub().returnsThis(),
+        clearRefinements: jest.fn().mockReturnValue(this),
+        clearTags: jest.fn().mockReturnValue(this),
       },
-      search: sinon.spy(),
+      search: jest.fn(),
     };
 
     widget.init({
@@ -69,14 +68,11 @@ describe('clearRefinements()', () => {
         instantSearchInstance: {},
       });
 
-      expect(ReactDOM.render.calledTwice).toBe(
-        true,
-        'ReactDOM.render called twice'
-      );
-      expect(ReactDOM.render.firstCall.args[0]).toMatchSnapshot();
-      expect(ReactDOM.render.firstCall.args[1]).toEqual(container);
-      expect(ReactDOM.render.secondCall.args[0]).toMatchSnapshot();
-      expect(ReactDOM.render.secondCall.args[1]).toEqual(container);
+      expect(ReactDOM.render).toHaveBeenCalledTimes(2);
+      expect(ReactDOM.render.mock.calls[0][0]).toMatchSnapshot();
+      expect(ReactDOM.render.mock.calls[0][1]).toEqual(container);
+      expect(ReactDOM.render.mock.calls[1][0]).toMatchSnapshot();
+      expect(ReactDOM.render.mock.calls[1][1]).toEqual(container);
     });
   });
 
@@ -89,19 +85,15 @@ describe('clearRefinements()', () => {
       widget.render({ results, helper, state: helper.state, createURL });
       widget.render({ results, helper, state: helper.state, createURL });
 
-      expect(ReactDOM.render.calledTwice).toBe(
-        true,
-        'ReactDOM.render called twice'
-      );
-      expect(ReactDOM.render.firstCall.args[0]).toMatchSnapshot();
-      expect(ReactDOM.render.firstCall.args[1]).toEqual(container);
-      expect(ReactDOM.render.secondCall.args[0]).toMatchSnapshot();
-      expect(ReactDOM.render.secondCall.args[1]).toEqual(container);
+      expect(ReactDOM.render).toHaveBeenCalledTimes(2);
+      expect(ReactDOM.render.mock.calls[0][0]).toMatchSnapshot();
+      expect(ReactDOM.render.mock.calls[0][1]).toEqual(container);
+      expect(ReactDOM.render.mock.calls[1][0]).toMatchSnapshot();
+      expect(ReactDOM.render.mock.calls[1][1]).toEqual(container);
     });
   });
 
   afterEach(() => {
     clearRefinements.__ResetDependency__('render');
-    clearRefinements.__ResetDependency__('defaultTemplates');
   });
 });

--- a/src/widgets/clear-refinements/clear-refinements.js
+++ b/src/widgets/clear-refinements/clear-refinements.js
@@ -1,14 +1,10 @@
 import React, { render, unmountComponentAtNode } from 'preact-compat';
 import ClearRefinements from '../../components/ClearRefinements/ClearRefinements.js';
 import cx from 'classnames';
-
-import { getContainerNode, prepareTemplateProps } from '../../lib/utils.js';
-
-import { component } from '../../lib/suit';
-
 import connectClearRefinements from '../../connectors/clear-refinements/connectClearRefinements.js';
-
 import defaultTemplates from './defaultTemplates.js';
+import { getContainerNode, prepareTemplateProps } from '../../lib/utils.js';
+import { component } from '../../lib/suit';
 
 const suit = component('ClearRefinements');
 
@@ -43,7 +39,7 @@ const renderer = ({
 const usage = `Usage:
 clearRefinements({
   container,
-  [ cssClasses.{root,button,disabledButton}={} ],
+  [ cssClasses.{root,button,disabledButton} ],
   [ templates.{resetLabel}={resetLabel: 'Clear all refinements'} ],
   [ collapsible=false ],
   [ excludedAttributes=[] ]
@@ -126,7 +122,7 @@ export default function clearRefinements({
       unmountComponentAtNode(containerNode)
     );
     return makeWidget({ excludedAttributes, clearsQuery });
-  } catch (e) {
+  } catch (error) {
     throw new Error(usage);
   }
 }

--- a/src/widgets/hits-per-page/hits-per-page.js
+++ b/src/widgets/hits-per-page/hits-per-page.js
@@ -1,7 +1,6 @@
 import React, { render, unmountComponentAtNode } from 'preact-compat';
 import cx from 'classnames';
 import find from 'lodash/find';
-
 import Selector from '../../components/Selector.js';
 import connectHitsPerPage from '../../connectors/hits-per-page/connectHitsPerPage.js';
 import { getContainerNode } from '../../lib/utils.js';
@@ -19,7 +18,7 @@ const renderer = ({ containerNode, cssClasses }) => (
     find(items, ({ isRefined }) => isRefined) || {};
 
   render(
-    <div className={cx(cssClasses.root)}>
+    <div className={cssClasses.root}>
       <Selector
         cssClasses={cssClasses}
         currentValue={currentValue}
@@ -35,7 +34,7 @@ const usage = `Usage:
 hitsPerPage({
   container,
   items,
-  [ cssClasses.{root, select, option}={} ],
+  [ cssClasses.{root, select, option} ],
   [ transformItems ]
 })`;
 
@@ -111,7 +110,7 @@ export default function hitsPerPage({
       unmountComponentAtNode(containerNode)
     );
     return makeHitsPerPage({ items, transformItems });
-  } catch (e) {
+  } catch (error) {
     throw new Error(usage);
   }
 }

--- a/src/widgets/menu-select/menu-select.js
+++ b/src/widgets/menu-select/menu-select.js
@@ -1,12 +1,9 @@
 import React, { render } from 'preact-compat';
 import cx from 'classnames';
-
 import connectMenu from '../../connectors/menu/connectMenu';
-import defaultTemplates from './defaultTemplates';
 import MenuSelect from '../../components/MenuSelect';
-
+import defaultTemplates from './defaultTemplates';
 import { prepareTemplateProps, getContainerNode } from '../../lib/utils';
-
 import { component } from '../../lib/suit';
 
 const suit = component('MenuSelect');
@@ -140,7 +137,7 @@ export default function menuSelect({
   try {
     const makeWidget = connectMenu(specializedRenderer);
     return makeWidget({ attribute, limit, sortBy, transformItems });
-  } catch (e) {
+  } catch (error) {
     throw new Error(usage);
   }
 }

--- a/src/widgets/range-input/range-input.js
+++ b/src/widgets/range-input/range-input.js
@@ -173,7 +173,7 @@ export default function rangeInput({
       max,
       precision,
     });
-  } catch (e) {
+  } catch (error) {
     throw new Error(usage);
   }
 }

--- a/src/widgets/sort-by/sort-by.js
+++ b/src/widgets/sort-by/sort-by.js
@@ -1,6 +1,5 @@
 import React, { render, unmountComponentAtNode } from 'preact-compat';
 import cx from 'classnames';
-
 import Selector from '../../components/Selector.js';
 import connectSortBy from '../../connectors/sort-by/connectSortBy.js';
 import { getContainerNode } from '../../lib/utils.js';
@@ -12,10 +11,12 @@ const renderer = ({ containerNode, cssClasses }) => (
   { currentRefinement, options, refine },
   isFirstRendering
 ) => {
-  if (isFirstRendering) return;
+  if (isFirstRendering) {
+    return;
+  }
 
   render(
-    <div className={cx(cssClasses.root)}>
+    <div className={cssClasses.root}>
       <Selector
         cssClasses={cssClasses}
         currentValue={currentRefinement}
@@ -31,8 +32,8 @@ const usage = `Usage:
 sortBy({
   container,
   items,
-  [cssClasses.{root,select,option}={}],
-  [autoHideContainer=false],
+  [cssClasses.{root, select, option}],
+  [autoHideContainer = false],
   [transformItems]
 })`;
 
@@ -108,7 +109,7 @@ export default function sortBy({
       unmountComponentAtNode(containerNode)
     );
     return makeWidget({ items, transformItems });
-  } catch (e) {
+  } catch (error) {
     throw new Error(usage);
   }
 }


### PR DESCRIPTION
This is the remaining of other PRs.

- Remove unused `cx()`
- Use functional functional components when possible
- Enforce prop types for class names
- Use Enzyme over React Test Renderer
- Convert Sinon to Jest