### PR TITLE
fix(ratingMenu): change context-based implementation

### DIFF
--- a/src/widgets/rating-menu/__tests__/rating-menu-test.js
+++ b/src/widgets/rating-menu/__tests__/rating-menu-test.js
@@ -90,31 +90,6 @@ describe('ratingMenu()', () => {
     expect(helper.search).toHaveBeenCalledTimes(0);
   });
 
-  it('refines the search', () => {
-    helper.getRefinements = jest.fn().mockReturnValue([]);
-    widget._toggleRefinement('3');
-    expect(helper.clearRefinements).toHaveBeenCalledTimes(1);
-    expect(helper.addDisjunctiveFacetRefinement).toHaveBeenCalledTimes(3);
-    expect(helper.search).toHaveBeenCalledTimes(1);
-  });
-
-  it('toggles the refinements', () => {
-    helper.addDisjunctiveFacetRefinement(attribute, 2);
-    helper.addDisjunctiveFacetRefinement.mockReset();
-    widget._toggleRefinement('2');
-    expect(helper.clearRefinements).toHaveBeenCalledTimes(1);
-    expect(helper.addDisjunctiveFacetRefinement).toHaveBeenCalledTimes(0);
-    expect(helper.search).toHaveBeenCalledTimes(1);
-  });
-
-  it('toggles the refinements with another facet', () => {
-    helper.getRefinements = jest.fn().mockReturnValue([{ value: '2' }]);
-    widget._toggleRefinement('4');
-    expect(helper.clearRefinements).toHaveBeenCalledTimes(1);
-    expect(helper.addDisjunctiveFacetRefinement).toHaveBeenCalledTimes(2);
-    expect(helper.search).toHaveBeenCalledTimes(1);
-  });
-
   it('should return the right facet counts and results', () => {
     const _widget = ratingMenu({
       container,


### PR DESCRIPTION
## The issue

The `connectRatingMenu` connector internally relies on `this` for both `createURL` and `toggleRefinement`.

Relying on `this`  makes the usage of the `ratingMenu` widget impossible within a `panel`.

The `panel` syntax is the following:

```js
const ratingList = panel({
  // ...
})(refinementList) // context is lost

search.addWidget(
  ratingList({
    // ...
  })
);
```

Since we don't call the widget directly, the context (`this`) is lost when the widget is instanciated, throwing errors.

## This solution

This solution gets rid of unnecessary `this` uses to make this widget compatible with any widget instanciation syntax.

---

These fixes must also be implemented for:

- Breadcrumb
- ClearRefinements
- Menu
- NumericMenu
- ToggleRefinements
