### PR TITLE
fix(infiniteHits): move `loadMoreLabel` option to templates

### DIFF
--- a/docgen/src/guides/v3-migration.md
+++ b/docgen/src/guides/v3-migration.md
@@ -393,9 +393,10 @@ With the redo button:
 
 #### Options
 
-| Before       | After        |
-| ------------ | ------------ |
-| `escapeHits` | `escapeHTML` |
+| Before          | After                |
+| --------------- | -------------------- |
+| `escapeHits`    | `escapeHTML`         |
+| `loadMoreLabel` | `templates.showMore` |
 
 - `escapeHTML` defaults to `true`
 
@@ -1195,7 +1196,7 @@ Finally, `autofocus` is now set to `false` by default and does not support the `
 const sortByItem = {
   value: string,
   label: string,
-}
+};
 ```
 
 #### CSS classes

--- a/src/components/InfiniteHits/InfiniteHits.js
+++ b/src/components/InfiniteHits/InfiniteHits.js
@@ -7,7 +7,6 @@ const InfiniteHits = ({
   results,
   hits,
   showMore,
-  loadMoreLabel,
   isLastPage,
   cssClasses,
   templateProps,
@@ -43,15 +42,18 @@ const InfiniteHits = ({
         ))}
       </ol>
 
-      <button
-        className={cx(cssClasses.loadMore, {
-          [cssClasses.disabledLoadMore]: isLastPage,
-        })}
-        disabled={isLastPage}
-        onClick={showMore}
-      >
-        {loadMoreLabel}
-      </button>
+      <Template
+        {...templateProps}
+        templateKey="showMore"
+        rootTagName="button"
+        rootProps={{
+          className: cx(cssClasses.loadMore, {
+            [cssClasses.disabledLoadMore]: isLastPage,
+          }),
+          disabled: isLastPage,
+          onClick: showMore,
+        }}
+      />
     </div>
   );
 };
@@ -68,7 +70,6 @@ InfiniteHits.propTypes = {
   hits: PropTypes.array.isRequired,
   results: PropTypes.object.isRequired,
   showMore: PropTypes.func,
-  loadMoreLabel: PropTypes.string,
   templateProps: PropTypes.object.isRequired,
   isLastPage: PropTypes.bool.isRequired,
 };

