### PR TITLE
feat(ratingMenu): merge labels and templates

### DIFF
--- a/docgen/src/guides/v3-migration.md
+++ b/docgen/src/guides/v3-migration.md
@@ -918,7 +918,9 @@ Widget removed.
 | Before          | After             |
 | --------------- | ----------------- |
 | `attributeName` | `attribute`       |
-| `labels.andUp`  | `templates.andUp` |
+| `labels.andUp`  | Removed           |
+
+The value for the label `andUp` is now inlined inside `templates.item`.
 
 ### CSS classes
 

--- a/docgen/src/guides/v3-migration.md
+++ b/docgen/src/guides/v3-migration.md
@@ -915,9 +915,10 @@ Widget removed.
 
 ### Options
 
-| Before          | After       |
-| --------------- | ----------- |
-| `attributeName` | `attribute` |
+| Before          | After             |
+| --------------- | ----------------- |
+| `attributeName` | `attribute`       |
+| `labels.andUp`  | `templates.andUp` |
 
 ### CSS classes
 

--- a/src/widgets/rating-menu/__tests__/__snapshots__/rating-menu-test.js.snap
+++ b/src/widgets/rating-menu/__tests__/__snapshots__/rating-menu-test.js.snap
@@ -33,16 +33,6 @@ exports[`ratingMenu() calls twice ReactDOM.render(<RefinementList props />, cont
           true,
           false,
         ],
-        "templates": Object {
-          "andUp": "& Up",
-          "item": "{{#count}}<a class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" href=\\"{{href}}\\">{{/count}}{{^count}}<div class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" disabled>{{/count}}
-  {{#stars}}<svg class=\\"{{cssClasses.starIcon}} {{#.}}{{cssClasses.fullStarIcon}}{{/.}}{{^.}}{{cssClasses.emptyStarIcon}}{{/.}}\\" aria-hidden=\\"true\\" width=\\"24\\" height=\\"24\\">
-    {{#.}}<use xlink:href=\\"#ais-RatingMenu-starSymbol\\"></use>{{/.}}{{^.}}<use xlink:href=\\"#ais-RatingMenu-starEmptySymbol\\"></use>{{/.}}
-  </svg>{{/stars}}
-  <span class=\\"{{cssClasses.label}}\\">{{templates.andUp}}</span>
-  {{#count}}<span class=\\"{{cssClasses.count}}\\">{{#helpers.formatNumber}}{{count}}{{/helpers.formatNumber}}</span>{{/count}}
-{{#count}}</a>{{/count}}{{^count}}</div>{{/count}}",
-        },
         "value": "4",
       },
       Object {
@@ -56,16 +46,6 @@ exports[`ratingMenu() calls twice ReactDOM.render(<RefinementList props />, cont
           false,
           false,
         ],
-        "templates": Object {
-          "andUp": "& Up",
-          "item": "{{#count}}<a class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" href=\\"{{href}}\\">{{/count}}{{^count}}<div class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" disabled>{{/count}}
-  {{#stars}}<svg class=\\"{{cssClasses.starIcon}} {{#.}}{{cssClasses.fullStarIcon}}{{/.}}{{^.}}{{cssClasses.emptyStarIcon}}{{/.}}\\" aria-hidden=\\"true\\" width=\\"24\\" height=\\"24\\">
-    {{#.}}<use xlink:href=\\"#ais-RatingMenu-starSymbol\\"></use>{{/.}}{{^.}}<use xlink:href=\\"#ais-RatingMenu-starEmptySymbol\\"></use>{{/.}}
-  </svg>{{/stars}}
-  <span class=\\"{{cssClasses.label}}\\">{{templates.andUp}}</span>
-  {{#count}}<span class=\\"{{cssClasses.count}}\\">{{#helpers.formatNumber}}{{count}}{{/helpers.formatNumber}}</span>{{/count}}
-{{#count}}</a>{{/count}}{{^count}}</div>{{/count}}",
-        },
         "value": "3",
       },
       Object {
@@ -79,16 +59,6 @@ exports[`ratingMenu() calls twice ReactDOM.render(<RefinementList props />, cont
           false,
           false,
         ],
-        "templates": Object {
-          "andUp": "& Up",
-          "item": "{{#count}}<a class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" href=\\"{{href}}\\">{{/count}}{{^count}}<div class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" disabled>{{/count}}
-  {{#stars}}<svg class=\\"{{cssClasses.starIcon}} {{#.}}{{cssClasses.fullStarIcon}}{{/.}}{{^.}}{{cssClasses.emptyStarIcon}}{{/.}}\\" aria-hidden=\\"true\\" width=\\"24\\" height=\\"24\\">
-    {{#.}}<use xlink:href=\\"#ais-RatingMenu-starSymbol\\"></use>{{/.}}{{^.}}<use xlink:href=\\"#ais-RatingMenu-starEmptySymbol\\"></use>{{/.}}
-  </svg>{{/stars}}
-  <span class=\\"{{cssClasses.label}}\\">{{templates.andUp}}</span>
-  {{#count}}<span class=\\"{{cssClasses.count}}\\">{{#helpers.formatNumber}}{{count}}{{/helpers.formatNumber}}</span>{{/count}}
-{{#count}}</a>{{/count}}{{^count}}</div>{{/count}}",
-        },
         "value": "2",
       },
       Object {
@@ -102,16 +72,6 @@ exports[`ratingMenu() calls twice ReactDOM.render(<RefinementList props />, cont
           false,
           false,
         ],
-        "templates": Object {
-          "andUp": "& Up",
-          "item": "{{#count}}<a class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" href=\\"{{href}}\\">{{/count}}{{^count}}<div class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" disabled>{{/count}}
-  {{#stars}}<svg class=\\"{{cssClasses.starIcon}} {{#.}}{{cssClasses.fullStarIcon}}{{/.}}{{^.}}{{cssClasses.emptyStarIcon}}{{/.}}\\" aria-hidden=\\"true\\" width=\\"24\\" height=\\"24\\">
-    {{#.}}<use xlink:href=\\"#ais-RatingMenu-starSymbol\\"></use>{{/.}}{{^.}}<use xlink:href=\\"#ais-RatingMenu-starEmptySymbol\\"></use>{{/.}}
-  </svg>{{/stars}}
-  <span class=\\"{{cssClasses.label}}\\">{{templates.andUp}}</span>
-  {{#count}}<span class=\\"{{cssClasses.count}}\\">{{#helpers.formatNumber}}{{count}}{{/helpers.formatNumber}}</span>{{/count}}
-{{#count}}</a>{{/count}}{{^count}}</div>{{/count}}",
-        },
         "value": "1",
       },
     ]
@@ -119,18 +79,16 @@ exports[`ratingMenu() calls twice ReactDOM.render(<RefinementList props />, cont
   templateProps={
     Object {
       "templates": Object {
-        "andUp": "& Up",
         "item": "{{#count}}<a class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" href=\\"{{href}}\\">{{/count}}{{^count}}<div class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" disabled>{{/count}}
   {{#stars}}<svg class=\\"{{cssClasses.starIcon}} {{#.}}{{cssClasses.fullStarIcon}}{{/.}}{{^.}}{{cssClasses.emptyStarIcon}}{{/.}}\\" aria-hidden=\\"true\\" width=\\"24\\" height=\\"24\\">
     {{#.}}<use xlink:href=\\"#ais-RatingMenu-starSymbol\\"></use>{{/.}}{{^.}}<use xlink:href=\\"#ais-RatingMenu-starEmptySymbol\\"></use>{{/.}}
   </svg>{{/stars}}
-  <span class=\\"{{cssClasses.label}}\\">{{templates.andUp}}</span>
+  <span class=\\"{{cssClasses.label}}\\">& Up</span>
   {{#count}}<span class=\\"{{cssClasses.count}}\\">{{#helpers.formatNumber}}{{count}}{{/helpers.formatNumber}}</span>{{/count}}
 {{#count}}</a>{{/count}}{{^count}}</div>{{/count}}",
       },
       "templatesConfig": undefined,
       "useCustomCompileOptions": Object {
-        "andUp": false,
         "item": false,
       },
     }
@@ -194,16 +152,6 @@ exports[`ratingMenu() calls twice ReactDOM.render(<RefinementList props />, cont
           true,
           false,
         ],
-        "templates": Object {
-          "andUp": "& Up",
-          "item": "{{#count}}<a class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" href=\\"{{href}}\\">{{/count}}{{^count}}<div class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" disabled>{{/count}}
-  {{#stars}}<svg class=\\"{{cssClasses.starIcon}} {{#.}}{{cssClasses.fullStarIcon}}{{/.}}{{^.}}{{cssClasses.emptyStarIcon}}{{/.}}\\" aria-hidden=\\"true\\" width=\\"24\\" height=\\"24\\">
-    {{#.}}<use xlink:href=\\"#ais-RatingMenu-starSymbol\\"></use>{{/.}}{{^.}}<use xlink:href=\\"#ais-RatingMenu-starEmptySymbol\\"></use>{{/.}}
-  </svg>{{/stars}}
-  <span class=\\"{{cssClasses.label}}\\">{{templates.andUp}}</span>
-  {{#count}}<span class=\\"{{cssClasses.count}}\\">{{#helpers.formatNumber}}{{count}}{{/helpers.formatNumber}}</span>{{/count}}
-{{#count}}</a>{{/count}}{{^count}}</div>{{/count}}",
-        },
         "value": "4",
       },
       Object {
@@ -217,16 +165,6 @@ exports[`ratingMenu() calls twice ReactDOM.render(<RefinementList props />, cont
           false,
           false,
         ],
-        "templates": Object {
-          "andUp": "& Up",
-          "item": "{{#count}}<a class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" href=\\"{{href}}\\">{{/count}}{{^count}}<div class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" disabled>{{/count}}
-  {{#stars}}<svg class=\\"{{cssClasses.starIcon}} {{#.}}{{cssClasses.fullStarIcon}}{{/.}}{{^.}}{{cssClasses.emptyStarIcon}}{{/.}}\\" aria-hidden=\\"true\\" width=\\"24\\" height=\\"24\\">
-    {{#.}}<use xlink:href=\\"#ais-RatingMenu-starSymbol\\"></use>{{/.}}{{^.}}<use xlink:href=\\"#ais-RatingMenu-starEmptySymbol\\"></use>{{/.}}
-  </svg>{{/stars}}
-  <span class=\\"{{cssClasses.label}}\\">{{templates.andUp}}</span>
-  {{#count}}<span class=\\"{{cssClasses.count}}\\">{{#helpers.formatNumber}}{{count}}{{/helpers.formatNumber}}</span>{{/count}}
-{{#count}}</a>{{/count}}{{^count}}</div>{{/count}}",
-        },
         "value": "3",
       },
       Object {
@@ -240,16 +178,6 @@ exports[`ratingMenu() calls twice ReactDOM.render(<RefinementList props />, cont
           false,
           false,
         ],
-        "templates": Object {
-          "andUp": "& Up",
-          "item": "{{#count}}<a class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" href=\\"{{href}}\\">{{/count}}{{^count}}<div class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" disabled>{{/count}}
-  {{#stars}}<svg class=\\"{{cssClasses.starIcon}} {{#.}}{{cssClasses.fullStarIcon}}{{/.}}{{^.}}{{cssClasses.emptyStarIcon}}{{/.}}\\" aria-hidden=\\"true\\" width=\\"24\\" height=\\"24\\">
-    {{#.}}<use xlink:href=\\"#ais-RatingMenu-starSymbol\\"></use>{{/.}}{{^.}}<use xlink:href=\\"#ais-RatingMenu-starEmptySymbol\\"></use>{{/.}}
-  </svg>{{/stars}}
-  <span class=\\"{{cssClasses.label}}\\">{{templates.andUp}}</span>
-  {{#count}}<span class=\\"{{cssClasses.count}}\\">{{#helpers.formatNumber}}{{count}}{{/helpers.formatNumber}}</span>{{/count}}
-{{#count}}</a>{{/count}}{{^count}}</div>{{/count}}",
-        },
         "value": "2",
       },
       Object {
@@ -263,16 +191,6 @@ exports[`ratingMenu() calls twice ReactDOM.render(<RefinementList props />, cont
           false,
           false,
         ],
-        "templates": Object {
-          "andUp": "& Up",
-          "item": "{{#count}}<a class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" href=\\"{{href}}\\">{{/count}}{{^count}}<div class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" disabled>{{/count}}
-  {{#stars}}<svg class=\\"{{cssClasses.starIcon}} {{#.}}{{cssClasses.fullStarIcon}}{{/.}}{{^.}}{{cssClasses.emptyStarIcon}}{{/.}}\\" aria-hidden=\\"true\\" width=\\"24\\" height=\\"24\\">
-    {{#.}}<use xlink:href=\\"#ais-RatingMenu-starSymbol\\"></use>{{/.}}{{^.}}<use xlink:href=\\"#ais-RatingMenu-starEmptySymbol\\"></use>{{/.}}
-  </svg>{{/stars}}
-  <span class=\\"{{cssClasses.label}}\\">{{templates.andUp}}</span>
-  {{#count}}<span class=\\"{{cssClasses.count}}\\">{{#helpers.formatNumber}}{{count}}{{/helpers.formatNumber}}</span>{{/count}}
-{{#count}}</a>{{/count}}{{^count}}</div>{{/count}}",
-        },
         "value": "1",
       },
     ]
@@ -280,18 +198,16 @@ exports[`ratingMenu() calls twice ReactDOM.render(<RefinementList props />, cont
   templateProps={
     Object {
       "templates": Object {
-        "andUp": "& Up",
         "item": "{{#count}}<a class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" href=\\"{{href}}\\">{{/count}}{{^count}}<div class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" disabled>{{/count}}
   {{#stars}}<svg class=\\"{{cssClasses.starIcon}} {{#.}}{{cssClasses.fullStarIcon}}{{/.}}{{^.}}{{cssClasses.emptyStarIcon}}{{/.}}\\" aria-hidden=\\"true\\" width=\\"24\\" height=\\"24\\">
     {{#.}}<use xlink:href=\\"#ais-RatingMenu-starSymbol\\"></use>{{/.}}{{^.}}<use xlink:href=\\"#ais-RatingMenu-starEmptySymbol\\"></use>{{/.}}
   </svg>{{/stars}}
-  <span class=\\"{{cssClasses.label}}\\">{{templates.andUp}}</span>
+  <span class=\\"{{cssClasses.label}}\\">& Up</span>
   {{#count}}<span class=\\"{{cssClasses.count}}\\">{{#helpers.formatNumber}}{{count}}{{/helpers.formatNumber}}</span>{{/count}}
 {{#count}}</a>{{/count}}{{^count}}</div>{{/count}}",
       },
       "templatesConfig": undefined,
       "useCustomCompileOptions": Object {
-        "andUp": false,
         "item": false,
       },
     }

--- a/src/widgets/rating-menu/__tests__/__snapshots__/rating-menu-test.js.snap
+++ b/src/widgets/rating-menu/__tests__/__snapshots__/rating-menu-test.js.snap
@@ -25,9 +25,6 @@ exports[`ratingMenu() calls twice ReactDOM.render(<RefinementList props />, cont
       Object {
         "count": 0,
         "isRefined": false,
-        "labels": Object {
-          "andUp": "& Up",
-        },
         "name": "4",
         "stars": Array [
           true,
@@ -36,14 +33,21 @@ exports[`ratingMenu() calls twice ReactDOM.render(<RefinementList props />, cont
           true,
           false,
         ],
+        "templates": Object {
+          "andUp": "& Up",
+          "item": "{{#count}}<a class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" href=\\"{{href}}\\">{{/count}}{{^count}}<div class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" disabled>{{/count}}
+  {{#stars}}<svg class=\\"{{cssClasses.starIcon}} {{#.}}{{cssClasses.fullStarIcon}}{{/.}}{{^.}}{{cssClasses.emptyStarIcon}}{{/.}}\\" aria-hidden=\\"true\\" width=\\"24\\" height=\\"24\\">
+    {{#.}}<use xlink:href=\\"#ais-RatingMenu-starSymbol\\"></use>{{/.}}{{^.}}<use xlink:href=\\"#ais-RatingMenu-starEmptySymbol\\"></use>{{/.}}
+  </svg>{{/stars}}
+  <span class=\\"{{cssClasses.label}}\\">{{templates.andUp}}</span>
+  {{#count}}<span class=\\"{{cssClasses.count}}\\">{{#helpers.formatNumber}}{{count}}{{/helpers.formatNumber}}</span>{{/count}}
+{{#count}}</a>{{/count}}{{^count}}</div>{{/count}}",
+        },
         "value": "4",
       },
       Object {
         "count": 0,
         "isRefined": false,
-        "labels": Object {
-          "andUp": "& Up",
-        },
         "name": "3",
         "stars": Array [
           true,
@@ -52,14 +56,21 @@ exports[`ratingMenu() calls twice ReactDOM.render(<RefinementList props />, cont
           false,
           false,
         ],
+        "templates": Object {
+          "andUp": "& Up",
+          "item": "{{#count}}<a class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" href=\\"{{href}}\\">{{/count}}{{^count}}<div class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" disabled>{{/count}}
+  {{#stars}}<svg class=\\"{{cssClasses.starIcon}} {{#.}}{{cssClasses.fullStarIcon}}{{/.}}{{^.}}{{cssClasses.emptyStarIcon}}{{/.}}\\" aria-hidden=\\"true\\" width=\\"24\\" height=\\"24\\">
+    {{#.}}<use xlink:href=\\"#ais-RatingMenu-starSymbol\\"></use>{{/.}}{{^.}}<use xlink:href=\\"#ais-RatingMenu-starEmptySymbol\\"></use>{{/.}}
+  </svg>{{/stars}}
+  <span class=\\"{{cssClasses.label}}\\">{{templates.andUp}}</span>
+  {{#count}}<span class=\\"{{cssClasses.count}}\\">{{#helpers.formatNumber}}{{count}}{{/helpers.formatNumber}}</span>{{/count}}
+{{#count}}</a>{{/count}}{{^count}}</div>{{/count}}",
+        },
         "value": "3",
       },
       Object {
         "count": 0,
         "isRefined": false,
-        "labels": Object {
-          "andUp": "& Up",
-        },
         "name": "2",
         "stars": Array [
           true,
@@ -68,14 +79,21 @@ exports[`ratingMenu() calls twice ReactDOM.render(<RefinementList props />, cont
           false,
           false,
         ],
+        "templates": Object {
+          "andUp": "& Up",
+          "item": "{{#count}}<a class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" href=\\"{{href}}\\">{{/count}}{{^count}}<div class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" disabled>{{/count}}
+  {{#stars}}<svg class=\\"{{cssClasses.starIcon}} {{#.}}{{cssClasses.fullStarIcon}}{{/.}}{{^.}}{{cssClasses.emptyStarIcon}}{{/.}}\\" aria-hidden=\\"true\\" width=\\"24\\" height=\\"24\\">
+    {{#.}}<use xlink:href=\\"#ais-RatingMenu-starSymbol\\"></use>{{/.}}{{^.}}<use xlink:href=\\"#ais-RatingMenu-starEmptySymbol\\"></use>{{/.}}
+  </svg>{{/stars}}
+  <span class=\\"{{cssClasses.label}}\\">{{templates.andUp}}</span>
+  {{#count}}<span class=\\"{{cssClasses.count}}\\">{{#helpers.formatNumber}}{{count}}{{/helpers.formatNumber}}</span>{{/count}}
+{{#count}}</a>{{/count}}{{^count}}</div>{{/count}}",
+        },
         "value": "2",
       },
       Object {
         "count": 0,
         "isRefined": false,
-        "labels": Object {
-          "andUp": "& Up",
-        },
         "name": "1",
         "stars": Array [
           true,
@@ -84,6 +102,16 @@ exports[`ratingMenu() calls twice ReactDOM.render(<RefinementList props />, cont
           false,
           false,
         ],
+        "templates": Object {
+          "andUp": "& Up",
+          "item": "{{#count}}<a class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" href=\\"{{href}}\\">{{/count}}{{^count}}<div class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" disabled>{{/count}}
+  {{#stars}}<svg class=\\"{{cssClasses.starIcon}} {{#.}}{{cssClasses.fullStarIcon}}{{/.}}{{^.}}{{cssClasses.emptyStarIcon}}{{/.}}\\" aria-hidden=\\"true\\" width=\\"24\\" height=\\"24\\">
+    {{#.}}<use xlink:href=\\"#ais-RatingMenu-starSymbol\\"></use>{{/.}}{{^.}}<use xlink:href=\\"#ais-RatingMenu-starEmptySymbol\\"></use>{{/.}}
+  </svg>{{/stars}}
+  <span class=\\"{{cssClasses.label}}\\">{{templates.andUp}}</span>
+  {{#count}}<span class=\\"{{cssClasses.count}}\\">{{#helpers.formatNumber}}{{count}}{{/helpers.formatNumber}}</span>{{/count}}
+{{#count}}</a>{{/count}}{{^count}}</div>{{/count}}",
+        },
         "value": "1",
       },
     ]
@@ -91,16 +119,18 @@ exports[`ratingMenu() calls twice ReactDOM.render(<RefinementList props />, cont
   templateProps={
     Object {
       "templates": Object {
+        "andUp": "& Up",
         "item": "{{#count}}<a class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" href=\\"{{href}}\\">{{/count}}{{^count}}<div class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" disabled>{{/count}}
   {{#stars}}<svg class=\\"{{cssClasses.starIcon}} {{#.}}{{cssClasses.fullStarIcon}}{{/.}}{{^.}}{{cssClasses.emptyStarIcon}}{{/.}}\\" aria-hidden=\\"true\\" width=\\"24\\" height=\\"24\\">
     {{#.}}<use xlink:href=\\"#ais-RatingMenu-starSymbol\\"></use>{{/.}}{{^.}}<use xlink:href=\\"#ais-RatingMenu-starEmptySymbol\\"></use>{{/.}}
   </svg>{{/stars}}
-  <span class=\\"{{cssClasses.label}}\\">{{labels.andUp}}</span>
+  <span class=\\"{{cssClasses.label}}\\">{{templates.andUp}}</span>
   {{#count}}<span class=\\"{{cssClasses.count}}\\">{{#helpers.formatNumber}}{{count}}{{/helpers.formatNumber}}</span>{{/count}}
 {{#count}}</a>{{/count}}{{^count}}</div>{{/count}}",
       },
       "templatesConfig": undefined,
       "useCustomCompileOptions": Object {
+        "andUp": false,
         "item": false,
       },
     }
@@ -156,9 +186,6 @@ exports[`ratingMenu() calls twice ReactDOM.render(<RefinementList props />, cont
       Object {
         "count": 0,
         "isRefined": false,
-        "labels": Object {
-          "andUp": "& Up",
-        },
         "name": "4",
         "stars": Array [
           true,
@@ -167,14 +194,21 @@ exports[`ratingMenu() calls twice ReactDOM.render(<RefinementList props />, cont
           true,
           false,
         ],
+        "templates": Object {
+          "andUp": "& Up",
+          "item": "{{#count}}<a class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" href=\\"{{href}}\\">{{/count}}{{^count}}<div class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" disabled>{{/count}}
+  {{#stars}}<svg class=\\"{{cssClasses.starIcon}} {{#.}}{{cssClasses.fullStarIcon}}{{/.}}{{^.}}{{cssClasses.emptyStarIcon}}{{/.}}\\" aria-hidden=\\"true\\" width=\\"24\\" height=\\"24\\">
+    {{#.}}<use xlink:href=\\"#ais-RatingMenu-starSymbol\\"></use>{{/.}}{{^.}}<use xlink:href=\\"#ais-RatingMenu-starEmptySymbol\\"></use>{{/.}}
+  </svg>{{/stars}}
+  <span class=\\"{{cssClasses.label}}\\">{{templates.andUp}}</span>
+  {{#count}}<span class=\\"{{cssClasses.count}}\\">{{#helpers.formatNumber}}{{count}}{{/helpers.formatNumber}}</span>{{/count}}
+{{#count}}</a>{{/count}}{{^count}}</div>{{/count}}",
+        },
         "value": "4",
       },
       Object {
         "count": 0,
         "isRefined": false,
-        "labels": Object {
-          "andUp": "& Up",
-        },
         "name": "3",
         "stars": Array [
           true,
@@ -183,14 +217,21 @@ exports[`ratingMenu() calls twice ReactDOM.render(<RefinementList props />, cont
           false,
           false,
         ],
+        "templates": Object {
+          "andUp": "& Up",
+          "item": "{{#count}}<a class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" href=\\"{{href}}\\">{{/count}}{{^count}}<div class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" disabled>{{/count}}
+  {{#stars}}<svg class=\\"{{cssClasses.starIcon}} {{#.}}{{cssClasses.fullStarIcon}}{{/.}}{{^.}}{{cssClasses.emptyStarIcon}}{{/.}}\\" aria-hidden=\\"true\\" width=\\"24\\" height=\\"24\\">
+    {{#.}}<use xlink:href=\\"#ais-RatingMenu-starSymbol\\"></use>{{/.}}{{^.}}<use xlink:href=\\"#ais-RatingMenu-starEmptySymbol\\"></use>{{/.}}
+  </svg>{{/stars}}
+  <span class=\\"{{cssClasses.label}}\\">{{templates.andUp}}</span>
+  {{#count}}<span class=\\"{{cssClasses.count}}\\">{{#helpers.formatNumber}}{{count}}{{/helpers.formatNumber}}</span>{{/count}}
+{{#count}}</a>{{/count}}{{^count}}</div>{{/count}}",
+        },
         "value": "3",
       },
       Object {
         "count": 0,
         "isRefined": false,
-        "labels": Object {
-          "andUp": "& Up",
-        },
         "name": "2",
         "stars": Array [
           true,
@@ -199,14 +240,21 @@ exports[`ratingMenu() calls twice ReactDOM.render(<RefinementList props />, cont
           false,
           false,
         ],
+        "templates": Object {
+          "andUp": "& Up",
+          "item": "{{#count}}<a class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" href=\\"{{href}}\\">{{/count}}{{^count}}<div class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" disabled>{{/count}}
+  {{#stars}}<svg class=\\"{{cssClasses.starIcon}} {{#.}}{{cssClasses.fullStarIcon}}{{/.}}{{^.}}{{cssClasses.emptyStarIcon}}{{/.}}\\" aria-hidden=\\"true\\" width=\\"24\\" height=\\"24\\">
+    {{#.}}<use xlink:href=\\"#ais-RatingMenu-starSymbol\\"></use>{{/.}}{{^.}}<use xlink:href=\\"#ais-RatingMenu-starEmptySymbol\\"></use>{{/.}}
+  </svg>{{/stars}}
+  <span class=\\"{{cssClasses.label}}\\">{{templates.andUp}}</span>
+  {{#count}}<span class=\\"{{cssClasses.count}}\\">{{#helpers.formatNumber}}{{count}}{{/helpers.formatNumber}}</span>{{/count}}
+{{#count}}</a>{{/count}}{{^count}}</div>{{/count}}",
+        },
         "value": "2",
       },
       Object {
         "count": 0,
         "isRefined": false,
-        "labels": Object {
-          "andUp": "& Up",
-        },
         "name": "1",
         "stars": Array [
           true,
@@ -215,6 +263,16 @@ exports[`ratingMenu() calls twice ReactDOM.render(<RefinementList props />, cont
           false,
           false,
         ],
+        "templates": Object {
+          "andUp": "& Up",
+          "item": "{{#count}}<a class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" href=\\"{{href}}\\">{{/count}}{{^count}}<div class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" disabled>{{/count}}
+  {{#stars}}<svg class=\\"{{cssClasses.starIcon}} {{#.}}{{cssClasses.fullStarIcon}}{{/.}}{{^.}}{{cssClasses.emptyStarIcon}}{{/.}}\\" aria-hidden=\\"true\\" width=\\"24\\" height=\\"24\\">
+    {{#.}}<use xlink:href=\\"#ais-RatingMenu-starSymbol\\"></use>{{/.}}{{^.}}<use xlink:href=\\"#ais-RatingMenu-starEmptySymbol\\"></use>{{/.}}
+  </svg>{{/stars}}
+  <span class=\\"{{cssClasses.label}}\\">{{templates.andUp}}</span>
+  {{#count}}<span class=\\"{{cssClasses.count}}\\">{{#helpers.formatNumber}}{{count}}{{/helpers.formatNumber}}</span>{{/count}}
+{{#count}}</a>{{/count}}{{^count}}</div>{{/count}}",
+        },
         "value": "1",
       },
     ]
@@ -222,16 +280,18 @@ exports[`ratingMenu() calls twice ReactDOM.render(<RefinementList props />, cont
   templateProps={
     Object {
       "templates": Object {
+        "andUp": "& Up",
         "item": "{{#count}}<a class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" href=\\"{{href}}\\">{{/count}}{{^count}}<div class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" disabled>{{/count}}
   {{#stars}}<svg class=\\"{{cssClasses.starIcon}} {{#.}}{{cssClasses.fullStarIcon}}{{/.}}{{^.}}{{cssClasses.emptyStarIcon}}{{/.}}\\" aria-hidden=\\"true\\" width=\\"24\\" height=\\"24\\">
     {{#.}}<use xlink:href=\\"#ais-RatingMenu-starSymbol\\"></use>{{/.}}{{^.}}<use xlink:href=\\"#ais-RatingMenu-starEmptySymbol\\"></use>{{/.}}
   </svg>{{/stars}}
-  <span class=\\"{{cssClasses.label}}\\">{{labels.andUp}}</span>
+  <span class=\\"{{cssClasses.label}}\\">{{templates.andUp}}</span>
   {{#count}}<span class=\\"{{cssClasses.count}}\\">{{#helpers.formatNumber}}{{count}}{{/helpers.formatNumber}}</span>{{/count}}
 {{#count}}</a>{{/count}}{{^count}}</div>{{/count}}",
       },
       "templatesConfig": undefined,
       "useCustomCompileOptions": Object {
+        "andUp": false,
         "item": false,
       },
     }

--- a/src/widgets/rating-menu/__tests__/rating-menu-test.js
+++ b/src/widgets/rating-menu/__tests__/rating-menu-test.js
@@ -78,7 +78,6 @@ describe('ratingMenu()', () => {
         name: '1',
         value: '1',
         stars: [true, false, false, false, false],
-        templates: expect.objectContaining({ andUp: '& Up' }),
       },
     ]);
   });
@@ -159,7 +158,7 @@ describe('ratingMenu()', () => {
       {
         count: 1000,
         isRefined: false,
-        templates: expect.objectContaining({ andUp: '& Up' }),
+
         name: '4',
         value: '4',
         stars: [true, true, true, true, false],
@@ -167,7 +166,7 @@ describe('ratingMenu()', () => {
       {
         count: 1050,
         isRefined: false,
-        templates: expect.objectContaining({ andUp: '& Up' }),
+
         name: '3',
         value: '3',
         stars: [true, true, true, false, false],
@@ -175,7 +174,7 @@ describe('ratingMenu()', () => {
       {
         count: 1070,
         isRefined: false,
-        templates: expect.objectContaining({ andUp: '& Up' }),
+
         name: '2',
         value: '2',
         stars: [true, true, false, false, false],
@@ -183,7 +182,7 @@ describe('ratingMenu()', () => {
       {
         count: 1080,
         isRefined: false,
-        templates: expect.objectContaining({ andUp: '& Up' }),
+
         name: '1',
         value: '1',
         stars: [true, false, false, false, false],

--- a/src/widgets/rating-menu/__tests__/rating-menu-test.js
+++ b/src/widgets/rating-menu/__tests__/rating-menu-test.js
@@ -79,6 +79,7 @@ describe('ratingMenu()', () => {
         name: '1',
         value: '1',
         stars: [true, false, false, false, false],
+        templates: expect.objectContaining({ andUp: '& Up' }),
       },
     ]);
   });
@@ -159,7 +160,7 @@ describe('ratingMenu()', () => {
       {
         count: 1000,
         isRefined: false,
-        templates: { andUp: '& Up' },
+        templates: expect.objectContaining({ andUp: '& Up' }),
         name: '4',
         value: '4',
         stars: [true, true, true, true, false],
@@ -167,7 +168,7 @@ describe('ratingMenu()', () => {
       {
         count: 1050,
         isRefined: false,
-        templates: { andUp: '& Up' },
+        templates: expect.objectContaining({ andUp: '& Up' }),
         name: '3',
         value: '3',
         stars: [true, true, true, false, false],
@@ -175,7 +176,7 @@ describe('ratingMenu()', () => {
       {
         count: 1070,
         isRefined: false,
-        templates: { andUp: '& Up' },
+        templates: expect.objectContaining({ andUp: '& Up' }),
         name: '2',
         value: '2',
         stars: [true, true, false, false, false],
@@ -183,7 +184,7 @@ describe('ratingMenu()', () => {
       {
         count: 1080,
         isRefined: false,
-        templates: { andUp: '& Up' },
+        templates: expect.objectContaining({ andUp: '& Up' }),
         name: '1',
         value: '1',
         stars: [true, false, false, false, false],

--- a/src/widgets/rating-menu/__tests__/rating-menu-test.js
+++ b/src/widgets/rating-menu/__tests__/rating-menu-test.js
@@ -1,6 +1,5 @@
 import jsHelper, { SearchResults } from 'algoliasearch-helper';
 import ratingMenu from '../rating-menu.js';
-import defaultTemplates from '../../../widgets/rating-menu/defaultTemplates.js';
 
 describe('ratingMenu()', () => {
   const attribute = 'anAttrName';

--- a/src/widgets/rating-menu/__tests__/rating-menu-test.js
+++ b/src/widgets/rating-menu/__tests__/rating-menu-test.js
@@ -1,6 +1,6 @@
 import jsHelper, { SearchResults } from 'algoliasearch-helper';
 import ratingMenu from '../rating-menu.js';
-import defaultLabels from '../../../widgets/rating-menu/defaultLabels.js';
+import defaultTemplates from '../../../widgets/rating-menu/defaultTemplates.js';
 
 describe('ratingMenu()', () => {
   const attribute = 'anAttrName';
@@ -79,7 +79,6 @@ describe('ratingMenu()', () => {
         name: '1',
         value: '1',
         stars: [true, false, false, false, false],
-        labels: defaultLabels,
       },
     ]);
   });
@@ -160,7 +159,7 @@ describe('ratingMenu()', () => {
       {
         count: 1000,
         isRefined: false,
-        labels: { andUp: '& Up' },
+        templates: { andUp: '& Up' },
         name: '4',
         value: '4',
         stars: [true, true, true, true, false],
@@ -168,7 +167,7 @@ describe('ratingMenu()', () => {
       {
         count: 1050,
         isRefined: false,
-        labels: { andUp: '& Up' },
+        templates: { andUp: '& Up' },
         name: '3',
         value: '3',
         stars: [true, true, true, false, false],
@@ -176,7 +175,7 @@ describe('ratingMenu()', () => {
       {
         count: 1070,
         isRefined: false,
-        labels: { andUp: '& Up' },
+        templates: { andUp: '& Up' },
         name: '2',
         value: '2',
         stars: [true, true, false, false, false],
@@ -184,7 +183,7 @@ describe('ratingMenu()', () => {
       {
         count: 1080,
         isRefined: false,
-        labels: { andUp: '& Up' },
+        templates: { andUp: '& Up' },
         name: '1',
         value: '1',
         stars: [true, false, false, false, false],

--- a/src/widgets/rating-menu/defaultLabels.js
+++ b/src/widgets/rating-menu/defaultLabels.js
@@ -1,3 +1,0 @@
-export default {
-  andUp: '& Up',
-};

--- a/src/widgets/rating-menu/defaultTemplates.js
+++ b/src/widgets/rating-menu/defaultTemplates.js
@@ -3,7 +3,8 @@ export default {
   {{#stars}}<svg class="{{cssClasses.starIcon}} {{#.}}{{cssClasses.fullStarIcon}}{{/.}}{{^.}}{{cssClasses.emptyStarIcon}}{{/.}}" aria-hidden="true" width="24" height="24">
     {{#.}}<use xlink:href="#ais-RatingMenu-starSymbol"></use>{{/.}}{{^.}}<use xlink:href="#ais-RatingMenu-starEmptySymbol"></use>{{/.}}
   </svg>{{/stars}}
-  <span class="{{cssClasses.label}}">{{labels.andUp}}</span>
+  <span class="{{cssClasses.label}}">{{templates.andUp}}</span>
   {{#count}}<span class="{{cssClasses.count}}">{{#helpers.formatNumber}}{{count}}{{/helpers.formatNumber}}</span>{{/count}}
 {{#count}}</a>{{/count}}{{^count}}</div>{{/count}}`,
+  andUp: '& Up',
 };

--- a/src/widgets/rating-menu/defaultTemplates.js
+++ b/src/widgets/rating-menu/defaultTemplates.js
@@ -3,8 +3,7 @@ export default {
   {{#stars}}<svg class="{{cssClasses.starIcon}} {{#.}}{{cssClasses.fullStarIcon}}{{/.}}{{^.}}{{cssClasses.emptyStarIcon}}{{/.}}" aria-hidden="true" width="24" height="24">
     {{#.}}<use xlink:href="#ais-RatingMenu-starSymbol"></use>{{/.}}{{^.}}<use xlink:href="#ais-RatingMenu-starEmptySymbol"></use>{{/.}}
   </svg>{{/stars}}
-  <span class="{{cssClasses.label}}">{{templates.andUp}}</span>
+  <span class="{{cssClasses.label}}">& Up</span>
   {{#count}}<span class="{{cssClasses.count}}">{{#helpers.formatNumber}}{{count}}{{/helpers.formatNumber}}</span>{{/count}}
 {{#count}}</a>{{/count}}{{^count}}</div>{{/count}}`,
-  andUp: '& Up',
 };

--- a/src/widgets/rating-menu/rating-menu.js
+++ b/src/widgets/rating-menu/rating-menu.js
@@ -3,19 +3,12 @@ import cx from 'classnames';
 import RefinementList from '../../components/RefinementList/RefinementList.js';
 import connectRatingMenu from '../../connectors/rating-menu/connectRatingMenu.js';
 import defaultTemplates from './defaultTemplates.js';
-import defaultLabels from './defaultLabels.js';
 import { prepareTemplateProps, getContainerNode } from '../../lib/utils.js';
 import { component } from '../../lib/suit.js';
 
 const suit = component('RatingMenu');
 
-const renderer = ({
-  containerNode,
-  cssClasses,
-  templates,
-  renderState,
-  labels,
-}) => (
+const renderer = ({ containerNode, cssClasses, templates, renderState }) => (
   { refine, items, createURL, instantSearchInstance },
   isFirstRendering
 ) => {
@@ -33,7 +26,7 @@ const renderer = ({
     <RefinementList
       createURL={createURL}
       cssClasses={cssClasses}
-      facetValues={items.map(item => ({ ...item, labels }))}
+      facetValues={items.map(item => ({ ...item, templates }))}
       templateProps={renderState.templateProps}
       toggleRefinement={refine}
     >
@@ -59,18 +52,13 @@ ratingMenu({
   attribute,
   [ max = 5 ],
   [ cssClasses.{root, list, item, selectedItem, disabledItem, link, starIcon, fullStarIcon, emptyStarIcon, label, count} ],
-  [ templates.{item} ],
-  [ labels.{andUp} ],
+  [ templates.{item, andUp} ],
 })`;
-
-/**
- * @typedef {Object} RatingMenuWidgetLabels
- * @property {string} [andUp] Label used to suffix the ratings.
- */
 
 /**
  * @typedef {Object} RatingMenuWidgetTemplates
  * @property  {string|function} [item] Item template, provided with `name`, `count`, `isRefined`, `url` data properties.
+ * @property {string} [andUp] Template used to suffix the rating item.
  */
 
 /**
@@ -94,7 +82,6 @@ ratingMenu({
  * @property {string|HTMLElement} container Place where to insert the widget in your webpage.
  * @property {string} attribute Name of the attribute in your records that contains the ratings.
  * @property {number} [max=5] The maximum rating value.
- * @property {RatingMenuWidgetLabels} [labels] Labels used by the default template.
  * @property {RatingMenuWidgetTemplates} [templates] Templates to use for the widget.
  * @property {RatingMenuWidgetCssClasses} [cssClasses] CSS classes to add.
  */
@@ -122,7 +109,7 @@ ratingMenu({
  *     container: '#stars',
  *     attribute: 'rating',
  *     max: 5,
- *     labels: {
+ *     templates: {
  *       andUp: '& Up'
  *     }
  *   })
@@ -133,7 +120,6 @@ export default function ratingMenu({
   attribute,
   max = 5,
   cssClasses: userCssClasses = {},
-  labels = defaultLabels,
   templates = defaultTemplates,
 } = {}) {
   if (!container) {
@@ -177,7 +163,6 @@ export default function ratingMenu({
     cssClasses,
     renderState: {},
     templates,
-    labels,
   });
 
   try {

--- a/src/widgets/rating-menu/rating-menu.js
+++ b/src/widgets/rating-menu/rating-menu.js
@@ -26,7 +26,7 @@ const renderer = ({ containerNode, cssClasses, templates, renderState }) => (
     <RefinementList
       createURL={createURL}
       cssClasses={cssClasses}
-      facetValues={items.map(item => ({ ...item, templates }))}
+      facetValues={items}
       templateProps={renderState.templateProps}
       toggleRefinement={refine}
     >
@@ -52,13 +52,12 @@ ratingMenu({
   attribute,
   [ max = 5 ],
   [ cssClasses.{root, list, item, selectedItem, disabledItem, link, starIcon, fullStarIcon, emptyStarIcon, label, count} ],
-  [ templates.{item, andUp} ],
+  [ templates.{item} ],
 })`;
 
 /**
  * @typedef {Object} RatingMenuWidgetTemplates
  * @property  {string|function} [item] Item template, provided with `name`, `count`, `isRefined`, `url` data properties.
- * @property {string} [andUp] Template used to suffix the rating item.
  */
 
 /**
@@ -81,7 +80,7 @@ ratingMenu({
  * @typedef {Object} RatingMenuWidgetOptions
  * @property {string|HTMLElement} container Place where to insert the widget in your webpage.
  * @property {string} attribute Name of the attribute in your records that contains the ratings.
- * @property {number} [max=5] The maximum rating value.
+ * @property {number} [max = 5] The maximum rating value.
  * @property {RatingMenuWidgetTemplates} [templates] Templates to use for the widget.
  * @property {RatingMenuWidgetCssClasses} [cssClasses] CSS classes to add.
  */
@@ -109,9 +108,6 @@ ratingMenu({
  *     container: '#stars',
  *     attribute: 'rating',
  *     max: 5,
- *     templates: {
- *       andUp: '& Up'
- *     }
  *   })
  * );
  */

--- a/storybook/app/builtin/stories/rating-menu.stories.js
+++ b/storybook/app/builtin/stories/rating-menu.stories.js
@@ -16,7 +16,7 @@ export default () => {
             container,
             attribute: 'rating',
             max: 5,
-            labels: {
+            templates: {
               andUp: '& Up',
             },
           })
@@ -31,7 +31,7 @@ export default () => {
             container,
             attribute: 'rating',
             max: 7,
-            labels: {
+            templates: {
               andUp: '& Up',
             },
           })

--- a/storybook/app/builtin/stories/rating-menu.stories.js
+++ b/storybook/app/builtin/stories/rating-menu.stories.js
@@ -16,9 +16,6 @@ export default () => {
             container,
             attribute: 'rating',
             max: 5,
-            templates: {
-              andUp: '& Up',
-            },
           })
         );
       })
@@ -31,9 +28,6 @@ export default () => {
             container,
             attribute: 'rating',
             max: 7,
-            templates: {
-              andUp: '& Up',
-            },
           })
         );
       })

--- a/storybook/app/init-unmount-widgets.js
+++ b/storybook/app/init-unmount-widgets.js
@@ -262,7 +262,7 @@ export default () => {
         container,
         attribute: 'rating',
         max: 5,
-        labels: {
+        templates: {
           andUp: '& Up',
         },
       })

--- a/storybook/app/init-unmount-widgets.js
+++ b/storybook/app/init-unmount-widgets.js
@@ -262,9 +262,6 @@ export default () => {
         container,
         attribute: 'rating',
         max: 5,
-        templates: {
-          andUp: '& Up',
-        },
       })
     )
   );


### PR DESCRIPTION
This merges the labels and the templates for the widget `ratingMenu`.

We now pass the templates to the templates themself to access `templates.andUp`.