### PR TITLE
chore(bundlesize): set max size for development bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,8 @@
       "maxSize": "80 kB"
     },
     {
-      "path": "./dist/instantsearch.development.js"
+      "path": "./dist/instantsearch.development.js",
+      "maxSize": "250 kB"
     }
   ]
 }


### PR DESCRIPTION
There are inconsistencies in how Bundlesize CLI and Bundlesize GitHub integration (showing `NaN`) behave so I added a size limit to the development bundle.

The development bundle will decrease when removing the JSDoc and hopefully increase when we add more warnings.