### PR TITLE
feat(insights): POC click analytics integration

### DIFF
--- a/src/components/Hits/withClickAnalytics.js
+++ b/src/components/Hits/withClickAnalytics.js
@@ -1,0 +1,67 @@
+import React, { Component } from 'preact-compat';
+import PropTypes from 'prop-types';
+
+export default C =>
+  class WithClickAnalyticsWrapper extends Component {
+    static propTypes = {
+      hits: PropTypes.array.isRequired,
+      results: PropTypes.object.isRequired,
+    };
+
+    constructor(props) {
+      super(props);
+      this.ref = null;
+    }
+
+    componentDidMount() {
+      const node = this.ref.getDOMNode();
+      node.addEventListener('click', ev => {
+        const event = ev.target.getAttribute('data-analytics-event');
+        const payload = ev.target.getAttribute('data-analytics-payload');
+        if (event && payload) {
+          // event should be oneOf ['clickedObjectIDsAfterSearch', ...]
+          // payload should be valid json
+          let jsonPayload;
+          try {
+            jsonPayload = JSON.parse(payload);
+          } catch (e) {
+            console.error('Invalid JSON event payload');
+            return;
+          }
+
+          // call aa(eventType, eventPayload)
+          console.log(event, jsonPayload);
+        }
+      });
+    }
+
+    render() {
+      const {
+        results: { index, hitsPerPage, page, queryID },
+      } = this.props;
+
+      const hits = this.props.hits.map((hit, position) => ({
+        ...hit,
+        __hitAbsoluteIndex: hitsPerPage * page + position + 1,
+        __index: index,
+        __queryID: queryID,
+        analytics: {
+          clickedObjectIDsAfterSearch: eventName => {
+            const payload = {
+              eventName,
+              index,
+              queryID,
+              objectIDs: [hit.objectID],
+              positions: [hitsPerPage * page + position + 1],
+            };
+            return `
+              data-analytics-event="clickedObjectIDsAfterSearch"
+              data-analytics-payload='${JSON.stringify(payload)}'
+            `;
+          },
+        },
+      }));
+
+      return <C ref={node => (this.ref = node)} {...this.props} hits={hits} />;
+    }
+  };

--- a/src/components/Hits/withClickAnalytics.js
+++ b/src/components/Hits/withClickAnalytics.js
@@ -1,11 +1,16 @@
 import React, { Component } from 'preact-compat';
 import PropTypes from 'prop-types';
+import {
+  readData as readAnalyticsData,
+  hasData as hasAnalyticsData,
+} from '../../helpers/analytics';
 
 export default C =>
   class WithClickAnalyticsWrapper extends Component {
     static propTypes = {
       hits: PropTypes.array.isRequired,
       results: PropTypes.object.isRequired,
+      analytics: PropTypes.object.isRequired,
     };
 
     constructor(props) {
@@ -13,55 +18,32 @@ export default C =>
       this.ref = null;
     }
 
-    componentDidMount() {
-      const node = this.ref.getDOMNode();
-      node.addEventListener('click', ev => {
-        const event = ev.target.getAttribute('data-analytics-event');
-        const payload = ev.target.getAttribute('data-analytics-payload');
-        if (event && payload) {
-          // event should be oneOf ['clickedObjectIDsAfterSearch', ...]
-          // payload should be valid json
-          let jsonPayload;
-          try {
-            jsonPayload = JSON.parse(payload);
-          } catch (e) {
-            console.error('Invalid JSON event payload');
-            return;
-          }
+    handleClick = ev => {
+      if (!hasAnalyticsData(ev.target)) return;
+      const { method, objectID, payload } = readAnalyticsData(ev.target);
+      if (typeof this.props.analytics[method] !== 'function') {
+        throw new Error(`Unknown insights method ${method}`);
+      }
+      this.props.analytics[method](objectID, payload);
+    };
 
-          // call aa(eventType, eventPayload)
-          console.log(event, jsonPayload);
-        }
-      });
+    componentDidMount() {
+      this.ref.getDOMNode().addEventListener('click', this.handleClick);
+    }
+
+    componentWillUnmount() {
+      this.ref.getDOMNode().removeEventListener('click', this.handleClick);
     }
 
     render() {
-      const {
-        results: { index, hitsPerPage, page, queryID },
-      } = this.props;
-
-      const hits = this.props.hits.map((hit, position) => ({
-        ...hit,
-        __hitAbsoluteIndex: hitsPerPage * page + position + 1,
-        __index: index,
-        __queryID: queryID,
-        analytics: {
-          clickedObjectIDsAfterSearch: eventName => {
-            const payload = {
-              eventName,
-              index,
-              queryID,
-              objectIDs: [hit.objectID],
-              positions: [hitsPerPage * page + position + 1],
-            };
-            return `
-              data-analytics-event="clickedObjectIDsAfterSearch"
-              data-analytics-payload='${JSON.stringify(payload)}'
-            `;
-          },
-        },
-      }));
-
-      return <C ref={node => (this.ref = node)} {...this.props} hits={hits} />;
+      const { analytics, ...otherProps } = this.props; // removing unused analytics
+      return (
+        <C
+          ref={node => {
+            this.ref = node;
+          }}
+          {...otherProps}
+        />
+      );
     }
   };

--- a/src/connectors/hits/connectHits.js
+++ b/src/connectors/hits/connectHits.js
@@ -2,6 +2,7 @@ import escapeHits, { TAG_PLACEHOLDER } from '../../lib/escape-highlight';
 import {
   checkRendering,
   createDocumentationMessageGenerator,
+  createAnalyticsHelpers,
 } from '../../lib/utils';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -66,6 +67,7 @@ export default function connectHits(renderFn, unmountFn) {
             results: undefined,
             instantSearchInstance,
             widgetParams,
+            analytics: undefined,
           },
           true
         );
