### PR TITLE
build(ci): run bundlesize on development bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,6 +176,9 @@
     {
       "path": "./dist/instantsearch.production.min.js",
       "maxSize": "90 kB"
+    },
+    {
+      "path": "./dist/instantsearch.development.js"
     }
   ]
 }


### PR DESCRIPTION
Although the development bundle is not limited to any size, it's useful to add it to the tracked bundles in order to see how the bundle size changes in PRs compared to the production bundle.

[See result →](https://bundlesize-store.now.sh/build?info=%7B%22files%22%3A%5B%7B%22maxSize%22%3A92160%2C%22path%22%3A%22.%2Fdist%2Finstantsearch.production.min.js%22%2C%22size%22%3A86482%2C%22compression%22%3A%22gzip%22%2C%22master%22%3A86563%7D%2C%7B%22maxSize%22%3Anull%2C%22path%22%3A%22.%2Fdist%2Finstantsearch.development.js%22%2C%22size%22%3A227360%2C%22compression%22%3A%22gzip%22%7D%5D%2C%22repo%22%3A%22algolia%2Finstantsearch.js%22%2C%22branch%22%3A%22ci%2Fbundlesize-development%22%2C%22commit_message%22%3A%22build(ci)%3A%20run%20bundlesize%20on%20development%20bundle%5Cn%5CnAlthough%20the%20development%20bundle%20is%20not%20limited%20to%20any%20size%2C%20it%27s%20useful%20to%20add%20it%20to%20the%20tracked%20bundles%20in%20order%20to%20see%20how%20the%20bundle%20size%20changes%20in%20PRs%20compared%20to%20the%20production%20bundle.%22%2C%22sha%22%3A%22b2d473c02d30de49edb0079dca8be689d4067fed%22%7D)