### PR TITLE
test(InfiniteHits): drop Rewire usage

### DIFF
--- a/src/widgets/infinite-hits/__tests__/__snapshots__/infinite-hits-test.js.snap
+++ b/src/widgets/infinite-hits/__tests__/__snapshots__/infinite-hits-test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`infiniteHits() calls twice ReactDOM.render(<Hits props />, container) 1`] = `
+exports[`infiniteHits() calls twice render(<Hits props />, container) 1`] = `
 <InfiniteHits
   cssClasses={
     Object {
@@ -50,7 +50,7 @@ exports[`infiniteHits() calls twice ReactDOM.render(<Hits props />, container) 1
 />
 `;
 
-exports[`infiniteHits() calls twice ReactDOM.render(<Hits props />, container) 2`] = `
+exports[`infiniteHits() calls twice render(<Hits props />, container) 2`] = `
 <InfiniteHits
   cssClasses={
     Object {

--- a/src/widgets/infinite-hits/__tests__/infinite-hits-test.js
+++ b/src/widgets/infinite-hits/__tests__/infinite-hits-test.js
@@ -51,7 +51,7 @@ describe('infiniteHits()', () => {
     widget.render({ results, state });
     widget.render({ results, state });
 
-    expect(render).toHaveBeenCalledTimes(2, 'render called twice');
+    expect(render).toHaveBeenCalledTimes(2);
     expect(render.mock.calls[0][0]).toMatchSnapshot();
     expect(render.mock.calls[0][1]).toEqual(container);
     expect(render.mock.calls[1][0]).toMatchSnapshot();

--- a/src/widgets/infinite-hits/__tests__/infinite-hits-test.js
+++ b/src/widgets/infinite-hits/__tests__/infinite-hits-test.js
@@ -89,7 +89,7 @@ describe('infiniteHits()', () => {
       state,
     });
 
-    expect(render).toHaveBeenCalledTimes(2, 'render called twice');
+    expect(render).toHaveBeenCalledTimes(2);
     expect(render.mock.calls[0][0]).toMatchSnapshot();
     expect(render.mock.calls[0][1]).toEqual(container);
     expect(render.mock.calls[1][0]).toMatchSnapshot();

--- a/src/widgets/infinite-hits/__tests__/infinite-hits-test.js
+++ b/src/widgets/infinite-hits/__tests__/infinite-hits-test.js
@@ -1,6 +1,15 @@
+import { render } from 'preact-compat';
 import algoliasearchHelper from 'algoliasearch-helper';
 import { TAG_PLACEHOLDER } from '../../../lib/escape-highlight';
 import infiniteHits from '../infinite-hits';
+
+jest.mock('preact-compat', () => {
+  const module = require.requireActual('preact-compat');
+
+  module.render = jest.fn();
+
+  return module;
+});
 
 describe('infiniteHits call', () => {
   it('throws an exception when no container', () => {
@@ -9,18 +18,16 @@ describe('infiniteHits call', () => {
 });
 
 describe('infiniteHits()', () => {
-  let ReactDOM;
   let container;
   let widget;
   let results;
   let helper;
 
   beforeEach(() => {
+    render.mockClear();
+
     helper = algoliasearchHelper({});
     helper.search = jest.fn();
-
-    ReactDOM = { render: jest.fn() };
-    infiniteHits.__Rewire__('render', ReactDOM.render);
 
     container = document.createElement('div');
     widget = infiniteHits({
@@ -39,23 +46,21 @@ describe('infiniteHits()', () => {
     });
   });
 
-  it('calls twice ReactDOM.render(<Hits props />, container)', () => {
+  it('calls twice render(<Hits props />, container)', () => {
     const state = { page: 0 };
     widget.render({ results, state });
     widget.render({ results, state });
 
-    expect(ReactDOM.render).toHaveBeenCalledTimes(
-      2,
-      'ReactDOM.render called twice'
-    );
-    expect(ReactDOM.render.mock.calls[0][0]).toMatchSnapshot();
-    expect(ReactDOM.render.mock.calls[0][1]).toEqual(container);
-    expect(ReactDOM.render.mock.calls[1][0]).toMatchSnapshot();
-    expect(ReactDOM.render.mock.calls[1][1]).toEqual(container);
+    expect(render).toHaveBeenCalledTimes(2, 'render called twice');
+    expect(render.mock.calls[0][0]).toMatchSnapshot();
+    expect(render.mock.calls[0][1]).toEqual(container);
+    expect(render.mock.calls[1][0]).toMatchSnapshot();
+    expect(render.mock.calls[1][1]).toEqual(container);
   });
 
   it('renders transformed items', () => {
     const state = { page: 0 };
+
     widget = infiniteHits({
       container,
       transformItems: items =>
@@ -63,13 +68,14 @@ describe('infiniteHits()', () => {
     });
 
     widget.init({ helper, instantSearchInstance: {} });
+
     widget.render({
       results,
       state,
       instantSearchInstance: {},
     });
 
-    expect(ReactDOM.render.mock.calls[0][0]).toMatchSnapshot();
+    expect(render.mock.calls[0][0]).toMatchSnapshot();
   });
 
   it('if it is the last page, then the props should contain isLastPage true', () => {
@@ -83,14 +89,11 @@ describe('infiniteHits()', () => {
       state,
     });
 
-    expect(ReactDOM.render).toHaveBeenCalledTimes(
-      2,
-      'ReactDOM.render called twice'
-    );
-    expect(ReactDOM.render.mock.calls[0][0]).toMatchSnapshot();
-    expect(ReactDOM.render.mock.calls[0][1]).toEqual(container);
-    expect(ReactDOM.render.mock.calls[1][0]).toMatchSnapshot();
-    expect(ReactDOM.render.mock.calls[1][1]).toEqual(container);
+    expect(render).toHaveBeenCalledTimes(2, 'render called twice');
+    expect(render.mock.calls[0][0]).toMatchSnapshot();
+    expect(render.mock.calls[0][1]).toEqual(container);
+    expect(render.mock.calls[1][0]).toMatchSnapshot();
+    expect(render.mock.calls[1][1]).toEqual(container);
   });
 
   it('does not accept allItems templates', () => {
@@ -114,9 +117,5 @@ describe('infiniteHits()', () => {
 
     expect(helper.state.page).toBe(1);
     expect(helper.search).toHaveBeenCalledTimes(1);
-  });
-
-  afterEach(() => {
-    infiniteHits.__ResetDependency__('render');
   });
 });


### PR DESCRIPTION
**Summary**

The PR drops the usage of Rewire for the InfiniteHits tests.