### PR TITLE
fix(range): update error messages

### DIFF
--- a/src/connectors/range/__tests__/connectRange-test.js
+++ b/src/connectors/range/__tests__/connectRange-test.js
@@ -2,10 +2,31 @@ import jsHelper, {
   SearchResults,
   SearchParameters,
 } from 'algoliasearch-helper';
-
 import connectRange from '../connectRange';
 
 describe('connectRange', () => {
+  describe('Usage', () => {
+    it('throws without render function', () => {
+      expect(() => {
+        connectRange()({});
+      }).toThrowErrorMatchingInlineSnapshot(`
+"The render function is not valid (got type \\"undefined\\").
+
+See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input/js/#connector, https://www.algolia.com/doc/api-reference/widgets/range-slider/js/#connector"
+`);
+    });
+
+    it('throws without attribute', () => {
+      expect(() => {
+        connectRange(() => {})({ attribute: undefined });
+      }).toThrowErrorMatchingInlineSnapshot(`
+"The \`attribute\` option is required.
+
+See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input/js/#connector, https://www.algolia.com/doc/api-reference/widgets/range-slider/js/#connector"
+`);
+    });
+  });
+
   it('Renders during init and render', () => {
     // test that the dummyRendering is called with the isFirstRendering
     // flag set accordingly

--- a/src/connectors/range/connectRange.js
+++ b/src/connectors/range/connectRange.js
@@ -1,29 +1,16 @@
 import find from 'lodash/find';
 import _isFinite from 'lodash/isFinite';
+import {
+  checkRendering,
+  createDocumentationMessageGenerator,
+} from '../../lib/utils';
 
-import { checkRendering } from '../../lib/utils';
-
-const usage = `Usage:
-var customRange = connectRange(function render(params, isFirstRendering) {
-  // params = {
-  //   refine,
-  //   range,
-  //   start,
-  //   format,
-  //   instantSearchInstance,
-  //   widgetParams,
-  // }
-});
-search.addWidget(
-  customRange({
-    attribute,
-    [ min ],
-    [ max ],
-    [ precision = 2 ],
-  })
+const withUsage = createDocumentationMessageGenerator(
+  ['range-input', 'range-slider'],
+  {
+    connector: true,
+  }
 );
-Full documentation available at https://community.algolia.com/instantsearch.js/v2/connectors/connectRange.html
-`;
 
 /**
  * @typedef {Object} CustomRangeWidgetOptions
@@ -57,7 +44,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  * @return {function(CustomRangeWidgetOptions)} Re-usable widget factory for a custom **Range** widget.
  */
 export default function connectRange(renderFn, unmountFn) {
-  checkRendering(renderFn, usage);
+  checkRendering(renderFn, withUsage());
 
   return (widgetParams = {}) => {
     const {
@@ -68,7 +55,7 @@ export default function connectRange(renderFn, unmountFn) {
     } = widgetParams;
 
     if (!attribute) {
-      throw new Error(usage);
+      throw new Error(withUsage('The `attribute` option is required.'));
     }
 
     const hasMinBound = _isFinite(minBound);

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -484,11 +484,21 @@ function createDocumentationLink(widget, { connector = false } = {}) {
   ].join('');
 }
 
-function createDocumentationMessageGenerator(widget, { connector } = {}) {
-  const link = createDocumentationLink(widget, { connector });
+function createDocumentationMessageGenerator(
+  widgetOrWidgets,
+  { connector } = {}
+) {
+  const widgets = Array.isArray(widgetOrWidgets)
+    ? widgetOrWidgets
+    : [widgetOrWidgets];
+  const links = widgets
+    .map(widget => createDocumentationLink(widget, { connector }))
+    .join(', ');
 
   return function(message) {
-    return [message, `See documentation: ${link}`].filter(Boolean).join('\n\n');
+    return [message, `See documentation: ${links}`]
+      .filter(Boolean)
+      .join('\n\n');
   };
 }
 

--- a/src/widgets/range-input/__tests__/range-input-test.js
+++ b/src/widgets/range-input/__tests__/range-input-test.js
@@ -11,6 +11,17 @@ jest.mock('preact-compat', () => {
 });
 
 describe('rangeInput', () => {
+  describe('Usage', () => {
+    it('throws without container', () => {
+      expect(() => rangeInput({ container: undefined }))
+        .toThrowErrorMatchingInlineSnapshot(`
+"The \`container\` option is required.
+
+See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input/js/"
+`);
+    });
+  });
+
   const attribute = 'aNumAttr';
   const createContainer = () => document.createElement('div');
   const instantSearchInstance = {};
@@ -296,20 +307,6 @@ describe('rangeInput', () => {
 
       expect(ReactDOM.render).toHaveBeenCalledTimes(1);
       expect(ReactDOM.render.mock.calls[0][0].props.step).toBe(0.1);
-    });
-  });
-
-  describe('throws', () => {
-    it('throws an exception when no container', () => {
-      expect(() => rangeInput({ attribute: '' })).toThrow(/^Usage:/);
-    });
-
-    it('throws an exception when no attribute', () => {
-      expect(() =>
-        rangeInput({
-          container: document.createElement('div'),
-        })
-      ).toThrow(/^Usage:/);
     });
   });
 });

--- a/src/widgets/range-input/range-input.js
+++ b/src/widgets/range-input/range-input.js
@@ -2,9 +2,14 @@ import React, { render } from 'preact-compat';
 import cx from 'classnames';
 import RangeInput from '../../components/RangeInput/RangeInput';
 import connectRange from '../../connectors/range/connectRange';
-import { prepareTemplateProps, getContainerNode } from '../../lib/utils';
+import {
+  prepareTemplateProps,
+  getContainerNode,
+  createDocumentationMessageGenerator,
+} from '../../lib/utils';
 import { component } from '../../lib/suit';
 
+const withUsage = createDocumentationMessageGenerator('range-input');
 const suit = component('RangeInput');
 
 const renderer = ({ containerNode, cssClasses, renderState, templates }) => (
@@ -42,17 +47,6 @@ const renderer = ({ containerNode, cssClasses, renderState, templates }) => (
     containerNode
   );
 };
-
-const usage = `Usage:
-rangeInput({
-  container,
-  attribute,
-  [ min ],
-  [ max ],
-  [ precision = 0 ],
-  [ templates.{separatorText, submitText} ],
-  [ cssClasses.{root, noRefinement, form, label, input, inputMin, inputMax, separator, submit} ],
-})`;
 
 /**
  * @typedef {Object} RangeInputClasses
@@ -120,7 +114,7 @@ export default function rangeInput({
   templates: userTemplates = {},
 } = {}) {
   if (!container) {
-    throw new Error(usage);
+    throw new Error(withUsage('The `container` option is required.'));
   }
 
   const containerNode = getContainerNode(container);
@@ -159,16 +153,12 @@ export default function rangeInput({
     renderState: {},
   });
 
-  try {
-    const makeWidget = connectRange(specializedRenderer);
+  const makeWidget = connectRange(specializedRenderer);
 
-    return makeWidget({
-      attribute,
-      min,
-      max,
-      precision,
-    });
-  } catch (error) {
-    throw new Error(usage);
-  }
+  return makeWidget({
+    attribute,
+    min,
+    max,
+    precision,
+  });
 }

--- a/src/widgets/range-slider/__tests__/__snapshots__/range-slider-test.js.snap
+++ b/src/widgets/range-slider/__tests__/__snapshots__/range-slider-test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`rangeSlider widget usage max option will use the results min when only max is passed 1`] = `
+exports[`rangeSlider Lifecycle max option will use the results min when only max is passed 1`] = `
 <Slider
   cssClasses={
     Object {
@@ -23,7 +23,7 @@ exports[`rangeSlider widget usage max option will use the results min when only 
 />
 `;
 
-exports[`rangeSlider widget usage min option sets the right range 1`] = `
+exports[`rangeSlider Lifecycle min option sets the right range 1`] = `
 <Slider
   cssClasses={
     Object {
@@ -46,7 +46,7 @@ exports[`rangeSlider widget usage min option sets the right range 1`] = `
 />
 `;
 
-exports[`rangeSlider widget usage min option will use the results max when only min passed 1`] = `
+exports[`rangeSlider Lifecycle min option will use the results max when only min passed 1`] = `
 <Slider
   cssClasses={
     Object {
@@ -69,7 +69,7 @@ exports[`rangeSlider widget usage min option will use the results max when only 
 />
 `;
 
-exports[`rangeSlider widget usage should render without results 1`] = `
+exports[`rangeSlider Lifecycle should render without results 1`] = `
 <Slider
   cssClasses={
     Object {
@@ -92,7 +92,7 @@ exports[`rangeSlider widget usage should render without results 1`] = `
 />
 `;
 
-exports[`rangeSlider widget usage with results calls twice render 1`] = `
+exports[`rangeSlider Lifecycle with results calls twice render 1`] = `
 <Slider
   cssClasses={
     Object {
@@ -115,7 +115,7 @@ exports[`rangeSlider widget usage with results calls twice render 1`] = `
 />
 `;
 
-exports[`rangeSlider widget usage with results calls twice render 2`] = `
+exports[`rangeSlider Lifecycle with results calls twice render 2`] = `
 <Slider
   cssClasses={
     Object {

--- a/src/widgets/range-slider/__tests__/range-slider-test.js
+++ b/src/widgets/range-slider/__tests__/range-slider-test.js
@@ -13,25 +13,18 @@ jest.mock('preact-compat', () => {
 const instantSearchInstance = { templatesConfig: undefined };
 
 describe('rangeSlider', () => {
-  it('throws an exception when no container', () => {
-    const attribute = '';
-    expect(() =>
-      rangeSlider({ attribute, step: 1, cssClasses: { root: '' } })
-    ).toThrow(/^Usage:/);
+  describe('Usage', () => {
+    it('throws without container', () => {
+      expect(() => rangeSlider({ container: undefined }))
+        .toThrowErrorMatchingInlineSnapshot(`
+"The \`container\` option is required.
+
+See documentation: https://www.algolia.com/doc/api-reference/widgets/range-slider/js/"
+`);
+    });
   });
 
-  it('throws an exception when no attribute', () => {
-    const container = document.createElement('div');
-    expect(() =>
-      rangeSlider({
-        container,
-        step: 1,
-        cssClasses: { root: '' },
-      })
-    ).toThrow(/^Usage:/);
-  });
-
-  describe('widget usage', () => {
+  describe('Lifecycle', () => {
     const attribute = 'aNumAttr';
 
     let container;

--- a/src/widgets/range-slider/range-slider.js
+++ b/src/widgets/range-slider/range-slider.js
@@ -2,9 +2,13 @@ import React, { render, unmountComponentAtNode } from 'preact-compat';
 import cx from 'classnames';
 import Slider from '../../components/Slider/Slider';
 import connectRange from '../../connectors/range/connectRange';
-import { getContainerNode } from '../../lib/utils';
+import {
+  getContainerNode,
+  createDocumentationMessageGenerator,
+} from '../../lib/utils';
 import { component } from '../../lib/suit';
 
+const withUsage = createDocumentationMessageGenerator('range-slider');
 const suit = component('RangeSlider');
 
 const renderer = ({ containerNode, cssClasses, pips, step, tooltips }) => (
@@ -44,20 +48,6 @@ const renderer = ({ containerNode, cssClasses, pips, step, tooltips }) => (
     containerNode
   );
 };
-
-const usage = `Usage:
-rangeSlider({
-  container,
-  attribute,
-  [ min ],
-  [ max ],
-  [ pips = true ],
-  [ step = 1 ],
-  [ precision = 0 ],
-  [ tooltips = true ],
-  [ cssClasses.{root, disabledRoot} ]
-});
-`;
 
 /**
  * @typedef {Object} RangeSliderCssClasses
@@ -129,7 +119,7 @@ export default function rangeSlider({
   tooltips = true,
 } = {}) {
   if (!container) {
-    throw new Error(usage);
+    throw new Error(withUsage('The `container` option is required.'));
   }
 
   const containerNode = getContainerNode(container);
@@ -150,12 +140,9 @@ export default function rangeSlider({
     cssClasses,
   });
 
-  try {
-    const makeWidget = connectRange(specializedRenderer, () =>
-      unmountComponentAtNode(containerNode)
-    );
-    return makeWidget({ attribute, min, max, precision });
-  } catch (error) {
-    throw new Error(usage);
-  }
+  const makeWidget = connectRange(specializedRenderer, () =>
+    unmountComponentAtNode(containerNode)
+  );
+
+  return makeWidget({ attribute, min, max, precision });
 }


### PR DESCRIPTION
Since `connectRange` is used for both `rangeInput` and `rangeSlider`, I had to slightly adjust the function to generate the documentation link. This is not optimal but it works for now.

We could change the signature to something like this later:

```ts
type DocumentationWidget = {
  name: string;
  connector?: boolean;
};

function createDocumentationMessageGenerator(...widgets: DocumentationWidget[]);
```

Usage:

```js
const withUsage = createDocumentationMessageGenerator(
  { name: 'range-input', connector: true },
  { name: 'range-slider', connector: true }
)
```