### PR TITLE
fix: update usage utils signature

### DIFF
--- a/src/connectors/autocomplete/__tests__/connectAutocomplete-test.js
+++ b/src/connectors/autocomplete/__tests__/connectAutocomplete-test.js
@@ -5,8 +5,14 @@ import { TAG_PLACEHOLDER } from '../../../lib/escape-highlight';
 const fakeClient = { addAlgoliaAgent: () => {} };
 
 describe('connectAutocomplete', () => {
-  it('throws without `renderFn`', () => {
-    expect(() => connectAutocomplete()).toThrow();
+  it('throws without render function', () => {
+    expect(() => {
+      connectAutocomplete();
+    }).toThrowErrorMatchingInlineSnapshot(`
+"The render function is not valid (got type \\"undefined\\").
+
+See documentation: https://www.algolia.com/doc/api-reference/widgets/autocomplete/js/#connector"
+`);
   });
 
   it('renders during init and render', () => {

--- a/src/connectors/autocomplete/connectAutocomplete.js
+++ b/src/connectors/autocomplete/connectAutocomplete.js
@@ -1,20 +1,13 @@
 import escapeHits, { TAG_PLACEHOLDER } from '../../lib/escape-highlight';
-import { checkRendering } from '../../lib/utils';
+import {
+  checkRendering,
+  createDocumentationMessageGenerator,
+} from '../../lib/utils';
 
-const usage = `Usage:
-var customAutcomplete = connectAutocomplete(function render(params, isFirstRendering) {
-  // params = {
-  //   indices,
-  //   refine,
-  //   currentRefinement
-  // }
+const withUsage = createDocumentationMessageGenerator({
+  name: 'autocomplete',
+  connector: true,
 });
-search.addWiget(customAutcomplete({
-  [ indices ],
-  [ escapeHTML = true ],
-}));
-Full documentation available at https://community.algolia.com/instantsearch.js/connectors/connectAutocomplete.html
-`;
 
 /**
  * @typedef {Object} Index
@@ -48,14 +41,16 @@ Full documentation available at https://community.algolia.com/instantsearch.js/c
  * @return {function(CustomAutocompleteWidgetOptions)} Re-usable widget factory for a custom **Autocomplete** widget.
  */
 export default function connectAutocomplete(renderFn, unmountFn) {
-  checkRendering(renderFn, usage);
+  checkRendering(renderFn, withUsage());
 
   return (widgetParams = {}) => {
     const { escapeHTML = true, indices = [] } = widgetParams;
 
     // user passed a wrong `indices` option type
     if (!Array.isArray(indices)) {
-      throw new Error(usage);
+      throw new Error(
+        withUsage('The `indices` option expects an array of objects.')
+      );
     }
 
     return {

--- a/src/connectors/breadcrumb/connectBreadcrumb.js
+++ b/src/connectors/breadcrumb/connectBreadcrumb.js
@@ -6,7 +6,8 @@ import {
   createDocumentationMessageGenerator,
 } from '../../lib/utils';
 
-const withUsage = createDocumentationMessageGenerator('breadcrumb', {
+const withUsage = createDocumentationMessageGenerator({
+  name: 'breadcrumb',
   connector: true,
 });
 

--- a/src/connectors/clear-refinements/connectClearRefinements.js
+++ b/src/connectors/clear-refinements/connectClearRefinements.js
@@ -5,7 +5,8 @@ import {
   createDocumentationMessageGenerator,
 } from '../../lib/utils';
 
-const withUsage = createDocumentationMessageGenerator('clear-refinements', {
+const withUsage = createDocumentationMessageGenerator({
+  name: 'clear-refinements',
   connector: true,
 });
 

--- a/src/connectors/configure/connectConfigure.js
+++ b/src/connectors/configure/connectConfigure.js
@@ -3,7 +3,8 @@ import isPlainObject from 'lodash/isPlainObject';
 import { createDocumentationMessageGenerator } from '../../lib/utils';
 import { enhanceConfiguration } from '../../lib/InstantSearch';
 
-const withUsage = createDocumentationMessageGenerator('configure', {
+const withUsage = createDocumentationMessageGenerator({
+  name: 'configure',
   connector: true,
 });
 

--- a/src/connectors/current-refinements/__tests__/connectCurrentRefinements-test.js
+++ b/src/connectors/current-refinements/__tests__/connectCurrentRefinements-test.js
@@ -6,14 +6,16 @@ describe('connectCurrentRefinements', () => {
     it('throws if given both `includedAttributes` and `excludedAttributes`', () => {
       const customCurrentRefinements = connectCurrentRefinements(() => {});
 
-      expect(
-        customCurrentRefinements.bind(null, {
+      expect(() => {
+        customCurrentRefinements({
           includedAttributes: ['query'],
           excludedAttributes: ['brand'],
-        })
-      ).toThrowErrorMatchingInlineSnapshot(
-        `"\`includedAttributes\` and \`excludedAttributes\` cannot be used together."`
-      );
+        });
+      }).toThrowErrorMatchingInlineSnapshot(`
+"The options \`includedAttributes\` and \`excludedAttributes\` cannot be used together.
+
+See documentation: https://www.algolia.com/doc/api-reference/widgets/current-refinements/js/#connector"
+`);
     });
   });
 

--- a/src/connectors/current-refinements/connectCurrentRefinements.js
+++ b/src/connectors/current-refinements/connectCurrentRefinements.js
@@ -1,24 +1,13 @@
-import { getRefinements, checkRendering } from '../../lib/utils';
+import {
+  getRefinements,
+  checkRendering,
+  createDocumentationMessageGenerator,
+} from '../../lib/utils';
 
-const usage = `Usage:
-var customCurrentRefinements = connectCurrentRefinements(function renderFn(params, isFirstRendering) {
-  // params = {
-  //   items,
-  //   refine,
-  //   createURL,
-  //   instantSearchInstance,
-  //   widgetParams,
-  // }
+const withUsage = createDocumentationMessageGenerator({
+  name: 'current-refinements',
+  connector: true,
 });
-search.addWidget(
-  customCurrentRefinements({
-    [ includedAttributes ],
-    [ excludedAttributes = ['query'] ],
-    [ transformItems ],
-  })
-);
-Full documentation available at https://community.algolia.com/instantsearch.js/v2/connectors/connectCurrentRefinements.html
-`;
 
 /**
  * @typedef {Object} Refinement
@@ -112,12 +101,14 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  * );
  */
 export default function connectCurrentRefinements(renderFn, unmountFn) {
-  checkRendering(renderFn, usage);
+  checkRendering(renderFn, withUsage());
 
   return (widgetParams = {}) => {
     if (widgetParams.includedAttributes && widgetParams.excludedAttributes) {
       throw new Error(
-        '`includedAttributes` and `excludedAttributes` cannot be used together.'
+        withUsage(
+          'The options `includedAttributes` and `excludedAttributes` cannot be used together.'
+        )
       );
     }
 

--- a/src/connectors/geo-search/connectGeoSearch.js
+++ b/src/connectors/geo-search/connectGeoSearch.js
@@ -7,7 +7,8 @@ import {
   createDocumentationMessageGenerator,
 } from '../../lib/utils';
 
-const withUsage = createDocumentationMessageGenerator('geo-search', {
+const withUsage = createDocumentationMessageGenerator({
+  name: 'geo-search',
   connector: true,
 });
 

--- a/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
+++ b/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
@@ -6,7 +6,8 @@ import {
   createDocumentationMessageGenerator,
 } from '../../lib/utils';
 
-const withUsage = createDocumentationMessageGenerator('hierarchical-menu', {
+const withUsage = createDocumentationMessageGenerator({
+  name: 'hierarchical-menu',
   connector: true,
 });
 

--- a/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
+++ b/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
@@ -5,15 +5,33 @@ const SearchParameters = jsHelper.SearchParameters;
 import connectHitsPerPage from '../connectHitsPerPage';
 
 describe('connectHitsPerPage', () => {
-  it('should throw when there is two default items defined', () => {
-    expect(() => {
-      connectHitsPerPage(() => {})({
-        items: [
-          { value: 3, label: '3 items per page', default: true },
-          { value: 10, label: '10 items per page', default: true },
-        ],
-      });
-    }).toThrow(/^\[Error\]/);
+  describe('Usage', () => {
+    it('throws without items', () => {
+      expect(() => {
+        connectHitsPerPage(() => {})({
+          items: undefined,
+        });
+      }).toThrowErrorMatchingInlineSnapshot(`
+"The \`items\` option expects an array of objects.
+
+See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-page/js/#connector"
+`);
+    });
+
+    it('throws with multiple default items', () => {
+      expect(() => {
+        connectHitsPerPage(() => {})({
+          items: [
+            { value: 3, label: '3 items per page', default: true },
+            { value: 10, label: '10 items per page', default: true },
+          ],
+        });
+      }).toThrowErrorMatchingInlineSnapshot(`
+"More than one default value is specified in \`items\`.
+
+See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-page/js/#connector"
+`);
+    });
   });
 
   it('Renders during init and render', () => {

--- a/src/connectors/hits-per-page/connectHitsPerPage.js
+++ b/src/connectors/hits-per-page/connectHitsPerPage.js
@@ -1,31 +1,15 @@
 import some from 'lodash/some';
 import find from 'lodash/find';
+import {
+  checkRendering,
+  warning,
+  createDocumentationMessageGenerator,
+} from '../../lib/utils';
 
-import { checkRendering, warning } from '../../lib/utils';
-
-const usage = `Usage:
-var customHitsPerPage = connectHitsPerPage(function render(params, isFirstRendering) {
-  // params = {
-  //   items,
-  //   createURL,
-  //   refine,
-  //   hasNoResults,
-  //   instantSearchInstance,
-  //   widgetParams,
-  // }
+const withUsage = createDocumentationMessageGenerator({
+  name: 'hits-per-page',
+  connector: true,
 });
-search.addWidget(
-  customHitsPerPage({
-    items: [
-      {value: 5, label: '5 results per page', default: true},
-      {value: 10, label: '10 results per page'},
-      {value: 42, label: '42 results per page'},
-    ],
-    [ transformItems ]
-  })
-);
-Full documentation available at https://community.algolia.com/instantsearch.js/v2/connectors/connectHitsPerPage.html
-`;
 
 /**
  * @typedef {Object} HitsPerPageRenderingOptionsItem
@@ -112,21 +96,22 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  * );
  */
 export default function connectHitsPerPage(renderFn, unmountFn) {
-  checkRendering(renderFn, usage);
+  checkRendering(renderFn, withUsage());
 
   return (widgetParams = {}) => {
     const { items: userItems, transformItems = items => items } = widgetParams;
     let items = userItems;
 
-    if (!items) {
-      throw new Error(usage);
+    if (!Array.isArray(items)) {
+      throw new Error(
+        withUsage('The `items` option expects an array of objects.')
+      );
     }
 
     const defaultValues = items.filter(item => item.default);
     if (defaultValues.length > 1) {
       throw new Error(
-        `[Error][hitsPerPage] more than one default value is specified in \`items[]\`
-The first one will be picked, you should probably set only one default value`
+        withUsage('More than one default value is specified in `items`.')
       );
     }
 

--- a/src/connectors/hits/connectHits.js
+++ b/src/connectors/hits/connectHits.js
@@ -4,7 +4,8 @@ import {
   createDocumentationMessageGenerator,
 } from '../../lib/utils';
 
-const withUsage = createDocumentationMessageGenerator('hits', {
+const withUsage = createDocumentationMessageGenerator({
+  name: 'hits',
   connector: true,
 });
 

--- a/src/connectors/infinite-hits/connectInfiniteHits.js
+++ b/src/connectors/infinite-hits/connectInfiniteHits.js
@@ -4,7 +4,8 @@ import {
   createDocumentationMessageGenerator,
 } from '../../lib/utils';
 
-const withUsage = createDocumentationMessageGenerator('infinite-hits', {
+const withUsage = createDocumentationMessageGenerator({
+  name: 'infinite-hits',
   connector: true,
 });
 

--- a/src/connectors/menu/connectMenu.js
+++ b/src/connectors/menu/connectMenu.js
@@ -3,7 +3,8 @@ import {
   createDocumentationMessageGenerator,
 } from '../../lib/utils';
 
-const withUsage = createDocumentationMessageGenerator('menu', {
+const withUsage = createDocumentationMessageGenerator({
+  name: 'menu',
   connector: true,
 });
 

--- a/src/connectors/numeric-menu/connectNumericMenu.js
+++ b/src/connectors/numeric-menu/connectNumericMenu.js
@@ -4,7 +4,8 @@ import {
   createDocumentationMessageGenerator,
 } from '../../lib/utils';
 
-const withUsage = createDocumentationMessageGenerator('numeric-menu', {
+const withUsage = createDocumentationMessageGenerator({
+  name: 'numeric-menu',
   connector: true,
 });
 

--- a/src/connectors/pagination/connectPagination.js
+++ b/src/connectors/pagination/connectPagination.js
@@ -4,7 +4,8 @@ import {
 } from '../../lib/utils';
 import Paginator from './Paginator';
 
-const withUsage = createDocumentationMessageGenerator('pagination', {
+const withUsage = createDocumentationMessageGenerator({
+  name: 'pagination',
   connector: true,
 });
 

--- a/src/connectors/powered-by/connectPoweredBy.js
+++ b/src/connectors/powered-by/connectPoweredBy.js
@@ -3,7 +3,8 @@ import {
   createDocumentationMessageGenerator,
 } from '../../lib/utils';
 
-const withUsage = createDocumentationMessageGenerator('powered-by', {
+const withUsage = createDocumentationMessageGenerator({
+  name: 'powered-by',
   connector: true,
 });
 

--- a/src/connectors/range/__tests__/connectRange-test.js
+++ b/src/connectors/range/__tests__/connectRange-test.js
@@ -2,10 +2,31 @@ import jsHelper, {
   SearchResults,
   SearchParameters,
 } from 'algoliasearch-helper';
-
 import connectRange from '../connectRange';
 
 describe('connectRange', () => {
+  describe('Usage', () => {
+    it('throws without render function', () => {
+      expect(() => {
+        connectRange()({});
+      }).toThrowErrorMatchingInlineSnapshot(`
+"The render function is not valid (got type \\"undefined\\").
+
+See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input/js/#connector, https://www.algolia.com/doc/api-reference/widgets/range-slider/js/#connector"
+`);
+    });
+
+    it('throws without attribute', () => {
+      expect(() => {
+        connectRange(() => {})({ attribute: undefined });
+      }).toThrowErrorMatchingInlineSnapshot(`
+"The \`attribute\` option is required.
+
+See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input/js/#connector, https://www.algolia.com/doc/api-reference/widgets/range-slider/js/#connector"
+`);
+    });
+  });
+
   it('Renders during init and render', () => {
     // test that the dummyRendering is called with the isFirstRendering
     // flag set accordingly

--- a/src/connectors/range/connectRange.js
+++ b/src/connectors/range/connectRange.js
@@ -1,29 +1,14 @@
 import find from 'lodash/find';
 import _isFinite from 'lodash/isFinite';
+import {
+  checkRendering,
+  createDocumentationMessageGenerator,
+} from '../../lib/utils';
 
-import { checkRendering } from '../../lib/utils';
-
-const usage = `Usage:
-var customRange = connectRange(function render(params, isFirstRendering) {
-  // params = {
-  //   refine,
-  //   range,
-  //   start,
-  //   format,
-  //   instantSearchInstance,
-  //   widgetParams,
-  // }
-});
-search.addWidget(
-  customRange({
-    attribute,
-    [ min ],
-    [ max ],
-    [ precision = 2 ],
-  })
+const withUsage = createDocumentationMessageGenerator(
+  { name: 'range-input', connector: true },
+  { name: 'range-slider', connector: true }
 );
-Full documentation available at https://community.algolia.com/instantsearch.js/v2/connectors/connectRange.html
-`;
 
 /**
  * @typedef {Object} CustomRangeWidgetOptions
@@ -57,7 +42,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  * @return {function(CustomRangeWidgetOptions)} Re-usable widget factory for a custom **Range** widget.
  */
 export default function connectRange(renderFn, unmountFn) {
-  checkRendering(renderFn, usage);
+  checkRendering(renderFn, withUsage());
 
   return (widgetParams = {}) => {
     const {
@@ -68,7 +53,7 @@ export default function connectRange(renderFn, unmountFn) {
     } = widgetParams;
 
     if (!attribute) {
-      throw new Error(usage);
+      throw new Error(withUsage('The `attribute` option is required.'));
     }
 
     const hasMinBound = _isFinite(minBound);

--- a/src/connectors/rating-menu/connectRatingMenu.js
+++ b/src/connectors/rating-menu/connectRatingMenu.js
@@ -3,7 +3,8 @@ import {
   createDocumentationMessageGenerator,
 } from '../../lib/utils';
 
-const withUsage = createDocumentationMessageGenerator('rating-menu', {
+const withUsage = createDocumentationMessageGenerator({
+  name: 'rating-menu',
   connector: true,
 });
 

--- a/src/connectors/refinement-list/connectRefinementList.js
+++ b/src/connectors/refinement-list/connectRefinementList.js
@@ -9,7 +9,8 @@ import {
 } from '../../lib/escape-highlight';
 import isEqual from 'lodash/isEqual';
 
-const withUsage = createDocumentationMessageGenerator('refinement-list', {
+const withUsage = createDocumentationMessageGenerator({
+  name: 'refinement-list',
   connector: true,
 });
 

--- a/src/connectors/search-box/connectSearchBox.js
+++ b/src/connectors/search-box/connectSearchBox.js
@@ -3,7 +3,8 @@ import {
   createDocumentationMessageGenerator,
 } from '../../lib/utils';
 
-const withUsage = createDocumentationMessageGenerator('search-box', {
+const withUsage = createDocumentationMessageGenerator({
+  name: 'search-box',
   connector: true,
 });
 

--- a/src/connectors/sort-by/connectSortBy.js
+++ b/src/connectors/sort-by/connectSortBy.js
@@ -4,7 +4,8 @@ import {
   createDocumentationMessageGenerator,
 } from '../../lib/utils';
 
-const withUsage = createDocumentationMessageGenerator('sort-by', {
+const withUsage = createDocumentationMessageGenerator({
+  name: 'sort-by',
   connector: true,
 });
 

--- a/src/connectors/stats/connectStats.js
+++ b/src/connectors/stats/connectStats.js
@@ -3,7 +3,8 @@ import {
   createDocumentationMessageGenerator,
 } from '../../lib/utils';
 
-const withUsage = createDocumentationMessageGenerator('stats', {
+const withUsage = createDocumentationMessageGenerator({
+  name: 'stats',
   connector: true,
 });
 

--- a/src/connectors/toggleRefinement/connectToggleRefinement.js
+++ b/src/connectors/toggleRefinement/connectToggleRefinement.js
@@ -6,7 +6,8 @@ import {
   createDocumentationMessageGenerator,
 } from '../../lib/utils';
 
-const withUsage = createDocumentationMessageGenerator('toggle-refinement', {
+const withUsage = createDocumentationMessageGenerator({
+  name: 'toggle-refinement',
   connector: true,
 });
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -475,20 +475,24 @@ if (__DEV__) {
   warning.cache = {};
 }
 
-function createDocumentationLink(widget, { connector = false } = {}) {
+function createDocumentationLink({ name, connector = false } = {}) {
   return [
     'https://www.algolia.com/doc/api-reference/widgets/',
-    widget,
+    name,
     '/js/',
     connector ? '#connector' : '',
   ].join('');
 }
 
-function createDocumentationMessageGenerator(widget, { connector } = {}) {
-  const link = createDocumentationLink(widget, { connector });
+function createDocumentationMessageGenerator(...widgets) {
+  const links = widgets
+    .map(widget => createDocumentationLink(widget))
+    .join(', ');
 
   return function(message) {
-    return [message, `See documentation: ${link}`].filter(Boolean).join('\n\n');
+    return [message, `See documentation: ${links}`]
+      .filter(Boolean)
+      .join('\n\n');
   };
 }
 

--- a/src/widgets/analytics/analytics.js
+++ b/src/widgets/analytics/analytics.js
@@ -1,6 +1,6 @@
 import { createDocumentationMessageGenerator } from '../../lib/utils';
 
-const withUsage = createDocumentationMessageGenerator('analytics');
+const withUsage = createDocumentationMessageGenerator({ name: 'analytics' });
 
 /**
  * @typedef {Object} AnalyticsWidgetOptions

--- a/src/widgets/breadcrumb/breadcrumb.js
+++ b/src/widgets/breadcrumb/breadcrumb.js
@@ -10,7 +10,7 @@ import {
 } from '../../lib/utils';
 import { component } from '../../lib/suit';
 
-const withUsage = createDocumentationMessageGenerator('breadcrumb');
+const withUsage = createDocumentationMessageGenerator({ name: 'breadcrumb' });
 const suit = component('Breadcrumb');
 
 const renderer = ({ containerNode, cssClasses, renderState, templates }) => (

--- a/src/widgets/clear-refinements/__tests__/clear-refinements-test.js
+++ b/src/widgets/clear-refinements/__tests__/clear-refinements-test.js
@@ -11,6 +11,18 @@ jest.mock('preact-compat', () => {
   return module;
 });
 
+describe('Usage', () => {
+  it('throws without container', () => {
+    expect(() => {
+      clearRefinements({ container: undefined });
+    }).toThrowErrorMatchingInlineSnapshot(`
+"The \`container\` option is required.
+
+See documentation: https://www.algolia.com/doc/api-reference/widgets/clear-refinements/js/"
+`);
+  });
+});
+
 describe('clearRefinements()', () => {
   let container;
   let results;

--- a/src/widgets/clear-refinements/clear-refinements.js
+++ b/src/widgets/clear-refinements/clear-refinements.js
@@ -3,9 +3,16 @@ import ClearRefinements from '../../components/ClearRefinements/ClearRefinements
 import cx from 'classnames';
 import connectClearRefinements from '../../connectors/clear-refinements/connectClearRefinements';
 import defaultTemplates from './defaultTemplates';
-import { getContainerNode, prepareTemplateProps } from '../../lib/utils';
+import {
+  getContainerNode,
+  prepareTemplateProps,
+  createDocumentationMessageGenerator,
+} from '../../lib/utils';
 import { component } from '../../lib/suit';
 
+const withUsage = createDocumentationMessageGenerator({
+  name: 'clear-refinements',
+});
 const suit = component('ClearRefinements');
 
 const renderer = ({ containerNode, cssClasses, renderState, templates }) => (
@@ -32,15 +39,6 @@ const renderer = ({ containerNode, cssClasses, renderState, templates }) => (
   );
 };
 
-const usage = `Usage:
-clearRefinements({
-  container,
-  [ includedAttributes = [] ],
-  [ excludedAttributes = ['query'] ],
-  [ transformItems ],
-  [ templates.{resetLabel} ],
-  [ cssClasses.{root, button, disabledButton} ],
-})`;
 /**
  * @typedef {Object} ClearRefinementsCSSClasses
  * @property {string|string[]} [root] CSS class to add to the wrapper element.
@@ -92,7 +90,7 @@ export default function clearRefinements({
   cssClasses: userCssClasses = {},
 }) {
   if (!container) {
-    throw new Error(usage);
+    throw new Error(withUsage('The `container` option is required.'));
   }
 
   const containerNode = getContainerNode(container);
@@ -113,16 +111,13 @@ export default function clearRefinements({
     templates,
   });
 
-  try {
-    const makeWidget = connectClearRefinements(specializedRenderer, () =>
-      unmountComponentAtNode(containerNode)
-    );
-    return makeWidget({
-      includedAttributes,
-      excludedAttributes,
-      transformItems,
-    });
-  } catch (error) {
-    throw new Error(usage);
-  }
+  const makeWidget = connectClearRefinements(specializedRenderer, () =>
+    unmountComponentAtNode(containerNode)
+  );
+
+  return makeWidget({
+    includedAttributes,
+    excludedAttributes,
+    transformItems,
+  });
 }

--- a/src/widgets/current-refinements/current-refinements.js
+++ b/src/widgets/current-refinements/current-refinements.js
@@ -8,7 +8,9 @@ import {
 } from '../../lib/utils';
 import { component } from '../../lib/suit';
 
-const withUsage = createDocumentationMessageGenerator('current-refinements');
+const withUsage = createDocumentationMessageGenerator({
+  name: 'current-refinements',
+});
 const suit = component('CurrentRefinements');
 
 const renderer = ({ containerNode, cssClasses }) => (

--- a/src/widgets/geo-search/geo-search.js
+++ b/src/widgets/geo-search/geo-search.js
@@ -12,7 +12,7 @@ import renderer from './GeoSearchRenderer';
 import defaultTemplates from './defaultTemplates';
 import createHTMLMarker from './createHTMLMarker';
 
-const withUsage = createDocumentationMessageGenerator('geo-search');
+const withUsage = createDocumentationMessageGenerator({ name: 'geo-search' });
 const suit = component('GeoSearch');
 
 /**

--- a/src/widgets/hierarchical-menu/hierarchical-menu.js
+++ b/src/widgets/hierarchical-menu/hierarchical-menu.js
@@ -10,7 +10,9 @@ import {
 } from '../../lib/utils';
 import { component } from '../../lib/suit';
 
-const withUsage = createDocumentationMessageGenerator('hierarchical-menu');
+const withUsage = createDocumentationMessageGenerator({
+  name: 'hierarchical-menu',
+});
 const suit = component('HierarchicalMenu');
 
 const renderer = ({

--- a/src/widgets/hits-per-page/__tests__/hits-per-page-test.js
+++ b/src/widgets/hits-per-page/__tests__/hits-per-page-test.js
@@ -9,15 +9,15 @@ jest.mock('preact-compat', () => {
   return module;
 });
 
-describe('hitsPerPage call', () => {
-  it('throws an exception when no items', () => {
-    const container = document.createElement('div');
-    expect(hitsPerPage.bind(null, { container })).toThrow(/^Usage:/);
-  });
+describe('Usage', () => {
+  it('throws without container', () => {
+    expect(() => {
+      hitsPerPage({ container: undefined });
+    }).toThrowErrorMatchingInlineSnapshot(`
+"The \`container\` option is required.
 
-  it('throws an exception when no container', () => {
-    const items = { a: { value: 'value', label: 'My value' } };
-    expect(hitsPerPage.bind(null, { items })).toThrow(/^Usage:/);
+See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-page/js/"
+`);
   });
 });
 

--- a/src/widgets/hits-per-page/hits-per-page.js
+++ b/src/widgets/hits-per-page/hits-per-page.js
@@ -3,9 +3,15 @@ import cx from 'classnames';
 import find from 'lodash/find';
 import Selector from '../../components/Selector/Selector';
 import connectHitsPerPage from '../../connectors/hits-per-page/connectHitsPerPage';
-import { getContainerNode } from '../../lib/utils';
+import {
+  getContainerNode,
+  createDocumentationMessageGenerator,
+} from '../../lib/utils';
 import { component } from '../../lib/suit';
 
+const withUsage = createDocumentationMessageGenerator({
+  name: 'hits-per-page',
+});
 const suit = component('HitsPerPage');
 
 const renderer = ({ containerNode, cssClasses }) => (
@@ -29,14 +35,6 @@ const renderer = ({ containerNode, cssClasses }) => (
     containerNode
   );
 };
-
-const usage = `Usage:
-hitsPerPage({
-  container,
-  items,
-  [ cssClasses.{root, select, option} ],
-  [ transformItems ]
-})`;
 
 /**
  * @typedef {Object} HitsPerPageCSSClasses
@@ -89,7 +87,7 @@ export default function hitsPerPage({
   transformItems,
 } = {}) {
   if (!container) {
-    throw new Error(usage);
+    throw new Error(withUsage('The `container` option is required.'));
   }
 
   const containerNode = getContainerNode(container);
@@ -105,12 +103,9 @@ export default function hitsPerPage({
     cssClasses,
   });
 
-  try {
-    const makeHitsPerPage = connectHitsPerPage(specializedRenderer, () =>
-      unmountComponentAtNode(containerNode)
-    );
-    return makeHitsPerPage({ items, transformItems });
-  } catch (error) {
-    throw new Error(usage);
-  }
+  const makeHitsPerPage = connectHitsPerPage(specializedRenderer, () =>
+    unmountComponentAtNode(containerNode)
+  );
+
+  return makeHitsPerPage({ items, transformItems });
 }

--- a/src/widgets/hits/hits.js
+++ b/src/widgets/hits/hits.js
@@ -12,7 +12,7 @@ import {
 } from '../../lib/utils';
 import { component } from '../../lib/suit';
 
-const withUsage = createDocumentationMessageGenerator('hits');
+const withUsage = createDocumentationMessageGenerator({ name: 'hits' });
 const suit = component('Hits');
 
 const renderer = ({ renderState, cssClasses, containerNode, templates }) => (
@@ -100,10 +100,10 @@ export default function hits({
     typeof templates.allItems === 'undefined',
     `The template \`allItems\` does not exist since InstantSearch.js 3.
 
-You may want to migrate using \`connectHits\`: ${createDocumentationLink(
-      'hits',
-      { connector: true }
-    )}.`
+You may want to migrate using \`connectHits\`: ${createDocumentationLink({
+      name: 'hits',
+      connector: true,
+    })}.`
   );
 
   const containerNode = getContainerNode(container);

--- a/src/widgets/infinite-hits/infinite-hits.js
+++ b/src/widgets/infinite-hits/infinite-hits.js
@@ -12,7 +12,9 @@ import {
 } from '../../lib/utils';
 import { component } from '../../lib/suit';
 
-const withUsage = createDocumentationMessageGenerator('infinite-hits');
+const withUsage = createDocumentationMessageGenerator({
+  name: 'infinite-hits',
+});
 const suit = component('InfiniteHits');
 
 const renderer = ({ cssClasses, containerNode, renderState, templates }) => (
@@ -109,8 +111,7 @@ export default function infiniteHits({
     `The template \`allItems\` does not exist since InstantSearch.js 3.
 
  You may want to migrate using \`connectInfiniteHits\`: ${createDocumentationLink(
-   'infinite-hits',
-   { connector: true }
+   { name: 'infinite-hits', connector: true }
  )}.`
   );
 

--- a/src/widgets/menu-select/menu-select.js
+++ b/src/widgets/menu-select/menu-select.js
@@ -10,7 +10,7 @@ import {
 } from '../../lib/utils';
 import { component } from '../../lib/suit';
 
-const withUsage = createDocumentationMessageGenerator('menu-select');
+const withUsage = createDocumentationMessageGenerator({ name: 'menu-select' });
 const suit = component('MenuSelect');
 
 const renderer = ({ containerNode, cssClasses, renderState, templates }) => (

--- a/src/widgets/menu/menu.js
+++ b/src/widgets/menu/menu.js
@@ -10,7 +10,7 @@ import {
 } from '../../lib/utils';
 import { component } from '../../lib/suit';
 
-const withUsage = createDocumentationMessageGenerator('menu');
+const withUsage = createDocumentationMessageGenerator({ name: 'menu' });
 const suit = component('Menu');
 
 const renderer = ({

--- a/src/widgets/numeric-menu/numeric-menu.js
+++ b/src/widgets/numeric-menu/numeric-menu.js
@@ -10,7 +10,7 @@ import {
 } from '../../lib/utils';
 import { component } from '../../lib/suit';
 
-const withUsage = createDocumentationMessageGenerator('numeric-menu');
+const withUsage = createDocumentationMessageGenerator({ name: 'numeric-menu' });
 const suit = component('NumericMenu');
 
 const renderer = ({

--- a/src/widgets/pagination/pagination.js
+++ b/src/widgets/pagination/pagination.js
@@ -8,7 +8,7 @@ import {
 } from '../../lib/utils';
 import { component } from '../../lib/suit';
 
-const withUsage = createDocumentationMessageGenerator('pagination');
+const withUsage = createDocumentationMessageGenerator({ name: 'pagination' });
 const suit = component('Pagination');
 
 const defaultTemplates = {

--- a/src/widgets/panel/__tests__/panel-test.js
+++ b/src/widgets/panel/__tests__/panel-test.js
@@ -1,6 +1,6 @@
 import panel from '../panel';
 
-describe('panel call', () => {
+describe('Usage', () => {
   test('without arguments does not throw', () => {
     expect(() => panel()).not.toThrow();
   });
@@ -39,8 +39,10 @@ describe('panel call', () => {
   test('with a widget without `container` throws', () => {
     const fakeWidget = () => {};
 
-    expect(() => panel()(fakeWidget)({})).toThrowErrorMatchingInlineSnapshot(
-      `"[InstantSearch.js] The \`container\` option is required in the widget within the panel."`
-    );
+    expect(() => panel()(fakeWidget)({})).toThrowErrorMatchingInlineSnapshot(`
+"The \`container\` option is required in the widget within the panel.
+
+See documentation: https://www.algolia.com/doc/api-reference/widgets/panel/js/"
+`);
   });
 });

--- a/src/widgets/panel/panel.js
+++ b/src/widgets/panel/panel.js
@@ -4,10 +4,12 @@ import {
   getContainerNode,
   prepareTemplateProps,
   warning,
+  createDocumentationMessageGenerator,
 } from '../../lib/utils';
 import { component } from '../../lib/suit';
 import Panel from '../../components/Panel/Panel';
 
+const withUsage = createDocumentationMessageGenerator({ name: 'panel' });
 const suit = component('Panel');
 
 const renderer = ({ containerNode, cssClasses, templateProps }) => ({
@@ -29,15 +31,6 @@ const renderer = ({ containerNode, cssClasses, templateProps }) => ({
 
   return { bodyRef };
 };
-
-const usage = `Usage:
-const widgetWithHeaderFooter = panel({
-  [ templates.{header, footer} ],
-  [ hidden ],
-  [ cssClasses.{root, noRefinementRoot, body, header, footer} ],
-})(widget);
-
-const myWidget = widgetWithHeaderFooter(widgetOptions)`;
 
 /**
  * @typedef {Object} PanelWidgetCSSClasses
@@ -108,7 +101,9 @@ export default function panel({
 
     if (!container) {
       throw new Error(
-        `[InstantSearch.js] The \`container\` option is required in the widget within the panel.`
+        withUsage(
+          `The \`container\` option is required in the widget within the panel.`
+        )
       );
     }
 
@@ -121,41 +116,37 @@ export default function panel({
       templateProps,
     });
 
-    try {
-      const { bodyRef } = renderPanel({
-        options: {},
-        hidden: true,
-      });
+    const { bodyRef } = renderPanel({
+      options: {},
+      hidden: true,
+    });
 
-      const widget = widgetFactory({
-        ...widgetOptions,
-        container: getContainerNode(bodyRef),
-      });
+    const widget = widgetFactory({
+      ...widgetOptions,
+      container: getContainerNode(bodyRef),
+    });
 
-      return {
-        ...widget,
-        dispose(...args) {
-          unmountComponentAtNode(getContainerNode(container));
+    return {
+      ...widget,
+      dispose(...args) {
+        unmountComponentAtNode(getContainerNode(container));
 
-          if (typeof widget.dispose === 'function') {
-            widget.dispose.call(this, ...args);
-          }
-        },
-        render(...args) {
-          const [options] = args;
+        if (typeof widget.dispose === 'function') {
+          widget.dispose.call(this, ...args);
+        }
+      },
+      render(...args) {
+        const [options] = args;
 
-          renderPanel({
-            options,
-            hidden: Boolean(hidden(options)),
-          });
+        renderPanel({
+          options,
+          hidden: Boolean(hidden(options)),
+        });
 
-          if (typeof widget.render === 'function') {
-            widget.render.call(this, ...args);
-          }
-        },
-      };
-    } catch (error) {
-      throw new Error(usage);
-    }
+        if (typeof widget.render === 'function') {
+          widget.render.call(this, ...args);
+        }
+      },
+    };
   };
 }

--- a/src/widgets/powered-by/powered-by.js
+++ b/src/widgets/powered-by/powered-by.js
@@ -9,7 +9,7 @@ import {
 import { component } from '../../lib/suit';
 
 const suit = component('PoweredBy');
-const withUsage = createDocumentationMessageGenerator('powered-by');
+const withUsage = createDocumentationMessageGenerator({ name: 'powered-by' });
 
 const renderer = ({ containerNode, cssClasses }) => (
   { url, widgetParams },

--- a/src/widgets/range-input/__tests__/range-input-test.js
+++ b/src/widgets/range-input/__tests__/range-input-test.js
@@ -11,6 +11,17 @@ jest.mock('preact-compat', () => {
 });
 
 describe('rangeInput', () => {
+  describe('Usage', () => {
+    it('throws without container', () => {
+      expect(() => rangeInput({ container: undefined }))
+        .toThrowErrorMatchingInlineSnapshot(`
+"The \`container\` option is required.
+
+See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input/js/"
+`);
+    });
+  });
+
   const attribute = 'aNumAttr';
   const createContainer = () => document.createElement('div');
   const instantSearchInstance = {};
@@ -296,20 +307,6 @@ describe('rangeInput', () => {
 
       expect(ReactDOM.render).toHaveBeenCalledTimes(1);
       expect(ReactDOM.render.mock.calls[0][0].props.step).toBe(0.1);
-    });
-  });
-
-  describe('throws', () => {
-    it('throws an exception when no container', () => {
-      expect(() => rangeInput({ attribute: '' })).toThrow(/^Usage:/);
-    });
-
-    it('throws an exception when no attribute', () => {
-      expect(() =>
-        rangeInput({
-          container: document.createElement('div'),
-        })
-      ).toThrow(/^Usage:/);
     });
   });
 });

--- a/src/widgets/range-input/range-input.js
+++ b/src/widgets/range-input/range-input.js
@@ -2,9 +2,14 @@ import React, { render } from 'preact-compat';
 import cx from 'classnames';
 import RangeInput from '../../components/RangeInput/RangeInput';
 import connectRange from '../../connectors/range/connectRange';
-import { prepareTemplateProps, getContainerNode } from '../../lib/utils';
+import {
+  prepareTemplateProps,
+  getContainerNode,
+  createDocumentationMessageGenerator,
+} from '../../lib/utils';
 import { component } from '../../lib/suit';
 
+const withUsage = createDocumentationMessageGenerator({ name: 'range-input' });
 const suit = component('RangeInput');
 
 const renderer = ({ containerNode, cssClasses, renderState, templates }) => (
@@ -42,17 +47,6 @@ const renderer = ({ containerNode, cssClasses, renderState, templates }) => (
     containerNode
   );
 };
-
-const usage = `Usage:
-rangeInput({
-  container,
-  attribute,
-  [ min ],
-  [ max ],
-  [ precision = 0 ],
-  [ templates.{separatorText, submitText} ],
-  [ cssClasses.{root, noRefinement, form, label, input, inputMin, inputMax, separator, submit} ],
-})`;
 
 /**
  * @typedef {Object} RangeInputClasses
@@ -120,7 +114,7 @@ export default function rangeInput({
   templates: userTemplates = {},
 } = {}) {
   if (!container) {
-    throw new Error(usage);
+    throw new Error(withUsage('The `container` option is required.'));
   }
 
   const containerNode = getContainerNode(container);
@@ -159,16 +153,12 @@ export default function rangeInput({
     renderState: {},
   });
 
-  try {
-    const makeWidget = connectRange(specializedRenderer);
+  const makeWidget = connectRange(specializedRenderer);
 
-    return makeWidget({
-      attribute,
-      min,
-      max,
-      precision,
-    });
-  } catch (error) {
-    throw new Error(usage);
-  }
+  return makeWidget({
+    attribute,
+    min,
+    max,
+    precision,
+  });
 }

--- a/src/widgets/range-slider/__tests__/__snapshots__/range-slider-test.js.snap
+++ b/src/widgets/range-slider/__tests__/__snapshots__/range-slider-test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`rangeSlider widget usage max option will use the results min when only max is passed 1`] = `
+exports[`rangeSlider Lifecycle max option will use the results min when only max is passed 1`] = `
 <Slider
   cssClasses={
     Object {
@@ -23,7 +23,7 @@ exports[`rangeSlider widget usage max option will use the results min when only 
 />
 `;
 
-exports[`rangeSlider widget usage min option sets the right range 1`] = `
+exports[`rangeSlider Lifecycle min option sets the right range 1`] = `
 <Slider
   cssClasses={
     Object {
@@ -46,7 +46,7 @@ exports[`rangeSlider widget usage min option sets the right range 1`] = `
 />
 `;
 
-exports[`rangeSlider widget usage min option will use the results max when only min passed 1`] = `
+exports[`rangeSlider Lifecycle min option will use the results max when only min passed 1`] = `
 <Slider
   cssClasses={
     Object {
@@ -69,7 +69,7 @@ exports[`rangeSlider widget usage min option will use the results max when only 
 />
 `;
 
-exports[`rangeSlider widget usage should render without results 1`] = `
+exports[`rangeSlider Lifecycle should render without results 1`] = `
 <Slider
   cssClasses={
     Object {
@@ -92,7 +92,7 @@ exports[`rangeSlider widget usage should render without results 1`] = `
 />
 `;
 
-exports[`rangeSlider widget usage with results calls twice render 1`] = `
+exports[`rangeSlider Lifecycle with results calls twice render 1`] = `
 <Slider
   cssClasses={
     Object {
@@ -115,7 +115,7 @@ exports[`rangeSlider widget usage with results calls twice render 1`] = `
 />
 `;
 
-exports[`rangeSlider widget usage with results calls twice render 2`] = `
+exports[`rangeSlider Lifecycle with results calls twice render 2`] = `
 <Slider
   cssClasses={
     Object {

--- a/src/widgets/range-slider/__tests__/range-slider-test.js
+++ b/src/widgets/range-slider/__tests__/range-slider-test.js
@@ -13,25 +13,18 @@ jest.mock('preact-compat', () => {
 const instantSearchInstance = { templatesConfig: undefined };
 
 describe('rangeSlider', () => {
-  it('throws an exception when no container', () => {
-    const attribute = '';
-    expect(() =>
-      rangeSlider({ attribute, step: 1, cssClasses: { root: '' } })
-    ).toThrow(/^Usage:/);
+  describe('Usage', () => {
+    it('throws without container', () => {
+      expect(() => rangeSlider({ container: undefined }))
+        .toThrowErrorMatchingInlineSnapshot(`
+"The \`container\` option is required.
+
+See documentation: https://www.algolia.com/doc/api-reference/widgets/range-slider/js/"
+`);
+    });
   });
 
-  it('throws an exception when no attribute', () => {
-    const container = document.createElement('div');
-    expect(() =>
-      rangeSlider({
-        container,
-        step: 1,
-        cssClasses: { root: '' },
-      })
-    ).toThrow(/^Usage:/);
-  });
-
-  describe('widget usage', () => {
+  describe('Lifecycle', () => {
     const attribute = 'aNumAttr';
 
     let container;

--- a/src/widgets/range-slider/range-slider.js
+++ b/src/widgets/range-slider/range-slider.js
@@ -2,9 +2,13 @@ import React, { render, unmountComponentAtNode } from 'preact-compat';
 import cx from 'classnames';
 import Slider from '../../components/Slider/Slider';
 import connectRange from '../../connectors/range/connectRange';
-import { getContainerNode } from '../../lib/utils';
+import {
+  getContainerNode,
+  createDocumentationMessageGenerator,
+} from '../../lib/utils';
 import { component } from '../../lib/suit';
 
+const withUsage = createDocumentationMessageGenerator({ name: 'range-slider' });
 const suit = component('RangeSlider');
 
 const renderer = ({ containerNode, cssClasses, pips, step, tooltips }) => (
@@ -44,20 +48,6 @@ const renderer = ({ containerNode, cssClasses, pips, step, tooltips }) => (
     containerNode
   );
 };
-
-const usage = `Usage:
-rangeSlider({
-  container,
-  attribute,
-  [ min ],
-  [ max ],
-  [ pips = true ],
-  [ step = 1 ],
-  [ precision = 0 ],
-  [ tooltips = true ],
-  [ cssClasses.{root, disabledRoot} ]
-});
-`;
 
 /**
  * @typedef {Object} RangeSliderCssClasses
@@ -129,7 +119,7 @@ export default function rangeSlider({
   tooltips = true,
 } = {}) {
   if (!container) {
-    throw new Error(usage);
+    throw new Error(withUsage('The `container` option is required.'));
   }
 
   const containerNode = getContainerNode(container);
@@ -150,12 +140,9 @@ export default function rangeSlider({
     cssClasses,
   });
 
-  try {
-    const makeWidget = connectRange(specializedRenderer, () =>
-      unmountComponentAtNode(containerNode)
-    );
-    return makeWidget({ attribute, min, max, precision });
-  } catch (error) {
-    throw new Error(usage);
-  }
+  const makeWidget = connectRange(specializedRenderer, () =>
+    unmountComponentAtNode(containerNode)
+  );
+
+  return makeWidget({ attribute, min, max, precision });
 }

--- a/src/widgets/rating-menu/rating-menu.js
+++ b/src/widgets/rating-menu/rating-menu.js
@@ -10,7 +10,7 @@ import {
 } from '../../lib/utils';
 import { component } from '../../lib/suit';
 
-const withUsage = createDocumentationMessageGenerator('rating-menu');
+const withUsage = createDocumentationMessageGenerator({ name: 'rating-menu' });
 const suit = component('RatingMenu');
 
 const renderer = ({ containerNode, cssClasses, templates, renderState }) => (

--- a/src/widgets/refinement-list/refinement-list.js
+++ b/src/widgets/refinement-list/refinement-list.js
@@ -10,7 +10,9 @@ import {
 } from '../../lib/utils';
 import { component } from '../../lib/suit';
 
-const withUsage = createDocumentationMessageGenerator('refinement-list');
+const withUsage = createDocumentationMessageGenerator({
+  name: 'refinement-list',
+});
 const suit = component('RefinementList');
 
 const renderer = ({

--- a/src/widgets/search-box/search-box.js
+++ b/src/widgets/search-box/search-box.js
@@ -11,7 +11,7 @@ import connectSearchBox from '../../connectors/search-box/connectSearchBox';
 import defaultTemplates from './defaultTemplates';
 import { component } from '../../lib/suit';
 
-const withUsage = createDocumentationMessageGenerator('search-box');
+const withUsage = createDocumentationMessageGenerator({ name: 'search-box' });
 const suit = component('SearchBox');
 
 const renderer = ({
@@ -214,10 +214,10 @@ export default function searchBox({
     throw new Error(
       `The \`container\` option doesn't accept \`input\` elements since InstantSearch.js 3.
 
-You may want to migrate using \`connectSearchBox\`: ${createDocumentationLink(
-        'searchbox',
-        { connector: true }
-      )}.`
+You may want to migrate using \`connectSearchBox\`: ${createDocumentationLink({
+        name: 'searchbox',
+        connector: true,
+      })}.`
     );
   }
 

--- a/src/widgets/sort-by/sort-by.js
+++ b/src/widgets/sort-by/sort-by.js
@@ -8,7 +8,7 @@ import {
 } from '../../lib/utils';
 import { component } from '../../lib/suit';
 
-const withUsage = createDocumentationMessageGenerator('sort-by');
+const withUsage = createDocumentationMessageGenerator({ name: 'sort-by' });
 const suit = component('SortBy');
 
 const renderer = ({ containerNode, cssClasses }) => (

--- a/src/widgets/stats/stats.js
+++ b/src/widgets/stats/stats.js
@@ -10,7 +10,7 @@ import {
 } from '../../lib/utils';
 import { component } from '../../lib/suit';
 
-const withUsage = createDocumentationMessageGenerator('stats');
+const withUsage = createDocumentationMessageGenerator({ name: 'stats' });
 const suit = component('Stats');
 
 const renderer = ({ containerNode, cssClasses, renderState, templates }) => (

--- a/src/widgets/toggleRefinement/toggleRefinement.js
+++ b/src/widgets/toggleRefinement/toggleRefinement.js
@@ -10,7 +10,9 @@ import {
 } from '../../lib/utils';
 import { component } from '../../lib/suit';
 
-const withUsage = createDocumentationMessageGenerator('toggle-refinement');
+const withUsage = createDocumentationMessageGenerator({
+  name: 'toggle-refinement',
+});
 const suit = component('ToggleRefinement');
 
 const renderer = ({ containerNode, cssClasses, renderState, templates }) => (


### PR DESCRIPTION
This updates the signature of the function to generate errors to handle multiple widgets.

The reason is explained in https://github.com/algolia/instantsearch.js/pull/3514#issue-251916573: the `connectRange` connector is shared between [`rangeInput#connector`](https://www.algolia.com/doc/api-reference/widgets/range-input/js/#connector) and [`rangeSlider#connector`](https://www.algolia.com/doc/api-reference/widgets/range-slider/js/#connector) and should link to both.

Function implementation: https://github.com/algolia/instantsearch.js/pull/3516/files#diff-fb54f78b07de422efaa3d2d82bb82db3