### PR TITLE
docs: warn jsDelivr usage

### DIFF
--- a/docgen/src/getting-started.md.hbs
+++ b/docgen/src/getting-started.md.hbs
@@ -53,7 +53,7 @@ We also provide you a default Algolia theme for the widgets to be effectively st
 
 You will then have access to the `instantsearch` function in the global scope (`window`).
 
-The jsDeliver CDN is highly available with [over 110 locations](https://www.jsdelivr.com/features/network-map) in the world.
+> We recommend using jsDelivr only for prototyping, **not for production applications**. Whenever possible, you should host your assets yourself or use a premium CDN service. jsDelivr is a free service and isn’t operated by Algolia, so we won’t be able to provide support if it fails.
 
 ### From NPM/Yarn
 

--- a/docgen/src/guides/usage.md
+++ b/docgen/src/guides/usage.md
@@ -7,7 +7,7 @@ category: guides
 withHeadings: true
 navWeight: 30
 editable: true
-githubSource: docgen/src/guides/usage.md.hbs
+githubSource: docgen/src/guides/usage.md
 ---
 
 ## Use InstantSearch.js
@@ -31,7 +31,7 @@ We also provide you a default Algolia theme for the widgets to be effectively st
 
 You will then have access to the `instantsearch` function in the global scope (window).
 
-The jsDeliver CDN is highly available with [over 110 locations](https://www.jsdelivr.com/features/network-map) in the world.
+> We recommend using jsDelivr only for prototyping, **not for production applications**. Whenever possible, you should host your assets yourself or use a premium CDN service. jsDelivr is a free service and isn’t operated by Algolia, so we won’t be able to provide support if it fails.
 
 ## With a build system
 
@@ -87,7 +87,7 @@ search.addWidget(connectSearchBox(function() { ... })({ ... }))
 
 We support the **last two versions of major browsers** (Chrome, Edge, Firefox, Safari).
 
-To support [IE11](https://en.wikipedia.org/wiki/Internet_Explorer_11), we recommend loading [polyfill.io](https://polyfill.io): 
+To support [IE11](https://en.wikipedia.org/wiki/Internet_Explorer_11), we recommend loading [polyfill.io](https://polyfill.io):
 
 ```html
 <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,Array.prototype.includes"></script>


### PR DESCRIPTION
This adds a warning when using the jsDelivr CDN.

The message was taken from our [official documentation](https://www.algolia.com/doc/tutorials/getting-started/quick-start-with-the-api-client/javascript/?language=javascript#script-tag-using-cdns).

I also renamed `usage.md.hbs` to `usage.md` (`.hbs` was unnecessary).

(`getting-started.md.hbs` remains un-renamed because the documentation build system seems to need a `.hbs` file to compile).

## Preview

- Getting started: https://deploy-preview-3266--instantsearchjs.netlify.com/v2/getting-started.html#from-a-cdn
- Usage: https://deploy-preview-3266--instantsearchjs.netlify.com/v2/guides/usage.html#directly-in-your-page