### PR TITLE
feat(hierarchicalMenu): merge showMore templates

### DIFF
--- a/docgen/src/guides/v3-migration.md
+++ b/docgen/src/guides/v3-migration.md
@@ -992,13 +992,27 @@ Widget removed.
 | `searchForFacetValues.isAlwaysActive`      | `searchableIsAlwaysActive`      |
 | `searchForFacetValues.escapeFacetValues`   | `searchableEscapeFacetValues`   |
 | `searchForFacetValues.templates.noResults` | `templates.searchableNoResults` |
-| `showMore.templates.active`                | `templates.showMoreActive`      |
-| `showMore.templates.inactive`              | `templates.showMoreInactive`    |
+| `showMore.templates.active`                | `templates.showMoreText`      |
+| `showMore.templates.inactive`              | `templates.showMoreText`    |
 
 - `searchablePlaceholder` defaults to `"Search..."`
 - `searchableEscapeFacetValues` defaults to `true`
 - `searchableIsAlwaysActive` defaults to `true`
 - `showMore` is now a boolean option (`searchForFacetValues.templates` and `showMore.templates` are now in `templates`)
+- An object containing `isShowingMore` is passed to `showMoreText` template to toggle between the two states:
+
+```
+{
+  showMoreText: `
+    {{#isShowingMore}}
+      Show less
+    {{/isShowingMore}}
+    {{^isShowingMore}}
+      Show more
+    {{/isShowingMore}}
+  `
+}
+```
 
 #### CSS classes
 

--- a/src/components/RefinementList/RefinementList.js
+++ b/src/components/RefinementList/RefinementList.js
@@ -158,13 +158,14 @@ class RefinementList extends Component {
     const showMoreButton = this.props.showMore === true && (
       <Template
         {...this.props.templateProps}
-        templateKey={
-          this.props.isShowingMore ? 'showMoreActive' : 'showMoreInactive'
-        }
+        templateKey="showMoreText"
         rootTagName="button"
         rootProps={{
           className: showMoreButtonClassName,
           onClick: this.props.toggleShowMore,
+        }}
+        data={{
+          isShowingMore: this.props.isShowingMore,
         }}
       />
     );

--- a/src/components/RefinementList/__tests__/RefinementList-test.js
+++ b/src/components/RefinementList/__tests__/RefinementList-test.js
@@ -140,7 +140,7 @@ describe('RefinementList', () => {
       };
 
       const root = shallowRender(props);
-      const wrapper = root.find('[templateKey="showMoreInactive"]');
+      const wrapper = root.find('[templateKey="showMoreText"]');
 
       expect(wrapper).toHaveLength(1);
     });
@@ -158,30 +158,9 @@ describe('RefinementList', () => {
       };
 
       const root = shallowRender(props);
-      const wrapper = root
-        .find('Template')
-        .filter({ templateKey: 'showMoreInactive' });
+      const wrapper = root.find('[templateKey="showMoreText"]');
 
       expect(wrapper).toHaveLength(0);
-    });
-
-    it('should displays showLess', () => {
-      const props = {
-        ...defaultProps,
-        facetValues: [
-          { value: 'foo', isRefined: false },
-          { value: 'bar', isRefined: false },
-          { value: 'baz', isRefined: false },
-        ],
-        showMore: true,
-        isShowingMore: true,
-        canToggleShowMore: true,
-      };
-
-      const root = shallowRender(props);
-      const wrapper = root.find('[templateKey="showMoreActive"]');
-
-      expect(wrapper).toHaveLength(1);
     });
   });
 
