### PR TITLE
 feat(hierarchicalMenu): update "show more" behavior

### DIFF
--- a/src/connectors/hierarchical-menu/__tests__/__snapshots__/connectHierarchicalMenu-test.js.snap
+++ b/src/connectors/hierarchical-menu/__tests__/__snapshots__/connectHierarchicalMenu-test.js.snap
@@ -47,7 +47,7 @@ SearchParameters {
   "insideBoundingBox": undefined,
   "insidePolygon": undefined,
   "length": undefined,
-  "maxValuesPerFacet": 20,
+  "maxValuesPerFacet": 10,
   "minProximity": undefined,
   "minWordSizefor1Typo": undefined,
   "minWordSizefor2Typos": undefined,

--- a/src/connectors/hierarchical-menu/__tests__/__snapshots__/connectHierarchicalMenu-test.js.snap
+++ b/src/connectors/hierarchical-menu/__tests__/__snapshots__/connectHierarchicalMenu-test.js.snap
@@ -47,7 +47,7 @@ SearchParameters {
   "insideBoundingBox": undefined,
   "insidePolygon": undefined,
   "length": undefined,
-  "maxValuesPerFacet": 10,
+  "maxValuesPerFacet": 20,
   "minProximity": undefined,
   "minWordSizefor1Typo": undefined,
   "minWordSizefor2Typos": undefined,

--- a/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.js
+++ b/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.js
@@ -25,7 +25,7 @@ describe('connectHierarchicalMenu', () => {
               showParentLevel: true,
             },
           ],
-          maxValuesPerFacet: 20,
+          maxValuesPerFacet: 10,
         });
       }
 
@@ -56,7 +56,7 @@ describe('connectHierarchicalMenu', () => {
               showParentLevel: true,
             },
           ],
-          maxValuesPerFacet: 20,
+          maxValuesPerFacet: 10,
         });
       }
     });
@@ -178,7 +178,7 @@ describe('connectHierarchicalMenu', () => {
           showParentLevel: true,
         },
       ],
-      maxValuesPerFacet: 20,
+      maxValuesPerFacet: 10,
     });
 
     // test if widget is not rendered yet at this point

--- a/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.js
+++ b/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.js
@@ -25,7 +25,7 @@ describe('connectHierarchicalMenu', () => {
               showParentLevel: true,
             },
           ],
-          maxValuesPerFacet: 10,
+          maxValuesPerFacet: 20,
         });
       }
 
@@ -56,7 +56,7 @@ describe('connectHierarchicalMenu', () => {
               showParentLevel: true,
             },
           ],
-          maxValuesPerFacet: 10,
+          maxValuesPerFacet: 20,
         });
       }
     });
@@ -115,8 +115,9 @@ describe('connectHierarchicalMenu', () => {
 
       const widget = makeWidget({
         attributes: ['category', 'sub_category'],
-        showMore: true,
         limit: 3,
+        showMore: true,
+        showMoreLimit: 6,
       });
 
       // when there is no other limit set
@@ -132,7 +133,7 @@ describe('connectHierarchicalMenu', () => {
               showParentLevel: true,
             },
           ],
-          maxValuesPerFacet: 3,
+          maxValuesPerFacet: 6,
         });
       }
 
@@ -177,7 +178,7 @@ describe('connectHierarchicalMenu', () => {
           showParentLevel: true,
         },
       ],
-      maxValuesPerFacet: 10,
+      maxValuesPerFacet: 20,
     });
 
     // test if widget is not rendered yet at this point
