### PR TITLE
feat(tourism): migrate example

### DIFF
--- a/docgen/layouts/example.pug
+++ b/docgen/layouts/example.pug
@@ -4,6 +4,9 @@ head
   title=title
   link(rel='stylesheet', href='https://cdn.jsdelivr.net/bootstrap/3.3.5/css/bootstrap.min.css')
   link(rel='stylesheet', href='https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css')
+  if stylesheets
+    each stylesheet in stylesheets
+      link(rel='stylesheet', href=stylesheet)
   link(href='https://fonts.googleapis.com/css?family=Roboto', rel='stylesheet', type='text/css')
   link(rel='stylesheet', type='text/css', href='main.css')
   script(src='https://cdn.polyfill.io/v2/polyfill.min.js?features=default,Array.prototype.includes')

--- a/docgen/src/examples/tourism/index.html
+++ b/docgen/src/examples/tourism/index.html
@@ -1,14 +1,19 @@
 ---
 layout: example.pug
 title: Geo search by Algolia
+stylesheets:
+  - https://cdn.jsdelivr.net/npm/instantsearch.css@7.1.0/themes/reset-min.css
 ---
+
 <!-- Header -->
 <div class="container-fluid" style="padding-left: 0; padding-right: 0;">
   <header class="navbar navbar-static-top aisdemo-navbar">
-    <a href="https://community.algolia.com/instantsearch.js/" class="is-logo"><img src="logo-is.png" width=40 ></a>
+    <a href="https://community.algolia.com/instantsearch.js/" class="is-logo">
+      <img src="logo-is.png" width=40 />
+    </a>
     <a href="./" class="logo">A</a>
     <i class="fa fa-search"></i>
-    <input type="text" class="form-control" id="q" />
+    <div id="search-box"></div>
   </header>
 </div>
 <!-- /Header -->
@@ -68,9 +73,8 @@ title: Geo search by Algolia
   </div>
 </div>
 <!-- /Results -->
-<script src="https://cdn.jsdelivr.net/react/15.5.4/react.min.js" async></script>
-<script src="https://cdn.jsdelivr.net/react/15.5.4/react-dom.min.js" async></script>
-<script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBawL8VbstJDdU5397SUX7pEt9DslAwWgQ" async></script>
-<script src="https://cdn.jsdelivr.net/instantsearch-googlemaps/1/instantsearch-googlemaps.min.js" async></script>
-<script src="https://cdn.jsdelivr.net/npm/algoliasearch@3.30.0"></script>
+
+<script src="https://cdn.jsdelivr.net/npm/scriptjs@2.5.9/dist/script.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/algoliasearch@3.32.0"></script>
+<script src="https://cdn.jsdelivr.net/npm/instantsearch.js@3.0.0"></script>
 <script src="search.js"></script>

--- a/docgen/src/examples/tourism/main.scss
+++ b/docgen/src/examples/tourism/main.scss
@@ -59,32 +59,39 @@ body {
     color: $aisdemo-color-gray-light;
   }
 
-  .ais-search-box {
+  .ais-SearchBox {
     position: absolute;
     top: 0;
     left: 180px;
     height: 100%;
     width: 33%;
+  }
 
-    &--reset {
-      fill: #BFC7D8;
-      top: calc(50% - 12px / 2);
-      right: 13px;
-    }
+  .ais-SearchBox-form {
+    position: absolute;
+    top: 15px;
+    width: 300px;
+    height: 40px;
+    border: 0;
+    box-shadow: none;
+  }
 
-    #q {
-      position: absolute;
-      top: 15px;
-      width: 300px;
-      height: 40px;
-      border: 0;
+  .ais-SearchBox-input {
+    position: absolute;
+    border: 0;
+    box-shadow: none;
+
+    &:focus {
+      outline: none;
       box-shadow: none;
-
-      &:focus {
-        outline: none;
-        box-shadow: none;
-      }
     }
+  }
+
+  .ais-SearchBox-reset {
+    position: absolute;
+    top: calc(50% - 25px / 2);
+    right: 13px;
+    fill: #BFC7D8;
   }
 }
 
