### PR TITLE
docs: add missing plus sign

### DIFF
--- a/docgen/src/guides/customization.md
+++ b/docgen/src/guides/customization.md
@@ -170,7 +170,7 @@ const customMenuRenderFn = function(renderParams, isFirstRendering) {
   const optionsHTML = items.map(function(item) {
     return (
       '<option value="' + item.value + '"' + (item.isRefined ? ' selected' : '') + '>' +
-      item.label + '(' + item.count ')' +
+      item.label + '(' + item.count + ')' +
       '</option>'
     );
   });


### PR DESCRIPTION
Fix the syntax error when somebody copy & pastes the provided example code.