### PR TITLE
feat(refinement-list): prevent refinement on disabled items

### DIFF
--- a/src/components/RefinementList/RefinementList.js
+++ b/src/components/RefinementList/RefinementList.js
@@ -102,6 +102,16 @@ class RefinementList extends Component {
       return;
     }
 
+    const isClassDisabled = new RegExp(/^ais-(.*)--disabled$/);
+
+    if (
+      [].slice
+        .call(originalEvent.currentTarget.classList)
+        .some(className => isClassDisabled.test(className))
+    ) {
+      return;
+    }
+
     let parent = originalEvent.target;
 
     while (parent !== originalEvent.currentTarget) {


### PR DESCRIPTION
This is a not-so-great solution to prevent clicking on disabled items (in RefinementList, MenuRating, etc.) based on their classname.

## Preview

### Before

https://deploy-preview-3161--algolia-instantsearch.netlify.com/v2/dev-novel/?selectedStory=RatingMenu.with%20disabled%20item

### After

https://deploy-preview-3187--algolia-instantsearch.netlify.com/v2/dev-novel/?selectedStory=RatingMenu.with%20disabled%20item

## Other solutions

### Based on `facetValue.count`

* Breaks the RefinementList: unable to unselect a facet with a count of 0 (see https://github.com/algolia/instantsearch.js/pull/3161#pullrequestreview-162017759)