### PR TITLE
fix(InstantSearch): avoid useless search on addWidgets

### DIFF
--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -205,7 +205,7 @@ To help you migrate, please refer to the migration guide: https://community.algo
     });
 
     // Init the widget directly if instantsearch has been already started
-    if (this.started) {
+    if (this.started && Boolean(widgets.length)) {
       this.searchParameters = this.widgets.reduce(enhanceConfiguration({}), {
         ...this.helper.state,
       });

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -620,6 +620,20 @@ describe('InstantSearch lifecycle', () => {
       expect(search.searchParameters.facets).toEqual(['price']);
       expect(search.searchParameters.disjunctiveFacets).toEqual(['categories']);
     });
+
+    it('should not trigger a search without widgets to add', () => {
+      search.start();
+
+      expect(helperSearchSpy.callCount).toBe(1);
+      expect(search.widgets).toHaveLength(0);
+      expect(search.started).toBe(true);
+
+      search.addWidgets([]);
+
+      expect(helperSearchSpy.callCount).toBe(1);
+      expect(search.widgets).toHaveLength(0);
+      expect(search.started).toBe(true);
+    });
   });
 
   it('should remove all widgets without triggering a search on dispose', () => {


### PR DESCRIPTION
**Summary**

The current implementation of `addWidgets` **always** trigger a search even without any widgets to add on InstantSearch. We should prevent this behaviour to avoid useless request each time a user call `addWidgets` without anything. 

This issue pops out with a dynamic facetting use case (see example below) - we get an infinite loop because we always call `addWidgets` without checking the length of the widgets to add. It should be the default behaviour.

```js
// We should not have to do this check inside user code

if (addWidgets.length) {
  search.addWidgets(addWidgets.map(item => item.widget));
}
```

> https://codesandbox.io/s/nnpvp2x8r4