### PR TITLE
feat(pagination): rename labels to templates

### DIFF
--- a/docgen/src/guides/v3-migration.md
+++ b/docgen/src/guides/v3-migration.md
@@ -868,12 +868,17 @@ Widget removed.
 
 #### Options
 
-| Before          | After                  |
-| --------------- | ---------------------- |
-| `maxPages`      | `totalPages`           |
-| `showFirstLast` | `showFirst` `showLast` |
-|                 | `showNext`             |
-|                 | `showPrevious`         |
+| Before            | After                  |
+| ----------------- | ---------------------- |
+| `maxPages`        | `totalPages`           |
+| `showFirstLast`   | `showFirst` `showLast` |
+|                   | `showNext`             |
+|                   | `showPrevious`         |
+| `labels`          | `templates`            |
+| `labels.previous` | `templates.previous`   |
+| `labels.next`     | `templates.next`       |
+| `labels.first`    | `templates.first`      |
+| `labels.last`     | `templates.last`       |
 
 #### CSS classes
 

--- a/src/components/Pagination/Pagination.js
+++ b/src/components/Pagination/Pagination.js
@@ -53,7 +53,7 @@ class Pagination extends Component {
       ariaLabel: 'Previous',
       additionalClassName: this.props.cssClasses.previousPageItem,
       isDisabled: this.props.nbHits === 0 || isFirstPage,
-      label: this.props.labels.previous,
+      label: this.props.templates.previous,
       pageNumber: currentPage - 1,
       createURL,
     });
@@ -64,7 +64,7 @@ class Pagination extends Component {
       ariaLabel: 'Next',
       additionalClassName: this.props.cssClasses.nextPageItem,
       isDisabled: this.props.nbHits === 0 || isLastPage,
-      label: this.props.labels.next,
+      label: this.props.templates.next,
       pageNumber: currentPage + 1,
       createURL,
     });
@@ -75,7 +75,7 @@ class Pagination extends Component {
       ariaLabel: 'First',
       additionalClassName: this.props.cssClasses.firstPageItem,
       isDisabled: this.props.nbHits === 0 || isFirstPage,
-      label: this.props.labels.first,
+      label: this.props.templates.first,
       pageNumber: 0,
       createURL,
     });
@@ -86,7 +86,7 @@ class Pagination extends Component {
       ariaLabel: 'Last',
       additionalClassName: this.props.cssClasses.lastPageItem,
       isDisabled: this.props.nbHits === 0 || isLastPage,
-      label: this.props.labels.last,
+      label: this.props.templates.last,
       pageNumber: nbPages - 1,
       createURL,
     });
@@ -151,7 +151,7 @@ Pagination.propTypes = {
     link: PropTypes.string.isRequired,
   }).isRequired,
   currentPage: PropTypes.number,
