### PR TITLE
fix(breadcrumb): rename noRefinement to noRefinementRoot

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.js
+++ b/src/components/Breadcrumb/Breadcrumb.js
@@ -51,7 +51,7 @@ const Breadcrumb = ({
 }) => (
   <div
     className={cx(cssClasses.root, {
-      [cssClasses.noRefinement]: items.length > 0,
+      [cssClasses.noRefinementRoot]: items.length > 0,
     })}
   >
     <ul className={cssClasses.list}>
@@ -84,7 +84,7 @@ Breadcrumb.propTypes = {
   createURL: PropTypes.func.isRequired,
   cssClasses: PropTypes.shape({
     root: PropTypes.string.isRequired,
-    noRefinement: PropTypes.string.isRequired,
+    noRefinementRoot: PropTypes.string.isRequired,
     list: PropTypes.string.isRequired,
     item: PropTypes.string.isRequired,
     selectedItem: PropTypes.string.isRequired,

--- a/src/components/Breadcrumb/Breadcrumb.js
+++ b/src/components/Breadcrumb/Breadcrumb.js
@@ -51,7 +51,7 @@ const Breadcrumb = ({
 }) => (
   <div
     className={cx(cssClasses.root, {
-      [cssClasses.noRefinementRoot]: items.length > 0,
+      [cssClasses.noRefinementRoot]: items.length === 0,
     })}
   >
     <ul className={cssClasses.list}>

--- a/src/components/Breadcrumb/__tests__/Breadcrumb-test.js
+++ b/src/components/Breadcrumb/__tests__/Breadcrumb-test.js
@@ -29,6 +29,7 @@ describe('Breadcrumb', () => {
     };
     const wrapper = mount(<Breadcrumb {...props} />);
 
+    expect(wrapper.find('.noRefinementRoot')).toHaveLength(1);
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -63,10 +64,11 @@ describe('Breadcrumb', () => {
     };
     const wrapper = mount(<Breadcrumb {...props} />);
 
+    expect(wrapper.find('.noRefinementRoot')).toHaveLength(0);
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('should render <Breadcrumb /> with items', () => {
+  it('should render <Breadcrumb /> with multiple items', () => {
     const props = {
       createURL: data => {
         JSON.stringify(data);
@@ -101,6 +103,7 @@ describe('Breadcrumb', () => {
     };
     const wrapper = mount(<Breadcrumb {...props} />);
 
+    expect(wrapper.find('.noRefinementRoot')).toHaveLength(0);
     expect(wrapper).toMatchSnapshot();
   });
 });

--- a/src/components/Breadcrumb/__tests__/Breadcrumb-test.js
+++ b/src/components/Breadcrumb/__tests__/Breadcrumb-test.js
@@ -12,7 +12,7 @@ describe('Breadcrumb', () => {
       items: [],
       cssClasses: {
         root: 'root',
-        noRefinement: 'noRefinement',
+        noRefinementRoot: 'noRefinementRoot',
         list: 'list',
         item: 'item',
         selectedItem: 'selectedItem',
@@ -46,7 +46,7 @@ describe('Breadcrumb', () => {
       ],
       cssClasses: {
         root: 'root',
-        noRefinement: 'noRefinement',
+        noRefinementRoot: 'noRefinementRoot',
         list: 'list',
         item: 'item',
         selectedItem: 'selectedItem',
@@ -84,7 +84,7 @@ describe('Breadcrumb', () => {
       ],
       cssClasses: {
         root: 'root',
-        noRefinement: 'noRefinement',
+        noRefinementRoot: 'noRefinementRoot',
         list: 'list',
         item: 'item',
         selectedItem: 'selectedItem',

--- a/src/components/Breadcrumb/__tests__/__snapshots__/Breadcrumb-test.js.snap
+++ b/src/components/Breadcrumb/__tests__/__snapshots__/Breadcrumb-test.js.snap
@@ -26,7 +26,7 @@ exports[`Breadcrumb should render <Breadcrumb /> 1`] = `
 
 exports[`Breadcrumb should render <Breadcrumb /> with a single item 1`] = `
 <div
-  className="root noRefinement"
+  className="root noRefinementRoot"
 >
   <ul
     className="list"
@@ -65,7 +65,7 @@ exports[`Breadcrumb should render <Breadcrumb /> with a single item 1`] = `
 
 exports[`Breadcrumb should render <Breadcrumb /> with items 1`] = `
 <div
-  className="root noRefinement"
+  className="root noRefinementRoot"
 >
   <ul
     className="list"

--- a/src/components/Breadcrumb/__tests__/__snapshots__/Breadcrumb-test.js.snap
+++ b/src/components/Breadcrumb/__tests__/__snapshots__/Breadcrumb-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Breadcrumb should render <Breadcrumb /> 1`] = `
 <div
-  className="root"
+  className="root noRefinementRoot"
 >
   <ul
     className="list"
@@ -26,7 +26,7 @@ exports[`Breadcrumb should render <Breadcrumb /> 1`] = `
 
 exports[`Breadcrumb should render <Breadcrumb /> with a single item 1`] = `
 <div
-  className="root noRefinementRoot"
+  className="root"
 >
   <ul
     className="list"
@@ -63,9 +63,9 @@ exports[`Breadcrumb should render <Breadcrumb /> with a single item 1`] = `
 </div>
 `;
 
-exports[`Breadcrumb should render <Breadcrumb /> with items 1`] = `
+exports[`Breadcrumb should render <Breadcrumb /> with multiple items 1`] = `
 <div
-  className="root noRefinementRoot"
+  className="root"
 >
   <ul
     className="list"

--- a/src/widgets/breadcrumb/__tests__/__snapshots__/breadcrumb-test.js.snap
+++ b/src/widgets/breadcrumb/__tests__/__snapshots__/breadcrumb-test.js.snap
@@ -9,7 +9,7 @@ exports[`breadcrumb() render renders transformed items correctly 1`] = `
       "item": "ais-Breadcrumb-item",
       "link": "ais-Breadcrumb-link",
       "list": "ais-Breadcrumb-list",
-      "noRefinementRoot": "ais-Breadcrumb--noRefinementRoot",
+      "noRefinementRoot": "ais-Breadcrumb--noRefinement",
       "root": "ais-Breadcrumb",
       "selectedItem": "ais-Breadcrumb-item--selected",
       "separator": "ais-Breadcrumb-separator",

--- a/src/widgets/breadcrumb/__tests__/__snapshots__/breadcrumb-test.js.snap
+++ b/src/widgets/breadcrumb/__tests__/__snapshots__/breadcrumb-test.js.snap
@@ -9,7 +9,7 @@ exports[`breadcrumb() render renders transformed items correctly 1`] = `
       "item": "ais-Breadcrumb-item",
       "link": "ais-Breadcrumb-link",
       "list": "ais-Breadcrumb-list",
-      "noRefinement": "ais-Breadcrumb--noRefinement",
+      "noRefinementRoot": "ais-Breadcrumb--noRefinementRoot",
       "root": "ais-Breadcrumb",
       "selectedItem": "ais-Breadcrumb-item--selected",
       "separator": "ais-Breadcrumb-separator",

--- a/src/widgets/breadcrumb/breadcrumb.js
+++ b/src/widgets/breadcrumb/breadcrumb.js
@@ -147,7 +147,7 @@ export default function breadcrumb({
   const cssClasses = {
     root: cx(suit(), userCssClasses.root),
     noRefinementRoot: cx(
-      suit({ modifierName: 'noRefinementRoot' }),
+      suit({ modifierName: 'noRefinement' }),
       userCssClasses.noRefinementRoot
     ),
     list: cx(suit({ descendantName: 'list' }), userCssClasses.list),

--- a/src/widgets/breadcrumb/breadcrumb.js
+++ b/src/widgets/breadcrumb/breadcrumb.js
@@ -39,7 +39,7 @@ const usage = `Usage:
 breadcrumb({
   container,
   attributes,
-  [ cssClasses.{root, noRefinement, list, item, selectedItem, separator, link} ],
+  [ cssClasses.{root, noRefinementRoot, list, item, selectedItem, separator, link} ],
   [ templates.{home, separator}]
   [ transformItems ],
 })`;
@@ -47,7 +47,7 @@ breadcrumb({
 /**
  * @typedef {Object} BreadcrumbCSSClasses
  * @property {string|string[]} [root] CSS class to add to the root element of the widget.
- * @property {string|string[]} [noRefinement] CSS class to add to the root element of the widget if there are no refinements.
+ * @property {string|string[]} [noRefinementRoot] CSS class to add to the root element of the widget if there are no refinements.
  * @property {string|string[]} [list] CSS class to add to the list element.
  * @property {string|string[]} [item] CSS class to add to the items of the list. The items contains the link and the separator.
  * @property {string|string[]} [selectedItem] CSS class to add to the selected item in the list: the last one or the home if there are no refinements.
@@ -146,9 +146,9 @@ export default function breadcrumb({
 
   const cssClasses = {
     root: cx(suit(), userCssClasses.root),
-    noRefinement: cx(
-      suit({ modifierName: 'noRefinement' }),
-      userCssClasses.noRefinement
+    noRefinementRoot: cx(
+      suit({ modifierName: 'noRefinementRoot' }),
+      userCssClasses.noRefinementRoot
     ),
     list: cx(suit({ descendantName: 'list' }), userCssClasses.list),
     item: cx(suit({ descendantName: 'item' }), userCssClasses.item),


### PR DESCRIPTION
The CSS class was wrongly named `noRefinement` instead of `noRefinementRoot`.