### PR TITLE
refactor(GeoSearch): flatten templates

### DIFF
--- a/docgen/src/guides/v3-migration.md
+++ b/docgen/src/guides/v3-migration.md
@@ -269,13 +269,14 @@ URL synchronization is done via Routing alone now.
 
 #### Options
 
-| Before                    | After                                                  |
-| ------------------------- | ------------------------------------------------------ |
-| `paddingBoundingBox`      | Removed                                                |
-| `enableGeolocationWithIP` | Removed - use the Configure widget instead (see below) |
-| `position`                | Removed - use the Configure widget instead (see below) |
-| `radius`                  | Removed - use the Configure widget instead (see below) |
-| `precision`               | Removed - use the Configure widget instead (see below) |
+| Before                      | After                                                  |
+| --------------------------- | ------------------------------------------------------ |
+| `customHTMLMarker.template` | `templates.HTMLMarker`                                 |
+| `paddingBoundingBox`        | Removed                                                |
+| `enableGeolocationWithIP`   | Removed - use the Configure widget instead (see below) |
+| `position`                  | Removed - use the Configure widget instead (see below) |
+| `radius`                    | Removed - use the Configure widget instead (see below) |
+| `precision`                 | Removed - use the Configure widget instead (see below) |
 
 - `paddingBoundingBox` was in conflict with the `routing` option - so we removed it to support URLSync for the GeoSearch widget.
 