@@ -143,11 +150,11 @@ body {
 
   #room_types {
 
-    .ais-refinement-list--count {
+    .ais-RefinementList-count {
       display: none;
     }
 
-    .ais-refinement-list--item {
+    .ais-RefinementList-item {
       display: inline-block;
       cursor: pointer;
 
@@ -161,7 +168,7 @@ body {
       }
     }
 
-    .ais-refinement-list--checkbox {
+    .ais-RefinementList-checkbox {
       position: relative;
       bottom: 3px;
       float: right;
@@ -178,9 +185,9 @@ body {
       }
     }
 
-    .ais-refinement-list--item__active {
+    .ais-RefinementList-item--selected {
 
-      .ais-refinement-list--checkbox {
+      .ais-RefinementList-checkbox {
 
         &::before {
           font-size: .85em;
@@ -196,11 +203,11 @@ body {
 
   #price {
 
-    .ais-range-slider--target {
+    .ais-RangeSlider-target {
       margin: 30px 9px 18px;
     }
 
-    .ais-range-slider--handle {
+    .ais-RangeSlider-handle {
       border-color: $aisdemo-primary-color;
     }
 
@@ -208,15 +215,8 @@ body {
       background-color: $aisdemo-primary-color !important;
     }
 
-    .ais-range-slider--tooltip {
-
-      &:last-child {
-        right: 0;
-      }
-    }
-
-    .ais-range-slider--connect {
-      background-color: $aisdemo-primary-color;
+    .rheostat-tooltip {
+      font-size: 0.8em;
     }
   }
 }
@@ -239,6 +239,25 @@ body {
   height: 400px;
 }
 
+.ais-GeoSearch,
+.ais-GeoSearch-map {
+  height: 100%;
+}
+
+.ais-GeoSearch-reset {
+  display: block;
+  position: absolute;
+  left: 50%;
+  bottom: 20px;
+  -webkit-transform: translateX(-50%);
+  transform: translateX(-50%);
+  background-color: #ff585b;
+  color: #fff;
+  padding: 5px;
+  border-radius: 3px;
+  font-size: 0.85em;
+}
+
 
 /* RESULTS
 // ------------------------- */
@@ -249,44 +268,48 @@ body {
 
 #hits {
 
-  .hit {
+  .ais-Hits-list {
+    list-style: none;
 
-    .pictures-wrapper {
-      position: relative;
+    .hit {
 
-      .picture {
-        width: 100%;
+      .pictures-wrapper {
+        position: relative;
+
+        .picture {
+          width: 100%;
+        }
+
+        .profile {
+          position: absolute;
+          bottom: -16px;
+          right: 12px;
+          width: 60px;
+          border: 4px solid rgba(255, 255, 255, .3);
+          border-radius: 30px;
+        }
       }
 
-      .profile {
-        position: absolute;
-        bottom: -16px;
-        right: 12px;
-        width: 60px;
-        border: 4px solid rgba(255, 255, 255, .3);
-        border-radius: 30px;
+      .infos {
+        height: 90px;
+        padding: 16px 20px;
+
+        h4 {
+          font-size: 1em;
+          font-weight: normal;
+        }
+
+        p {
+          font-size: .8em;
+          color: $aisdemo-text-lighter-color;
+        }
+
+        em {
+          font-style: normal;
+          color: $aisdemo-primary-color;
+        }
+
       }
-    }
-
-    .infos {
-      height: 90px;
-      padding: 16px 20px;
-
-      h4 {
-        font-size: 1em;
-        font-weight: normal;
-      }
-
-      p {
-        font-size: .8em;
-        color: $aisdemo-text-lighter-color;
-      }
-
-      em {
-        font-style: normal;
-        color: $aisdemo-primary-color;
-      }
-
     }
   }
 }
@@ -297,12 +320,18 @@ body {
 #pagination {
   text-align: center;
 
-  .ais-pagination--item {
-    display: inline-block;
-    margin: 1px;
+  .ais-Pagination-list {
+    justify-content: center;
+    margin: 20px 0;
   }
 
-  .ais-pagination--link {
+  .ais-Pagination-item {
+    display: inline-block;
+    margin: 1px;
+    padding: 3px;
+  }
+
+  .ais-Pagination-link {
     color: $aisdemo-primary-color;
     border-radius: 4px;
     background: transparent;
@@ -316,7 +345,8 @@ body {
 
   .pagination > li > a, .pagination > li > span {
 
-    &:focus, &:hover {
+    &:focus,
+    &:hover {
       color: $aisdemo-color-white;
       border-color: $aisdemo-primary-color;
       background: $aisdemo-primary-color;

--- a/docgen/src/examples/tourism/search.js
+++ b/docgen/src/examples/tourism/search.js
@@ -1,6 +1,6 @@
-/* global instantsearch algoliasearch */
+/* global instantsearch algoliasearch $script */
 
-window.addEventListener('load', function() {
+$script('https://maps.googleapis.com/maps/api/js?v=weekly&key=AIzaSyBawL8VbstJDdU5397SUX7pEt9DslAwWgQ', function() {
   var search = instantsearch({
     searchClient: algoliasearch('latency', '6be0576ff61c053d5f9a3225e2a90f76'),
     indexName: 'airbnb',
@@ -8,10 +8,20 @@ window.addEventListener('load', function() {
   });
 
   search.addWidget(
+    instantsearch.widgets.configure({
+      aroundLatLngViaIP: true,
+      hitsPerPage: 12,
+    })
+  );
+
+  search.addWidget(
     instantsearch.widgets.searchBox({
-      container: '#q',
+      container: '#search-box',
       placeholder: 'Where are you going?',
-      showSubmit: false
+      showSubmit: false,
+      cssClasses: {
+        input: 'form-control',
+      }
     })
   );
 
@@ -38,7 +48,6 @@ window.addEventListener('load', function() {
   search.addWidget(
     instantsearch.widgets.hits({
       container: '#hits',
-      hitsPerPage: 12,
       templates: {
         empty: noResultsTemplate,
         item: hitTemplate
@@ -51,8 +60,8 @@ window.addEventListener('load', function() {
       container: '#pagination',
       scrollTo: '#results',
       cssClasses: {
-        root: 'pagination',
-        active: 'active'
+        list: 'pagination',
+        selectedItem: 'active'
       }
     })
   );
@@ -60,31 +69,39 @@ window.addEventListener('load', function() {
   search.addWidget(
     instantsearch.widgets.refinementList({
       container: '#room_types',
-      attributeName: 'room_type',
-      operator: 'or',
-      cssClasses: {item: ['col-sm-3']},
-      limit: 10,
-      sortBy: ['name:asc']
+      attribute: 'room_type',
+      sortBy: ['name:asc'],
+      cssClasses: {
+        item: ['col-sm-3']
+      },
     })
   );
 
   search.addWidget(
     instantsearch.widgets.rangeSlider({
       container: '#price',
-      attributeName: 'price',
+      attribute: 'price',
       pips: false,
-      tooltips: {format: function(rawValue) {return '$' + parseInt(rawValue)}}
+      tooltips: {
+        format: function(rawValue) {
+          return '$' + parseInt(rawValue);
+        },
+      },
     })
-    );
+  );
 
   search.addWidget(
-    instantsearch.widgets.googleMaps({
-      container: document.querySelector('#map'),
-      prepareMarkerData: function(hit, index, hits) {
-        return {
-          title: hit.description
-        };
-      }
+    instantsearch.widgets.geoSearch({
+      container: '#map',
+      googleReference: window.google,
+      enableRefineControl: false,
+      builtInMarker: {
+        createOption: function(hit) {
+          return {
+            title: hit.description
+          };
+        },
+      },
     })
   );
 

--- a/docgen/src/examples/tourism/search.js
+++ b/docgen/src/examples/tourism/search.js
@@ -38,8 +38,12 @@ $script('https://maps.googleapis.com/maps/api/js?v=weekly&key=AIzaSyBawL8VbstJDd
       '<img class="profile" src="{{user.user.thumbnail_url}}" />' +
     '</div>' +
     '<div class="infos">' +
-    '<h4 class="media-heading">{{{_highlightResult.name.value}}}</h4>' +
-    '<p>{{room_type}} - {{{_highlightResult.city.value}}}, {{{_highlightResult.country.value}}}</p>' +
+    '<h4 class="media-heading">{{#helpers.highlight}}{ "attribute": "name" }{{/helpers.highlight}}</h4>' +
+    '<p>' +
+    '{{room_type}} - ' +
+    '{{#helpers.highlight}}{ "attribute": "city" }{{/helpers.highlight}},'+
+    '{{#helpers.highlight}}{ "attribute": "country" }{{/helpers.highlight}}' +
+    '</p>' +
     '</div>' +
     '</div>';
 


### PR DESCRIPTION
Move the example to `instantsearch.js@3.0.0`. Note that depending the size of the page the map can zoom out. It's a know issue that we have with Google Maps and float dimensions (see [#1737](https://github.com/algolia/react-instantsearch/issues/1737)). It's possible to fix it with fixed (integer) dimension. We gonna try to fix it directly inside the lib but we didn't have the time to take a look yet.

> https://deploy-preview-3373--instantsearchjs.netlify.com/examples/tourism