### PR TITLE
fix(connectHits): default escapeHTML to true

### DIFF
--- a/src/connectors/hits/__tests__/connectHits-test.js
+++ b/src/connectors/hits/__tests__/connectHits-test.js
@@ -52,6 +52,17 @@ describe('connectHits', () => {
     );
   });
 
+  it('sets the default configuration', () => {
+    const rendering = jest.fn();
+    const makeWidget = connectHits(rendering);
+    const widget = makeWidget();
+
+    expect(widget.getConfiguration()).toEqual({
+      highlightPreTag: TAG_PLACEHOLDER.highlightPreTag,
+      highlightPostTag: TAG_PLACEHOLDER.highlightPostTag,
+    });
+  });
+
   it('Provides the hits and the whole results', () => {
     const rendering = jest.fn();
     const makeWidget = connectHits(rendering);

--- a/src/connectors/hits/__tests__/connectHits-test.js
+++ b/src/connectors/hits/__tests__/connectHits-test.js
@@ -76,6 +76,7 @@ describe('connectHits', () => {
     );
 
     const hits = [{ fake: 'data' }, { sample: 'infos' }];
+    hits.__escaped = true;
 
     const results = new SearchResults(helper.state, [
       { hits: [].concat(hits) },

--- a/src/connectors/hits/connectHits.js
+++ b/src/connectors/hits/connectHits.js
@@ -1,4 +1,4 @@
-import escapeHTML, { TAG_PLACEHOLDER } from '../../lib/escape-highlight.js';
+import escapeHits, { TAG_PLACEHOLDER } from '../../lib/escape-highlight.js';
 import { checkRendering } from '../../lib/utils.js';
 
 const usage = `Usage:
@@ -62,11 +62,11 @@ export default function connectHits(renderFn, unmountFn) {
   checkRendering(renderFn, usage);
 
   return (widgetParams = {}) => {
-    const { transformItems = items => items } = widgetParams;
+    const { escapeHTML = true, transformItems = items => items } = widgetParams;
 
     return {
       getConfiguration() {
-        return widgetParams.escapeHTML ? TAG_PLACEHOLDER : undefined;
+        return escapeHTML ? TAG_PLACEHOLDER : undefined;
       },
 
       init({ instantSearchInstance }) {
@@ -82,12 +82,8 @@ export default function connectHits(renderFn, unmountFn) {
       },
 
       render({ results, instantSearchInstance }) {
-        if (
-          widgetParams.escapeHTML &&
-          results.hits &&
-          results.hits.length > 0
-        ) {
-          results.hits = escapeHTML(results.hits);
+        if (escapeHTML && results.hits && results.hits.length > 0) {
+          results.hits = escapeHits(results.hits);
         }
 
         results.hits = transformItems(results.hits);

--- a/src/widgets/hits/hits.js
+++ b/src/widgets/hits/hits.js
@@ -88,10 +88,10 @@ hits({
  */
 export default function hits({
   container,
-  cssClasses: userCssClasses = {},
-  templates = defaultTemplates,
-  escapeHTML = true,
+  escapeHTML,
   transformItems,
+  templates = defaultTemplates,
+  cssClasses: userCssClasses = {},
 }) {
   if (!container) {
     throw new Error(`Must provide a container.${usage}`);


### PR DESCRIPTION
This makes `connectHits` `escapeHTML` default to `true` at the connector level rather than at the widget level.

It escapes by default the custom hits user implementations.