--- a/src/widgets/geo-search/__tests__/__snapshots__/geo-search-test.js.snap
+++ b/src/widgets/geo-search/__tests__/__snapshots__/geo-search-test.js.snap
@@ -31,12 +31,14 @@ Array [
     templateProps={
       Object {
         "templates": Object {
+          "HTMLMarker": "<p>Your custom HTML Marker</p>",
           "redo": "Redo search here",
           "reset": "Clear the map refinement",
           "toggle": "Search as I move the map",
         },
         "templatesConfig": undefined,
         "useCustomCompileOptions": Object {
+          "HTMLMarker": true,
           "redo": true,
           "reset": true,
           "toggle": true,
@@ -81,12 +83,14 @@ Array [
     templateProps={
       Object {
         "templates": Object {
+          "HTMLMarker": "<p>Your custom HTML Marker</p>",
           "redo": "Redo search here",
           "reset": "Clear the map refinement",
           "toggle": "Search as I move the map",
         },
         "templatesConfig": undefined,
         "useCustomCompileOptions": Object {
+          "HTMLMarker": true,
           "redo": true,
           "reset": true,
           "toggle": true,

--- a/src/widgets/geo-search/__tests__/geo-search-test.js
+++ b/src/widgets/geo-search/__tests__/geo-search-test.js
@@ -232,6 +232,7 @@ describe('GeoSearch', () => {
     const actual = renderer.mock.calls[0][0].widgetParams.templates;
 
     const expectation = {
+      HTMLMarker: '<p>Your custom HTML Marker</p>',
       reset: 'Clear the map refinement',
       toggle: 'Search when the map move',
       redo: 'Redo search here',
@@ -924,7 +925,9 @@ describe('GeoSearch', () => {
           createOptions: item => ({
             title: `ID: ${item.objectID}`,
           }),
-          template: '<p>{{objectID}}</p>',
+        },
+        templates: {
+          HTMLMarker: '<p>{{objectID}}</p>',
         },
       });
 

--- a/src/widgets/geo-search/__tests__/geo-search-test.js
+++ b/src/widgets/geo-search/__tests__/geo-search-test.js
@@ -977,6 +977,131 @@ describe('GeoSearch', () => {
       createHTMLMarker.mockRestore();
     });
 
+    it('expect to render custom HTML markers with only the template provided', () => {
+      const container = createContainer();
+      const instantSearchInstance = createFakeInstantSearch();
+      const helper = createFakeHelper();
+      const googleReference = createFakeGoogleReference();
+      const HTMLMarker = jest.fn(createFakeMarkerInstance);
+
+      createHTMLMarker.mockImplementation(() => HTMLMarker);
+
+      const widget = geoSearch({
+        googleReference,
+        container,
+        templates: {
+          HTMLMarker: '<p>{{objectID}}</p>',
+        },
+      });
+
+      widget.init({
+        helper,
+        instantSearchInstance,
+        state: helper.state,
+      });
+
+      widget.render({
+        helper,
+        instantSearchInstance,
+        results: {
+          hits: [
+            { objectID: 123, _geoloc: true },
+            { objectID: 456, _geoloc: true },
+            { objectID: 789, _geoloc: true },
+          ],
+        },
+      });
+
+      expect(HTMLMarker).toHaveBeenCalledTimes(3);
+      expect(HTMLMarker.mock.calls).toEqual([
+        [
+          expect.objectContaining({
+            __id: 123,
+            template: '<p>123</p>',
+          }),
+        ],
+        [
+          expect.objectContaining({
+            __id: 456,
+            template: '<p>456</p>',
+          }),
+        ],
+        [
+          expect.objectContaining({
+            __id: 789,
+            template: '<p>789</p>',
+          }),
+        ],
+      ]);
+
+      createHTMLMarker.mockRestore();
+    });
+
+    it('expect to render custom HTML markers with only the object provided', () => {
+      const container = createContainer();
+      const instantSearchInstance = createFakeInstantSearch();
+      const helper = createFakeHelper();
+      const googleReference = createFakeGoogleReference();
+      const HTMLMarker = jest.fn(createFakeMarkerInstance);
+
+      createHTMLMarker.mockImplementation(() => HTMLMarker);
+
+      const widget = geoSearch({
+        googleReference,
+        container,
+        customHTMLMarker: {
+          createOptions: item => ({
+            title: `ID: ${item.objectID}`,
+          }),
+        },
+      });
+
+      widget.init({
+        helper,
+        instantSearchInstance,
+        state: helper.state,
+      });
+
+      widget.render({
+        helper,
+        instantSearchInstance,
+        results: {
+          hits: [
+            { objectID: 123, _geoloc: true },
+            { objectID: 456, _geoloc: true },
+            { objectID: 789, _geoloc: true },
+          ],
+        },
+      });
+
+      expect(HTMLMarker).toHaveBeenCalledTimes(3);
+      expect(HTMLMarker.mock.calls).toEqual([
+        [
+          expect.objectContaining({
+            __id: 123,
+            title: 'ID: 123',
+            template: '<p>Your custom HTML Marker</p>',
+          }),
+        ],
+        [
+          expect.objectContaining({
+            __id: 456,
+            title: 'ID: 456',
+            template: '<p>Your custom HTML Marker</p>',
+          }),
+        ],
+        [
+          expect.objectContaining({
+            __id: 789,
+            title: 'ID: 789',
+            template: '<p>Your custom HTML Marker</p>',
+          }),
+        ],
+      ]);
+
+      createHTMLMarker.mockRestore();
+    });
+
     it('expect to setup listeners on custom HTML markers', () => {
       const container = createContainer();
       const instantSearchInstance = createFakeInstantSearch();

--- a/src/widgets/geo-search/defaultTemplates.js
+++ b/src/widgets/geo-search/defaultTemplates.js
@@ -1,4 +1,5 @@
 export default {
+  HTMLMarker: '<p>Your custom HTML Marker</p>',
   reset: 'Clear the map refinement',
   toggle: 'Search as I move the map',
   redo: 'Redo search here',

--- a/src/widgets/geo-search/geo-search.js
+++ b/src/widgets/geo-search/geo-search.js
@@ -126,7 +126,7 @@ const geoSearch = ({
   templates: userTemplates = {},
   cssClasses: userCssClasses = {},
   builtInMarker: userBuiltInMarker = {},
-  customHTMLMarker: userCustomHTMLMarker = false,
+  customHTMLMarker: userCustomHTMLMarker,
   enableRefine = true,
   enableClearMapRefinement = true,
   enableRefineControl = true,
@@ -184,7 +184,10 @@ const geoSearch = ({
     ...userBuiltInMarker,
   };
 
-  const customHTMLMarker = Boolean(userCustomHTMLMarker) && {
+  const isCustomHTMLMarker =
+    Boolean(userCustomHTMLMarker) || Boolean(userTemplates.HTMLMarker);
+
+  const customHTMLMarker = isCustomHTMLMarker && {
     ...defaultCustomHTMLMarker,
     ...userCustomHTMLMarker,
   };

--- a/src/widgets/geo-search/geo-search.js
+++ b/src/widgets/geo-search/geo-search.js
@@ -88,7 +88,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  * @property {object} [mapOptions] Option forwarded to the Google Maps constructor. <br />
  * See [the documentation](https://developers.google.com/maps/documentation/javascript/reference/3/#MapOptions) for more information.
  * @property {BuiltInMarkerOptions} [builtInMarker] Options for customize the built-in Google Maps marker. This option is ignored when the `customHTMLMarker` is provided.
- * @property {CustomHTMLMarkerOptions|boolean} [customHTMLMarker=false] Options for customize the HTML marker. We provide an alternative to the built-in Google Maps marker in order to have a full control of the marker rendering. You can use plain HTML to build your marker.
+ * @property {CustomHTMLMarkerOptions} [customHTMLMarker] Options for customize the HTML marker. We provide an alternative to the built-in Google Maps marker in order to have a full control of the marker rendering. You can use plain HTML to build your marker.
  * @property {boolean} [enableRefine=true] If true, the map is used to search - otherwise it's for display purposes only.
  * @property {boolean} [enableClearMapRefinement=true] If true, a button is displayed on the map when the refinement is coming from the map in order to remove it.
  * @property {boolean} [enableRefineControl=true] If true, the user can toggle the option `enableRefineOnMapMove` directly from the map.

--- a/src/widgets/geo-search/geo-search.js
+++ b/src/widgets/geo-search/geo-search.js
@@ -38,7 +38,6 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
 
 /**
  * @typedef {object} CustomHTMLMarkerOptions
- * @property {string|function(item): string} template Template to use for the marker.
  * @property {function(item): HTMLMarkerOptions} [createOptions] Function used to create the options passed to the HTMLMarker.
  * @property {{ eventType: function(object) }} [events] Object that takes an event type (ex: `click`, `mouseover`) as key and a listener as value. The listener is provided with an object that contains `event`, `item`, `marker`, `map`.
  */
@@ -65,6 +64,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
 
 /**
  * @typedef {object} GeoSearchTemplates
+ * @property {string|function(object): string} [HTMLMarker] Template to use for the marker.
  * @property {string|function(object): string} [reset] Template for the reset button.
  * @property {string|function(object): string} [toggle] Template for the toggle label.
  * @property {string|function(object): string} [redo] Template for the redo button.

--- a/src/widgets/geo-search/geo-search.js
+++ b/src/widgets/geo-search/geo-search.js
@@ -140,7 +140,6 @@ const geoSearch = ({
   };
 
   const defaultCustomHTMLMarker = {
-    template: '<p>Your custom HTML Marker</p>',
     createOptions: noop,
     events: {},
   };
@@ -207,8 +206,8 @@ const geoSearch = ({
       position: item._geoloc,
       className: cx(suit({ descendantName: 'marker' })),
       template: renderTemplate({
-        templateKey: 'template',
-        templates: customHTMLMarker,
+        templateKey: 'HTMLMarker',
+        templates,
         data: item,
       }),
     });

--- a/storybook/app/builtin/stories/geo-search.stories.js
+++ b/storybook/app/builtin/stories/geo-search.stories.js
@@ -470,16 +470,18 @@ export default () => {
                     y: 5,
                   },
                 }),
-                template: `
-                  <div class="my-custom-marker">
-                    {{price_formatted}}
-                  </div>
-                `,
                 events: {
                   click: ({ event, item, marker, map }) => {
                     logger(event, item, marker, map);
                   },
                 },
+              },
+              templates: {
+                HTMLMarker: `
+                  <div class="my-custom-marker">
+                    {{price_formatted}}
+                  </div>
+                `,
               },
               container,
               initialPosition,
@@ -515,11 +517,6 @@ export default () => {
                     y: 5,
                   },
                 }),
-                template: `
-                  <div class="my-custom-marker">
-                    {{price_formatted}}
-                  </div>
-                `,
                 events: {
                   click: ({ item, marker, map }) => {
                     if (InfoWindow.getMap()) {
@@ -531,6 +528,13 @@ export default () => {
                     InfoWindow.open(map, marker);
                   },
                 },
+              },
+              templates: {
+                HTMLMarker: `
+                  <div class="my-custom-marker">
+                    {{price_formatted}}
+                  </div>
+                `,
               },
               container,
               initialPosition,
@@ -576,11 +580,6 @@ export default () => {
                     y: 5,
                   },
                 }),
-                template: `
-                  <div class="my-custom-marker">
-                    {{price_formatted}}
-                  </div>
-                `,
                 events: {
                   click: ({ item, marker, map }) => {
                     if (InfoBoxInstance.getMap()) {
@@ -596,6 +595,13 @@ export default () => {
                     InfoBoxInstance.open(map, marker);
                   },
                 },
+              },
+              templates: {
+                HTMLMarker: `
+                  <div class="my-custom-marker">
+                    {{price_formatted}}
+                  </div>
+                `,
               },
               container,
               initialPosition,
@@ -663,11 +669,6 @@ export default () => {
                     y: 5,
                   },
                 }),
-                template: `
-                  <div class="my-custom-marker" data-id="{{objectID}}">
-                    {{price_formatted}}
-                  </div>
-                `,
                 events: {
                   mouseover: ({ item }) => {
                     removeActiveHitClassNames();
@@ -682,6 +683,13 @@ export default () => {
                     removeActiveHitClassNames();
                   },
                 },
+              },
+              templates: {
+                HTMLMarker: `
+                  <div class="my-custom-marker" data-id="{{objectID}}">
+                    {{price_formatted}}
+                  </div>
+                `,
               },
               container,
               initialPosition,


### PR DESCRIPTION
> The PR **must** be merged before: https://github.com/algolia/instantsearch.js/pull/3319

**Summary**

This PR flatten the template of the `HTMLMarker` inside the `templates` options. It feels a bit odd at first but since we do it in the other widgets it's better to apply the pattern here too. Here is difference in term of usage:

```diff
search.addWidget(
  instantsearch.widgets.geoSearch({
    // ...
-    customHTMLMarker: {
-       template: `
-        <div class="my-custom-marker">
-          {{price_formatted}}
-        </div>
-      `,
-    },
+    templates: {
+      HTMLMarker: `
+        <div class="my-custom-marker">
+          {{price_formatted}}
+        </div>
+      `,
    },
  })
);
```

The main difference now is that the widget will use the `HTMLMarker` when:
  -  `customHTMLMarker` is provided, we use it either with the provided template or the default one (same behaviour than before)
  -  `templates.HTMLMarker` is provided, we use it either with the provided options or the default ones