### PR TITLE
test(Stats): drop Rewire usage

### DIFF
--- a/src/widgets/stats/__tests__/__snapshots__/stats-test.js.snap
+++ b/src/widgets/stats/__tests__/__snapshots__/stats-test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`stats() calls twice ReactDOM.render(<Stats props />, container) 1`] = `
+exports[`stats() calls twice render(<Stats props />, container) 1`] = `
 <Stats
   cssClasses={
     Object {
@@ -30,7 +30,7 @@ exports[`stats() calls twice ReactDOM.render(<Stats props />, container) 1`] = `
 />
 `;
 
-exports[`stats() calls twice ReactDOM.render(<Stats props />, container) 2`] = `
+exports[`stats() calls twice render(<Stats props />, container) 2`] = `
 <Stats
   cssClasses={
     Object {

--- a/src/widgets/stats/__tests__/stats-test.js
+++ b/src/widgets/stats/__tests__/stats-test.js
@@ -1,4 +1,13 @@
+import { render } from 'preact-compat';
 import stats from '../stats';
+
+jest.mock('preact-compat', () => {
+  const module = require.requireActual('preact-compat');
+
+  module.render = jest.fn();
+
+  return module;
+});
 
 const instantSearchInstance = { templatesConfig: undefined };
 
@@ -9,15 +18,11 @@ describe('stats call', () => {
 });
 
 describe('stats()', () => {
-  let ReactDOM;
   let container;
   let widget;
   let results;
 
   beforeEach(() => {
-    ReactDOM = { render: jest.fn() };
-    stats.__Rewire__('render', ReactDOM.render);
-
     container = document.createElement('div');
     widget = stats({ container, cssClasses: { text: ['text', 'cx'] } });
     results = {
@@ -34,23 +39,22 @@ describe('stats()', () => {
       helper: { state: {} },
       instantSearchInstance,
     });
+
+    render.mockClear();
   });
 
   it('configures nothing', () => {
     expect(widget.getConfiguration).toEqual(undefined);
   });
 
-  it('calls twice ReactDOM.render(<Stats props />, container)', () => {
+  it('calls twice render(<Stats props />, container)', () => {
     widget.render({ results, instantSearchInstance });
     widget.render({ results, instantSearchInstance });
-    expect(ReactDOM.render).toHaveBeenCalledTimes(2);
-    expect(ReactDOM.render.mock.calls[0][0]).toMatchSnapshot();
-    expect(ReactDOM.render.mock.calls[0][1]).toEqual(container);
-    expect(ReactDOM.render.mock.calls[1][0]).toMatchSnapshot();
-    expect(ReactDOM.render.mock.calls[1][1]).toEqual(container);
-  });
 
-  afterEach(() => {
-    stats.__ResetDependency__('render');
+    expect(render).toHaveBeenCalledTimes(2);
+    expect(render.mock.calls[0][0]).toMatchSnapshot();
+    expect(render.mock.calls[0][1]).toEqual(container);
+    expect(render.mock.calls[1][0]).toMatchSnapshot();
+    expect(render.mock.calls[1][1]).toEqual(container);
   });
 });


### PR DESCRIPTION
This removes the usage of Rewire in the Stats tests.