### PR TITLE
fix(InfiniteHits): correctly set the class for last page

### DIFF
--- a/src/components/InfiniteHits/InfiniteHits.js
+++ b/src/components/InfiniteHits/InfiniteHits.js
@@ -43,18 +43,15 @@ const InfiniteHits = ({
         ))}
       </ol>
 
-      {isLastPage ? (
-        <button disabled className={cssClasses.loadMore}>
-          {loadMoreLabel}
-        </button>
-      ) : (
-        <button
-          onClick={showMore}
-          className={cx(cssClasses.loadMore, cssClasses.disabledLoadMore)}
-        >
-          {loadMoreLabel}
-        </button>
-      )}
+      <button
+        className={cx(cssClasses.loadMore, {
+          [cssClasses.disabledLoadMore]: isLastPage,
+        })}
+        disabled={isLastPage}
+        onClick={showMore}
+      >
+        {loadMoreLabel}
+      </button>
     </div>
   );
 };

--- a/src/components/InfiniteHits/__tests__/__snapshots__/InfiniteHits-test.js.snap
+++ b/src/components/InfiniteHits/__tests__/__snapshots__/InfiniteHits-test.js.snap
@@ -25,7 +25,8 @@ exports[`InfiniteHits markup should render <InfiniteHits /> on first page 1`] = 
     />
   </ol>
   <button
-    className="loadMore disabledLoadMore"
+    className="loadMore"
+    disabled={false}
   />
 </div>
 `;
@@ -55,7 +56,7 @@ exports[`InfiniteHits markup should render <InfiniteHits /> on last page 1`] = `
     />
   </ol>
   <button
-    className="loadMore"
+    className="loadMore disabledLoadMore"
     disabled={true}
   />
 </div>


### PR DESCRIPTION
**Summary**

The current implementation invert the condition for the disabled className. I've also updated how we render the button, now we always render the same element only the props change.

**Before**

<img width="551" alt="screen shot 2018-10-25 at 13 21 59" src="https://user-images.githubusercontent.com/6513513/47528048-00afa480-d859-11e8-9bfd-e0deeb75dba5.png">

**After**

<img width="553" alt="screen shot 2018-10-25 at 13 22 08" src="https://user-images.githubusercontent.com/6513513/47528060-04432b80-d859-11e8-8b15-507a3c817df6.png">
