### PR TITLE
refactor(GeoSearch): fix typo in name

### DIFF
--- a/src/connectors/geo-search/connectGeoSearch.js
+++ b/src/connectors/geo-search/connectGeoSearch.js
@@ -168,7 +168,7 @@ const connectGeoSearch = (renderFn, unmountFn) => {
 
     const toggleRefineOnMapMove = () =>
       widgetState.internalToggleRefineOnMapMove();
-    const createInternalToggleRefinementonMapMove = (render, args) => () => {
+    const createInternalToggleRefinementOnMapMove = (render, args) => () => {
       widgetState.isRefineOnMapMove = !widgetState.isRefineOnMapMove;
 
       render(args);
@@ -196,7 +196,7 @@ const connectGeoSearch = (renderFn, unmountFn) => {
       const { state, helper, instantSearchInstance } = initArgs;
       const isFirstRendering = true;
 
-      widgetState.internalToggleRefineOnMapMove = createInternalToggleRefinementonMapMove(
+      widgetState.internalToggleRefineOnMapMove = createInternalToggleRefinementOnMapMove(
         noop,
         initArgs
       );
@@ -248,7 +248,7 @@ const connectGeoSearch = (renderFn, unmountFn) => {
       widgetState.lastRefinePosition = state.aroundLatLng || '';
       widgetState.lastRefineBoundingBox = state.insideBoundingBox || '';
 
-      widgetState.internalToggleRefineOnMapMove = createInternalToggleRefinementonMapMove(
+      widgetState.internalToggleRefineOnMapMove = createInternalToggleRefinementOnMapMove(
         render,
         renderArgs
       );


### PR DESCRIPTION
`createInternalToggleRefinementonMapMove` -> `createInternalToggleRefinementOnMapMove`, super tiny, but noticed this was autocompleted wrong a while ago

Just making this PR so the branch can be removed