### PR TITLE
docs(migration): fix widget links

### DIFF
--- a/docgen/src/guides/migration.md
+++ b/docgen/src/guides/migration.md
@@ -31,7 +31,7 @@ search.addWidget(instantsearch.widgets.searchbox({
 }));
 ```
 
-You can read more about these options [here](../widgets/searchBox.html).
+You can read more about these options [here](widgets/searchBox.html).
 
 ## No more `hitsPerPage` in `hits` and `infiniteHits`
 
@@ -41,7 +41,7 @@ this option of the engine, there are still three ways:
  - use the [dashboard](https://www.algolia.com/explorer/display/) or
    the [client](https://www.algolia.com/doc/api-client/default/settings/#set-settings),
    to change the setting at the index level.
- - use the [hitsPerPageSelector](../widgets/hitsPerPageSelector.html) widget.
+ - use the [hitsPerPageSelector](widgets/hitsPerPageSelector.html) widget.
  - use the configuration option of `instantsearch`:
 
 ```javascript
@@ -83,8 +83,8 @@ yourSearch.addWidget(
 ```
 
 If you want to learn more about sorting the values, check out the widget API to see what are
-the valid values for the `sortBy` option of [menu](../widgets/menu.html#struct-MenuWidgetOptions-sortBy) or
-[refinementList](../widgets/refinementList.html#struct-RefinementListWidgetOptions-sortBy)
+the valid values for the `sortBy` option of [menu](widgets/menu.html#struct-MenuWidgetOptions-sortBy) or
+[refinementList](widgets/refinementList.html#struct-RefinementListWidgetOptions-sortBy)
 
 ## Some variables have been changed
 


### PR DESCRIPTION
**Summary**

Changed broken links from `(../widgets` to `(widgets`. For example, [the "hitsPerPageSelector" link in "use the hitsPerPageSelector widget"](https://community.algolia.com/instantsearch.js/v2/guides/migration.html#no-more-hitsperpage-in-hits-and-infinitehits)

**Result**

The link was changed to be similar to [the routing page links](https://github.com/algolia/instantsearch.js/blob/develop/docgen/src/guides/routing.md) that are within the same `src/guides` folder level. For example, [the "searchBox" link under the "User friendly urls" heading](https://community.algolia.com/instantsearch.js/v2/guides/routing.html#user-friendly-urls).