### PR TITLE
fix(breadcrumb): rename item's "name" to "label"

### DIFF
--- a/docgen/src/guides/v3-migration.md
+++ b/docgen/src/guides/v3-migration.md
@@ -1278,6 +1278,10 @@ We've moved the `label` into the `templates.labelText` template to make it consi
 
 ## Connectors
 
+### connectBreadcrumb
+
+- The BreadcrumbItem `name` property is renamed to `label`.
+
 ### connectRange
 
 #### Options

--- a/src/components/Breadcrumb/Breadcrumb.js
+++ b/src/components/Breadcrumb/Breadcrumb.js
@@ -10,7 +10,7 @@ const renderLink = ({ cssClasses, createURL, refine, templateProps }) => (
 ) => {
   const isLast = idx === items.length - 1;
   const link = isLast ? (
-    item.name
+    item.label
   ) : (
     <a
       className={cssClasses.link}
@@ -20,13 +20,13 @@ const renderLink = ({ cssClasses, createURL, refine, templateProps }) => (
         refine(item.value);
       }}
     >
-      {item.name}
+      {item.label}
     </a>
   );
 
   return (
     <li
-      key={item.name + idx}
+      key={item.label + idx}
       className={cx(cssClasses.item, {
         [cssClasses.selectedItem]: isLast,
       })}
@@ -93,7 +93,7 @@ Breadcrumb.propTypes = {
   }).isRequired,
   items: PropTypes.arrayOf(
     PropTypes.shape({
-      name: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
       value: PropTypes.string,
     })
   ).isRequired,

--- a/src/components/Breadcrumb/__tests__/Breadcrumb-test.js
+++ b/src/components/Breadcrumb/__tests__/Breadcrumb-test.js
@@ -41,7 +41,7 @@ describe('Breadcrumb', () => {
       items: [
         {
           value: 'val0',
-          name: 'name0',
+          label: 'label0',
         },
       ],
       cssClasses: {
@@ -75,11 +75,11 @@ describe('Breadcrumb', () => {
       items: [
         {
           value: 'val0',
-          name: 'name0',
+          label: 'label0',
         },
         {
           value: 'val1',
-          name: 'name1',
+          label: 'label1',
         },
       ],
       cssClasses: {

--- a/src/components/Breadcrumb/__tests__/__snapshots__/Breadcrumb-test.js.snap
+++ b/src/components/Breadcrumb/__tests__/__snapshots__/Breadcrumb-test.js.snap
@@ -46,7 +46,7 @@ exports[`Breadcrumb should render <Breadcrumb /> with a single item 1`] = `
     </li>
     <li
       className="item selectedItem"
-      key="name00"
+      key="label00"
     >
       <span
         aria-hidden={true}
@@ -57,7 +57,7 @@ exports[`Breadcrumb should render <Breadcrumb /> with a single item 1`] = `
           }
         }
       />
-      name0
+      label0
     </li>
   </ul>
 </div>
@@ -85,7 +85,7 @@ exports[`Breadcrumb should render <Breadcrumb /> with items 1`] = `
     </li>
     <li
       className="item"
-      key="name00"
+      key="label00"
     >
       <span
         aria-hidden={true}
@@ -100,12 +100,12 @@ exports[`Breadcrumb should render <Breadcrumb /> with items 1`] = `
         className="link"
         onClick={[Function]}
       >
-        name0
+        label0
       </a>
     </li>
     <li
       className="item selectedItem"
-      key="name11"
+      key="label11"
     >
       <span
         aria-hidden={true}
@@ -116,7 +116,7 @@ exports[`Breadcrumb should render <Breadcrumb /> with items 1`] = `
           }
         }
       />
-      name1
+      label1
     </li>
   </ul>
 </div>

--- a/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.js
+++ b/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.js
@@ -198,7 +198,7 @@ describe('connectBreadcrumb', () => {
 
     const secondRenderingOptions = rendering.mock.calls[1][0];
     expect(secondRenderingOptions.items).toEqual([
-      { name: 'Decoration', value: null },
+      { label: 'Decoration', value: null },
     ]);
   });
 
@@ -251,7 +251,7 @@ describe('connectBreadcrumb', () => {
     const widget = makeWidget({
       attributes: ['category', 'sub_category'],
       transformItems: items =>
-        items.map(item => ({ ...item, name: 'transformed' })),
+        items.map(item => ({ ...item, label: 'transformed' })),
     });
 
     const config = widget.getConfiguration({});
@@ -299,7 +299,7 @@ describe('connectBreadcrumb', () => {
 
     const secondRenderingOptions = rendering.mock.calls[1][0];
     expect(secondRenderingOptions.items).toEqual([
-      expect.objectContaining({ name: 'transformed' }),
+      expect.objectContaining({ label: 'transformed' }),
     ]);
   });
 

--- a/src/connectors/breadcrumb/connectBreadcrumb.js
+++ b/src/connectors/breadcrumb/connectBreadcrumb.js
@@ -24,7 +24,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
 
 /**
  * @typedef {Object} BreadcrumbItem
- * @property {string} name Name of the category or subcategory.
+ * @property {string} label Label of the category or subcategory.
  * @property {string} value Value of breadcrumb item.
  */
 
@@ -181,7 +181,7 @@ function prepareItems(data) {
   return data.reduce((result, currentItem) => {
     if (currentItem.isRefined) {
       result.push({
-        name: currentItem.name,
+        label: currentItem.name,
         value: currentItem.path,
       });
       if (Array.isArray(currentItem.data)) {
@@ -194,7 +194,7 @@ function prepareItems(data) {
 
 function shiftItemsValues(array) {
   return array.map((x, idx) => ({
-    name: x.name,
+    label: x.label,
     value: idx + 1 === array.length ? null : array[idx + 1].value,
   }));
 }

--- a/src/widgets/breadcrumb/__tests__/__snapshots__/breadcrumb-test.js.snap
+++ b/src/widgets/breadcrumb/__tests__/__snapshots__/breadcrumb-test.js.snap
@@ -18,12 +18,12 @@ exports[`breadcrumb() render renders transformed items correctly 1`] = `
   items={
     Array [
       Object {
-        "name": "Cameras & Camcorders",
+        "label": "Cameras & Camcorders",
         "transformed": true,
         "value": "Cameras & Camcorders > Digital Cameras",
       },
       Object {
-        "name": "Digital Cameras",
+        "label": "Digital Cameras",
         "transformed": true,
         "value": null,
       },


### PR DESCRIPTION
This renames the breadcrumb items `name` property to `label`.

This is the naming we're going for in v3, as well as [the current naming in React InstantSearch](https://github.com/algolia/react-instantsearch/blob/master/packages/react-instantsearch-core/src/connectors/connectBreadcrumb.js#L20).