--- a/src/components/InfiniteHits/__tests__/InfiniteHits-test.js
+++ b/src/components/InfiniteHits/__tests__/InfiniteHits-test.js
@@ -32,6 +32,7 @@ describe('InfiniteHits', () => {
         templateProps: {
           templates: {
             item: 'item',
+            showMore: 'showMore',
           },
         },
         cssClasses,
@@ -61,6 +62,7 @@ describe('InfiniteHits', () => {
         templateProps: {
           templates: {
             item: 'item',
+            showMore: 'showMore',
           },
         },
         cssClasses,
@@ -81,6 +83,7 @@ describe('InfiniteHits', () => {
         templateProps: {
           templates: {
             empty: 'empty',
+            showMore: 'showMore',
           },
         },
         cssClasses,
@@ -101,6 +104,7 @@ describe('InfiniteHits', () => {
         templateProps: {
           templates: {
             empty: 'empty',
+            showMore: 'showMore',
           },
         },
         cssClasses,

--- a/src/components/InfiniteHits/__tests__/__snapshots__/InfiniteHits-test.js.snap
+++ b/src/components/InfiniteHits/__tests__/__snapshots__/InfiniteHits-test.js.snap
@@ -26,6 +26,11 @@ exports[`InfiniteHits markup should render <InfiniteHits /> on first page 1`] = 
   </ol>
   <button
     className="loadMore"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "showMore",
+      }
+    }
     disabled={false}
   />
 </div>
@@ -57,6 +62,11 @@ exports[`InfiniteHits markup should render <InfiniteHits /> on last page 1`] = `
   </ol>
   <button
     className="loadMore disabledLoadMore"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "showMore",
+      }
+    }
     disabled={true}
   />
 </div>

--- a/src/widgets/infinite-hits/__tests__/__snapshots__/infinite-hits-test.js.snap
+++ b/src/widgets/infinite-hits/__tests__/__snapshots__/infinite-hits-test.js.snap
@@ -21,7 +21,6 @@ exports[`infiniteHits() calls twice ReactDOM.render(<Hits props />, container) 1
     ]
   }
   isLastPage={false}
-  loadMoreLabel="Show more results"
   results={
     Object {
       "hits": Array [
@@ -38,11 +37,13 @@ exports[`infiniteHits() calls twice ReactDOM.render(<Hits props />, container) 1
       "templates": Object {
         "empty": "No results",
         "item": [Function],
+        "showMore": "Show more results",
       },
       "templatesConfig": undefined,
       "useCustomCompileOptions": Object {
         "empty": false,
         "item": false,
+        "showMore": false,
       },
     }
   }
@@ -70,7 +71,6 @@ exports[`infiniteHits() calls twice ReactDOM.render(<Hits props />, container) 2
     ]
   }
   isLastPage={false}
-  loadMoreLabel="Show more results"
   results={
     Object {
       "hits": Array [
@@ -87,11 +87,13 @@ exports[`infiniteHits() calls twice ReactDOM.render(<Hits props />, container) 2
       "templates": Object {
         "empty": "No results",
         "item": [Function],
+        "showMore": "Show more results",
       },
       "templatesConfig": undefined,
       "useCustomCompileOptions": Object {
         "empty": false,
         "item": false,
+        "showMore": false,
       },
     }
   }
@@ -119,7 +121,6 @@ exports[`infiniteHits() if it is the last page, then the props should contain is
     ]
   }
   isLastPage={false}
-  loadMoreLabel="Show more results"
   results={
     Object {
       "hits": Array [
@@ -138,11 +139,13 @@ exports[`infiniteHits() if it is the last page, then the props should contain is
       "templates": Object {
         "empty": "No results",
         "item": [Function],
+        "showMore": "Show more results",
       },
       "templatesConfig": undefined,
       "useCustomCompileOptions": Object {
         "empty": false,
         "item": false,
+        "showMore": false,
       },
     }
   }
@@ -170,7 +173,6 @@ exports[`infiniteHits() if it is the last page, then the props should contain is
     ]
   }
   isLastPage={true}
-  loadMoreLabel="Show more results"
   results={
     Object {
       "hits": Array [
@@ -189,11 +191,13 @@ exports[`infiniteHits() if it is the last page, then the props should contain is
       "templates": Object {
         "empty": "No results",
         "item": [Function],
+        "showMore": "Show more results",
       },
       "templatesConfig": undefined,
       "useCustomCompileOptions": Object {
         "empty": false,
         "item": false,
+        "showMore": false,
       },
     }
   }
@@ -222,7 +226,6 @@ exports[`infiniteHits() renders transformed items 1`] = `
     ]
   }
   isLastPage={false}
-  loadMoreLabel="Show more results"
   results={
     Object {
       "hits": Array [
@@ -240,11 +243,13 @@ exports[`infiniteHits() renders transformed items 1`] = `
       "templates": Object {
         "empty": "No results",
         "item": [Function],
+        "showMore": "Show more results",
       },
       "templatesConfig": undefined,
       "useCustomCompileOptions": Object {
         "empty": false,
         "item": false,
+        "showMore": false,
       },
     }
   }

--- a/src/widgets/infinite-hits/__tests__/infinite-hits-test.js
+++ b/src/widgets/infinite-hits/__tests__/infinite-hits-test.js
@@ -117,6 +117,5 @@ describe('infiniteHits()', () => {
 
   afterEach(() => {
     infiniteHits.__ResetDependency__('render');
-    infiniteHits.__ResetDependency__('defaultTemplates');
   });
 });

--- a/src/widgets/infinite-hits/defaultTemplates.js
+++ b/src/widgets/infinite-hits/defaultTemplates.js
@@ -1,5 +1,6 @@
 export default {
   empty: 'No results',
+  showMore: 'Show more results',
   item(data) {
     return JSON.stringify(data, null, 2);
   },

--- a/src/widgets/infinite-hits/infinite-hits.js
+++ b/src/widgets/infinite-hits/infinite-hits.js
@@ -8,13 +8,7 @@ import { component } from '../../lib/suit';
 
 const suit = component('InfiniteHits');
 
-const renderer = ({
-  cssClasses,
-  containerNode,
-  renderState,
-  templates,
-  loadMoreLabel,
-}) => (
+const renderer = ({ cssClasses, containerNode, renderState, templates }) => (
   { hits, results, showMore, isLastPage, instantSearchInstance },
   isFirstRendering
 ) => {
@@ -33,7 +27,6 @@ const renderer = ({
       hits={hits}
       results={results}
       showMore={showMore}
-      loadMoreLabel={loadMoreLabel}
       templateProps={renderState.templateProps}
       isLastPage={isLastPage}
     />,
@@ -47,21 +40,15 @@ infiniteHits({
   container,
   [ escapeHTML = true ],
   [ transformItems ],
-  [ loadMoreLabel = "Show more results" ],
   [ cssClasses.{root, emptyRoot, list, item, loadMore, disabledLoadMore} ],
-  [ templates.{empty,item} | templates.{empty} ],
+  [ templates.{empty, item, showMore} ],
 })`;
 
 /**
  * @typedef {Object} InfiniteHitsTemplates
- * @property {string|function} [empty=""] Template used when there are no results.
- * @property {string|function} [item=""] Template used for each result. This template will receive an object containing a single record.
- */
-
-/**
- * @typedef {Object} InfiniteHitsTransforms
- * @property {function} [empty] Method used to change the object passed to the `empty` template.
- * @property {function} [item] Method used to change the object passed to the `item` template.
+ * @property {string|function} [empty = "No results"] Template used when there are no results.
+ * @property {string|function} [showMore = "Show more results"] Template used for the "load more" button.
+ * @property {string|function} [item = ""] Template used for each result. This template will receive an object containing a single record.
  */
 
 /**
@@ -78,7 +65,6 @@ infiniteHits({
  * @typedef {Object} InfiniteHitsWidgetOptions
  * @property  {string|HTMLElement} container CSS Selector or HTMLElement to insert the widget.
  * @property  {InfiniteHitsTemplates} [templates] Templates to use for the widget.
- * @property  {string} [loadMoreLabel="Show more results"] label used on the load more button.
  * @property  {InfiniteHitsCSSClasses} [cssClasses] CSS classes to add.
  * @property {boolean} [escapeHTML = true] Escape HTML entities from hits string values.
  * @property {function(object[]):object[]} [transformItems] Function to transform the items passed to the templates.
@@ -101,6 +87,7 @@ infiniteHits({
  *     container: '#infinite-hits-container',
  *     templates: {
  *       empty: 'No results',
+ *       showMore: 'Show more results',
  *       item: '<strong>Hit {{objectID}}</strong>: {{{_highlightResult.name.value}}}'
  *     },
  *     transformItems: items => items.map(item => item),
@@ -110,7 +97,6 @@ infiniteHits({
 export default function infiniteHits({
   container,
   cssClasses: userCssClasses = {},
-  loadMoreLabel = 'Show more results',
   templates = defaultTemplates,
   escapeHTML = true,
   transformItems,
@@ -144,7 +130,6 @@ export default function infiniteHits({
     containerNode,
     cssClasses,
     templates,
-    loadMoreLabel,
     renderState: {},
   });
 

--- a/storybook/app/builtin/stories/infinite-hits.stories.js
+++ b/storybook/app/builtin/stories/infinite-hits.stories.js
@@ -14,7 +14,6 @@ export default () => {
         window.search.addWidget(
           instantsearch.widgets.infiniteHits({
             container,
-            loadMoreLabel: 'Show more',
             templates: {
               item: '{{name}}',
             },
@@ -34,7 +33,6 @@ export default () => {
         window.search.addWidget(
           instantsearch.widgets.infiniteHits({
             container,
-            loadMoreLabel: 'Show more',
             cssClasses: {
               loadMore: 'button',
             },
@@ -46,12 +44,25 @@ export default () => {
       })
     )
     .add(
+      'with custom "showMore" template',
+      wrapWithHits(container => {
+        window.search.addWidget(
+          instantsearch.widgets.infiniteHits({
+            container,
+            templates: {
+              item: '{{name}}',
+              showMore: 'Load more',
+            },
+          })
+        );
+      })
+    )
+    .add(
       'with transformed items',
       wrapWithHits(container => {
         window.search.addWidget(
           instantsearch.widgets.infiniteHits({
             container,
-            loadMoreLabel: 'Show more',
             templates: {
               item: '{{name}}',
             },


### PR DESCRIPTION
This moves the `loadMoreLabel` option of the `infiniteHits` widget to `templates.showMore`.

## Stories

https://deploy-preview-3300--instantsearchjs.netlify.com/stories/?selectedStory=InfiniteHits.default