### PR TITLE
docs(getting-started): fix mustache link

### DIFF
--- a/docgen/src/getting-started.md.hbs
+++ b/docgen/src/getting-started.md.hbs
@@ -140,7 +140,7 @@ All the widgets provided by the library can be found in the namespace `instantse
 
 You should now be able to see the results without any styling. This view lets you inspect the values that are retrieved from Algolia, in order to build your custom view.
 
-In order to customize the view for each product, we can use a special option of the hit widget: `templates`. This option accepts a [Mustache](https://community.algolia.com/instantsearch.js/documentation/) template string or a function returning a string.
+In order to customize the view for each product, we can use a special option of the hit widget: `templates`. This option accepts a [Mustache](https://mustache.github.io/mustache.5.html) template string or a function returning a string.
 
 ```html
 <div id="hits">


### PR DESCRIPTION
The original link to the `https://community.algolia.com/instantsearch.js/documentation/` from the `Mustache` word looks strange, this PR changes the link to lead to the Mustache docs instead.