@@ -343,11 +322,12 @@ describe('RefinementList', () => {
         cssClasses,
         className: 'customClassName',
         showMore: true,
+        isShowingMore: false,
         canToggleShowMore: true,
         templateProps: {
           templates: {
             item: item => item,
-            showMoreInactive: x => x,
+            showMoreText: x => x,
           },
         },
         toggleRefinement: () => {},
@@ -377,11 +357,12 @@ describe('RefinementList', () => {
         cssClasses,
         className: 'customClassName',
         showMore: true,
+        isShowingMore: false,
         canToggleShowMore: false,
         templateProps: {
           templates: {
             item: item => item,
-            showMoreInactive: x => x,
+            showMoreText: x => x,
           },
         },
         toggleRefinement: () => {},

--- a/src/components/RefinementList/__tests__/__snapshots__/RefinementList-test.js.snap
+++ b/src/components/RefinementList/__tests__/__snapshots__/RefinementList-test.js.snap
@@ -155,7 +155,9 @@ exports[`RefinementList rendering with facets and disabled show more 1`] = `
     className="showMore disabledShowMore"
     dangerouslySetInnerHTML={
       Object {
-        "__html": Object {},
+        "__html": Object {
+          "isShowingMore": false,
+        },
       }
     }
   />
@@ -240,7 +242,9 @@ exports[`RefinementList rendering with facets and show more 1`] = `
     className="showMore"
     dangerouslySetInnerHTML={
       Object {
-        "__html": Object {},
+        "__html": Object {
+          "isShowingMore": false,
+        },
       }
     }
   />

--- a/src/widgets/hierarchical-menu/__tests__/__snapshots__/hierarchical-menu-test.js.snap
+++ b/src/widgets/hierarchical-menu/__tests__/__snapshots__/hierarchical-menu-test.js.snap
@@ -39,14 +39,19 @@ exports[`hierarchicalMenu() render calls ReactDOM.render 1`] = `
     Object {
       "templates": Object {
         "item": "<a class=\\"{{cssClasses.link}}\\" href=\\"{{url}}\\"><span class=\\"{{cssClasses.label}}\\">{{label}}</span><span class=\\"{{cssClasses.count}}\\">{{#helpers.formatNumber}}{{count}}{{/helpers.formatNumber}}</span></a>",
-        "showMoreActive": "Show less",
-        "showMoreInactive": "Show more",
+        "showMoreText": "
+    {{#isShowingMore}}
+      Show less
+    {{/isShowingMore}}
+    {{^isShowingMore}}
+      Show more
+    {{/isShowingMore}}
+  ",
       },
       "templatesConfig": undefined,
       "useCustomCompileOptions": Object {
         "item": false,
-        "showMoreActive": false,
-        "showMoreInactive": false,
+        "showMoreText": false,
       },
     }
   }
@@ -94,14 +99,19 @@ exports[`hierarchicalMenu() render has a templates option 1`] = `
     Object {
       "templates": Object {
         "item": "item2",
-        "showMoreActive": "Show less",
-        "showMoreInactive": "Show more",
+        "showMoreText": "
+    {{#isShowingMore}}
+      Show less
+    {{/isShowingMore}}
+    {{^isShowingMore}}
+      Show more
+    {{/isShowingMore}}
+  ",
       },
       "templatesConfig": undefined,
       "useCustomCompileOptions": Object {
         "item": true,
-        "showMoreActive": false,
-        "showMoreInactive": false,
+        "showMoreText": false,
       },
     }
   }
@@ -151,14 +161,19 @@ exports[`hierarchicalMenu() render has a transformItems options 1`] = `
     Object {
       "templates": Object {
         "item": "<a class=\\"{{cssClasses.link}}\\" href=\\"{{url}}\\"><span class=\\"{{cssClasses.label}}\\">{{label}}</span><span class=\\"{{cssClasses.count}}\\">{{#helpers.formatNumber}}{{count}}{{/helpers.formatNumber}}</span></a>",
-        "showMoreActive": "Show less",
-        "showMoreInactive": "Show more",
+        "showMoreText": "
+    {{#isShowingMore}}
+      Show less
+    {{/isShowingMore}}
+    {{^isShowingMore}}
+      Show more
+    {{/isShowingMore}}
+  ",
       },
       "templatesConfig": undefined,
       "useCustomCompileOptions": Object {
         "item": false,
-        "showMoreActive": false,
-        "showMoreInactive": false,
+        "showMoreText": false,
       },
     }
   }
@@ -195,14 +210,19 @@ exports[`hierarchicalMenu() render sets facetValues to empty array when no resul
     Object {
       "templates": Object {
         "item": "<a class=\\"{{cssClasses.link}}\\" href=\\"{{url}}\\"><span class=\\"{{cssClasses.label}}\\">{{label}}</span><span class=\\"{{cssClasses.count}}\\">{{#helpers.formatNumber}}{{count}}{{/helpers.formatNumber}}</span></a>",
-        "showMoreActive": "Show less",
-        "showMoreInactive": "Show more",
+        "showMoreText": "
+    {{#isShowingMore}}
+      Show less
+    {{/isShowingMore}}
+    {{^isShowingMore}}
+      Show more
+    {{/isShowingMore}}
+  ",
       },
       "templatesConfig": undefined,
       "useCustomCompileOptions": Object {
         "item": false,
-        "showMoreActive": false,
-        "showMoreInactive": false,
+        "showMoreText": false,
       },
     }
   }
@@ -239,14 +259,19 @@ exports[`hierarchicalMenu() render sets shouldAutoHideContainer to true when no 
     Object {
       "templates": Object {
         "item": "<a class=\\"{{cssClasses.link}}\\" href=\\"{{url}}\\"><span class=\\"{{cssClasses.label}}\\">{{label}}</span><span class=\\"{{cssClasses.count}}\\">{{#helpers.formatNumber}}{{count}}{{/helpers.formatNumber}}</span></a>",
-        "showMoreActive": "Show less",
-        "showMoreInactive": "Show more",
+        "showMoreText": "
+    {{#isShowingMore}}
+      Show less
+    {{/isShowingMore}}
+    {{^isShowingMore}}
+      Show more
+    {{/isShowingMore}}
+  ",
       },
       "templatesConfig": undefined,
       "useCustomCompileOptions": Object {
         "item": false,
-        "showMoreActive": false,
-        "showMoreInactive": false,
+        "showMoreText": false,
       },
     }
   }
@@ -294,14 +319,19 @@ exports[`hierarchicalMenu() render understand provided cssClasses 1`] = `
     Object {
       "templates": Object {
         "item": "<a class=\\"{{cssClasses.link}}\\" href=\\"{{url}}\\"><span class=\\"{{cssClasses.label}}\\">{{label}}</span><span class=\\"{{cssClasses.count}}\\">{{#helpers.formatNumber}}{{count}}{{/helpers.formatNumber}}</span></a>",
-        "showMoreActive": "Show less",
-        "showMoreInactive": "Show more",
+        "showMoreText": "
+    {{#isShowingMore}}
+      Show less
+    {{/isShowingMore}}
+    {{^isShowingMore}}
+      Show more
+    {{/isShowingMore}}
+  ",
       },
       "templatesConfig": undefined,
       "useCustomCompileOptions": Object {
         "item": false,
-        "showMoreActive": false,
-        "showMoreInactive": false,
+        "showMoreText": false,
       },
     }
   }

--- a/src/widgets/hierarchical-menu/defaultTemplates.js
+++ b/src/widgets/hierarchical-menu/defaultTemplates.js
@@ -4,6 +4,12 @@ export default {
     '<span class="{{cssClasses.label}}">{{label}}</span>' +
     '<span class="{{cssClasses.count}}">{{#helpers.formatNumber}}{{count}}{{/helpers.formatNumber}}</span>' +
     '</a>',
-  showMoreActive: 'Show less',
-  showMoreInactive: 'Show more',
+  showMoreText: `
+    {{#isShowingMore}}
+      Show less
+    {{/isShowingMore}}
+    {{^isShowingMore}}
+      Show more
+    {{/isShowingMore}}
+  `,
 };

--- a/src/widgets/hierarchical-menu/hierarchical-menu.js
+++ b/src/widgets/hierarchical-menu/hierarchical-menu.js
@@ -83,7 +83,7 @@ hierarchicalMenu({
 /**
  * @typedef {Object} HierarchicalMenuTemplates
  * @property {string|function(object):string} [item] Item template, provided with `name`, `count`, `isRefined`, `url` data properties.
- * @property {string|function} [showMoreText] Template used for the show more text.
+ * @property {string|function} [showMoreText] Template used for the show more text, provided with `isShowingMore` data property.
  */
 
 /**

--- a/src/widgets/hierarchical-menu/hierarchical-menu.js
+++ b/src/widgets/hierarchical-menu/hierarchical-menu.js
@@ -61,7 +61,7 @@ hierarchicalMenu({
   [ limit=10 ],
   [ sortBy=['name:asc'] ],
   [ cssClasses.{root, noRefinementRoot, list, childList, item, selectedItem, parentItem, link, label, count, showMore, disabledShowMore} ],
-  [ templates.{item, showMoreActive, showMoreInactive} ],
+  [ templates.{item, showMoreText} ],
   [ transformItems ]
 })`;
 /**
@@ -83,8 +83,7 @@ hierarchicalMenu({
 /**
  * @typedef {Object} HierarchicalMenuTemplates
  * @property {string|function(object):string} [item] Item template, provided with `name`, `count`, `isRefined`, `url` data properties.
- * @property {string|function} [showMoreActive] Template used when showMore was clicked.
- * @property {string|function} [showMoreInactive] Template used when showMore not clicked.
+ * @property {string|function} [showMoreText] Template used for the show more text.
  */
 
 /**


### PR DESCRIPTION
@samouss and I decided to merge `showMoreActive` and `showMoreInactive` by creating a `showMoreText` template which is passed the argument `isShowingMore`.

## Previous usage

```js
instantsearch.widgets.hierarchicalMenu({
  // ...
  templates: {
    showMoreActive: 'Show less',
    showMoreInactive: 'Show more',
  },
});
```

## New usage

```js
instantsearch.widgets.hierarchicalMenu({
  // ...
  templates: {
    showMoreText: `
      {{#isShowingMore}}
        Show less
      {{/isShowingMore}}
      {{^isShowingMore}}
        Show more
      {{/isShowingMore}}
    `,
  },
});
```

## Stories

https://deploy-preview-3318--instantsearchjs.netlify.com/stories/?selectedStory=HierarchicalMenu.with%20show%20more