### PR TITLE
fix(connectToggleRefinement): keep user provided, but falsy values

### DIFF
--- a/src/connectors/toggleRefinement/__tests__/connectToggleRefinement-test.js
+++ b/src/connectors/toggleRefinement/__tests__/connectToggleRefinement-test.js
@@ -423,6 +423,83 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
     }
   });
 
+  it('sets user-provided "off" value by default (falsy)', () => {
+    const makeWidget = connectToggleRefinement(() => {});
+    const widget = makeWidget({
+      attribute: 'whatever',
+      off: false,
+    });
+
+    const helper = jsHelper({}, '', widget.getConfiguration());
+    widget.init({ helper, state: helper.state });
+
+    expect(helper.state.disjunctiveFacetsRefinements).toEqual(
+      expect.objectContaining({
+        whatever: ['false'],
+      })
+    );
+  });
+
+  it('sets user-provided "off" value by default (truthy)', () => {
+    const makeWidget = connectToggleRefinement(() => {});
+    const widget = makeWidget({
+      attribute: 'whatever',
+      off: true,
+    });
+
+    const helper = jsHelper({}, '', widget.getConfiguration());
+    widget.init({ helper, state: helper.state });
+
+    expect(helper.state.disjunctiveFacetsRefinements).toEqual(
+      expect.objectContaining({
+        whatever: ['true'],
+      })
+    );
+  });
+
+  it('sets user-provided "on" value on refine (falsy)', () => {
+    let caughtRefine;
+    const makeWidget = connectToggleRefinement(({ refine }) => {
+      caughtRefine = refine;
+    });
+    const widget = makeWidget({
+      attribute: 'whatever',
+      on: false,
+    });
+
+    const helper = jsHelper({ search() {} }, '', widget.getConfiguration());
+    helper.search = jest.fn();
+
+    widget.init({ helper, state: helper.state });
+
+    expect(helper.state.disjunctiveFacetsRefinements).toEqual({});
+
+    widget.render({
+      results: new SearchResults(helper.state, [
+        {
+          facets: {
+            whatever: {
+              true: 45,
+              false: 40,
+            },
+          },
+          nbHits: 85,
+        },
+      ]),
+      state: helper.state,
+      helper,
+    });
+
+    // toggle the value
+    caughtRefine();
+
+    expect(helper.state.disjunctiveFacetsRefinements).toEqual(
+      expect.objectContaining({
+        whatever: ['false'],
+      })
+    );
+  });
+
   describe('routing', () => {
     const getInitializedWidget = (config = {}) => {
       const rendering = jest.fn();

--- a/src/connectors/toggleRefinement/connectToggleRefinement.js
+++ b/src/connectors/toggleRefinement/connectToggleRefinement.js
@@ -97,8 +97,9 @@ export default function connectToggleRefinement(renderFn, unmountFn) {
     }
 
     const hasAnOffValue = userOff !== undefined;
-    const on = userOn ? escapeRefinement(userOn) : undefined;
-    const off = userOff ? escapeRefinement(userOff) : undefined;
+    const hasAnOnValue = userOn !== undefined;
+    const on = hasAnOnValue ? escapeRefinement(userOn) : undefined;
+    const off = hasAnOffValue ? escapeRefinement(userOff) : undefined;
 
     return {
       getConfiguration() {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

If `off` is passed a falsy value, before this change the helper would store the string "undefined", instead of the actual falsy value.

This behaviour likely broke in v2 -> v3, since with v2 this works.

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

1. check wether `widgetParams#on` and `widgetParams#off` are possible values (not undefined), instead of doing a ternary on their value
2. added new tests for this behaviour

The new "(falsy)" tests fail without my change.

This should be released in a patch before Vue InstantSearch stable releases 👍 