### PR TITLE
fix(hits): transform items after escaping

### DIFF
--- a/src/connectors/hits/__tests__/connectHits-test.js
+++ b/src/connectors/hits/__tests__/connectHits-test.js
@@ -199,4 +199,83 @@ describe('connectHits', () => {
       expect.anything()
     );
   });
+
+  it('transform items after escaping', () => {
+    const rendering = jest.fn();
+    const makeWidget = connectHits(rendering);
+    const widget = makeWidget({
+      transformItems: items =>
+        items.map(item => ({
+          ...item,
+          _highlightResult: {
+            name: {
+              value: item._highlightResult.name.value.toUpperCase(),
+            },
+          },
+        })),
+      escapeHTML: true,
+    });
+
+    const helper = jsHelper({}, '', {});
+    helper.search = jest.fn();
+
+    widget.init({
+      helper,
+      state: helper.state,
+      createURL: () => '#',
+    });
+
+    const hits = [
+      {
+        name: 'hello',
+        _highlightResult: {
+          name: {
+            value: 'he__ais-highlight__llo__/ais-highlight__',
+          },
+        },
+      },
+      {
+        name: 'halloween',
+        _highlightResult: {
+          name: {
+            value: 'ha__ais-highlight__llo__/ais-highlight__ween',
+          },
+        },
+      },
+    ];
+
+    const results = new SearchResults(helper.state, [{ hits }]);
+    widget.render({
+      results,
+      state: helper.state,
+      helper,
+      createURL: () => '#',
+    });
+
+    expect(rendering).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        hits: [
+          {
+            name: 'hello',
+            _highlightResult: {
+              name: {
+                value: 'HE<MARK>LLO</MARK>',
+              },
+            },
+          },
+          {
+            name: 'halloween',
+            _highlightResult: {
+              name: {
+                value: 'HA<MARK>LLO</MARK>WEEN',
+              },
+            },
+          },
+        ],
+        results,
+      }),
+      expect.anything()
+    );
+  });
 });

--- a/src/connectors/hits/connectHits.js
+++ b/src/connectors/hits/connectHits.js
@@ -82,8 +82,6 @@ export default function connectHits(renderFn, unmountFn) {
       },
 
       render({ results, instantSearchInstance }) {
-        results.hits = transformItems(results.hits);
-
         if (
           widgetParams.escapeHTML &&
           results.hits &&
@@ -91,6 +89,8 @@ export default function connectHits(renderFn, unmountFn) {
         ) {
           results.hits = escapeHTML(results.hits);
         }
+
+        results.hits = transformItems(results.hits);
 
         renderFn(
           {

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.js
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.js
@@ -254,6 +254,85 @@ describe('connectInfiniteHits', () => {
     expect(secondRenderingOptions.results).toEqual(results);
   });
 
+  it('transform items after escaping', () => {
+    const rendering = jest.fn();
+    const makeWidget = connectInfiniteHits(rendering);
+    const widget = makeWidget({
+      transformItems: items =>
+        items.map(item => ({
+          ...item,
+          _highlightResult: {
+            name: {
+              value: item._highlightResult.name.value.toUpperCase(),
+            },
+          },
+        })),
+      escapeHTML: true,
+    });
+
+    const helper = jsHelper({}, '', {});
+    helper.search = jest.fn();
+
+    widget.init({
+      helper,
+      state: helper.state,
+      createURL: () => '#',
+    });
+
+    const hits = [
+      {
+        name: 'hello',
+        _highlightResult: {
+          name: {
+            value: 'he__ais-highlight__llo__/ais-highlight__',
+          },
+        },
+      },
+      {
+        name: 'halloween',
+        _highlightResult: {
+          name: {
+            value: 'ha__ais-highlight__llo__/ais-highlight__ween',
+          },
+        },
+      },
+    ];
+
+    const results = new SearchResults(helper.state, [{ hits }]);
+    widget.render({
+      results,
+      state: helper.state,
+      helper,
+      createURL: () => '#',
+    });
+
+    expect(rendering).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        hits: [
+          {
+            name: 'hello',
+            _highlightResult: {
+              name: {
+                value: 'HE<MARK>LLO</MARK>',
+              },
+            },
+          },
+          {
+            name: 'halloween',
+            _highlightResult: {
+              name: {
+                value: 'HA<MARK>LLO</MARK>WEEN',
+              },
+            },
+          },
+        ],
+        results,
+      }),
+      expect.anything()
+    );
+  });
+
   it('does not render the same page twice', () => {
     const rendering = jest.fn();
     const makeWidget = connectInfiniteHits(rendering);

--- a/src/connectors/infinite-hits/connectInfiniteHits.js
+++ b/src/connectors/infinite-hits/connectInfiniteHits.js
@@ -113,8 +113,6 @@ export default function connectInfiniteHits(renderFn, unmountFn) {
           lastReceivedPage = -1;
         }
 
-        results.hits = transformItems(results.hits);
-
         if (
           widgetParams.escapeHTML &&
           results.hits &&
@@ -122,6 +120,8 @@ export default function connectInfiniteHits(renderFn, unmountFn) {
         ) {
           results.hits = escapeHTML(results.hits);
         }
+
+        results.hits = transformItems(results.hits);
 
         if (lastReceivedPage < state.page) {
           hitsCache = [...hitsCache, ...results.hits];


### PR DESCRIPTION
This applies the items transformation after escaping. It fixes issues when we transform highlighted values.

An example could be that the highlighted value gets uppercased, and therefore changes the default tag `__ais-highlight__` to `__AIS-HIGHLIGHT__` which doesn't get caught by the regex to be replaced by a `mark` tag.

The fix is implemented for both Hits and InfiniteHits connectors.

Closes #3250

> Note: the other connectors apply `transformItems` as last step already.