@@ -76,6 +78,16 @@ export default function connectHits(renderFn, unmountFn) {
           results.hits = escapeHits(results.hits);
         }
 
+        // should we expose this only if instantSearchInstance contains clickAnalytics: true?
+        const analyticsHelpers = createAnalyticsHelpers(
+          instantSearchInstance,
+          results
+        );
+        results.hits = results.hits.map(hit => ({
+          ...hit,
+          __analytics: analyticsHelpers._getAnalyticsData(hit.objectID),
+        }));
+
         results.hits = transformItems(results.hits);
 
         renderFn(
@@ -84,6 +96,7 @@ export default function connectHits(renderFn, unmountFn) {
             results,
             instantSearchInstance,
             widgetParams,
+            analytics: analyticsHelpers, // expose helpers to be used by other flavours or custom components
           },
           false
         );

--- a/src/helpers/analytics.js
+++ b/src/helpers/analytics.js
@@ -35,7 +35,7 @@ function writeData({ method, objectID, payload }) {
      data-analytics-payload='${serializedPayload}'`;
 }
 export function hasData(domElement) {
-  return !!domElement.getAttribute('data-analytics-method');
+  return domElement.hasAttribute('data-analytics-method');
 }
 export function readData(domElement) {
   const method = domElement.getAttribute('data-analytics-method');

--- a/src/helpers/analytics.js
+++ b/src/helpers/analytics.js
@@ -1,0 +1,59 @@
+// we could decide to have more specific helpers to make the code lighter for func templates
+// clickedObjectIDsAfterSearch(payload)
+// etc
+export function clickedObjectIDsAfterSearch(objectID, payload) {
+  return writeData({
+    method: 'clickedObjectIDsAfterSearch',
+    objectID,
+    payload,
+  });
+}
+
+export function convertedObjectIDsAfterSearch(objectID, payload) {
+  return writeData({
+    method: 'convertedObjectIDsAfterSearch',
+    objectID,
+    payload,
+  });
+}
+
+function writeData({ method, objectID, payload }) {
+  // TODO: serialize payload in base64
+  let serializedPayload;
+  if (typeof payload === 'string') {
+    serializedPayload = payload;
+  } else if (typeof payload === 'object') {
+    try {
+      serializedPayload = JSON.stringify(payload);
+    } catch (e) {
+      throw new Error(
+        `The analytics helper expects payload to be either a string or a JSON object`
+      );
+    }
+  }
+  return `data-analytics-method="${method}" data-analytics-object-id="${objectID}" 
+     data-analytics-payload='${serializedPayload}'`;
+}
+export function hasData(domElement) {
+  return !!domElement.getAttribute('data-analytics-method');
+}
+export function readData(domElement) {
+  const method = domElement.getAttribute('data-analytics-method');
+  const objectID = domElement.getAttribute('data-analytics-object-id');
+  const serializedPayload = domElement.getAttribute('data-analytics-payload');
+  let payload;
+  if (typeof serializedPayload !== 'string') {
+    throw new Error(
+      `The analytics helper expects payload to be either a string or a JSON object`
+    );
+  }
+
+  // TODO: unserialize payload in base64
+  try {
+    payload = JSON.parse(serializedPayload);
+  } catch (e) {
+    // assume it's the eventName
+    payload = { eventName: serializedPayload };
+  }
+  return { method, objectID, payload };
+}

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,2 +1,3 @@
 export { default as highlight } from './highlight';
 export { default as snippet } from './snippet';
+export { clickedObjectIDsAfterSearch, convertedObjectIDsAfterSearch } from './analytics';

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -45,6 +45,8 @@ class InstantSearch extends EventEmitter {
       searchFunction,
       stalledSearchDelay = 200,
       searchClient = null,
+      // TODO: check the version number and output error message if < 1.0.0
+      insightsClient = null,
     } = options;
 
     if (indexName === null || searchClient === null) {
@@ -72,6 +74,7 @@ class InstantSearch extends EventEmitter {
 
     this.client = searchClient;
     this.helper = null;
+    this.insightsClient = insightsClient;
     this.indexName = indexName;
     this.searchParameters = { ...searchParameters, index: indexName };
     this.widgets = [];

--- a/src/lib/createHelpers.js
+++ b/src/lib/createHelpers.js
@@ -1,4 +1,9 @@
-import { highlight, snippet } from '../helpers';
+import {
+  highlight,
+  snippet,
+  clickedObjectIDsAfterSearch,
+  convertedObjectIDsAfterSearch,
+} from '../helpers';
 
 export default function({ numberLocale }) {
   return {
@@ -36,6 +41,23 @@ The highlight helper expects a JSON object of the format:
 The snippet helper expects a JSON object of the format:
 { "attribute": "name", "highlightedTagName": "mark" }`);
       }
