### PR TITLE
fix(toggleRefinement): provide `name` to templates

### DIFF
--- a/docgen/src/guides/v3-migration.md
+++ b/docgen/src/guides/v3-migration.md
@@ -1252,7 +1252,7 @@ const sortByItem = {
 
 `collapsible` and `autoHideContainer` options have been removed. These options are now implemented as part of the Panel widget wrapper.
 
-We've moved the `label` into the `templates.labelText` template to make it consistent with the templates parameters of other widgets and we removed the `item` template. We are now providing the data that were provided to `templates.item` to `templates.labelText`.
+The `label` options has been moved into the `templates.labelText` template to make it consistent with the templates parameters of other widgets and we removed the `item` template. We are now providing the data that were provided to `templates.item` to `templates.labelText`. If your index attribute is called `free_shipping`, the default template will display "free_shipping". To rename it, change `templates.labelText` to "Free shipping".
 
 #### CSS classes
 

--- a/src/components/ToggleRefinement/ToggleRefinement.js
+++ b/src/components/ToggleRefinement/ToggleRefinement.js
@@ -16,12 +16,13 @@ const ToggleRefinement = ({
         checked={currentRefinement.isRefined}
         onChange={event => refine(!event.target.checked)}
       />
+
       <Template
+        {...templateProps}
         rootTagName="span"
         rootProps={{ className: cssClasses.labelText }}
         templateKey="labelText"
         data={currentRefinement}
-        {...templateProps}
       />
     </label>
   </div>

--- a/src/connectors/toggleRefinement/__tests__/connectToggleRefinement-test.js
+++ b/src/connectors/toggleRefinement/__tests__/connectToggleRefinement-test.js
@@ -44,6 +44,7 @@ describe('connectToggleRefinement', () => {
         rendering.mock.calls.length - 1
       ][0];
       expect(value).toEqual({
+        name: 'isShippingFree',
         count: null,
         isRefined: false,
         onFacetValue: {
@@ -90,6 +91,7 @@ describe('connectToggleRefinement', () => {
         rendering.mock.calls.length - 1
       ][0];
       expect(value).toEqual({
+        name: 'isShippingFree',
         count: 45,
         isRefined: false,
         onFacetValue: {
@@ -132,6 +134,7 @@ describe('connectToggleRefinement', () => {
         rendering.mock.calls[rendering.mock.calls.length - 1][0];
       const { refine, value } = renderOptions;
       expect(value).toEqual({
+        name: 'isShippingFree',
         count: null,
         isRefined: false,
         onFacetValue: {
@@ -179,6 +182,7 @@ describe('connectToggleRefinement', () => {
         rendering.mock.calls[rendering.mock.calls.length - 1][0];
       const { refine, value } = renderOptions;
       expect(value).toEqual({
+        name: 'isShippingFree',
         count: 45,
         isRefined: false,
         onFacetValue: {
@@ -230,6 +234,7 @@ describe('connectToggleRefinement', () => {
         rendering.mock.calls[rendering.mock.calls.length - 1][0];
       const { refine, value } = renderOptions;
       expect(value).toEqual({
+        name: 'isShippingFree',
         count: 85,
         isRefined: true,
         onFacetValue: {
@@ -279,6 +284,7 @@ describe('connectToggleRefinement', () => {
       const { refine, value } = renderOptions;
 
       expect(value).toEqual({
+        name: 'isShippingFree',
         count: null,
         isRefined: false,
         onFacetValue: {
@@ -335,6 +341,7 @@ describe('connectToggleRefinement', () => {
       const { refine, value } = renderOptions;
       expect(value).toEqual({
         // the value is the one that is not selected
+        name: 'isShippingFree',
         count: 45,
         isRefined: false,
         onFacetValue: {
@@ -386,6 +393,7 @@ describe('connectToggleRefinement', () => {
         rendering.mock.calls[rendering.mock.calls.length - 1][0];
       const { refine, value } = renderOptions;
       expect(value).toEqual({
+        name: 'isShippingFree',
         count: 40,
         isRefined: true,
         onFacetValue: {

--- a/src/connectors/toggleRefinement/connectToggleRefinement.js
+++ b/src/connectors/toggleRefinement/connectToggleRefinement.js
@@ -37,14 +37,14 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
 /**
  * @typedef {Object} CustomToggleWidgetOptions
  * @property {string} attribute Name of the attribute for faceting (eg. "free_shipping").
- * @property {Object} [on=true] Value to filter on when toggled.
+ * @property {Object} [on = true] Value to filter on when toggled.
  * @property {Object} [off] Value to filter on when not toggled.
  */
 
 /**
  * @typedef {Object} ToggleRenderingOptions
  * @property {ToggleValue} value The current toggle value.
- * @property {function(): string} createURL Creates an URL for the next state.
+ * @property {function():string} createURL Creates an URL for the next state.
  * @property {function(value)} refine Updates to the next state by applying the toggle refinement.
  * @property {Object} widgetParams All original `CustomToggleWidgetOptions` forwarded to the `renderFn`.
  */
@@ -182,6 +182,7 @@ export default function connectToggleRefinement(renderFn, unmountFn) {
         };
 
         const value = {
+          name: attribute,
           isRefined,
           count: null,
           onFacetValue,
@@ -234,6 +235,7 @@ export default function connectToggleRefinement(renderFn, unmountFn) {
         const nextRefinement = isRefined ? offFacetValue : onFacetValue;
 
         const value = {
+          name: attribute,
           isRefined,
           count: nextRefinement === undefined ? null : nextRefinement.count,
           onFacetValue,

--- a/src/widgets/toggleRefinement/__tests__/__snapshots__/currentToggle-test.js.snap
+++ b/src/widgets/toggleRefinement/__tests__/__snapshots__/currentToggle-test.js.snap
@@ -15,6 +15,7 @@ exports[`currentToggle() good usage render supports negative numeric off or on v
     Object {
       "count": 1,
       "isRefined": false,
+      "name": "world!",
       "offFacetValue": Object {
         "count": 2,
         "isRefined": true,
@@ -55,6 +56,7 @@ exports[`currentToggle() good usage render supports negative numeric off or on v
     Object {
       "count": 1,
       "isRefined": false,
+      "name": "world!",
       "offFacetValue": Object {
         "count": 2,
         "isRefined": true,
@@ -95,6 +97,7 @@ exports[`currentToggle() good usage render understands cssClasses 1`] = `
     Object {
       "count": 2,
       "isRefined": false,
+      "name": "world!",
       "offFacetValue": Object {
         "count": 3,
         "isRefined": false,
@@ -135,6 +138,7 @@ exports[`currentToggle() good usage render when refined 1`] = `
     Object {
       "count": 3,
       "isRefined": true,
+      "name": "world!",
       "offFacetValue": Object {
         "count": 3,
         "isRefined": false,
@@ -175,6 +179,7 @@ exports[`currentToggle() good usage render when refined 2`] = `
     Object {
       "count": 3,
       "isRefined": true,
+      "name": "world!",
       "offFacetValue": Object {
         "count": 3,
         "isRefined": false,
@@ -215,6 +220,7 @@ exports[`currentToggle() good usage render with facet values 1`] = `
     Object {
       "count": 2,
       "isRefined": false,
+      "name": "world!",
       "offFacetValue": Object {
         "count": 3,
         "isRefined": false,
@@ -255,6 +261,7 @@ exports[`currentToggle() good usage render with facet values 2`] = `
     Object {
       "count": 2,
       "isRefined": false,
+      "name": "world!",
       "offFacetValue": Object {
         "count": 3,
         "isRefined": false,
@@ -295,6 +302,7 @@ exports[`currentToggle() good usage render without facet values 1`] = `
     Object {
       "count": null,
       "isRefined": false,
+      "name": "world!",
       "offFacetValue": Object {
         "count": 0,
         "isRefined": false,
@@ -335,6 +343,7 @@ exports[`currentToggle() good usage render without facet values 2`] = `
     Object {
       "count": null,
       "isRefined": false,
+      "name": "world!",
       "offFacetValue": Object {
         "count": 0,
         "isRefined": false,

--- a/src/widgets/toggleRefinement/toggleRefinement.js
+++ b/src/widgets/toggleRefinement/toggleRefinement.js
@@ -65,8 +65,8 @@ toggleRefinement({
  * @typedef {Object} ToggleWidgetOptions
  * @property {string|HTMLElement} container Place where to insert the widget in your webpage.
  * @property {string} attribute Name of the attribute for faceting (eg. "free_shipping").
- * @property  {string|number|boolean} on Value to filter on when checked.
- * @property  {string|number|boolean} off Value to filter on when unchecked.
+ * @property {string|number|boolean} on Value to filter on when checked.
+ * @property {string|number|boolean} off Value to filter on when unchecked.
  * element (when using the default template). By default when switching to `off`, no refinement will be asked. So you
  * will get both `true` and `false` results. If you set the off value to `false` then you will get only objects
  * having `false` has a value for the selected attribute.

--- a/storybook/app/builtin/stories/toggleRefinement.stories.js
+++ b/storybook/app/builtin/stories/toggleRefinement.stories.js
@@ -15,6 +15,17 @@ export default () => {
           instantsearch.widgets.toggleRefinement({
             container,
             attribute: 'free_shipping',
+          })
+        );
+      })
+    )
+    .add(
+      'with label',
+      wrapWithHits(container => {
+        window.search.addWidget(
+          instantsearch.widgets.toggleRefinement({
+            container,
+            attribute: 'free_shipping',
             templates: {
               labelText: 'Free Shipping (toggle single value)',
             },


### PR DESCRIPTION
## Context

> The default template uses the `name` attribute but it’s not provided to the template. It renders something blank on the page. We should find a “good“ default value or we make the `template.labelText` required. Previously it was to the label that was a required option.
> – @samouss 

## This solution

We pass the attribute (called `name`) to the value passed by the connector `connectToggleRefinement`. The refinement now has a `name` property usable in the template.

If your attribute is called `free_shipping`, the default template will display "free_shipping". You will then need to specify `templates.labelText` to change it to "Free shipping".

## Stories

https://deploy-preview-3303--instantsearchjs.netlify.com/stories/?selectedStory=ToggleRefinement.default