### PR TITLE
fix(InstantSearch): remove event listeners

### DIFF
--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -345,6 +345,7 @@ class InstantSearch extends EventEmitter {
 
     // The helper needs to be reset to perform the next search from a fresh state.
     // If not reset, it would use the state stored before calling `dispose()`.
+    this.helper.removeAllListeners();
     this.helper = null;
   }
 

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -547,6 +547,33 @@ describe('dispose', () => {
 
     expect(search.helper).not.toBe(null);
   });
+
+  it('should remove the listeners on the helper', done => {
+    const search = new InstantSearch({
+      indexName: '',
+      searchClient: {
+        search() {
+          return Promise.resolve({
+            results: [
+              {
+                query: 'fake query',
+              },
+            ],
+          });
+        },
+      },
+    });
+
+    search.on('error', () => {
+      done.fail('InstantSearch should not throw an error.');
+    });
+
+    search.start();
+
+    search.dispose();
+
+    done();
+  });
 });
 
 it('Allows to start without widgets', () => {

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -522,7 +522,17 @@ describe('dispose', () => {
   it('should set the helper to `null`', () => {
     const search = new InstantSearch({
       indexName: '',
-      searchClient: { async search() {} },
+      searchClient: {
+        search() {
+          return Promise.resolve({
+            results: [
+              {
+                query: 'fake query',
+              },
+            ],
+          });
+        },
+      },
     });
 
     search.start();


### PR DESCRIPTION
**Summary**

We recently updated the `dispose` function to set the `helper` to `null`. It's indeed the right approach but it might happen that a `render` occurs after the `dispose` e.g `start` → `dispose` right after the start. The search is async so the render is called after we set the helper to null and it throws an error. To avoid this issue we have to remove the listeners on the helper before we lose his reference.