### PR TITLE
fix(core): dispose sets helper to null

### DIFF
--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -340,6 +340,7 @@ class InstantSearch extends EventEmitter {
   dispose() {
     this.removeWidgets(this.widgets);
     this.started = false;
+    this.helper = null;
   }
 
   createURL(params) {

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -516,6 +516,21 @@ describe('InstantSearch lifecycle', () => {
     expect(helperSearchSpy).toHaveBeenCalledTimes(1);
     expect(search.started).toBe(false);
   });
+
+  it('should set the helper to `null`', () => {
+    search = new InstantSearch({
+      indexName,
+      searchClient: algoliasearch(appId, apiKey),
+    });
+
+    search.start();
+
+    expect(search.helper).not.toBe(null);
+
+    search.dispose();
+
+    expect(search.helper).toBe(null);
+  });
 });
 
 it('Allows to start without widgets', () => {


### PR DESCRIPTION
Without this change, if you dispose an instance and start it again, a search (not necessarily a request, since the cache isn't cleared) should be done again with a fresh state, and not the state of before the dispose

similar to #3399