-  labels: PropTypes.shape({
+  templates: PropTypes.shape({
     first: PropTypes.string.isRequired,
     last: PropTypes.string.isRequired,
     next: PropTypes.string.isRequired,

--- a/src/components/Pagination/__tests__/Pagination-test.js
+++ b/src/components/Pagination/__tests__/Pagination-test.js
@@ -25,7 +25,7 @@ describe('Pagination', () => {
       link: 'link',
     },
     createURL: (...args) => JSON.stringify(args),
-    labels: { first: '', last: '', next: '', previous: '' },
+    templates: { first: '', last: '', next: '', previous: '' },
     currentPage: 0,
     nbHits: 200,
     pages: pager.pages(),

--- a/src/widgets/pagination/__tests__/__snapshots__/pagination-test.js.snap
+++ b/src/widgets/pagination/__tests__/__snapshots__/pagination-test.js.snap
@@ -22,14 +22,6 @@ exports[`pagination() calls twice ReactDOM.render(<Pagination props />, containe
   currentPage={0}
   isFirstPage={true}
   isLastPage={false}
-  labels={
-    Object {
-      "first": "«",
-      "last": "»",
-      "next": "›",
-      "previous": "‹",
-    }
-  }
   nbHits={200}
   nbPages={20}
   pages={
@@ -48,6 +40,14 @@ exports[`pagination() calls twice ReactDOM.render(<Pagination props />, containe
   showLast={true}
   showNext={true}
   showPrevious={true}
+  templates={
+    Object {
+      "first": "«",
+      "last": "»",
+      "next": "›",
+      "previous": "‹",
+    }
+  }
 />
 `;
 
@@ -73,14 +73,6 @@ exports[`pagination() calls twice ReactDOM.render(<Pagination props />, containe
   currentPage={0}
   isFirstPage={true}
   isLastPage={false}
-  labels={
-    Object {
-      "first": "«",
-      "last": "»",
-      "next": "›",
-      "previous": "‹",
-    }
-  }
   nbHits={200}
   nbPages={20}
   pages={
@@ -99,5 +91,13 @@ exports[`pagination() calls twice ReactDOM.render(<Pagination props />, containe
   showLast={true}
   showNext={true}
   showPrevious={true}
+  templates={
+    Object {
+      "first": "«",
+      "last": "»",
+      "next": "›",
+      "previous": "‹",
+    }
+  }
 />
 `;

--- a/src/widgets/pagination/pagination.js
+++ b/src/widgets/pagination/pagination.js
@@ -1,6 +1,5 @@
 import React, { render, unmountComponentAtNode } from 'preact-compat';
 import cx from 'classnames';
-import defaults from 'lodash/defaults';
 import Pagination from '../../components/Pagination/Pagination.js';
 import connectPagination from '../../connectors/pagination/connectPagination.js';
 import { getContainerNode } from '../../lib/utils.js';
@@ -8,7 +7,7 @@ import { component } from '../../lib/suit';
 
 const suit = component('Pagination');
 
-const defaultLabels = {
+const defaultTemplates = {
   previous: '‹',
   next: '›',
   first: '«',
@@ -18,7 +17,7 @@ const defaultLabels = {
 const renderer = ({
   containerNode,
   cssClasses,
-  labels,
+  templates,
   totalPages,
   showFirst,
   showLast,
@@ -53,7 +52,7 @@ const renderer = ({
       createURL={createURL}
       cssClasses={cssClasses}
       currentPage={currentRefinement}
-      labels={labels}
+      templates={templates}
       nbHits={nbHits}
       nbPages={nbPages}
       pages={pages}
@@ -73,15 +72,15 @@ const renderer = ({
 const usage = `Usage:
 pagination({
   container,
-  [ cssClasses.{root, noRefinementRoot, list, item, itemFirstPage, itemLastPage, itemPreviousPage, itemNextPage, itemPage, selectedItem, disabledItem, link} ],
-  [ labels.{previous,next,first,last} ],
   [ totalPages ],
-  [ padding=3 ],
-  [ showFirst=true ],
-  [ showLast=true ],
-  [ showPrevious=true ],
-  [ showNext=true ],
-  [ scrollTo='body' ]
+  [ padding = 3 ],
+  [ showFirst = true ],
+  [ showLast = true ],
+  [ showPrevious = true ],
+  [ showNext = true ],
+  [ scrollTo = 'body' ]
+  [ templates.{previous, next, first, last} ],
+  [ cssClasses.{root, noRefinementRoot, list, item, itemFirstPage, itemLastPage, itemPreviousPage, itemNextPage, itemPage, selectedItem, disabledItem, link} ],
 })`;
 
 /**
@@ -101,7 +100,7 @@ pagination({
  */
 
 /**
- * @typedef {Object} PaginationLabels
+ * @typedef {Object} PaginationTemplates
  * @property  {string} [previous] Label for the Previous link.
  * @property  {string} [next] Label for the Next link.
  * @property  {string} [first] Label for the First link.
@@ -118,7 +117,7 @@ pagination({
  * @property  {boolean} [showLast=true] Whether to show the last page” control
  * @property  {boolean} [showNext=true] Whether to show the “next page” control
  * @property  {boolean} [showPrevious=true] 	Whether to show the “previous page” control
- * @property  {PaginationLabels} [labels] Text to display in the various links (prev, next, first, last).
+ * @property  {PaginationTemplates} [templates] Text to display in the links.
  * @property  {PaginationCSSClasses} [cssClasses] CSS classes to be added.
  */
 
@@ -152,7 +151,7 @@ pagination({
  */
 export default function pagination({
   container,
-  labels: userLabels = defaultLabels,
+  templates: userTemplates = {},
   cssClasses: userCssClasses = {},
   totalPages,
   padding,
@@ -210,12 +209,12 @@ export default function pagination({
     link: cx(suit({ descendantName: 'link' }), userCssClasses.link),
   };
 
-  const labels = defaults(userLabels, defaultLabels);
+  const templates = { ...defaultTemplates, ...userTemplates };
 
   const specializedRenderer = renderer({
     containerNode,
     cssClasses,
-    labels,
+    templates,
     showFirst,
     showLast,
     showPrevious,

--- a/storybook/app/builtin/stories/pagination.stories.js
+++ b/storybook/app/builtin/stories/pagination.stories.js
@@ -73,5 +73,21 @@ export default () => {
           })
         );
       })
+    )
+    .add(
+      'with templates',
+      wrapWithHits(container => {
+        window.search.addWidget(
+          instantsearch.widgets.pagination({
+            container,
+            templates: {
+              previous: 'Previous',
+              next: 'Next',
+              first: 'First',
+              last: 'Last',
+            },
+          })
+        );
+      })
     );
 };


### PR DESCRIPTION
This renames `labels` to `templates` in the `pagination` widget for consistency with other widgets.