### PR TITLE
chore(url): remove createQueryString

### DIFF
--- a/docgen/src/guides/v3-migration.md
+++ b/docgen/src/guides/v3-migration.md
@@ -97,6 +97,10 @@ Here are the elements you need to migrate:
 
 `createAlgoliaClient` is replaced by `searchClient`.
 
+### `createQueryString` is dropped
+
+URL synchronization is done via Routing alone now.
+
 ## Widgets
 
 ### Breadcrumb

--- a/index.es6.js
+++ b/index.es6.js
@@ -1,5 +1,4 @@
 /* eslint max-len: 0 */
-import algoliasearchHelper from 'algoliasearch-helper';
 import toFactory from 'to-factory';
 
 /* eslint-disable import/no-unresolved */
@@ -13,8 +12,6 @@ import { snippet, highlight } from './helpers';
 const instantSearchFactory = toFactory(InstantSearch);
 
 instantSearchFactory.version = version;
-instantSearchFactory.createQueryString =
-  algoliasearchHelper.url.getQueryStringFromState;
 instantSearchFactory.snippet = snippet;
 instantSearchFactory.highlight = highlight;
 

--- a/src/lib/__tests__/main-test.js
+++ b/src/lib/__tests__/main-test.js
@@ -10,21 +10,6 @@ describe('instantsearch()', () => {
     );
   });
 
-  it('statically creates a URL', () => {
-    expect(instantsearch.createQueryString({ hitsPerPage: 42 })).toEqual(
-      'hPP=42'
-    );
-  });
-
-  it('statically creates a complex URL', () => {
-    expect(
-      instantsearch.createQueryString({
-        hitsPerPage: 42,
-        facetsRefinements: { category: 'Home' },
-      })
-    ).toEqual('hPP=42&fR[category]=Home');
-  });
-
   it('includes the widget functions', () => {
     forEach(instantsearch.widgets, widget => {
       expect(typeof widget).toEqual('function', 'A widget must be a function');

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -1,7 +1,6 @@
 /** @module module:instantsearch */
 
 import toFactory from 'to-factory';
-import algoliasearchHelper from 'algoliasearch-helper';
 
 import InstantSearch from './InstantSearch.js';
 import version from './version.js';
@@ -127,8 +126,6 @@ const instantsearch = toFactory(InstantSearch);
 
 instantsearch.routers = routers;
 instantsearch.stateMappings = stateMappings;
-instantsearch.createQueryString =
-  algoliasearchHelper.url.getQueryStringFromState;
 instantsearch.connectors = connectors;
 instantsearch.widgets = widgets;
 instantsearch.version = version;


### PR DESCRIPTION
This wasn't used for anything, nor documented, so can safely be removed. I didn't document that you can import it directly from the helper, since we don't plan to keep that long-term.

I added it to the migration guide

BREAKING CHANGE