@@ -537,118 +538,13 @@ describe('connectHierarchicalMenu', () => {
   });
 
   describe('show more', () => {
-    it('can toggle the limits based on limit', () => {
+    it('can toggle the limits based on the default showMoreLimit value', () => {
       const rendering = jest.fn();
       const makeWidget = connectHierarchicalMenu(rendering);
       const widget = makeWidget({
         attributes: ['category'],
         limit: 2,
         showMore: true,
-      });
-
-      const helper = jsHelper({}, '', widget.getConfiguration({}));
-      helper.search = jest.fn();
-
-      widget.init({
-        helper,
-        state: helper.state,
-        createURL: () => '#',
-        onHistoryChange: () => {},
-      });
-
-      widget.render({
-        results: new SearchResults(helper.state, [
-          {
-            hits: [],
-            facets: {
-              category: {
-                a: 880,
-                b: 880,
-                c: 880,
-                d: 880,
-              },
-            },
-          },
-          {
-            facets: {
-              category: {
-                a: 880,
-                b: 880,
-                c: 880,
-                d: 880,
-              },
-            },
-          },
-        ]),
-        state: helper.state,
-        helper,
-        createURL: () => '#',
-      });
-
-      const { toggleShowMore } = rendering.mock.calls[1][0];
-
-      expect(rendering).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          items: [
-            {
-              label: 'a',
-              value: 'a',
-              count: 880,
-              isRefined: false,
-              data: null,
-            },
-            {
-              label: 'b',
-              value: 'b',
-              count: 880,
-              isRefined: false,
-              data: null,
-            },
-          ],
-        }),
-        expect.anything()
-      );
-
-      toggleShowMore();
-
-      expect(rendering).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          items: [
-            {
-              label: 'a',
-              value: 'a',
-              count: 880,
-              isRefined: false,
-              data: null,
-            },
-            {
-              label: 'b',
-              value: 'b',
-              count: 880,
-              isRefined: false,
-              data: null,
-            },
-            {
-              label: 'c',
-              value: 'c',
-              count: 880,
-              isRefined: false,
-              data: null,
-            },
-          ],
-        }),
-        expect.anything()
-      );
-    });
-
-    it('can toggle the limits based on showMoreLimit', () => {
-      const rendering = jest.fn();
-      const makeWidget = connectHierarchicalMenu(rendering);
-      const widget = makeWidget({
-        attributes: ['category'],
-        limit: 2,
-        showMore: true,
-        showMoreLimit: 5,
       });
 
       const helper = jsHelper({}, '', widget.getConfiguration({}));
@@ -743,6 +639,111 @@ describe('connectHierarchicalMenu', () => {
             {
               label: 'd',
               value: 'd',
+              count: 880,
+              isRefined: false,
+              data: null,
+            },
+          ],
+        }),
+        expect.anything()
+      );
+    });
+
+    it('can toggle the limits based on showMoreLimit', () => {
+      const rendering = jest.fn();
+      const makeWidget = connectHierarchicalMenu(rendering);
+      const widget = makeWidget({
+        attributes: ['category'],
+        limit: 2,
+        showMore: true,
+        showMoreLimit: 3,
+      });
+
+      const helper = jsHelper({}, '', widget.getConfiguration({}));
+      helper.search = jest.fn();
+
+      widget.init({
+        helper,
+        state: helper.state,
+        createURL: () => '#',
+        onHistoryChange: () => {},
+      });
+
+      widget.render({
+        results: new SearchResults(helper.state, [
+          {
+            hits: [],
+            facets: {
+              category: {
+                a: 880,
+                b: 880,
+                c: 880,
+                d: 880,
+              },
+            },
+          },
+          {
+            facets: {
+              category: {
+                a: 880,
+                b: 880,
+                c: 880,
+                d: 880,
+              },
+            },
+          },
+        ]),
+        state: helper.state,
+        helper,
+        createURL: () => '#',
+      });
+
+      const { toggleShowMore } = rendering.mock.calls[1][0];
+
+      expect(rendering).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          items: [
+            {
+              label: 'a',
+              value: 'a',
+              count: 880,
+              isRefined: false,
+              data: null,
+            },
+            {
+              label: 'b',
+              value: 'b',
+              count: 880,
+              isRefined: false,
+              data: null,
+            },
+          ],
+        }),
+        expect.anything()
+      );
+
+      toggleShowMore();
+
+      expect(rendering).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          items: [
+            {
+              label: 'a',
+              value: 'a',
+              count: 880,
+              isRefined: false,
+              data: null,
+            },
+            {
+              label: 'b',
+              value: 'b',
+              count: 880,
+              isRefined: false,
+              data: null,
+            },
+            {
+              label: 'c',
+              value: 'c',
               count: 880,
               isRefined: false,
               data: null,

--- a/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.js
+++ b/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.js
@@ -537,12 +537,117 @@ describe('connectHierarchicalMenu', () => {
   });
 
   describe('show more', () => {
-    it('can toggle the limits', () => {
+    it('can toggle the limits based on limit', () => {
       const rendering = jest.fn();
       const makeWidget = connectHierarchicalMenu(rendering);
       const widget = makeWidget({
         attributes: ['category'],
         limit: 2,
+        showMore: true,
+      });
+
+      const helper = jsHelper({}, '', widget.getConfiguration({}));
+      helper.search = jest.fn();
+
+      widget.init({
+        helper,
+        state: helper.state,
+        createURL: () => '#',
+        onHistoryChange: () => {},
+      });
+
+      widget.render({
+        results: new SearchResults(helper.state, [
+          {
+            hits: [],
+            facets: {
+              category: {
+                a: 880,
+                b: 880,
+                c: 880,
+                d: 880,
+              },
+            },
+          },
+          {
+            facets: {
+              category: {
+                a: 880,
+                b: 880,
+                c: 880,
+                d: 880,
+              },
+            },
+          },
+        ]),
+        state: helper.state,
+        helper,
+        createURL: () => '#',
+      });
+
+      const { toggleShowMore } = rendering.mock.calls[1][0];
+
+      expect(rendering).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          items: [
+            {
+              label: 'a',
+              value: 'a',
+              count: 880,
+              isRefined: false,
+              data: null,
+            },
+            {
+              label: 'b',
+              value: 'b',
+              count: 880,
+              isRefined: false,
+              data: null,
+            },
+          ],
+        }),
+        expect.anything()
+      );
+
+      toggleShowMore();
+
+      expect(rendering).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          items: [
+            {
+              label: 'a',
+              value: 'a',
+              count: 880,
+              isRefined: false,
+              data: null,
+            },
+            {
+              label: 'b',
+              value: 'b',
+              count: 880,
+              isRefined: false,
+              data: null,
+            },
+            {
+              label: 'c',
+              value: 'c',
+              count: 880,
+              isRefined: false,
+              data: null,
+            },
+          ],
+        }),
+        expect.anything()
+      );
+    });
+
+    it('can toggle the limits based on showMoreLimit', () => {
+      const rendering = jest.fn();
+      const makeWidget = connectHierarchicalMenu(rendering);
+      const widget = makeWidget({
+        attributes: ['category'],
+        limit: 2,
+        showMore: true,
         showMoreLimit: 5,
       });
 

--- a/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
+++ b/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
@@ -20,7 +20,7 @@ search.addWidget(
     [ showParentLevel = true ],
     [ limit = 10 ],
     [ showMore = false ],
-    [ showMoreLimit = limit * 2 ],
+    [ showMoreLimit = 20 ],
     [ sortBy = ['name:asc'] ],
     [ transformItems ],
   })
@@ -44,9 +44,9 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  * @property {string} [rootPath = null] Prefix path to use if the first level is not the root level.
  * @property {boolean} [showParentLevel=false] Show the siblings of the selected parent levels of the current refined value. This
  * does not impact the root level.
- * @property {number} [limit = 10] Max number of value to display.
+ * @property {number} [limit = 10] Max number of values to display.
  * @property {boolean} [showMore = false] Whether to display the "show more" button.
- * @property {number} [showMoreLimit = limit * 2] Max number of value to display when showing more.
+ * @property {number} [showMoreLimit = 20] Max number of values to display when showing more.
  * @property  {string[]|function} [sortBy = ['name:asc']] How to sort refinements. Possible values: `count|isRefined|name:asc|name:desc`.
  *
  * You can also use a sort function that behaves like the standard Javascript [compareFunction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#Syntax).
@@ -87,13 +87,17 @@ export default function connectHierarchicalMenu(renderFn, unmountFn) {
       showParentLevel = true,
       limit = 10,
       showMore,
-      showMoreLimit = limit * 2,
+      showMoreLimit = 20,
       sortBy = ['name:asc'],
       transformItems = items => items,
     } = widgetParams;
 
     if (!attributes || !attributes.length) {
       throw new Error(usage);
+    }
+
+    if (showMore === true && showMoreLimit <= limit) {
+      throw new Error('`showMoreLimit` must be greater than `limit`.');
     }
 
     // we need to provide a hierarchicalFacet name for the search state

--- a/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
+++ b/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
@@ -86,7 +86,7 @@ export default function connectHierarchicalMenu(renderFn, unmountFn) {
       rootPath = null,
       showParentLevel = true,
       limit = 10,
-      showMore,
+      showMore = false,
       showMoreLimit = 20,
       sortBy = ['name:asc'],
       transformItems = items => items,
@@ -163,7 +163,7 @@ export default function connectHierarchicalMenu(renderFn, unmountFn) {
 
         widgetConfiguration.maxValuesPerFacet = Math.max(
           currentMaxValuesPerFacet,
-          showMoreLimit
+          showMore ? showMoreLimit : limit
         );
 
         return widgetConfiguration;

--- a/src/widgets/hierarchical-menu/__tests__/hierarchical-menu-test.js
+++ b/src/widgets/hierarchical-menu/__tests__/hierarchical-menu-test.js
@@ -292,10 +292,6 @@ describe('hierarchicalMenu()', () => {
         ReactDOM.render.mock.calls[0][0].props.facetValues;
       expect(actualFacetValues).toEqual(expectedFacetValues);
     });
-
-    afterEach(() => {
-      hierarchicalMenu.__ResetDependency__('defaultTemplates');
-    });
   });
 
   afterEach(() => {

--- a/src/widgets/hierarchical-menu/__tests__/hierarchical-menu-test.js
+++ b/src/widgets/hierarchical-menu/__tests__/hierarchical-menu-test.js
@@ -49,7 +49,7 @@ describe('hierarchicalMenu()', () => {
             showParentLevel: true,
           },
         ],
-        maxValuesPerFacet: 20,
+        maxValuesPerFacet: 10,
       });
     });
 
