### PR TITLE
ci: use vm-based travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ branches:
   - develop
   - feat/instantsearch.js/v2
   - "/^feat\\/\\d+\\.\\d+$/"
-sudo: false
 cache:
   yarn: true
 script:


### PR DESCRIPTION
this will become the default, so let's see if this breaks now https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration