### PR TITLE
ci: run Travis on all branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,6 @@ before_install:
 - git config --global user.email "algobot@users.noreply.github.com"
 - git config --global user.name "algobot"
 - npm install -g yarn@1.10.1
-branches:
-  only:
-  - master
-  - develop
-  - feat/instantsearch.js/v2
-  - "/^feat\\/\\d+\\.\\d+$/"
 cache:
   yarn: true
 script:


### PR DESCRIPTION
The complex branch patterns for running Travis are unnecessary and make it hard to run the CI on v3 branches.

Closes #3305