@@ -66,7 +66,7 @@ describe('hierarchicalMenu()', () => {
             showParentLevel: true,
           },
         ],
-        maxValuesPerFacet: 20,
+        maxValuesPerFacet: 10,
       });
     });
 
@@ -86,7 +86,7 @@ describe('hierarchicalMenu()', () => {
             showParentLevel: false,
           },
         ],
-        maxValuesPerFacet: 20,
+        maxValuesPerFacet: 10,
       });
     });
 
@@ -103,7 +103,7 @@ describe('hierarchicalMenu()', () => {
             showParentLevel: true,
           },
         ],
-        maxValuesPerFacet: 20,
+        maxValuesPerFacet: 10,
       });
     });
 
@@ -126,7 +126,7 @@ describe('hierarchicalMenu()', () => {
           hierarchicalMenu({ limit: 10, ...options }).getConfiguration({
             maxValuesPerFacet: 3,
           }).maxValuesPerFacet
-        ).toBe(20));
+        ).toBe(10));
     });
   });
 

--- a/src/widgets/hierarchical-menu/__tests__/hierarchical-menu-test.js
+++ b/src/widgets/hierarchical-menu/__tests__/hierarchical-menu-test.js
@@ -49,7 +49,7 @@ describe('hierarchicalMenu()', () => {
             showParentLevel: true,
           },
         ],
