### PR TITLE
fix(configure): make lifecycle functions optional

### DIFF
--- a/src/connectors/configure/__tests__/connectConfigure-test.js
+++ b/src/connectors/configure/__tests__/connectConfigure-test.js
@@ -14,12 +14,12 @@ describe('connectConfigure', () => {
   });
 
   describe('Usage', () => {
-    it('without searchParameters throws', () => {
+    it('throws without searchParameters', () => {
       const makeWidget = connectConfigure();
       expect(() => makeWidget()).toThrow();
     });
 
-    it('with a render function but no unmount function does not throw', () => {
+    it('does not throw with a render function but without an unmount function', () => {
       expect(() => connectConfigure(jest.fn(), undefined)).not.toThrow();
     });
 
@@ -27,8 +27,8 @@ describe('connectConfigure', () => {
       expect(() => connectConfigure(undefined, jest.fn())).not.toThrow();
     });
 
-    it('without unmount and render functions does not throw', () => {
-      expect(() => connectConfigure(undefined, jest.fn())).not.toThrow();
+    it('does not throw without render and unmount functions', () => {
+      expect(() => connectConfigure(undefined, undefined)).not.toThrow();
     });
   });
 

--- a/src/connectors/configure/__tests__/connectConfigure-test.js
+++ b/src/connectors/configure/__tests__/connectConfigure-test.js
@@ -13,18 +13,22 @@ describe('connectConfigure', () => {
     helper = algoliasearchHelper(fakeClient, '', {});
   });
 
-  describe('throws on bad usage', () => {
-    it('without searchParameters', () => {
+  describe('Usage', () => {
+    it('without searchParameters throws', () => {
       const makeWidget = connectConfigure();
       expect(() => makeWidget()).toThrow();
     });
 
-    it('with a renderFn but no unmountFn', () => {
-      expect(() => connectConfigure(jest.fn(), undefined)).toThrow();
+    it('with a render function but no unmount function does not throw', () => {
+      expect(() => connectConfigure(jest.fn(), undefined)).not.toThrow();
     });
 
-    it('with a unmountFn but no renderFn', () => {
-      expect(() => connectConfigure(undefined, jest.fn())).toThrow();
+    it('with a unmount function but no render function does not throw', () => {
+      expect(() => connectConfigure(undefined, jest.fn())).not.toThrow();
+    });
+
+    it('without unmount and render functions does not throw', () => {
+      expect(() => connectConfigure(undefined, jest.fn())).not.toThrow();
     });
   });
 

--- a/src/connectors/configure/connectConfigure.js
+++ b/src/connectors/configure/connectConfigure.js
@@ -13,7 +13,11 @@ var customConfigure = connectConfigure(
   }
 );
 search.addWidget(
-  customConfigure({})
+  customConfigure({
+    searchParameters: {
+      // any search parameter: https://www.algolia.com/doc/api-reference/search-api-parameters/
+    }
+  })
 );
 Full documentation available at https://community.algolia.com/instantsearch.js/v2/connectors/connectConfigure.html
 `;

--- a/src/connectors/configure/connectConfigure.js
+++ b/src/connectors/configure/connectConfigure.js
@@ -1,18 +1,21 @@
-import isFunction from 'lodash/isFunction';
+import noop from 'lodash/noop';
 import isPlainObject from 'lodash/isPlainObject';
 
 import { enhanceConfiguration } from '../../lib/InstantSearch.js';
 
 const usage = `Usage:
-var customConfigureWidget = connectConfigure(
+var customConfigure = connectConfigure(
   function renderFn(params, isFirstRendering) {
     // params = {
     //   refine,
-    //   widgetParams
+    //   widgetParams,
     // }
-  },
-  function disposeFn() {}
-)
+  }
+);
+search.addWidget(
+  customConfigure({})
+);
+Full documentation available at https://community.algolia.com/instantsearch.js/v2/connectors/connectConfigure.html
 `;
 
 /**
@@ -35,14 +38,7 @@ var customConfigureWidget = connectConfigure(
  * @param {function} unmountFn Unmount function called when the widget is disposed.
  * @return {function(CustomConfigureWidgetOptions)} Re-usable widget factory for a custom **Configure** widget.
  */
-export default function connectConfigure(renderFn, unmountFn) {
-  if (
-    (isFunction(renderFn) && !isFunction(unmountFn)) ||
-    (!isFunction(renderFn) && isFunction(unmountFn))
-  ) {
-    throw new Error(usage);
-  }
-
+export default function connectConfigure(renderFn = noop, unmountFn = noop) {
   return (widgetParams = {}) => {
     if (!isPlainObject(widgetParams.searchParameters)) {
       throw new Error(usage);
@@ -56,15 +52,13 @@ export default function connectConfigure(renderFn, unmountFn) {
       init({ helper }) {
         this._refine = this.refine(helper);
 
-        if (isFunction(renderFn)) {
-          renderFn(
-            {
-              refine: this._refine,
-              widgetParams,
-            },
-            true
-          );
-        }
+        renderFn(
+          {
+            refine: this._refine,
+            widgetParams,
+          },
+          true
+        );
       },
 
       refine(helper) {
@@ -87,19 +81,18 @@ export default function connectConfigure(renderFn, unmountFn) {
       },
 
       render() {
-        if (renderFn) {
-          renderFn(
-            {
-              refine: this._refine,
-              widgetParams,
-            },
-            false
-          );
-        }
+        renderFn(
+          {
+            refine: this._refine,
+            widgetParams,
+          },
+          false
+        );
       },
 
       dispose({ state }) {
-        if (unmountFn) unmountFn();
+        unmountFn();
+
         return this.removeSearchParameters(state);
       },
 

--- a/src/widgets/configure/configure.js
+++ b/src/widgets/configure/configure.js
@@ -3,7 +3,7 @@ import connectConfigure from '../../connectors/configure/connectConfigure.js';
 const usage = `Usage:
 search.addWidget(
   instantsearch.widgets.configure({
-    // any searchParameter
+    // any search parameter: https://www.algolia.com/doc/api-reference/search-api-parameters/
   })
 );
 Full documentation available at https://community.algolia.com/instantsearch.js/v2/widgets/configure.html
@@ -35,7 +35,7 @@ export default function configure(searchParameters) {
     // We do not have default renderFn && unmountFn for this widget
     const makeWidget = connectConfigure();
     return makeWidget({ searchParameters });
-  } catch (e) {
+  } catch (error) {
     throw new Error(usage);
   }
 }


### PR DESCRIPTION
This makes the render and unmount lifecycle functions optional for the `configure` widget. It's more straightforward to use `connectConfigure`.