### PR TITLE
feat(poweredBy): disable setting URL from widget

### DIFF
--- a/src/connectors/powered-by/connectPoweredBy.js
+++ b/src/connectors/powered-by/connectPoweredBy.js
@@ -3,13 +3,12 @@ import { checkRendering } from '../../lib/utils.js';
 const usage = `Usage:
 var customPoweredBy = connectPoweredBy(function render(params, isFirstRendering) {
   // params = {
+  //   url,
   //   widgetParams,
-  //   instantSearchInstance,
   // }
 });
 search.addWidget(customPoweredBy({
-  [ theme = 'light' ],
-  [ url ]
+  [ url ],
 }));
 Full documentation available at https://community.algolia.com/instantsearch.js/v2/connectors/connectPoweredBy.html`;
 
@@ -36,25 +35,26 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
 export default function connectPoweredBy(renderFn, unmountFn) {
   checkRendering(renderFn, usage);
 
+  const defaultUrl =
+    'https://www.algolia.com/?' +
+    'utm_source=instantsearch.js&' +
+    'utm_medium=website&' +
+    `utm_content=${
+      typeof window !== 'undefined' && window.location
+        ? window.location.hostname
+        : ''
+    }&` +
+    'utm_campaign=poweredby';
+
   return (widgetParams = {}) => {
-    const url =
-      widgetParams.url ||
-      'https://www.algolia.com/?' +
-        'utm_source=instantsearch.js&' +
-        'utm_medium=website&' +
-        `utm_content=${
-          typeof window !== 'undefined' && window.location
-            ? window.location.hostname
-            : ''
-        }&` +
-        'utm_campaign=poweredby';
+    const { url = defaultUrl } = widgetParams;
 
     return {
       init() {
         renderFn(
           {
-            widgetParams,
             url,
+            widgetParams,
           },
           true
         );
@@ -63,8 +63,8 @@ export default function connectPoweredBy(renderFn, unmountFn) {
       render() {
         renderFn(
           {
-            widgetParams,
             url,
+            widgetParams,
           },
           false
         );

--- a/src/widgets/powered-by/powered-by.js
+++ b/src/widgets/powered-by/powered-by.js
@@ -27,7 +27,6 @@ const usage = `Usage:
 poweredBy({
   container,
   [ theme = 'light' ],
-  [ url ],
 })`;
 
 /**
@@ -41,7 +40,6 @@ poweredBy({
  * @typedef {Object} PoweredByWidgetOptions
  * @property {string|HTMLElement} container Place where to insert the widget in your webpage.
  * @property {string} [theme] The theme of the logo ("light" or "dark").
- * @property {string} [url] The URL to redirect to.
  * @property {PoweredByWidgetCssClasses} [cssClasses] CSS classes to add.
  */
 
@@ -64,7 +62,6 @@ export default function poweredBy({
   container,
   cssClasses: userCssClasses = {},
   theme = 'light',
-  url,
 } = {}) {
   if (!container) {
     throw new Error(usage);
@@ -91,7 +88,8 @@ export default function poweredBy({
     const makeWidget = connectPoweredBy(specializedRenderer, () =>
       unmountComponentAtNode(containerNode)
     );
-    return makeWidget({ url, theme });
+
+    return makeWidget({ theme });
   } catch (error) {
     throw new Error(usage);
   }

--- a/storybook/app/builtin/stories/powered-by.stories.js
+++ b/storybook/app/builtin/stories/powered-by.stories.js
@@ -7,31 +7,24 @@ import { wrapWithHits } from '../../utils/wrap-with-hits.js';
 const stories = storiesOf('PoweredBy');
 
 export default () => {
-  stories.add(
-    'default',
-    wrapWithHits(container => {
-      window.search.addWidget(instantsearch.widgets.poweredBy({ container }));
-    })
-  );
-  stories.add(
-    'with dark theme',
-    wrapWithHits(container => {
-      container.style.backgroundColor = '#282c34';
+  stories
+    .add(
+      'default',
+      wrapWithHits(container => {
+        window.search.addWidget(instantsearch.widgets.poweredBy({ container }));
+      })
+    )
+    .add(
+      'with dark theme',
+      wrapWithHits(container => {
+        container.style.backgroundColor = '#282c34';
 
-      window.search.addWidget(
-        instantsearch.widgets.poweredBy({ container, theme: 'dark' })
-      );
-    })
-  );
-  stories.add(
-    'with custom URL',
-    wrapWithHits(container => {
-      window.search.addWidget(
-        instantsearch.widgets.poweredBy({
-          container,
-          url: 'https://algolia.com',
-        })
-      );
-    })
-  );
+        window.search.addWidget(
+          instantsearch.widgets.poweredBy({
+            container,
+            theme: 'dark',
+          })
+        );
+      })
+    );
 };


### PR DESCRIPTION
This disables setting the `url` from the widget `poweredBy`, but only from the connector.