### PR TITLE
fix(panel): bind widget methods from panel

### DIFF
--- a/src/widgets/panel/panel.js
+++ b/src/widgets/panel/panel.js
@@ -129,33 +129,25 @@ export default function panel({
         container: getContainerNode(bodyRef),
       });
 
-      // All widget's methods need to be bound to not lose the `this`
-      // context when called from the `panel` widget.
-      // We need to check the type of the widget's attributes before binding them
-      // because some are not methods.
-      Object.keys(widget)
-        .filter(attribute => typeof widget[attribute] === 'function')
-        .forEach(method => {
-          widget[method] = widget[method].bind(widget);
-        });
-
       return {
         ...widget,
-        dispose(options) {
+        dispose(...args) {
           unmountComponentAtNode(getContainerNode(container));
 
           if (typeof widget.dispose === 'function') {
-            widget.dispose(options);
+            widget.dispose.call(this, ...args);
           }
         },
-        render(options) {
+        render(...args) {
+          const [options] = args;
+
           renderPanel({
             options,
             hidden: Boolean(hidden(options)),
           });
 
           if (typeof widget.render === 'function') {
-            widget.render(options);
+            widget.render.call(this, ...args);
           }
         },
       };

--- a/src/widgets/panel/panel.js
+++ b/src/widgets/panel/panel.js
@@ -129,13 +129,23 @@ export default function panel({
         container: getContainerNode(bodyRef),
       });
 
+      // All widget's methods need to be bound to not lose the `this`
+      // context when called from the `panel` widget.
+      // We need to check the type of the widget's attributes before binding them
+      // because some are not methods.
+      Object.keys(widget)
+        .filter(attribute => typeof widget[attribute] === 'function')
+        .forEach(method => {
+          widget[method] = widget[method].bind(widget);
+        });
+
       return {
         ...widget,
-        dispose() {
+        dispose(options) {
           unmountComponentAtNode(getContainerNode(container));
 
           if (typeof widget.dispose === 'function') {
-            widget.dispose();
+            widget.dispose(options);
           }
         },
         render(options) {

--- a/storybook/app/builtin/stories/panel.stories.js
+++ b/storybook/app/builtin/stories/panel.stories.js
@@ -33,7 +33,6 @@ export default () => {
           instantsearch.widgets.panel({
             templates: {
               header: ({ results }) =>
-                console.log(results) ||
                 `Header ${results ? `| ${results.nbHits} results` : ''}`,
               footer: 'Footer',
             },

--- a/storybook/app/builtin/stories/panel.stories.js
+++ b/storybook/app/builtin/stories/panel.stories.js
@@ -7,22 +7,60 @@ import { wrapWithHits } from '../../utils/wrap-with-hits.js';
 const stories = storiesOf('Panel');
 
 export default () => {
-  stories.add(
-    'with default',
-    wrapWithHits(container => {
-      window.search.addWidget(
-        instantsearch.widgets.panel({
-          templates: {
-            header: ({ results }) =>
-              `Header ${results ? `| ${results.nbHits} results` : ''}`,
-            footer: 'Footer',
-          },
-          hidden: ({ results }) => results.nbHits === 0,
-        })(instantsearch.widgets.refinementList)({
-          container,
-          attribute: 'brand',
-        })
-      );
-    })
-  );
+  stories
+    .add(
+      'with default',
+      wrapWithHits(container => {
+        window.search.addWidget(
+          instantsearch.widgets.panel({
+            templates: {
+              header: ({ results }) =>
+                `Header ${results ? `| ${results.nbHits} results` : ''}`,
+              footer: 'Footer',
+            },
+            hidden: ({ results }) => results.nbHits === 0,
+          })(instantsearch.widgets.refinementList)({
+            container,
+            attribute: 'brand',
+          })
+        );
+      })
+    )
+    .add(
+      'with ratingMenu',
+      wrapWithHits(container => {
+        window.search.addWidget(
+          instantsearch.widgets.panel({
+            templates: {
+              header: ({ results }) =>
+                console.log(results) ||
+                `Header ${results ? `| ${results.nbHits} results` : ''}`,
+              footer: 'Footer',
+            },
+            hidden: ({ results }) => results.nbHits === 0,
+          })(instantsearch.widgets.ratingMenu)({
+            container,
+            attribute: 'price',
+          })
+        );
+      })
+    )
+    .add(
+      'with menu',
+      wrapWithHits(container => {
+        window.search.addWidget(
+          instantsearch.widgets.panel({
+            templates: {
+              header: ({ results }) =>
+                `Header ${results ? `| ${results.nbHits} results` : ''}`,
+              footer: 'Footer',
+            },
+            hidden: ({ results }) => results.nbHits === 0,
+          })(instantsearch.widgets.menu)({
+            container,
+            attribute: 'brand',
+          })
+        );
+      })
+    );
 };


### PR DESCRIPTION
All widget's methods need to be bound to not lose the `this` context when called from the `panel` widget.
We need to check the type of the widget's attributes before binding them because some are not methods.

An example of a previously failing widget using `panel` is `ratingMenu`.

Closes #3347.