### PR TITLE
fix(connectRangeSlider): remove deprecated connector

### DIFF
--- a/docgen/src/guides/v3-migration.md
+++ b/docgen/src/guides/v3-migration.md
@@ -1111,6 +1111,10 @@ We've moved the `label` into the `templates.labelText` template to make it consi
 | --------------- | ----------- |
 | `attributeName` | `attribute` |
 
+### connectRangeSlider
+
+Connector removed (use `connectRange` instead).
+
 ### connectClearRefinements (formerly connectClearAll)
 
 #### Options

--- a/src/connectors/index.js
+++ b/src/connectors/index.js
@@ -21,9 +21,6 @@ export {
 export {
   default as connectPagination,
 } from './pagination/connectPagination.js';
-export {
-  default as connectRangeSlider,
-} from './range-slider/connectRangeSlider.js';
 export { default as connectRange } from './range/connectRange.js';
 export {
   default as connectRefinementList,

--- a/src/connectors/range-slider/connectRangeSlider.js
+++ b/src/connectors/range-slider/connectRangeSlider.js
@@ -1,8 +1,0 @@
-import { deprecate } from '../../lib/utils';
-import connectRange from '../range/connectRange';
-
-export default deprecate(
-  connectRange,
-  `'connectRangeSlider' was replaced by 'connectRange'.
-  Please see https://community.algolia.com/instantsearch.js/v2/connectors/connectRange.html`
-);


### PR DESCRIPTION
`connectRangeSlider` has been deprecated for a long time. The next major version is the opportunity to remove it completely.