### PR TITLE
feat(utils): add `throwUsage()`

### DIFF
--- a/src/lib/__tests__/utils-test.js
+++ b/src/lib/__tests__/utils-test.js
@@ -931,6 +931,26 @@ describe('utils.warn', () => {
   });
 });
 
+describe('utils.throwUsage', () => {
+  it('throws the correct error', () => {
+    expect(() =>
+      utils.throwUsage('Usage: bad usage', () => 'option does not exist')
+    ).toThrowErrorMatchingInlineSnapshot(`
+"[InstantSearch.js] option does not exist
+
+Usage: bad usage"
+`);
+  });
+
+  it('with empty message does not throw', () => {
+    expect(() => utils.throwUsage('Usage: bad usage', () => '')).not.toThrow();
+  });
+
+  it('with no function does not throw', () => {
+    expect(() => utils.throwUsage('Usage: bad usage')).not.toThrow();
+  });
+});
+
 describe('utils.parseAroundLatLngFromString', () => {
   it('expect to return a LatLng object from string', () => {
     const samples = [

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -437,6 +437,14 @@ function warn(message) {
   }
 }
 
+export function throwUsage(usageError, getErrorMessage = () => '') {
+  const errorMessage = getErrorMessage();
+
+  if (errorMessage) {
+    throw new Error(`[InstantSearch.js] ${errorMessage}\n\n${usageError}`);
+  }
+}
+
 const latLngRegExp = /^(-?\d+(?:\.\d+)?),\s*(-?\d+(?:\.\d+)?)$/;
 function parseAroundLatLngFromString(value) {
   const pattern = value.match(latLngRegExp);

--- a/src/widgets/refinement-list/__tests__/__snapshots__/refinement-list-test.js.snap
+++ b/src/widgets/refinement-list/__tests__/__snapshots__/refinement-list-test.js.snap
@@ -1,5 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`refinementList() instantiated with wrong parameters throws an exception when showMoreLimit is lower than limit 1`] = `
+"[InstantSearch.js] \`showMoreLimit\` should be a number greater or equal than \`limit\`.
+
+Usage:
+refinementList({
+  container,
+  attribute,
+  operator?: string = 'or',
+  sortBy?: string[]|function = ['isRefined', 'count:desc', 'name:asc'] ],
+  limit?: number = 10,
+  showMore?: boolean = false,
+  showMoreLimit?: number = 10,
+  cssClasses?: { root, noRefinementRoot, searchBox, list, item, selectedItem, label, checkbox, labelText, count, noResults, showMore, disabledShowMore },
+  templates?: { item, searchableNoResults, showMoreActive, showMoreInactive },
+  searchable?: boolean = false,
+  searchablePlaceholder?: string = 'Search...',
+  searchableIsAlwaysActive?: boolean = true,
+  searchableEscapeFacetValues?: boolean = true,
+  transformItems?: function,
+})"
+`;
+
+exports[`refinementList() instantiated with wrong parameters throws an exception when showMoreLimit without showMore option 1`] = `
+"[InstantSearch.js] \`showMoreLimit\` must be used with \`showMore\` set to \`true\`.
+
+Usage:
+refinementList({
+  container,
+  attribute,
+  operator?: string = 'or',
+  sortBy?: string[]|function = ['isRefined', 'count:desc', 'name:asc'] ],
+  limit?: number = 10,
+  showMore?: boolean = false,
+  showMoreLimit?: number = 10,
+  cssClasses?: { root, noRefinementRoot, searchBox, list, item, selectedItem, label, checkbox, labelText, count, noResults, showMore, disabledShowMore },
+  templates?: { item, searchableNoResults, showMoreActive, showMoreInactive },
+  searchable?: boolean = false,
+  searchablePlaceholder?: string = 'Search...',
+  searchableIsAlwaysActive?: boolean = true,
+  searchableEscapeFacetValues?: boolean = true,
+  transformItems?: function,
+})"
+`;
+
 exports[`refinementList() render renders transformed items correctly 1`] = `
 <RefinementList
   canToggleShowMore={false}

--- a/src/widgets/refinement-list/__tests__/refinement-list-test.js
+++ b/src/widgets/refinement-list/__tests__/refinement-list-test.js
@@ -25,7 +25,7 @@ describe('refinementList()', () => {
       expect(() => {
         // When
         refinementList(options);
-      }).toThrow(/^Usage:/);
+      }).toThrow(/Usage:/);
     });
 
     it('throws an exception when showMoreLimit without showMore option', () => {
@@ -35,9 +35,7 @@ describe('refinementList()', () => {
           container,
           showMoreLimit: 10,
         })
-      ).toThrowErrorMatchingInlineSnapshot(
-        `"\`showMoreLimit\` must be used with \`showMore\` set to \`true\`."`
-      );
+      ).toThrowErrorMatchingSnapshot();
     });
 
     it('throws an exception when showMoreLimit is lower than limit', () => {
@@ -49,9 +47,7 @@ describe('refinementList()', () => {
           showMore: true,
           showMoreLimit: 10,
         })
-      ).toThrowErrorMatchingInlineSnapshot(
-        `"\`showMoreLimit\` should be greater than \`limit\`."`
-      );
+      ).toThrowErrorMatchingSnapshot();
     });
   });
 

--- a/src/widgets/refinement-list/refinement-list.js
+++ b/src/widgets/refinement-list/refinement-list.js
@@ -3,7 +3,11 @@ import cx from 'classnames';
 import RefinementList from '../../components/RefinementList/RefinementList.js';
 import connectRefinementList from '../../connectors/refinement-list/connectRefinementList.js';
 import defaultTemplates from './defaultTemplates.js';
-import { prepareTemplateProps, getContainerNode } from '../../lib/utils.js';
+import {
+  prepareTemplateProps,
+  getContainerNode,
+  throwUsage,
+} from '../../lib/utils.js';
 import { component } from '../../lib/suit';
 
 const suit = component('RefinementList');
@@ -66,18 +70,18 @@ const usage = `Usage:
 refinementList({
   container,
   attribute,
-  [ operator='or' ],
-  [ sortBy = ['isRefined', 'count:desc', 'name:asc'] ],
-  [ limit = 10 ],
-  [ showMore = false],
-  [ showMoreLimit = 10 ],
-  [ cssClasses.{root, noRefinementRoot, searchBox, list, item, selectedItem, label, checkbox, labelText, count, noResults, showMore, disabledShowMore}],
-  [ templates.{item, searchableNoResults, showMoreActive, showMoreInactive} ],
-  [ searchable ],
-  [ searchablePlaceholder ],
-  [ searchableIsAlwaysActive = true ],
-  [ searchableEscapeFacetValues = true ],
-  [ transformItems ],
+  operator?: string = 'or',
+  sortBy?: string[]|function = ['isRefined', 'count:desc', 'name:asc'] ],
+  limit?: number = 10,
+  showMore?: boolean = false,
+  showMoreLimit?: number = 10,
+  cssClasses?: { root, noRefinementRoot, searchBox, list, item, selectedItem, label, checkbox, labelText, count, noResults, showMore, disabledShowMore },
+  templates?: { item, searchableNoResults, showMoreActive, showMoreInactive },
+  searchable?: boolean = false,
+  searchablePlaceholder?: string = 'Search...',
+  searchableIsAlwaysActive?: boolean = true,
+  searchableEscapeFacetValues?: boolean = true,
+  transformItems?: function,
 })`;
 
 /**
@@ -186,19 +190,25 @@ export default function refinementList({
   templates = defaultTemplates,
   transformItems,
 } = {}) {
-  if (!container) {
-    throw new Error(usage);
-  }
+  throwUsage(usage, () => {
+    if (!container) {
+      return '`container` is missing.';
+    }
 
-  if (!showMore && showMoreLimit) {
-    throw new Error(
-      '`showMoreLimit` must be used with `showMore` set to `true`.'
-    );
-  }
+    if (!attribute) {
+      return '`attribute` is missing.';
+    }
 
-  if (showMore && showMoreLimit < limit) {
-    throw new Error('`showMoreLimit` should be greater than `limit`.');
-  }
+    if (!showMore && showMoreLimit) {
+      return '`showMoreLimit` must be used with `showMore` set to `true`.';
+    }
+
+    if (showMore && showMoreLimit < limit) {
+      return '`showMoreLimit` should be a number greater or equal than `limit`.';
+    }
+
+    return '';
+  });
 
   const escapeFacetValues = searchable
     ? Boolean(searchableEscapeFacetValues)


### PR DESCRIPTION
This PR is an attempt at making InstantSearch.js errors more understandable. It provides a `throwUsage()` function that prefixes the error with `[InstantSearch.js]`, displays what's wrong with the widget/connector usage and the usage itself.

I also propose a new syntax for the widget options.

This effort tries to fix #3078.

I didn't update other widgets waiting for an approval.

## Example

```
[InstantSearch.js] `showMoreLimit` should be a number greater or equal than `limit`.

Usage:
refinementList({
  container,
  attribute,
  operator?: string = 'or',
  sortBy?: string[]|function = ['isRefined', 'count:desc', 'name:asc'] ],
  limit?: number = 10,
  showMore?: boolean = false,
  showMoreLimit?: number = 10,
  cssClasses?: { root, noRefinementRoot, searchBox, list, item, selectedItem, label, checkbox, labelText, count, noResults, showMore, disabledShowMore },
  templates?: { item, searchableNoResults, showMoreActive, showMoreInactive },
  searchable?: boolean = false,
  searchablePlaceholder?: string = 'Search...',
  searchableIsAlwaysActive?: boolean = true,
  searchableEscapeFacetValues?: boolean = true,
  transformItems?: function,
})
```