### PR TITLE
feat(sortBy): implement Panel specs

### DIFF
--- a/dev/app/builtin/stories/panel.stories.js
+++ b/dev/app/builtin/stories/panel.stories.js
@@ -32,7 +32,12 @@ export default () => {
           instantsearch.widgets.panel({
             templates: {
               header: 'Header',
-              footer: 'Footer',
+              footer: ({ items, currentRefinement }) =>
+                items
+                  ? `${
+                      items.length
+                    } items available ("${currentRefinement}" selected)`
+                  : '',
             },
           })(instantsearch.widgets.sortBy)({
             container,

--- a/dev/app/builtin/stories/panel.stories.js
+++ b/dev/app/builtin/stories/panel.stories.js
@@ -7,21 +7,42 @@ import { wrapWithHits } from '../../utils/wrap-with-hits.js';
 const stories = storiesOf('Panel');
 
 export default () => {
-  stories.add(
-    'with default',
-    wrapWithHits(container => {
-      window.search.addWidget(
-        instantsearch.widgets.panel({
-          templates: {
-            header: 'Header',
-            footer: 'Footer',
-          },
-          hidden: ({ canRefine }) => !canRefine,
-        })(instantsearch.widgets.refinementList)({
-          container,
-          attribute: 'brand',
-        })
-      );
-    })
-  );
+  stories
+    .add(
+      'with default',
+      wrapWithHits(container => {
+        window.search.addWidget(
+          instantsearch.widgets.panel({
+            templates: {
+              header: 'Header',
+              footer: 'Footer',
+            },
+            hidden: ({ canRefine }) => !canRefine,
+          })(instantsearch.widgets.refinementList)({
+            container,
+            attribute: 'brand',
+          })
+        );
+      })
+    )
+    .add(
+      'with sortBy',
+      wrapWithHits(container => {
+        window.search.addWidget(
+          instantsearch.widgets.panel({
+            templates: {
+              header: 'Header',
+              footer: 'Footer',
+            },
+          })(instantsearch.widgets.sortBy)({
+            container,
+            items: [
+              { value: 'instant_search', label: 'Most relevant' },
+              { value: 'instant_search_price_asc', label: 'Lowest price' },
+              { value: 'instant_search_price_desc', label: 'Highest price' },
+            ],
+          })
+        );
+      })
+    );
 };

--- a/src/components/Selector/Selector.js
+++ b/src/components/Selector/Selector.js
@@ -12,7 +12,7 @@ class Selector extends Component {
   }
 
   render() {
-    const { currentValue, options } = this.props;
+    const { currentValue, items } = this.props;
 
     return (
       <select
@@ -20,7 +20,7 @@ class Selector extends Component {
         onChange={this.handleChange}
         value={`${currentValue}`}
       >
-        {options.map(option => (
+        {items.map(option => (
           <option
             className={cx(this.props.cssClasses.option)}
             key={option.label + option.value}
@@ -50,7 +50,7 @@ Selector.propTypes = {
     ]),
   }),
   currentValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  options: PropTypes.arrayOf(
+  items: PropTypes.arrayOf(
     PropTypes.shape({
       value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
       label: PropTypes.string.isRequired,

--- a/src/components/Selector/__tests__/Selector-test.js
+++ b/src/components/Selector/__tests__/Selector-test.js
@@ -12,7 +12,7 @@ describe('Selector', () => {
         select: 'custom-select',
         option: 'custom-option',
       },
-      options: [
+      items: [
         { value: 'index-a', label: 'Index A' },
         { value: 'index-b', label: 'Index B' },
       ],
@@ -30,7 +30,7 @@ describe('Selector', () => {
         select: 'custom-select',
         option: 'custom-option',
       },
-      options: [
+      items: [
         { value: 10, label: '10 results per page' },
         { value: 20, label: '20 results per page' },
       ],

--- a/src/connectors/sort-by/__tests__/connectSortBy-test.js
+++ b/src/connectors/sort-by/__tests__/connectSortBy-test.js
@@ -300,4 +300,11 @@ describe('connectSortBy', () => {
       });
     });
   });
+
+  it('provides getRenderingOptions()', () => {
+    const makeWidget = connectSortBy(() => {});
+    const widget = makeWidget({ items: [] });
+
+    expect(widget.getRenderingOptions).toBeDefined();
+  });
 });

--- a/src/connectors/sort-by/__tests__/connectSortBy-test.js
+++ b/src/connectors/sort-by/__tests__/connectSortBy-test.js
@@ -42,7 +42,7 @@ describe('connectSortBy', () => {
       expect.objectContaining({
         currentRefinement: helper.state.index,
         widgetParams: { items },
-        options: [
+        items: [
           { label: 'Sort products by relevance', value: 'relevance' },
           { label: 'Sort products by price', value: 'priceASC' },
         ],
@@ -63,7 +63,7 @@ describe('connectSortBy', () => {
       expect.objectContaining({
         currentRefinement: helper.state.index,
         widgetParams: { items },
-        options: [
+        items: [
           { label: 'Sort products by relevance', value: 'relevance' },
           { label: 'Sort products by price', value: 'priceASC' },
         ],
@@ -101,7 +101,7 @@ describe('connectSortBy', () => {
 
     expect(rendering).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        options: [
+        items: [
           { label: 'transformed', value: 'relevance' },
           { label: 'transformed', value: 'priceASC' },
         ],
@@ -118,7 +118,7 @@ describe('connectSortBy', () => {
 
     expect(rendering).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        options: [
+        items: [
           { label: 'transformed', value: 'relevance' },
           { label: 'transformed', value: 'priceASC' },
         ],

--- a/src/connectors/sort-by/connectSortBy.js
+++ b/src/connectors/sort-by/connectSortBy.js
@@ -177,7 +177,7 @@ export default function connectSortBy(renderFn, unmountFn) {
         return {
           items: transformItems(items),
           canRefine: results && results.nbHits > 0,
-          currentIndex: helper.getIndex(),
+          currentRefinement: helper.getIndex(),
         };
       },
     };

--- a/src/connectors/sort-by/connectSortBy.js
+++ b/src/connectors/sort-by/connectSortBy.js
@@ -108,7 +108,7 @@ export default function connectSortBy(renderFn, unmountFn) {
       throw new Error(usage);
     }
 
-    let _setIndex;
+    let setIndex;
 
     return {
       init({ helper, instantSearchInstance }) {
@@ -122,13 +122,12 @@ export default function connectSortBy(renderFn, unmountFn) {
         }
 
         this.initialIndex = instantSearchInstance.indexName;
-        _setIndex = indexName => helper.setIndex(indexName).search();
+        setIndex = indexName => helper.setIndex(indexName).search();
 
         renderFn(
           {
-            ...this.getRenderingOptions(),
-            currentRefinement: currentIndex,
-            refine: _setIndex,
+            ...this.getRenderingOptions({ helper }),
+            refine: setIndex,
             widgetParams,
             instantSearchInstance,
           },
@@ -139,9 +138,8 @@ export default function connectSortBy(renderFn, unmountFn) {
       render({ helper, results, instantSearchInstance }) {
         renderFn(
           {
-            ...this.getRenderingOptions({ results }),
-            currentRefinement: helper.getIndex(),
-            refine: _setIndex,
+            ...this.getRenderingOptions({ results, helper }),
+            refine: setIndex,
             widgetParams,
             instantSearchInstance,
           },
@@ -175,10 +173,11 @@ export default function connectSortBy(renderFn, unmountFn) {
         );
       },
 
-      getRenderingOptions({ results } = {}) {
+      getRenderingOptions({ results, helper }) {
         return {
           items: transformItems(items),
           canRefine: results && results.nbHits > 0,
+          currentIndex: helper.getIndex(),
         };
       },
     };

--- a/src/widgets/hits-per-page/__tests__/__snapshots__/hits-per-page-test.js.snap
+++ b/src/widgets/hits-per-page/__tests__/__snapshots__/hits-per-page-test.js.snap
@@ -13,7 +13,7 @@ exports[`hitsPerPage() calls twice ReactDOM.render(<Selector props />, container
       }
     }
     currentValue={10}
-    options={
+    items={
       Array [
         Object {
           "isRefined": true,
@@ -45,7 +45,7 @@ exports[`hitsPerPage() renders transformed items 1`] = `
       }
     }
     currentValue={10}
-    options={
+    items={
       Array [
         Object {
           "isRefined": true,

--- a/src/widgets/hits-per-page/hits-per-page.js
+++ b/src/widgets/hits-per-page/hits-per-page.js
@@ -22,7 +22,7 @@ const renderer = ({ containerNode, cssClasses }) => (
       <Selector
         cssClasses={cssClasses}
         currentValue={currentValue}
-        options={items}
+        items={items}
         setValue={refine}
       />
     </div>,
@@ -53,7 +53,7 @@ hitsPerPage({
  */
 
 /**
- * @typedef {Object} HitsPerPageWidgetOptions
+ * @typedef {Object} HitsPerPageWidgetItems
  * @property {string|HTMLElement} container CSS Selector or HTMLElement to insert the widget.
  * @property {HitsPerPageItems[]} items Array of objects defining the different values and labels.
  * @property {HitsPerPageCSSClasses} [cssClasses] CSS classes to be added.
@@ -68,7 +68,7 @@ hitsPerPage({
  * @type {WidgetFactory}
  * @devNovel HitsPerPage
  * @category basic
- * @param {HitsPerPageWidgetOptions} $0 The options of the HitPerPageSelector widget.
+ * @param {HitsPerPageWidgetItems} $0 The options of the HitPerPageSelector widget.
  * @return {Widget} A new instance of the HitPerPageSelector widget.
  * @example
  * search.addWidget(

--- a/src/widgets/sort-by/__tests__/__snapshots__/sort-by-test.js.snap
+++ b/src/widgets/sort-by/__tests__/__snapshots__/sort-by-test.js.snap
@@ -13,7 +13,7 @@ exports[`sortBy() calls twice ReactDOM.render(<Selector props />, container) 1`]
       }
     }
     currentValue="index-a"
-    options={
+    items={
       Array [
         Object {
           "label": "Index A",
@@ -43,7 +43,7 @@ exports[`sortBy() calls twice ReactDOM.render(<Selector props />, container) 2`]
       }
     }
     currentValue="index-a"
-    options={
+    items={
       Array [
         Object {
           "label": "Index A",
@@ -73,7 +73,7 @@ exports[`sortBy() renders transformed items 1`] = `
       }
     }
     currentValue="index-a"
-    options={
+    items={
       Array [
         Object {
           "label": "Index A",

--- a/src/widgets/sort-by/__tests__/sort-by-test.js
+++ b/src/widgets/sort-by/__tests__/sort-by-test.js
@@ -88,12 +88,6 @@ describe('sortBy()', () => {
     expect(ReactDOM.render.mock.calls[0][0]).toMatchSnapshot();
   });
 
-  it('sets the underlying index', () => {
-    widget.setIndex('index-b');
-    expect(helper.setIndex).toHaveBeenCalledTimes(1, 'setIndex called once');
-    expect(helper.search).toHaveBeenCalledTimes(1, 'search called once');
-  });
-
   it('should throw if there is no name attribute in a passed object', () => {
     items.length = 0;
     items.push({ label: 'Label without a name' });

--- a/src/widgets/sort-by/sort-by.js
+++ b/src/widgets/sort-by/sort-by.js
@@ -8,7 +8,7 @@ import { component } from '../../lib/suit.js';
 const suit = component('SortBy');
 
 const renderer = ({ containerNode, cssClasses }) => (
-  { currentRefinement, options, refine },
+  { currentRefinement, items, refine },
   isFirstRendering
 ) => {
   if (isFirstRendering) {
@@ -20,7 +20,7 @@ const renderer = ({ containerNode, cssClasses }) => (
       <Selector
         cssClasses={cssClasses}
         currentValue={currentRefinement}
-        options={options}
+        items={items}
         setValue={refine}
       />
     </div>,
@@ -50,7 +50,7 @@ sortBy({
  */
 
 /**
- * @typedef {Object} SortByWidgetOptions
+ * @typedef {Object} SortByWidgetItems
  * @property {string|HTMLElement} container CSS Selector or HTMLElement to insert the widget.
  * @property {SortByIndexDefinition[]} items Array of objects defining the different indices to choose from.
  * @property {SortByWidgetCssClasses} [cssClasses] CSS classes to be added.
@@ -65,7 +65,7 @@ sortBy({
  * @type {WidgetFactory}
  * @devNovel SortBy
  * @category sort
- * @param {SortByWidgetOptions} $0 Options for the SortBy widget
+ * @param {SortByWidgetItems} $0 Options for the SortBy widget
  * @return {Widget} Creates a new instance of the SortBy widget.
  * @example
  * search.addWidget(


### PR DESCRIPTION
This is a POC to show how to implement the new panel specification (#3253).

This also updates:

- `options` rendering option to `items`
- `hasNoResults` rendering option to `canRefine`

This is still untested, waiting for your opinion on this new direction.

## Stories

https://deploy-preview-3254--instantsearchjs.netlify.com/v2/dev-novel/?selectedStory=Panel.with%20sortBy