### PR TITLE
chore(InstantSearch): use warn utility function

### DIFF
--- a/src/connectors/breadcrumb/connectBreadcrumb.js
+++ b/src/connectors/breadcrumb/connectBreadcrumb.js
@@ -1,6 +1,6 @@
 import find from 'lodash/find';
 import isEqual from 'lodash/isEqual';
-import { checkRendering } from '../../lib/utils.js';
+import { checkRendering, warn } from '../../lib/utils.js';
 
 const usage = `Usage:
 var customBreadcrumb = connectBreadcrumb(function renderFn(params, isFirstRendering) {
@@ -82,8 +82,7 @@ export default function connectBreadcrumb(renderFn, unmountFn) {
               !isEqual(isFacetSet.attributes, attributes) ||
               isFacetSet.separator !== separator
             ) {
-              // eslint-disable-next-line no-console
-              console.warn(
+              warn(
                 'Using Breadcrumb & HierarchicalMenu on the same facet with different options. Adding that one will override the configuration of the HierarchicalMenu. Check your options.'
               );
             }

--- a/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
+++ b/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
@@ -1,7 +1,7 @@
 import find from 'lodash/find';
 import isEqual from 'lodash/isEqual';
 
-import { checkRendering } from '../../lib/utils.js';
+import { checkRendering, warn } from '../../lib/utils.js';
 
 const usage = `Usage:
 var customHierarchicalMenu = connectHierarchicalMenu(function renderFn(params, isFirstRendering) {
@@ -110,8 +110,7 @@ export default function connectHierarchicalMenu(renderFn, unmountFn) {
               isFacetSet.separator === separator
             )
           ) {
-            // eslint-disable-next-line no-console
-            console.warn(
+            warn(
               'using Breadcrumb & HierarchicalMenu on the same facet with different options'
             );
             return {};

--- a/src/connectors/hits-per-page/connectHitsPerPage.js
+++ b/src/connectors/hits-per-page/connectHitsPerPage.js
@@ -1,7 +1,7 @@
 import some from 'lodash/some';
 import find from 'lodash/find';
 
-import { checkRendering } from '../../lib/utils.js';
+import { checkRendering, warn } from '../../lib/utils.js';
 
 const usage = `Usage:
 var customHitsPerPage = connectHitsPerPage(function render(params, isFirstRendering) {
@@ -146,14 +146,14 @@ The first one will be picked, you should probably set only one default value`
         if (!isCurrentInOptions) {
           if (state.hitsPerPage === undefined) {
             if (window.console) {
-              window.console.warn(
+              warn(
                 `[Warning][hitsPerPageSelector] hitsPerPage not defined.
   You should probably set the value \`hitsPerPage\`
   using the searchParameters attribute of the instantsearch constructor.`
               );
             }
           } else if (window.console) {
-            window.console.warn(
+            warn(
               `[Warning][hitsPerPageSelector] No item in \`items\`
   with \`value: hitsPerPage\` (hitsPerPage: ${state.hitsPerPage})`
             );

--- a/src/connectors/hits-per-page/connectHitsPerPage.js
+++ b/src/connectors/hits-per-page/connectHitsPerPage.js
@@ -147,14 +147,14 @@ The first one will be picked, you should probably set only one default value`
           if (state.hitsPerPage === undefined) {
             if (window.console) {
               warn(
-                `[Warning][hitsPerPageSelector] hitsPerPage not defined.
+                `[hitsPerPageSelector] hitsPerPage not defined.
   You should probably set the value \`hitsPerPage\`
   using the searchParameters attribute of the instantsearch constructor.`
               );
             }
           } else if (window.console) {
             warn(
-              `[Warning][hitsPerPageSelector] No item in \`items\`
+              `[hitsPerPageSelector] No item in \`items\`
   with \`value: hitsPerPage\` (hitsPerPage: ${state.hitsPerPage})`
             );
           }

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -13,6 +13,7 @@ import simpleMapping from './stateMappings/simple.js';
 import historyRouter from './routers/history.js';
 import version from './version.js';
 import createHelpers from './createHelpers.js';
+import { warn } from './utils';
 
 const ROUTING_DEFAULT_OPTIONS = {
   stateMapping: simpleMapping(),
@@ -133,21 +134,20 @@ class InstantSearch extends EventEmitter {
           'InstantSearch configuration error: it is not possible to use `urlSync` and `routing` at the same time'
         );
       }
-      /* eslint-disable no-console */
-      console.warn(
-        'InstantSearch.js: `urlSync` option is deprecated and will be removed in the next major version.'
+
+      warn(
+        '`urlSync` option is deprecated and will be removed in the next major version.\n' +
+          'You can now use the new `routing` option.'
       );
-      console.warn('You can now use the new `routing` option');
 
       if (urlSync === true) {
         // when using urlSync: true
-        console.warn('Use it like this: `routing: true`');
+        warn('Use it like this: `routing: true`');
       }
 
-      console.warn(
+      warn(
         'For advanced use cases, checkout the documentation: https://community.algolia.com/instantsearch.js/v2/guides/routing.html#migrating-from-urlsync'
       );
-      /* eslint-enable no-console */
     }
 
     this.urlSync = urlSync === true ? {} : urlSync;
@@ -159,9 +159,8 @@ class InstantSearch extends EventEmitter {
       };
 
     if (options.createAlgoliaClient) {
-      // eslint-disable-next-line no-console
-      console.warn(`
-InstantSearch.js: \`createAlgoliaClient\` option is deprecated and will be removed in the next major version.
+      warn(`
+\`createAlgoliaClient\` option is deprecated and will be removed in the next major version.
 Please use \`searchClient\` instead: https://community.algolia.com/instantsearch.js/v2/instantsearch.html#struct-InstantSearchOptions-searchClient.
 To help you migrate, please refer to the migration guide: https://community.algolia.com/instantsearch.js/v2/guides/prepare-for-v3.html`);
     }

--- a/src/widgets/hits-per-page-selector/__tests__/hits-per-page-selector-test.js
+++ b/src/widgets/hits-per-page-selector/__tests__/hits-per-page-selector-test.js
@@ -116,7 +116,7 @@ describe('hitsPerPageSelector()', () => {
     widget.init({ state: helper.state, helper });
     expect(consoleWarn).toHaveBeenCalledTimes(1, 'console.warn called once');
     expect(consoleWarn.mock.calls[0][0]).toEqual(
-      `[Warning][hitsPerPageSelector] No item in \`items\`
+      `[InstantSearch.js]: [Warning][hitsPerPageSelector] No item in \`items\`
   with \`value: hitsPerPage\` (hitsPerPage: 20)`
     );
   });
@@ -126,7 +126,7 @@ describe('hitsPerPageSelector()', () => {
     widget.init({ state: helper.state, helper });
     expect(consoleWarn).toHaveBeenCalledTimes(1, 'console.warn called once');
     expect(consoleWarn.mock.calls[0][0]).toEqual(
-      `[Warning][hitsPerPageSelector] No item in \`items\`
+      `[InstantSearch.js]: [Warning][hitsPerPageSelector] No item in \`items\`
   with \`value: hitsPerPage\` (hitsPerPage: -1)`
     );
   });

--- a/src/widgets/hits-per-page-selector/__tests__/hits-per-page-selector-test.js
+++ b/src/widgets/hits-per-page-selector/__tests__/hits-per-page-selector-test.js
@@ -116,7 +116,7 @@ describe('hitsPerPageSelector()', () => {
     widget.init({ state: helper.state, helper });
     expect(consoleWarn).toHaveBeenCalledTimes(1, 'console.warn called once');
     expect(consoleWarn.mock.calls[0][0]).toEqual(
-      `[InstantSearch.js]: [Warning][hitsPerPageSelector] No item in \`items\`
+      `[InstantSearch.js]: [hitsPerPageSelector] No item in \`items\`
   with \`value: hitsPerPage\` (hitsPerPage: 20)`
     );
   });
@@ -126,7 +126,7 @@ describe('hitsPerPageSelector()', () => {
     widget.init({ state: helper.state, helper });
     expect(consoleWarn).toHaveBeenCalledTimes(1, 'console.warn called once');
     expect(consoleWarn.mock.calls[0][0]).toEqual(
-      `[InstantSearch.js]: [Warning][hitsPerPageSelector] No item in \`items\`
+      `[InstantSearch.js]: [hitsPerPageSelector] No item in \`items\`
   with \`value: hitsPerPage\` (hitsPerPage: -1)`
     );
   });


### PR DESCRIPTION
This is an extension of the PR #3246, removing the prefix `"[Warning]"` from the `console.warn` call (because of redundancy).

This PR is now meant to be merged on `develop`.