### PR TITLE
feat(refinementList): merge showMore template

### DIFF
--- a/src/widgets/refinement-list/__tests__/__snapshots__/refinement-list-test.js.snap
+++ b/src/widgets/refinement-list/__tests__/__snapshots__/refinement-list-test.js.snap
@@ -56,11 +56,20 @@ exports[`refinementList() render renders transformed items correctly 1`] = `
   <span class=\\"{{cssClasses.count}}\\">{{#helpers.formatNumber}}{{count}}{{/helpers.formatNumber}}</span>
 </label>",
         "searchableNoResults": "No results",
+        "showMoreText": "
+    {{#isShowingMore}}
+      Show less
+    {{/isShowingMore}}
+    {{^isShowingMore}}
+      Show more
+    {{/isShowingMore}}
+    ",
       },
       "templatesConfig": Object {},
       "useCustomCompileOptions": Object {
         "item": false,
         "searchableNoResults": false,
+        "showMoreText": false,
       },
     }
   }

--- a/src/widgets/refinement-list/defaultTemplates.js
+++ b/src/widgets/refinement-list/defaultTemplates.js
@@ -7,5 +7,13 @@ export default {
   <span class="{{cssClasses.labelText}}">{{{highlighted}}}</span>
   <span class="{{cssClasses.count}}">{{#helpers.formatNumber}}{{count}}{{/helpers.formatNumber}}</span>
 </label>`,
+  showMoreText: `
+    {{#isShowingMore}}
+      Show less
+    {{/isShowingMore}}
+    {{^isShowingMore}}
+      Show more
+    {{/isShowingMore}}
+    `,
   searchableNoResults: 'No results',
 };

--- a/src/widgets/refinement-list/refinement-list.js
+++ b/src/widgets/refinement-list/refinement-list.js
@@ -72,7 +72,7 @@ refinementList({
   [ showMore = false],
   [ showMoreLimit = 10 ],
   [ cssClasses.{root, noRefinementRoot, searchBox, list, item, selectedItem, label, checkbox, labelText, count, noResults, showMore, disabledShowMore}],
-  [ templates.{item, searchableNoResults, showMoreActive, showMoreInactive} ],
+  [ templates.{item, searchableNoResults, showMoreText} ],
   [ searchable ],
   [ searchablePlaceholder ],
   [ searchableIsAlwaysActive = true ],
@@ -84,8 +84,7 @@ refinementList({
  * @typedef {Object} RefinementListTemplates
  * @property  {string|function(RefinementListItemData):string} [item] Item template, provided with `label`, `highlighted`, `value`, `count`, `isRefined`, `url` data properties.
  * @property {string|function} [searchableNoResults] Templates to use for search for facet values.
- * @property {string|function} [showMoreActive] Template used when showMore was clicked.
- * @property {string|function} [showMoreInactive] Template used when showMore not clicked.
+ * @property {string|function} [showMoreText] Template used for the show more text, provided with `isShowingMore` data property.
  */
 
 /**

--- a/storybook/app/builtin/stories/refinement-list.stories.js
+++ b/storybook/app/builtin/stories/refinement-list.stories.js
@@ -29,9 +29,28 @@ export default () => {
             limit: 3,
             showMore: true,
             showMoreLimit: 10,
+          })
+        );
+      })
+    )
+    .add(
+      'with show more and templates',
+      wrapWithHits(container => {
+        window.search.addWidget(
+          instantsearch.widgets.refinementList({
+            container,
+            attribute: 'brand',
+            limit: 3,
+            showMore: true,
+            showMoreLimit: 10,
             templates: {
-              showMoreActive: 'Show way less',
-              showMoreInactive: 'Show way less',
+              showMoreText: `
+                {{#isShowingMore}}
+                  ⬆️
+                {{/isShowingMore}}
+                {{^isShowingMore}}
+                  ⬇️
+                {{/isShowingMore}}`,
             },
           })
         );


### PR DESCRIPTION
This implements #3318 for the `refinementList` widget.

It also fixes an error thrown where no templates are given but the `showMore` option is used, by giving a default `showMoreText` template (like for `hierarchicalMenu` and `menu`).

## Stories

