### PR TITLE
feat(hitsPerPage): expose createURL to render function

### DIFF
--- a/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
+++ b/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
@@ -205,6 +205,33 @@ describe('connectHitsPerPage', () => {
     expect(helper.search).toHaveBeenCalledTimes(2);
   });
 
+  it('provides a createURL function', () => {
+    const rendering = jest.fn();
+    const makeWidget = connectHitsPerPage(rendering);
+    const widget = makeWidget({
+      items: [
+        { value: 3, label: '3 items per page' },
+        { value: 10, label: '10 items per page' },
+        { value: 20, label: '20 items per page' },
+      ],
+    });
+    const helper = jsHelper({}, '', {
+      hitsPerPage: 20,
+    });
+    helper.search = jest.fn();
+
+    widget.init({
+      helper,
+      state: helper.state,
+      createURL: state => state,
+    });
+
+    const { createURL } = rendering.mock.calls[0][0];
+    expect(helper.getQueryParameter('hitsPerPage')).toEqual(20);
+    const URLState = createURL(3);
+    expect(URLState.hitsPerPage).toEqual(3);
+  });
+
   it('provides the current hitsPerPage value', () => {
     const rendering = jest.fn();
     const makeWidget = connectHitsPerPage(rendering);

--- a/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
+++ b/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
@@ -226,10 +226,20 @@ describe('connectHitsPerPage', () => {
       createURL: state => state,
     });
 
-    const { createURL } = rendering.mock.calls[0][0];
+    const createURLAtInit = rendering.mock.calls[0][0].createURL;
     expect(helper.getQueryParameter('hitsPerPage')).toEqual(20);
-    const URLState = createURL(3);
-    expect(URLState.hitsPerPage).toEqual(3);
+    const URLStateAtInit = createURLAtInit(3);
+    expect(URLStateAtInit.hitsPerPage).toEqual(3);
+
+    widget.render({
+      results: new SearchResults(helper.state, [{}]),
+      state: helper.state,
+      createURL: state => state,
+    });
+
+    const createURLAtRender = rendering.mock.calls[1][0].createURL;
+    const URLStateAtRender = createURLAtRender(5);
+    expect(URLStateAtRender.hitsPerPage).toEqual(5);
   });
 
   it('provides the current hitsPerPage value', () => {

--- a/src/connectors/hits-per-page/connectHitsPerPage.js
+++ b/src/connectors/hits-per-page/connectHitsPerPage.js
@@ -170,10 +170,13 @@ Learn more: https://community.algolia.com/instantsearch.js/v2/widgets/configure.
             ? helper.setQueryParameter('hitsPerPage', undefined).search()
             : helper.setQueryParameter('hitsPerPage', value).search();
 
-        createURLFn = value => {
-          this.setHitsPerPage(value);
-          return createURL(helper.state);
-        };
+        createURLFn = value =>
+          createURL(
+            helper.state.setQueryParameter(
+              'hitsPerPage',
+              !value && value !== 0 ? undefined : value
+            )
+          );
 
         renderFn(
           {

--- a/src/connectors/hits-per-page/connectHitsPerPage.js
+++ b/src/connectors/hits-per-page/connectHitsPerPage.js
@@ -7,6 +7,7 @@ const usage = `Usage:
 var customHitsPerPage = connectHitsPerPage(function render(params, isFirstRendering) {
   // params = {
   //   items,
+  //   createURL,
   //   refine,
   //   hasNoResults,
   //   instantSearchInstance,
@@ -43,6 +44,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
 /**
  * @typedef {Object} HitsPerPageRenderingOptions
  * @property {HitsPerPageRenderingOptionsItem[]} items Array of objects defining the different values and labels.
+ * @property {function(item.value)} createURL Creates the URL for a single item name in the list.
  * @property {function(number)} refine Sets the number of hits per page and trigger a search.
  * @property {boolean} hasNoResults `true` if the last search contains no result.
  * @property {Object} widgetParams Original `HitsPerPageWidgetOptions` forwarded to `renderFn`.
@@ -115,6 +117,7 @@ export default function connectHitsPerPage(renderFn, unmountFn) {
   return (widgetParams = {}) => {
     const { items: userItems, transformItems = items => items } = widgetParams;
     let items = userItems;
+    let createURLFn;
 
     if (!items) {
       throw new Error(usage);
@@ -137,7 +140,7 @@ The first one will be picked, you should probably set only one default value`
           : {};
       },
 
-      init({ helper, state, instantSearchInstance }) {
+      init({ helper, createURL, state, instantSearchInstance }) {
         const isCurrentInOptions = some(
           items,
           item => Number(state.hitsPerPage) === Number(item.value)
@@ -167,10 +170,16 @@ Learn more: https://community.algolia.com/instantsearch.js/v2/widgets/configure.
             ? helper.setQueryParameter('hitsPerPage', undefined).search()
             : helper.setQueryParameter('hitsPerPage', value).search();
 
+        createURLFn = value => {
+          this.setHitsPerPage(value);
+          return createURL(helper.state);
+        };
+
         renderFn(
           {
             items: transformItems(this._normalizeItems(state)),
             refine: this.setHitsPerPage,
+            createURL: createURLFn,
             hasNoResults: true,
             widgetParams,
             instantSearchInstance,
@@ -186,6 +195,7 @@ Learn more: https://community.algolia.com/instantsearch.js/v2/widgets/configure.
           {
             items: transformItems(this._normalizeItems(state)),
             refine: this.setHitsPerPage,
+            createURL: createURLFn,
             hasNoResults,
             widgetParams,
             instantSearchInstance,

--- a/src/connectors/hits-per-page/connectHitsPerPage.js
+++ b/src/connectors/hits-per-page/connectHitsPerPage.js
@@ -117,7 +117,6 @@ export default function connectHitsPerPage(renderFn, unmountFn) {
   return (widgetParams = {}) => {
     const { items: userItems, transformItems = items => items } = widgetParams;
     let items = userItems;
-    let createURLFn;
 
     if (!items) {
       throw new Error(usage);
@@ -170,9 +169,9 @@ Learn more: https://community.algolia.com/instantsearch.js/v2/widgets/configure.
             ? helper.setQueryParameter('hitsPerPage', undefined).search()
             : helper.setQueryParameter('hitsPerPage', value).search();
 
-        createURLFn = value =>
+        this.createURL = state => value =>
           createURL(
-            helper.state.setQueryParameter(
+            state.setQueryParameter(
               'hitsPerPage',
               !value && value !== 0 ? undefined : value
             )
@@ -182,7 +181,7 @@ Learn more: https://community.algolia.com/instantsearch.js/v2/widgets/configure.
           {
             items: transformItems(this._normalizeItems(state)),
             refine: this.setHitsPerPage,
-            createURL: createURLFn,
+            createURL: this.createURL(helper.state),
             hasNoResults: true,
             widgetParams,
             instantSearchInstance,
@@ -198,7 +197,7 @@ Learn more: https://community.algolia.com/instantsearch.js/v2/widgets/configure.
           {
             items: transformItems(this._normalizeItems(state)),
             refine: this.setHitsPerPage,
-            createURL: createURLFn,
+            createURL: this.createURL(state),
             hasNoResults,
             widgetParams,
             instantSearchInstance,

--- a/src/connectors/hits-per-page/connectHitsPerPage.js
+++ b/src/connectors/hits-per-page/connectHitsPerPage.js
@@ -169,9 +169,9 @@ Learn more: https://community.algolia.com/instantsearch.js/v2/widgets/configure.
             ? helper.setQueryParameter('hitsPerPage', undefined).search()
             : helper.setQueryParameter('hitsPerPage', value).search();
 
-        this.createURL = state => value =>
+        this.createURL = helperState => value =>
           createURL(
-            state.setQueryParameter(
+            helperState.setQueryParameter(
               'hitsPerPage',
               !value && value !== 0 ? undefined : value
             )


### PR DESCRIPTION
The `createURL` parameter was missing from `connectHitsPerPage`.