### PR TITLE
fix(searchbox): fix `loadingIndicator` and `reset` templates

### DIFF
--- a/src/widgets/search-box/__tests__/search-box-test.js
+++ b/src/widgets/search-box/__tests__/search-box-test.js
@@ -79,15 +79,20 @@ describe('searchBox()', () => {
         root: ['root', 'customRoot'],
         form: 'form',
         input: 'input',
+        submit: 'submit',
         reset: 'reset',
         resetIcon: 'resetIcon',
         loadingIndicator: 'loadingIndicator',
         loadingIcon: 'loadingIcon',
-        submit: 'submit',
       };
 
       widget = searchBox(opts);
       widget.init({ state, helper, onHistoryChange });
+      widget.render({
+        state,
+        helper,
+        searchMetadata: { isSearchStalled: false },
+      });
 
       expect(container.querySelector('.ais-SearchBox').classList).toContain(
         'root'
@@ -102,14 +107,14 @@ describe('searchBox()', () => {
         container.querySelector('.ais-SearchBox-input').classList
       ).toContain('input');
       expect(
+        container.querySelector('.ais-SearchBox-submit').classList
+      ).toContain('submit');
+      expect(
         container.querySelector('.ais-SearchBox-reset').classList
       ).toContain('reset');
       expect(
         container.querySelector('.ais-SearchBox-resetIcon').classList
       ).toContain('resetIcon');
-      expect(
-        container.querySelector('.ais-SearchBox-submit').classList
-      ).toContain('submit');
       expect(
         container.querySelector('.ais-SearchBox-loadingIndicator').classList
       ).toContain('loadingIndicator');

--- a/src/widgets/search-box/search-box.js
+++ b/src/widgets/search-box/search-box.js
@@ -97,21 +97,26 @@ const renderer = ({
       `.${cssClasses.loadingIndicator}`
     );
 
-    if (isSearchStalled) {
-      loadingIndicatorElement.removeAttribute('hidden');
-    } else {
-      loadingIndicatorElement.setAttribute('hidden', '');
+    if (loadingIndicatorElement) {
+      if (isSearchStalled) {
+        loadingIndicatorElement.removeAttribute('hidden');
+      } else {
+        loadingIndicatorElement.setAttribute('hidden', '');
+      }
     }
   }
 
   if (showReset) {
     const resetElement = containerNode.querySelector(`.${cssClasses.reset}`);
-    const isUserTyping = Boolean(query && query.trim());
 
-    if (isUserTyping && !isSearchStalled) {
-      resetElement.removeAttribute('hidden');
-    } else {
-      resetElement.setAttribute('hidden', '');
+    if (resetElement) {
+      const isUserTyping = Boolean(query && query.trim());
+
+      if (isUserTyping && !isSearchStalled) {
+        resetElement.removeAttribute('hidden');
+      } else {
+        resetElement.setAttribute('hidden', '');
+      }
     }
   }
 };
@@ -126,7 +131,7 @@ const usage = `Usage:
 searchBox({
   container,
   [ placeholder ],
-  [ cssClasses.{root, input, reset, submit, loadingIndicator} ],
+  [ cssClasses.{root, form, input, submit, submitIcon, reset, resetIcon, loadingIndicator, loadingIcon} ],
   [ autofocus = false ],
   [ searchAsYouType = true ],
   [ showReset = true ],
@@ -148,11 +153,12 @@ searchBox({
  * @property {string|string[]} [root] CSS class to add to the wrapping `<div>`
  * @property {string|string[]} [form] CSS class to add to the form
  * @property {string|string[]} [input] CSS class to add to the input.
+ * @property {string|string[]} [submit] CSS classes added to the submit button.
+ * @property {string|string[]} [submitIcon] CSS classes added to the submit icon.
  * @property {string|string[]} [reset] CSS classes added to the reset button.
  * @property {string|string[]} [resetIcon] CSS classes added to the reset icon.
  * @property {string|string[]} [loadingIndicator] CSS classes added to the loading indicator element.
  * @property {string|string[]} [loadingIcon] CSS classes added to the loading indicator icon.
- * @property {string|string[]} [submit] CSS classes added to the submit.
  */
 
 /**


### PR DESCRIPTION
This fixes the issues where the `loadingIndicator` and `reset` templates throw when the nodes cannot be found.

This is now covered by a test by actually rendering the widget.