-        maxValuesPerFacet: 10,
+        maxValuesPerFacet: 20,
       });
     });
 
@@ -66,7 +66,7 @@ describe('hierarchicalMenu()', () => {
             showParentLevel: true,
           },
         ],
-        maxValuesPerFacet: 10,
+        maxValuesPerFacet: 20,
       });
     });
 
@@ -86,7 +86,7 @@ describe('hierarchicalMenu()', () => {
             showParentLevel: false,
           },
         ],
-        maxValuesPerFacet: 10,
+        maxValuesPerFacet: 20,
       });
     });
 
@@ -103,7 +103,7 @@ describe('hierarchicalMenu()', () => {
             showParentLevel: true,
           },
         ],
-        maxValuesPerFacet: 10,
+        maxValuesPerFacet: 20,
       });
     });
 
@@ -126,7 +126,7 @@ describe('hierarchicalMenu()', () => {
           hierarchicalMenu({ limit: 10, ...options }).getConfiguration({
             maxValuesPerFacet: 3,
           }).maxValuesPerFacet
-        ).toBe(10));
+        ).toBe(20));
     });
   });
 

--- a/src/widgets/hierarchical-menu/hierarchical-menu.js
+++ b/src/widgets/hierarchical-menu/hierarchical-menu.js
@@ -55,15 +55,18 @@ const usage = `Usage:
 hierarchicalMenu({
   container,
   attributes,
-  [ separator=' > ' ],
+  [ separator = ' > ' ],
   [ rootPath ],
-  [ showParentLevel=false ],
-  [ limit=10 ],
-  [ sortBy=['name:asc'] ],
+  [ showParentLevel = true ],
+  [ limit = 10 ],
+  [ showMore = false ],
+  [ showMoreLimit = limit * 2 ],
+  [ sortBy = ['name:asc'] ],
   [ cssClasses.{root, noRefinementRoot, list, childList, item, selectedItem, parentItem, link, label, count, showMore, disabledShowMore} ],
   [ templates.{item, showMoreText} ],
   [ transformItems ]
 })`;
