### PR TITLE
feat(InstantSearch): add in dev timeout when start is not called

### DIFF
--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -13,6 +13,7 @@ import simpleMapping from './stateMappings/simple.js';
 import historyRouter from './routers/history.js';
 import version from './version.js';
 import createHelpers from './createHelpers.js';
+import { warn } from './utils';
 
 const ROUTING_DEFAULT_OPTIONS = {
   stateMapping: simpleMapping(),
@@ -232,9 +233,8 @@ To help you migrate, please refer to the migration guide: https://community.algo
       clearTimeout(this._widgetTimer);
       this._widgetTimer = setTimeout(
         () =>
-          // eslint-disable-next-line no-console
-          console.warn(
-            `InstantSearch.js: search.start() was not called within 5 seconds of adding your last widget. Please make sure you are calling search.start()`
+          warn(
+            `search.start() was not called within 5 seconds of adding your last widget. Please make sure you are calling search.start()`
           ),
         5000
       );

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -227,6 +227,18 @@ To help you migrate, please refer to the migration guide: https://community.algo
 
       this.helper.search();
     }
+
+    if (process.env.NODE_ENV === 'development' && !this.started) {
+      clearTimeout(this._widgetTimer);
+      this._widgetTimer = setTimeout(
+        () =>
+          // eslint-disable-next-line no-console
+          console.warn(
+            `InstantSearch.js: search.start() was not called within 5 seconds of adding your last widget. Please make sure you are calling search.start()`
+          ),
+        5000
+      );
+    }
   }
 
   /**
@@ -401,6 +413,10 @@ To help you migrate, please refer to the migration guide: https://community.algo
         }, this._stalledSearchDelay);
       }
     });
+
+    if (process.env.NODE_ENV === 'development') {
+      clearTimeout(this._widgetTimer);
+    }
 
     // track we started the search if we add more widgets,
     // to init them directly after add


### PR DESCRIPTION
**Summary**

Closes #2671

When `NODE_ENV === 'development'` and `this.started` has not been set. A new timer will be set each time `addWidgets` is called. Only one timer is ever active and when `this.started` is called, it will be cleared.

**Result**

When widgets are added during development with `yarn dev` if `.start()`  is not called within 5 seconds a warning will be displayed in the console.
