### PR TITLE
style(InstantSearch): remove remaining comment on Meteor.js issue

### DIFF
--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -1,5 +1,3 @@
-// we use the full path to the lite build to solve a meteor.js issue:
-// https://github.com/algolia/instantsearch.js/issues/1024#issuecomment-221618284
 import algoliasearchHelper from 'algoliasearch-helper';
 import mergeWith from 'lodash/mergeWith';
 import union from 'lodash/union';


### PR DESCRIPTION
This is a remaining comment from #1097 that should have been removed some time ago.

It was about an `algoliasearch` import that is not present anymore.