### PR TITLE
fix(widgets): remove `collapsible` option

### DIFF
--- a/src/widgets/range-input/__tests__/__snapshots__/range-input-test.js.snap
+++ b/src/widgets/range-input/__tests__/__snapshots__/range-input-test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`rangeInput expect to render with custom classNames 1`] = `
 <RangeInput
-  collapsible={false}
   cssClasses={
     Object {
       "form": "ais-RangeInput-form custom-form",
@@ -37,7 +36,6 @@ exports[`rangeInput expect to render with custom classNames 1`] = `
 
 exports[`rangeInput expect to render with custom labels 1`] = `
 <RangeInput
-  collapsible={false}
   cssClasses={
     Object {
       "form": "ais-RangeInput-form",
@@ -72,7 +70,6 @@ exports[`rangeInput expect to render with custom labels 1`] = `
 
 exports[`rangeInput expect to render with refinement 1`] = `
 <RangeInput
-  collapsible={false}
   cssClasses={
     Object {
       "form": "ais-RangeInput-form",
@@ -107,7 +104,6 @@ exports[`rangeInput expect to render with refinement 1`] = `
 
 exports[`rangeInput expect to render with refinement at boundaries 1`] = `
 <RangeInput
-  collapsible={false}
   cssClasses={
     Object {
       "form": "ais-RangeInput-form",
@@ -142,7 +138,6 @@ exports[`rangeInput expect to render with refinement at boundaries 1`] = `
 
 exports[`rangeInput expect to render with results 1`] = `
 <RangeInput
-  collapsible={false}
   cssClasses={
     Object {
       "form": "ais-RangeInput-form",
@@ -177,7 +172,6 @@ exports[`rangeInput expect to render with results 1`] = `
 
 exports[`rangeInput expect to render without results 1`] = `
 <RangeInput
-  collapsible={false}
   cssClasses={
     Object {
       "form": "ais-RangeInput-form",

--- a/src/widgets/range-input/range-input.js
+++ b/src/widgets/range-input/range-input.js
@@ -7,13 +7,10 @@ import { component } from '../../lib/suit';
 
 const suit = component('RangeInput');
 
-const renderer = ({
-  containerNode,
-  cssClasses,
-  labels,
-  collapsible,
-  renderState,
-}) => ({ refine, range, start, widgetParams }, isFirstRendering) => {
+const renderer = ({ containerNode, cssClasses, labels, renderState }) => (
+  { refine, range, start, widgetParams },
+  isFirstRendering
+) => {
   if (isFirstRendering) {
     return;
   }
@@ -37,7 +34,6 @@ const renderer = ({
       cssClasses={cssClasses}
       labels={labels}
       refine={refine}
-      collapsible={collapsible}
       templateProps={renderState.templateProps}
     />,
     containerNode
@@ -53,7 +49,6 @@ rangeInput({
   [ precision = 0 ],
   [ cssClasses.{root, form, fieldset, labelMin, inputMin, separator, labelMax, inputMax, submit} ],
   [ labels.{separator, submit} ],
-  [ collapsible=false ]
 })`;
 
 /**
@@ -84,7 +79,6 @@ rangeInput({
  * @property {number} [precision = 0] Number of digits after decimal point to use.
  * @property {RangeInputClasses} [cssClasses] CSS classes to add.
  * @property {RangeInputLabels} [labels] Labels to use for the widget.
- * @property {boolean} [collapsible=false] Hide the widget body and footer when clicking on header.
  */
 
 /**
@@ -121,7 +115,6 @@ export default function rangeInput({
   precision = 0,
   cssClasses: userCssClasses = {},
   labels: userLabels = {},
-  collapsible = false,
 } = {}) {
   if (!container) {
     throw new Error(usage);
@@ -160,7 +153,6 @@ export default function rangeInput({
     containerNode,
     cssClasses,
     labels,
-    collapsible,
     renderState: {},
   });
 

--- a/src/widgets/stats/__tests__/__snapshots__/stats-test.js.snap
+++ b/src/widgets/stats/__tests__/__snapshots__/stats-test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`stats() calls twice ReactDOM.render(<Stats props />, container) 1`] = `
 <Stats
-  collapsible={false}
   cssClasses={
     Object {
       "root": "ais-Stats",
@@ -33,7 +32,6 @@ exports[`stats() calls twice ReactDOM.render(<Stats props />, container) 1`] = `
 
 exports[`stats() calls twice ReactDOM.render(<Stats props />, container) 2`] = `
 <Stats
-  collapsible={false}
   cssClasses={
     Object {
       "root": "ais-Stats",

--- a/src/widgets/stats/stats.js
+++ b/src/widgets/stats/stats.js
@@ -8,13 +8,7 @@ import { component } from '../../lib/suit';
 
 const suit = component('Stats');
 
-const renderer = ({
-  containerNode,
-  cssClasses,
-  collapsible,
-  renderState,
-  templates,
-}) => (
+const renderer = ({ containerNode, cssClasses, renderState, templates }) => (
   {
     hitsPerPage,
     nbHits,
@@ -38,7 +32,6 @@ const renderer = ({
 
   render(
     <Stats
-      collapsible={collapsible}
       cssClasses={cssClasses}
       hitsPerPage={hitsPerPage}
       nbHits={nbHits}
@@ -116,7 +109,6 @@ stats({
 export default function stats({
   container,
   cssClasses: userCssClasses = {},
-  collapsible = false,
   templates = defaultTemplates,
 } = {}) {
   if (!container) {
@@ -133,7 +125,6 @@ export default function stats({
   const specializedRenderer = renderer({
     containerNode,
     cssClasses,
-    collapsible,
     renderState: {},
     templates,
   });

--- a/storybook/app/builtin/stories/range-input.stories.js
+++ b/storybook/app/builtin/stories/range-input.stories.js
@@ -39,21 +39,6 @@ export default () => {
       })
     )
     .add(
-      'collapsible',
-      wrapWithHits(container => {
-        window.search.addWidget(
-          instantsearch.widgets.rangeInput({
-            container,
-            attribute: 'price',
-            collapsible: true,
-            templates: {
-              header: 'Range input',
-            },
-          })
-        );
-      })
-    )
-    .add(
       'with floating number',
       wrapWithHits(container => {
         window.search.addWidget(

--- a/storybook/app/builtin/stories/range-slider.stories.js
+++ b/storybook/app/builtin/stories/range-slider.stories.js
@@ -49,23 +49,6 @@ export default () => {
       })
     )
     .add(
-      'collapsible',
-      wrapWithHits(container => {
-        window.search.addWidget(
-          instantsearch.widgets.rangeSlider({
-            container,
-            attribute: 'price',
-            collapsible: {
-              collapsed: false,
-            },
-            templates: {
-              header: 'Price',
-            },
-          })
-        );
-      })
-    )
-    .add(
       'with step',
       wrapWithHits(container => {
         window.search.addWidget(


### PR DESCRIPTION
This removes the remaining `collapsible` options in the widgets `rangeInput` and `stats`, as well as stories using `collapsible`.

The `clearRefinements` widget remains untouched because it will be addressed in another PR.