+    },
+    // did not namespace theses for now because it overcomplicates the code
+    clickedObjectIDsAfterSearch(payload, render) {
+      return render(
+        clickedObjectIDsAfterSearch({
+          objectID: this.objectID,
+          payload,
+        })
+      );
+    },
+    convertedObjectIDsAfterSearch(payload, render) {
+      return render(
+        convertedObjectIDsAfterSearch({
+          objectID: this.objectID,
+          payload,
+        })
+      );
     },
   };
 }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -9,7 +9,6 @@ import mapKeys from 'lodash/mapKeys';
 import mapValues from 'lodash/mapValues';
 import curry from 'lodash/curry';
 import hogan from 'hogan.js';
-import isEqual from '../index';
 
 function capitalize(string) {
   return (

--- a/src/widgets/hits/hits.js
+++ b/src/widgets/hits/hits.js
@@ -2,6 +2,7 @@ import React, { render, unmountComponentAtNode } from 'preact-compat';
 import cx from 'classnames';
 import connectHits from '../../connectors/hits/connectHits';
 import Hits from '../../components/Hits/Hits';
+import withClickAnalytics from '../../components/Hits/withClickAnalytics';
 import defaultTemplates from './defaultTemplates';
 import {
   prepareTemplateProps,
@@ -14,6 +15,7 @@ import { component } from '../../lib/suit';
 
 const withUsage = createDocumentationMessageGenerator({ name: 'hits' });
 const suit = component('Hits');
+const HitsWithClickAnalytics = withClickAnalytics(Hits);
 
 const renderer = ({ renderState, cssClasses, containerNode, templates }) => (
   { hits: receivedHits, results, instantSearchInstance },
@@ -28,8 +30,11 @@ const renderer = ({ renderState, cssClasses, containerNode, templates }) => (
     return;
   }
 
+  const hasClickAnalytics =
+    instantSearchInstance.searchParameters.clickAnalytics;
+  const _Hits = hasClickAnalytics ? HitsWithClickAnalytics : Hits;
   render(
-    <Hits
+    <_Hits
       cssClasses={cssClasses}
       hits={receivedHits}
       results={results}

--- a/src/widgets/hits/hits.js
+++ b/src/widgets/hits/hits.js
@@ -18,7 +18,7 @@ const suit = component('Hits');
 const HitsWithClickAnalytics = withClickAnalytics(Hits);
 
 const renderer = ({ renderState, cssClasses, containerNode, templates }) => (
-  { hits: receivedHits, results, instantSearchInstance },
+  { hits: receivedHits, results, instantSearchInstance, analytics },
   isFirstRendering
 ) => {
   if (isFirstRendering) {
@@ -30,18 +30,24 @@ const renderer = ({ renderState, cssClasses, containerNode, templates }) => (
     return;
   }
 
+  const hitsProps = {
+    cssClasses,
+    hits: receivedHits,
+    results,
+    templateProps: renderState.templateProps,
+  };
+
   const hasClickAnalytics =
     instantSearchInstance.searchParameters.clickAnalytics;
-  const _Hits = hasClickAnalytics ? HitsWithClickAnalytics : Hits;
-  render(
-    <_Hits
-      cssClasses={cssClasses}
-      hits={receivedHits}
-      results={results}
-      templateProps={renderState.templateProps}
-    />,
-    containerNode
-  );
+
+  if (hasClickAnalytics) {
+    render(
+      <HitsWithClickAnalytics {...hitsProps} analytics={analytics} />,
+      containerNode
+    );
+  } else {
+    render(<Hits {...hitsProps} />, containerNode);
+  }
 };
 
 /**

--- a/stories/clickAnalytics.stories.js
+++ b/stories/clickAnalytics.stories.js
@@ -1,27 +1,143 @@
 import { storiesOf } from '@storybook/html';
 import { withHits } from '../.storybook/decorators';
+import * as analyticsHelpers from '../src/helpers/analytics';
 
-storiesOf('ClickAnalytics', module).add(
-  'basic',
-  withHits(({ search, container, instantsearch }) => {
-    search.addWidgets([
-      instantsearch.widgets.configure({
-        clickAnalytics: true,
-      }),
-      instantsearch.widgets.hits({
-        container,
-        templates: {
-          item: ({ analytics: { clickedObjectIDsAfterSearch }, ...item }) =>
-            `
+const insightsClientMock = (eventName, payload) => {
+  console.log('mocked insights client:', eventName, payload);
+};
+
+storiesOf('ClickAnalytics', module)
+  .add(
+    'with function template',
+    withHits(
+      ({ search, container, instantsearch }) => {
+        search.addWidget(
+          instantsearch.widgets.hits({
+            container,
+            templates: {
+              item: item =>
+                `
               <h3> ${item.name} </h3> 
               <div>
-                 <button ${clickedObjectIDsAfterSearch('Add to basket')}>
-                  Add to basket
-                </button>
+                <button ${analyticsHelpers.clickedObjectIDsAfterSearch(
+                  item.objectID,
+                  {
+                    eventName: 'Add to basket',
+                  }
+                )}> Add to basket (click) </button>
+                <button ${analyticsHelpers.convertedObjectIDsAfterSearch(
+                  item.objectID,
+                  {
+                    eventName: 'Add to favorite',
+                  }
+                )}> Add to basket (convert) </button>
+                <a href="view/?qid=${item.__analytics.queryID}">
+                  View item
+                </a>
               </div>
               `,
+            },
+          })
+        );
+      },
+      {
+        searchParameters: {
+          clickAnalytics: true,
         },
-      }),
-    ]);
-  })
-);
+        insightsClient: insightsClientMock,
+      }
+    )
+  )
+  .add(
+    'with hogan templates',
+    withHits(
+      ({ search, container, instantsearch }) => {
+        search.addWidget(
+          instantsearch.widgets.hits({
+            container,
+            templates: {
+              item: `
+              <h3> {{name}} </h3>
+              <button 
+                {{#helpers.clickedObjectIDsAfterSearch}}{ 
+                  eventName: 'Add to cart'
+                }{{/helpers.clickedObjectIDsAfterSearch}}>
+                Add to basket
+              </button>
+              <a href="view/?qid={{__analytics.queryID}}">
+                View item
+              </a>
+            `,
+            },
+          })
+        );
+      },
+      {
+        searchParameters: {
+          clickAnalytics: true,
+        },
+        insightsClient: insightsClientMock,
+      }
+    )
+  )
+  .add(
+    'with custom hits widget',
+    withHits(
+      ({ search, container, instantsearch }) => {
+        const renderHits = (renderOptions, isFirstRender) => {
+          const { hits, widgetParams, analytics } = renderOptions;
+
+          const ul = document.createElement('div');
+          ul.innerHTML = hits
+            .map(
+              item =>
+                `<li>
+                       ${instantsearch.highlight({
+                         attribute: 'name',
+                         hit: item,
+                       })}
+                      <button ${analyticsHelpers.convertedObjectIDsAfterSearch(
+                        item.objectID,
+                        { eventName: 'Add to cart' }
+                      )}>
+                        Add to cart
+                      </button>
+                    </li>
+                   `
+            )
+            .join('');
+
+          ul.addEventListener('click', ev => {
+            if (!analyticsHelpers.hasData(ev.target)) return;
+            const { method, objectID, payload } = analyticsHelpers.readData(
+              ev.target
+            );
+            analytics[method](objectID, payload);
+          });
+
+          widgetParams.container.innerHTML = '';
+          widgetParams.container.appendChild(ul);
+
+          if (isFirstRender) {
+            return;
+          }
+        };
+
+        // Create the custom widget
+        const customHits = instantsearch.connectors.connectHits(renderHits);
+
+        // Instantiate the custom widget
+        search.addWidget(
+          customHits({
+            container,
+          })
+        );
+      },
+      {
+        searchParameters: {
+          clickAnalytics: true,
+        },
+        insightsClient: insightsClientMock,
+      }
+    )
+  );

--- a/stories/clickAnalytics.stories.js
+++ b/stories/clickAnalytics.stories.js
@@ -1,0 +1,27 @@
+import { storiesOf } from '@storybook/html';
+import { withHits } from '../.storybook/decorators';
+
+storiesOf('ClickAnalytics', module).add(
+  'basic',
+  withHits(({ search, container, instantsearch }) => {
+    search.addWidgets([
+      instantsearch.widgets.configure({
+        clickAnalytics: true,
+      }),
+      instantsearch.widgets.hits({
+        container,
+        templates: {
+          item: ({ analytics: { clickedObjectIDsAfterSearch }, ...item }) =>
+            `
+              <h3> ${item.name} </h3> 
+              <div>
+                 <button ${clickedObjectIDsAfterSearch('Add to basket')}>
+                  Add to basket
+                </button>
+              </div>
+              `,
+        },
+      }),
+    ]);
+  })
+);


### PR DESCRIPTION
This POC demonstrating a possible integration between our clickAnalytics and InstantSearchJS.

> How we currently do it: https://www.algolia.com/doc/guides/building-search-ui/going-further/plug-analytics/js/?language=js#using-algolia-insights-with-instantsearchjs

### Test this out
1. Go on https://deploy-preview-3547--instantsearchjs.netlify.com/stories/?selectedKind=ClickAnalytics&selectedStory=with%20function%20template&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel
2. open your browser console
2. click on `add to cart`

### How it is used

For instant search user, sending `click` events (or other events types) can be done with the following way

```js
import * as analytics from "../src/helpers/analytics";

// initialize the search-insights clients
aa("init", {
  appId: "APPLICATION_ID",
  apiKey: "SEARCH_API_KEY",
  userHasOptedOut: false
});
aa("setUserToken", "xxx");

const search = instantsearch({
  indexName: "instant_search",
  /* ... */
  insightsClient: aa
});

// add the hits widget
search.addWidgets([
  instantsearch.widgets.configure({
    clickAnalytics: true
  }),
  instantsearch.widgets.hits({
    container,
    templates: {
      item: item => `
        <h3> ${item.name} </h3>
        <button ${analytics.clickedObjectIDsAfterSearch(item.objectID, {
          eventName: "Add to basket"
        })}>
           Add to basket
        </button>
      `
    }
  })
]);
```

This is going to call the [clickedObjectIDsAfterSearch](https://github.com/algolia/search-insights.js#reporting-a-click-event) in the following way:

```js
aa("clickedObjectIDsAfterSearch", {
  eventName: "Add to basket", // user provided
  index: "instant_search", // infered from `results`,
  queryID: "***", // infered from `results`,
  objectIDs: ["1"], // infered from `hit`,
  positions: [1] // computed and infered from `hit` and `results`,
});
```
#### With Hogan

```handlebars
<button
  {{#helpers.clickedObjectIDsAfterSearch}}{
    eventName: 'Add to cart'
  }{{/helpers.clickedObjectIDsAfterSearch}}>
  Add to basket
</button>
```

### How it works

There are three parts:

- `connectHits` is using `createAnalyticsHelpers()`:
  - exposes `analytics` object with methods that call the insights client directly (useful for other flavours)
  - inject in every hit `hit.__analytics = { index: "instant_search", queryID: "xxx", objectIDs: ["1"], positions: [10] }`
- helpers `analytics.clickedObjectIDsAfterSearch` are helpers generates data attributes
- the `WithClickAnalyticsWrapper` wraps the Hits component and sets a click listener that reads data attribute and calls connector analytics methods

### Possible improvements and unresolved questions

- Conversion events are often sent outside the contexte of instantsearch. Can we help in that situation?
We expose the queryID so the user can extract the queryID in the following way:
```html
  <a href="https://mywebsite.com/?queryID=${item.__analytics.queryID}"> Add to basket </a>
```
```handlebars
  <a href="https://mywebsite.com/?queryID={{__analytics.queryID}}"> Add to basket </a>
```
- This POC is intended to work on InfiniteHits as well.
