### PR TITLE
fix(pagination): rename `maxPages` to `totalPages`

### DIFF
--- a/docgen/src/getting-started.md.hbs
+++ b/docgen/src/getting-started.md.hbs
@@ -328,7 +328,7 @@ Those two features are implemented respectively with the [pagination](widgets/pa
   search.addWidget(
     instantsearch.widgets.pagination({
       container: '#pagination',
-      maxPages: 20,
+      totalPages: 20,
       // default is to scroll to 'body', here we disable this behavior
       scrollTo: false
     })

--- a/functional-tests/app/app.js
+++ b/functional-tests/app/app.js
@@ -1,7 +1,8 @@
 /* global instantsearch algoliasearch */
 /* eslint-disable object-shorthand, prefer-template, prefer-arrow-callback */
 
-var search = instantsearch({ // eslint-disable-line
+// eslint-disable-next-line no-var
+var search = instantsearch({
   indexName: 'instant_search',
   searchClient: algoliasearch('latency', '6be0576ff61c053d5f9a3225e2a90f76'),
   routing: true,
@@ -69,7 +70,7 @@ search.addWidget(
       root: 'pagination', // This uses Bootstrap classes
       active: 'active',
     },
-    maxPages: 20,
+    totalPages: 20,
   })
 );
 

--- a/src/connectors/pagination/connectPagination.js
+++ b/src/connectors/pagination/connectPagination.js
@@ -15,7 +15,7 @@ var customPagination = connectPagination(function render(params, isFirstRenderin
 });
 search.addWidget(
   customPagination({
-    [ maxPages ]
+    [ totalPages ]
     [ padding ]
   })
 );
@@ -24,8 +24,8 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
 
 /**
  * @typedef {Object} CustomPaginationWidgetOptions
- * @property {number} [maxPages] The max number of pages to browse.
- * @property {number} [padding=3] The padding of pages to show around the current page
+ * @property {number} [totalPages] The total number of pages to browse.
+ * @property {number} [padding = 3] The padding of pages to show around the current page
  */
 
 /**
@@ -92,7 +92,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  * search.addWidget(
  *   customPagination({
  *     containerNode: $('#custom-pagination-container'),
- *     maxPages: 20,
+ *     totalPages: 20,
  *     padding: 4,
  *   })
  * );
@@ -101,7 +101,7 @@ export default function connectPagination(renderFn, unmountFn) {
   checkRendering(renderFn, usage);
 
   return (widgetParams = {}) => {
-    const { maxPages, padding = 3 } = widgetParams;
+    const { totalPages, padding = 3 } = widgetParams;
 
     const pager = new Paginator({
       currentPage: 0,
@@ -136,7 +136,9 @@ export default function connectPagination(renderFn, unmountFn) {
       },
 
       getMaxPage({ nbPages }) {
-        return maxPages !== undefined ? Math.min(maxPages, nbPages) : nbPages;
+        return totalPages !== undefined
+          ? Math.min(totalPages, nbPages)
+          : nbPages;
       },
 
       render({ results, state, instantSearchInstance }) {

--- a/src/widgets/pagination/__tests__/__snapshots__/pagination-test.js.snap
+++ b/src/widgets/pagination/__tests__/__snapshots__/pagination-test.js.snap
@@ -5,18 +5,18 @@ exports[`pagination() calls twice ReactDOM.render(<Pagination props />, containe
   createURL={[Function]}
   cssClasses={
     Object {
-      "disabledItem": "ais-Pagination-item--disabled",
-      "firstPageItem": "ais-Pagination-item--firstPage",
+      "disabledItem": "ais-Pagination-item--disabled disabledItem",
+      "firstPageItem": "ais-Pagination-item--firstPage firstPageItem",
       "item": "ais-Pagination-item item",
-      "lastPageItem": "ais-Pagination-item--lastPage",
+      "lastPageItem": "ais-Pagination-item--lastPage lastPageItem",
       "link": "ais-Pagination-link link",
-      "list": "ais-Pagination-list",
-      "nextPageItem": "ais-Pagination-item--nextPage",
-      "noRefinementRoot": "ais-Pagination--noRefinement",
-      "pageItem": "ais-Pagination-item--page",
-      "previousPageItem": "ais-Pagination-item--previousPage",
-      "root": "ais-Pagination root cx",
-      "selectedItem": "ais-Pagination-item--selected",
+      "list": "ais-Pagination-list list",
+      "nextPageItem": "ais-Pagination-item--nextPage nextPageItem",
+      "noRefinementRoot": "ais-Pagination--noRefinement noRefinementRoot",
+      "pageItem": "ais-Pagination-item--page pageItem",
+      "previousPageItem": "ais-Pagination-item--previousPage previousPageItem",
+      "root": "ais-Pagination root customRoot",
+      "selectedItem": "ais-Pagination-item--selected selectedItem",
     }
   }
   currentPage={0}
@@ -56,18 +56,18 @@ exports[`pagination() calls twice ReactDOM.render(<Pagination props />, containe
   createURL={[Function]}
   cssClasses={
     Object {
-      "disabledItem": "ais-Pagination-item--disabled",
-      "firstPageItem": "ais-Pagination-item--firstPage",
+      "disabledItem": "ais-Pagination-item--disabled disabledItem",
+      "firstPageItem": "ais-Pagination-item--firstPage firstPageItem",
       "item": "ais-Pagination-item item",
-      "lastPageItem": "ais-Pagination-item--lastPage",
+      "lastPageItem": "ais-Pagination-item--lastPage lastPageItem",
       "link": "ais-Pagination-link link",
-      "list": "ais-Pagination-list",
-      "nextPageItem": "ais-Pagination-item--nextPage",
-      "noRefinementRoot": "ais-Pagination--noRefinement",
-      "pageItem": "ais-Pagination-item--page",
-      "previousPageItem": "ais-Pagination-item--previousPage",
-      "root": "ais-Pagination root cx",
-      "selectedItem": "ais-Pagination-item--selected",
+      "list": "ais-Pagination-list list",
+      "nextPageItem": "ais-Pagination-item--nextPage nextPageItem",
+      "noRefinementRoot": "ais-Pagination--noRefinement noRefinementRoot",
+      "pageItem": "ais-Pagination-item--page pageItem",
+      "previousPageItem": "ais-Pagination-item--previousPage previousPageItem",
+      "root": "ais-Pagination root customRoot",
+      "selectedItem": "ais-Pagination-item--selected selectedItem",
     }
   }
   currentPage={0}

--- a/src/widgets/pagination/__tests__/pagination-test.js
+++ b/src/widgets/pagination/__tests__/pagination-test.js
@@ -20,16 +20,18 @@ describe('pagination()', () => {
 
     container = document.createElement('div');
     cssClasses = {
-      root: ['root', 'cx'],
+      root: ['root', 'customRoot'],
+      noRefinementRoot: 'noRefinementRoot',
+      list: 'list',
       item: 'item',
+      firstPageItem: 'firstPageItem',
+      lastPageItem: 'lastPageItem',
+      previousPageItem: 'previousPageItem',
+      nextPageItem: 'nextPageItem',
+      pageItem: 'pageItem',
+      selectedItem: 'selectedItem',
+      disabledItem: 'disabledItem',
       link: 'link',
-      page: 'page',
-      previous: 'previous',
-      next: 'next',
-      first: 'first',
-      last: 'last',
-      active: 'active',
-      disabled: 'disabled',
     };
     widget = pagination({ container, scrollTo: false, cssClasses });
     results = {
@@ -121,15 +123,17 @@ describe('pagination MaxPage', () => {
     container = document.createElement('div');
     cssClasses = {
       root: 'root',
+      noRefinementRoot: 'noRefinementRoot',
+      list: 'list',
       item: 'item',
+      firstPageItem: 'firstPageItem',
+      lastPageItem: 'lastPageItem',
+      previousPageItem: 'previousPageItem',
+      nextPageItem: 'nextPageItem',
+      pageItem: 'pageItem',
+      selectedItem: 'selectedItem',
+      disabledItem: 'disabledItem',
       link: 'link',
-      page: 'page',
-      previous: 'previous',
-      next: 'next',
-      first: 'first',
-      last: 'last',
-      active: 'active',
-      disabled: 'disabled',
     };
     results = {
       hits: [{ first: 'hit', second: 'hit' }],
@@ -145,14 +149,14 @@ describe('pagination MaxPage', () => {
     expect(widget.getMaxPage(results)).toEqual(30);
   });
 
-  it('does reduce the number of page if lower than nbPages', () => {
-    paginationOptions.maxPages = 20;
+  it('does reduce the number of pages if lower than nbPages', () => {
+    paginationOptions.totalPages = 20;
     widget = pagination(paginationOptions);
     expect(widget.getMaxPage(results)).toEqual(20);
   });
 
-  it('does not reduce the number of page if greater than nbPages', () => {
-    paginationOptions.maxPages = 40;
+  it('does not reduce the number of pages if greater than nbPages', () => {
+    paginationOptions.totalPages = 40;
     widget = pagination(paginationOptions);
     expect(widget.getMaxPage(results)).toEqual(30);
   });

--- a/src/widgets/pagination/pagination.js
+++ b/src/widgets/pagination/pagination.js
@@ -142,7 +142,7 @@ pagination({
  * search.addWidget(
  *   instantsearch.widgets.pagination({
  *     container: '#pagination-container',
- *     maxPages: 20,
+ *     totalPages: 20,
  *     // default is to scroll to 'body', here we disable this behavior
  *     scrollTo: false,
  *     showFirst: false,
@@ -154,7 +154,7 @@ export default function pagination({
   container,
   labels: userLabels = defaultLabels,
   cssClasses: userCssClasses = {},
-  maxPages,
+  totalPages,
   padding,
   showFirst = true,
   showLast = true,
@@ -228,7 +228,7 @@ export default function pagination({
     const makeWidget = connectPagination(specializedRenderer, () =>
       unmountComponentAtNode(containerNode)
     );
-    return makeWidget({ maxPages, padding });
+    return makeWidget({ totalPages, padding });
   } catch (error) {
     throw new Error(usage);
   }

--- a/storybook/app/init-unmount-widgets.js
+++ b/storybook/app/init-unmount-widgets.js
@@ -210,7 +210,7 @@ export default () => {
     wrapWithUnmount(container =>
       instantsearch.widgets.pagination({
         container,
-        maxPages: 20,
+        totalPages: 20,
       })
     )
   );

--- a/storybook/app/utils/wrap-with-hits.js
+++ b/storybook/app/utils/wrap-with-hits.js
@@ -69,7 +69,7 @@ export const wrapWithHits = (
   window.search.addWidget(
     instantsearch.widgets.pagination({
       container: '#results-pagination-container',
-      maxPages: 20,
+      totalPages: 20,
     })
   );
 


### PR DESCRIPTION
This renames the previous `maxPages` to `totalPages` ([see Pagination spec](https://instantsearch-css.netlify.com/widgets/pagination/)).