### PR TITLE
fix(core): make sure instance.dispose sets started flag

### DIFF
--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -339,6 +339,7 @@ class InstantSearch extends EventEmitter {
    */
   dispose() {
     this.removeWidgets(this.widgets);
+    this.started = false;
   }
 
   createURL(params) {

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -508,11 +508,13 @@ describe('InstantSearch lifecycle', () => {
 
     expect(search.widgets).toHaveLength(5);
     expect(helperSearchSpy).toHaveBeenCalledTimes(1);
+    expect(search.started).toBe(true);
 
     search.dispose();
 
     expect(search.widgets).toHaveLength(0);
     expect(helperSearchSpy).toHaveBeenCalledTimes(1);
+    expect(search.started).toBe(false);
   });
 });
 


### PR DESCRIPTION
This can not immediately cause any bugs; but in Vue InstantSearch we were manually calling `render` before `init` gets called. Since `render` itself (obviously) assumes the search is already done, it uses helper functions of past-search.

This fix prevents such a situation, since `started` would be false as long as the next search has not yet been done

see also https://github.com/algolia/vue-instantsearch/pull/607
