### PR TITLE
chore: drop Rewire

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -135,7 +135,6 @@
       ],
       "plugins": [
         "@babel/plugin-proposal-class-properties",
-        "rewire",
         [
           "module-resolver",
           {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "babel-loader": "8.0.5",
     "babel-plugin-inline-replace-variables": "1.3.1",
     "babel-plugin-module-resolver": "3.1.3",
-    "babel-plugin-rewire": "1.2.0",
     "babel-plugin-syntax-jsx": "6.18.0",
     "babel-plugin-transform-react-pure-class-to-function": "1.0.1",
     "babel-plugin-transform-react-remove-prop-types": "0.4.23",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2220,11 +2220,6 @@ babel-plugin-module-resolver@3.1.3:
     reselect "^3.0.1"
     resolve "^1.4.0"
 
-babel-plugin-rewire@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-rewire/-/babel-plugin-rewire-1.2.0.tgz#822562d72ed2c84e47c0f95ee232c920853e9d89"
-  integrity sha512-JBZxczHw3tScS+djy6JPLMjblchGhLI89ep15H3SyjujIzlxo5nr6Yjo7AXotdeVczeBmWs0tF8PgJWDdgzAkQ==
-
 babel-plugin-syntax-jsx@6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"


### PR DESCRIPTION
**Summary**

The PR drops the Rewire plugin from the Babel configuration and dependencies.