### PR TITLE
chore(examples): migrate Calendar Widget example

### DIFF
--- a/docgen/layouts/example.pug
+++ b/docgen/layouts/example.pug
@@ -7,6 +7,5 @@ head
   link(href='https://fonts.googleapis.com/css?family=Roboto', rel='stylesheet', type='text/css')
   link(rel='stylesheet', type='text/css', href='main.css')
   script(src='https://cdn.polyfill.io/v2/polyfill.min.js?features=default,Array.prototype.includes')
-  script(src='/lib/instantsearch.production.min.js')
 body
   | !{contents}

--- a/docgen/src/examples/calendar-widget/app.js
+++ b/docgen/src/examples/calendar-widget/app.js
@@ -34,7 +34,9 @@ search.addWidget(
 
 const makeRangeWidget = instantsearch.connectors.connectRange(
   (options, isFirstRendering) => {
-    if (!isFirstRendering) return;
+    if (!isFirstRendering) {
+      return;
+    }
 
     const { refine } = options;
 
@@ -58,7 +60,7 @@ const makeRangeWidget = instantsearch.connectors.connectRange(
 );
 
 const dateRangeWidget = makeRangeWidget({
-  attributeName: 'date',
+  attribute: 'date',
 });
 
 search.addWidget(dateRangeWidget);

--- a/docgen/src/examples/calendar-widget/app.js
+++ b/docgen/src/examples/calendar-widget/app.js
@@ -20,8 +20,10 @@ search.addWidget(
       item: hit => `
         <li class="hit">
           <h3>
-            ${hit._highlightResult.name.value}
-            <small>in ${hit._highlightResult.location.value}</small>
+            ${instantsearch.highlight({ attribute: 'name', hit })}
+            <small>
+              ${instantsearch.highlight({ attribute: 'location', hit })}
+            </small>
           </h3>
           <small>on <strong>${moment(hit.date).format(
             'dddd MMMM Do YYYY'

--- a/docgen/src/examples/calendar-widget/app.js
+++ b/docgen/src/examples/calendar-widget/app.js
@@ -25,9 +25,9 @@ search.addWidget(
               ${instantsearch.highlight({ attribute: 'location', hit })}
             </small>
           </h3>
-          <small>on <strong>${moment(hit.date).format(
-            'dddd MMMM Do YYYY'
-          )}</strong></small>
+          <small>
+            on <strong>${moment(hit.date).format('dddd MMMM Do YYYY')}</strong>
+          </small>
         </li>
       `,
     },

--- a/docgen/src/examples/calendar-widget/index.html
+++ b/docgen/src/examples/calendar-widget/index.html
@@ -1,8 +1,7 @@
 <html>
 
 <head>
-  <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/instantsearch.js@2.4.1/dist/instantsearch.min.css">
-  <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/instantsearch.js@2.4.1/dist/instantsearch-theme-algolia.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/instantsearch.css@7.1.0/themes/algolia.min.css">
   <link rel="stylesheet" type="text/css" href="main.css">
   <link rel="stylesheet" type="text/css" href="calendar.css">
   <title>InstantSearch Calendar Widget</title>
@@ -43,7 +42,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.20.1/moment.min.js"></script>
   <script src="https://unpkg.com/BaremetricsCalendar@1.0.11/public/js/Calendar.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/algoliasearch@3.30.0"></script>
-  <script src="https://cdn.jsdelivr.net/npm/instantsearch.js@2.10.2"></script>
+  <script src="https://cdn.jsdelivr.net/npm/instantsearch.js@beta"></script>
   <script src="app.js"></script>
 </body>
 

--- a/docgen/src/examples/calendar-widget/main.css
+++ b/docgen/src/examples/calendar-widget/main.css
@@ -91,29 +91,8 @@ h3 {
   margin-bottom: 20px;
 }
 
-.ais-hits {
-  display: flex;
-  flex-wrap: wrap;
-  margin-top: 20px;
-}
-
-.ais-hits--item {
-  flex: 0 0 30%;
-  padding: 10px 20px 20px;
-  margin-bottom: 10px;
-  margin-right: 10px;
-  border: solid 1px #eee;
-  box-shadow: 0 0 3px #f6f6f6;
-  color: #333;
-}
-
-.ais-hits--item em {
-  font-style: normal;
-  background-color: rgba(254, 207, 80, 0.3);
-}
-
 .hits-container {
-  margin: 0;
+  margin: 0 0 2rem 0;
   padding: 0;
   list-style: none;
 }

--- a/docgen/src/guides/calendar-widget.md
+++ b/docgen/src/guides/calendar-widget.md
@@ -152,12 +152,12 @@ const datePicker = instantsearch.connectors.connectRange(
 );
 ```
 
-We've now created our widget factory `datePicker`. In order to use it, you must instantiate it with a [`CustomRangeWidgetOptions`](connectors/connectRange.html#struct-CustomRangeWidgetOptions) object, specifying the `attributeName` parameter: the index key we are refining with. In our case, since it is a calendar widget, we want to refine on the `date` attribute of our dataset.
+We've now created our widget factory `datePicker`. In order to use it, you must instantiate it with a [`CustomRangeWidgetOptions`](connectors/connectRange.html#struct-CustomRangeWidgetOptions) object, specifying the `attribute` parameter: the index key we are refining with. In our case, since it is a calendar widget, we want to refine on the `date` attribute of our dataset.
 
 ```javascript
 search.addWidget(
   datePicker({
-    attributeName: 'date',
+    attribute: 'date',
   })
 );
 ```

--- a/docgen/src/guides/calendar-widget.md
+++ b/docgen/src/guides/calendar-widget.md
@@ -66,10 +66,14 @@ search.addWidget(
       item: hit => `
         <li class="hit">
           <h3>
-            ${hit._highlightResult.name.value}
-            <small>in ${hit._highlightResult.location.value}</small>
+            ${instantsearch.highlight({ attribute: 'name', hit })}
+            <small>
+              ${instantsearch.highlight({ attribute: 'location', hit })}
+            </small>
           </h3>
-          <small>on <strong>${new Date(hit.date)}</strong></small>
+          <small>
+            on <strong>${new Date(hit.date)}</strong>
+          </small>
         </li>
       `,
     },


### PR DESCRIPTION
This uses the latest beta version for now (https://cdn.jsdelivr.net/npm/instantsearch.js@beta).
Demo: https://deploy-preview-3351--instantsearchjs.netlify.com/examples/calendar-widget/