### PR TITLE
test(Hits): drop Rewire usage

### DIFF
--- a/src/widgets/hits/__tests__/__snapshots__/hits-test.js.snap
+++ b/src/widgets/hits/__tests__/__snapshots__/hits-test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`hits() calls twice ReactDOM.render(<Hits props />, container) 1`] = `
+exports[`hits() calls twice render(<Hits props />, container) 1`] = `
 <Hits
   cssClasses={
     Object {
@@ -44,7 +44,7 @@ exports[`hits() calls twice ReactDOM.render(<Hits props />, container) 1`] = `
 />
 `;
 
-exports[`hits() calls twice ReactDOM.render(<Hits props />, container) 2`] = `
+exports[`hits() calls twice render(<Hits props />, container) 2`] = `
 <Hits
   cssClasses={
     Object {

--- a/src/widgets/hits/__tests__/hits-test.js
+++ b/src/widgets/hits/__tests__/hits-test.js
@@ -1,5 +1,14 @@
-import hits from '../hits';
+import { render } from 'preact-compat';
 import defaultTemplates from '../defaultTemplates';
+import hits from '../hits';
+
+jest.mock('preact-compat', () => {
+  const module = require.requireActual('preact-compat');
+
+  module.render = jest.fn();
+
+  return module;
+});
 
 describe('hits call', () => {
   it('throws an exception when no container', () => {
@@ -8,15 +17,13 @@ describe('hits call', () => {
 });
 
 describe('hits()', () => {
-  let ReactDOM;
   let container;
   let templateProps;
   let widget;
   let results;
 
   beforeEach(() => {
-    ReactDOM = { render: jest.fn() };
-    hits.__Rewire__('render', ReactDOM.render);
+    render.mockClear();
 
     container = document.createElement('div');
     templateProps = {
@@ -29,15 +36,15 @@ describe('hits()', () => {
     results = { hits: [{ first: 'hit', second: 'hit' }] };
   });
 
-  it('calls twice ReactDOM.render(<Hits props />, container)', () => {
+  it('calls twice render(<Hits props />, container)', () => {
     widget.render({ results });
     widget.render({ results });
 
-    expect(ReactDOM.render).toHaveBeenCalledTimes(2);
-    expect(ReactDOM.render.mock.calls[0][0]).toMatchSnapshot();
-    expect(ReactDOM.render.mock.calls[0][1]).toEqual(container);
-    expect(ReactDOM.render.mock.calls[1][0]).toMatchSnapshot();
-    expect(ReactDOM.render.mock.calls[1][1]).toEqual(container);
+    expect(render).toHaveBeenCalledTimes(2);
+    expect(render.mock.calls[0][0]).toMatchSnapshot();
+    expect(render.mock.calls[0][1]).toEqual(container);
+    expect(render.mock.calls[1][0]).toMatchSnapshot();
+    expect(render.mock.calls[1][1]).toEqual(container);
   });
 
   it('renders transformed items', () => {
@@ -50,16 +57,12 @@ describe('hits()', () => {
     widget.init({ instantSearchInstance: {} });
     widget.render({ results });
 
-    expect(ReactDOM.render.mock.calls[0][0]).toMatchSnapshot();
+    expect(render.mock.calls[0][0]).toMatchSnapshot();
   });
 
   it('does not accept both item and allItems templates', () => {
     expect(
       hits.bind({ container, templates: { item: '', allItems: '' } })
     ).toThrow();
-  });
-
-  afterEach(() => {
-    hits.__ResetDependency__('render');
   });
 });


### PR DESCRIPTION
**Summary**

The PR drops the usage of Rewire for the Hits tests.