+
 /**
  * @typedef {Object} HierarchicalMenuCSSClasses
  * @property {string|string[]} [root] CSS class to add to the root element.
@@ -90,10 +93,12 @@ hierarchicalMenu({
  * @typedef {Object} HierarchicalMenuWidgetOptions
  * @property {string|HTMLElement} container CSS Selector or HTMLElement to insert the widget.
  * @property {string[]} attributes Array of attributes to use to generate the hierarchy of the menu.
- * @property {number} [limit=10] How much facet values to get.
- * @property {string} [separator=" > "] Separator used in the attributes to separate level values.
+ * @property {string} [separator = " > "] Separator used in the attributes to separate level values.
  * @property {string} [rootPath] Prefix path to use if the first level is not the root level.
- * @property {boolean} [showParentLevel=true] Show the siblings of the selected parent level of the current refined value. This
+ * @property {boolean} [showParentLevel = true] Show the siblings of the selected parent level of the current refined value. This
+ * @property {number} [limit = 10] How much facet values to get.
+ * @property {boolean} [showMore = false] Whether to display the "show more" button.
+ * @property {number} [showMoreLimit = limit * 2] How much facet values to get when showing more.
  * does not impact the root level.
  *
  * The hierarchical menu is able to show or hide the siblings with `showParentLevel`.
@@ -115,12 +120,12 @@ hierarchicalMenu({
  *     - **lvl2**
  * - Parent lvl0
  * - Parent lvl0
- * @property {string[]|function} [sortBy=['name:asc']] How to sort refinements. Possible values: `count|isRefined|name:asc|name:desc`.
+ * @property {string[]|function} [sortBy = ['name:asc']] How to sort refinements. Possible values: `count|isRefined|name:asc|name:desc`.
  *
  * You can also use a sort function that behaves like the standard Javascript [compareFunction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#Syntax).
+ * @property {function(object[]):object[]} [transformItems] Function to transform the items passed to the templates.
  * @property {HierarchicalMenuTemplates} [templates] Templates to use for the widget.
  * @property {HierarchicalMenuCSSClasses} [cssClasses] CSS classes to add to the wrapping elements.
- * @property {function(object[]):object[]} [transformItems] Function to transform the items passed to the templates.
  */
 
 /**
@@ -177,16 +182,16 @@ hierarchicalMenu({
 export default function hierarchicalMenu({
   container,
   attributes,
-  separator = ' > ',
-  rootPath = null,
-  showParentLevel = true,
-  limit = 10,
-  sortBy = ['name:asc'],
-  cssClasses: userCssClasses = {},
-  templates = defaultTemplates,
+  separator,
+  rootPath,
+  showParentLevel,
+  limit,
   showMore = false,
   showMoreLimit,
+  sortBy,
   transformItems,
+  templates = defaultTemplates,
+  cssClasses: userCssClasses = {},
 } = {}) {
   if (!container || !attributes || !attributes.length) {
     throw new Error(usage);
@@ -237,12 +242,14 @@ export default function hierarchicalMenu({
       specializedRenderer,
       () => unmountComponentAtNode(containerNode)
     );
+
     return makeHierarchicalMenu({
       attributes,
       separator,
       rootPath,
       showParentLevel,
       limit,
+      showMore,
       showMoreLimit,
       sortBy,
       transformItems,

--- a/src/widgets/hierarchical-menu/hierarchical-menu.js
+++ b/src/widgets/hierarchical-menu/hierarchical-menu.js
@@ -98,7 +98,7 @@ hierarchicalMenu({
  * @property {boolean} [showParentLevel = true] Show the siblings of the selected parent level of the current refined value. This
  * @property {number} [limit = 10] Max number of values to display.
  * @property {boolean} [showMore = false] Whether to display the "show more" button.
- * @property {number} [showMoreLimit = 10] Max number of values to display when showing more.
+ * @property {number} [showMoreLimit = 20] Max number of values to display when showing more.
  * does not impact the root level.
  *
  * The hierarchical menu is able to show or hide the siblings with `showParentLevel`.

--- a/src/widgets/hierarchical-menu/hierarchical-menu.js
+++ b/src/widgets/hierarchical-menu/hierarchical-menu.js
@@ -60,7 +60,7 @@ hierarchicalMenu({
   [ showParentLevel = true ],
   [ limit = 10 ],
   [ showMore = false ],
-  [ showMoreLimit = limit * 2 ],
+  [ showMoreLimit = 20 ],
   [ sortBy = ['name:asc'] ],
   [ cssClasses.{root, noRefinementRoot, list, childList, item, selectedItem, parentItem, link, label, count, showMore, disabledShowMore} ],
   [ templates.{item, showMoreText} ],
@@ -96,9 +96,9 @@ hierarchicalMenu({
  * @property {string} [separator = " > "] Separator used in the attributes to separate level values.
  * @property {string} [rootPath] Prefix path to use if the first level is not the root level.
  * @property {boolean} [showParentLevel = true] Show the siblings of the selected parent level of the current refined value. This
- * @property {number} [limit = 10] How much facet values to get.
+ * @property {number} [limit = 10] Max number of values to display.
  * @property {boolean} [showMore = false] Whether to display the "show more" button.
- * @property {number} [showMoreLimit = limit * 2] How much facet values to get when showing more.
+ * @property {number} [showMoreLimit = 10] Max number of values to display when showing more.
  * does not impact the root level.
  *
  * The hierarchical menu is able to show or hide the siblings with `showParentLevel`.

--- a/storybook/app/builtin/stories/hierarchical-menu.stories.js
+++ b/storybook/app/builtin/stories/hierarchical-menu.stories.js
@@ -94,9 +94,27 @@ export default () => {
               'hierarchicalCategories.lvl2',
               'hierarchicalCategories.lvl3',
             ],
-            showMore: true,
             limit: 3,
-            showMoreLimit: 10,
+            showMore: true,
+          })
+        );
+      })
+    )
+    .add(
+      'with show more and showMoreLimit',
+      wrapWithHits(container => {
+        window.search.addWidget(
+          instantsearch.widgets.hierarchicalMenu({
+            container,
+            attributes: [
+              'hierarchicalCategories.lvl0',
+              'hierarchicalCategories.lvl1',
+              'hierarchicalCategories.lvl2',
+              'hierarchicalCategories.lvl3',
+            ],
+            limit: 3,
+            showMore: true,
+            showMoreLimit: 6,
           })
         );
       })
@@ -113,8 +131,8 @@ export default () => {
               'hierarchicalCategories.lvl2',
               'hierarchicalCategories.lvl3',
             ],
-            showMore: true,
             limit: 200,
+            showMore: true,
             showMoreLimit: 1000,
           })
         );


### PR DESCRIPTION
- The show more button displays when the option `showMore` is `true`
- `limit` defaults to 10 (no change)
- `showMoreLimit` defaults to 20
- Throw an error if `showMoreLimit <= limit`