### PR TITLE
Update search-box type

### DIFF
--- a/src/connectors/search-box/connectSearchBox.js
+++ b/src/connectors/search-box/connectSearchBox.js
@@ -42,7 +42,7 @@ const withUsage = createDocumentationMessageGenerator({
  * // custom `renderFn` to render the custom SearchBox widget
  * function renderFn(SearchBoxRenderingOptions, isFirstRendering) {
  *   if (isFirstRendering) {
- *     SearchBoxRenderingOptions.widgetParams.containerNode.html('<input type="text" />');
+ *     SearchBoxRenderingOptions.widgetParams.containerNode.html('<input type="search" />');
  *     SearchBoxRenderingOptions.widgetParams.containerNode
  *       .find('input')
  *       .on('keyup', function() {

--- a/src/widgets/search-box/__tests__/__snapshots__/search-box-test.js.snap
+++ b/src/widgets/search-box/__tests__/__snapshots__/search-box-test.js.snap
@@ -17,7 +17,7 @@ exports[`searchBox() markup renders correctly 1`] = `
       placeholder=""
       role="textbox"
       spellcheck="false"
-      type="text"
+      type="search"
       value=""
     />
     <button

--- a/src/widgets/search-box/__tests__/search-box-test.js
+++ b/src/widgets/search-box/__tests__/search-box-test.js
@@ -89,7 +89,7 @@ You may want to migrate using \`connectSearchBox\`: https://www.algolia.com/doc/
       expect(input.getAttribute('placeholder')).toEqual('');
       expect(input.getAttribute('role')).toEqual('textbox');
       expect(input.getAttribute('spellcheck')).toEqual('false');
-      expect(input.getAttribute('type')).toEqual('text');
+      expect(input.getAttribute('type')).toEqual('search');
     });
 
     it('supports cssClasses option', () => {

--- a/src/widgets/search-box/search-box.js
+++ b/src/widgets/search-box/search-box.js
@@ -278,7 +278,7 @@ function addDefaultAttributesToInput(placeholder, input, query, cssClasses) {
     placeholder,
     role: 'textbox',
     spellcheck: 'false',
-    type: 'text',
+    type: 'search',
     value: query,
   };
 


### PR DESCRIPTION
Change <input> type  to  search

**Summary**

A customer complained  that the <input> type  is text and not search. type='search' makes the CTA button on iOS keyboards read 'search' instead of 'done'. I noticed in React IS this is already the case.


