### PR TITLE
chore(core): remove lodash/foreach from main

### DIFF
--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -1,7 +1,6 @@
 // we use the full path to the lite build to solve a meteor.js issue:
 // https://github.com/algolia/instantsearch.js/issues/1024#issuecomment-221618284
 import algoliasearchHelper from 'algoliasearch-helper';
-import forEach from 'lodash/forEach';
 import mergeWith from 'lodash/mergeWith';
 import union from 'lodash/union';
 import isPlainObject from 'lodash/isPlainObject';
@@ -356,7 +355,7 @@ class InstantSearch extends EventEmitter {
       this._isSearchStalled = false;
     }
 
-    forEach(this.widgets, widget => {
+    this.widgets.forEach(widget => {
       if (!widget.render) {
         return;
       }
@@ -382,7 +381,7 @@ class InstantSearch extends EventEmitter {
   }
 
   _init(state, helper) {
-    forEach(this.widgets, widget => {
+    this.widgets.forEach(widget => {
       if (widget.init) {
         widget.init({
           state,

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -252,9 +252,6 @@ class InstantSearch extends EventEmitter {
    * @return {undefined} Does not return anything
    */
   start() {
-    if (!this.widgets)
-      throw new Error('No widgets were added to instantsearch.js');
-
     if (this.started) throw new Error('start() has been already called once');
 
     let searchParametersFromUrl;

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -515,3 +515,46 @@ describe('InstantSearch lifecycle', () => {
     expect(helperSearchSpy).toHaveBeenCalledTimes(1);
   });
 });
+
+it('Allows to start without widgets', () => {
+  const instance = new InstantSearch({
+    searchClient: {
+      search() {
+        return Promise.resolve({
+          results: [
+            {
+              query: 'fake query',
+            },
+          ],
+        });
+      },
+    },
+    indexName: 'bogus',
+  });
+
+  expect(() => instance.start()).not.toThrow();
+});
+
+it('Does not allow to start twice', () => {
+  const instance = new InstantSearch({
+    searchClient: {
+      search() {
+        return Promise.resolve({
+          results: [
+            {
+              query: 'fake query',
+            },
+          ],
+        });
+      },
+    },
+    indexName: 'bogus',
+  });
+
+  expect(() => instance.start()).not.toThrow();
+  expect(() => {
+    instance.start();
+  }).toThrowErrorMatchingInlineSnapshot(
+    `"start() has been already called once"`
+  );
+});


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

lodash/forEach was used there I found out by accident, and thought: this one doesn't need to be there!

1. figure out if `this.widgets` is ever an object -> no
2. figure out if `this.widgets` is ever undefined -> no (initialised with empty array)
3. find that the error message on start can not be called -> removed it

expected outcome: tiny bit smaller code 🙏 

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
  
  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot): 
  
  1. the documentation site (/)
  2. a widget playground (/dev-novel)
-->

1. removed impossible warning
2. added new test that proved warning is impossible
3. removed lodash/forEach from that file

