### PR TITLE
build(rollup): display minified file size

### DIFF
--- a/scripts/rollup.config.js
+++ b/scripts/rollup.config.js
@@ -23,7 +23,7 @@ const plugins = [
   }),
   commonjs(),
   filesize({
-    showMinifiedSize: false,
+    showMinifiedSize: true,
     showGzippedSize: true,
   }),
 ];


### PR DESCRIPTION
We used to only display the Gzipped file size during build. The minified size is also interesting to track.
