### PR TITLE
chore: setup canonical meta

### DIFF
--- a/docgen/layouts/common/meta.pug
+++ b/docgen/layouts/common/meta.pug
@@ -34,4 +34,9 @@ html
     link(rel='stylesheet', href="stylesheets/style.css")
     link(rel="stylesheet", href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css")
 
+    if canonical
+      link(rel='canonical', href=canonical)
+    else
+      meta(name="robots", content="noindex, nofollow")
+
     block head

--- a/docgen/plugins/documentationjs-data.js
+++ b/docgen/plugins/documentationjs-data.js
@@ -94,6 +94,8 @@ function groupSymbolsByCategories(symbols) {
 function mapInstantSearch([instantsearchFactory, InstantSearch], symbols, files) {
   const fileName = 'instantsearch.html';
 
+  const canonical = instantsearchFactory.tags.find(t => t.title === 'canonical') || false;
+
   files[fileName] = {
     mode: '0764',
     contents: '',
@@ -112,6 +114,7 @@ function mapInstantSearch([instantsearchFactory, InstantSearch], symbols, files)
     withHeadings: true,
     editable: true,
     githubSource: getGithubSource(InstantSearch),
+    canonical: createCanonicalURL(canonical),
   };
 }
 

--- a/docgen/plugins/documentationjs-data.js
+++ b/docgen/plugins/documentationjs-data.js
@@ -154,6 +154,7 @@ function mapWidgets(widgets, symbols, files) {
     const staticExamples = symbol.tags.filter(t => t.title === 'staticExample');
     const requirements = symbol.tags.find(t => t.title === 'requirements') || { description: '' };
     const devNovel = symbol.tags.find(t => t.title === 'devNovel') || false;
+    const canonical = symbol.tags.find(t => t.title === 'canonical') || false;
 
     const symbolWithRelatedType = {
       ...symbol,
@@ -175,6 +176,7 @@ function mapWidgets(widgets, symbols, files) {
       withHeadings: true,
       editable: true,
       githubSource: getGithubSource(symbolWithRelatedType),
+      canonical: createCanonicalURL(canonical),
     };
   });
 }
@@ -235,4 +237,8 @@ function isCustomType(name) {
 
 function createDevNovelURL(devNovel) {
   return devNovel ? `dev-novel?selectedStory=${devNovel.description}.default` : '';
+}
+
+function createCanonicalURL(canonical) {
+  return canonical && canonical.description ? canonical.description : '';
 }

--- a/docgen/plugins/documentationjs-data.js
+++ b/docgen/plugins/documentationjs-data.js
@@ -122,6 +122,7 @@ function mapConnectors(connectors, symbols, files) {
     const relatedTypes = findRelatedTypes(symbol, symbols);
     const staticExamples = symbol.tags.filter(t => t.title === 'staticExample');
     const requirements = symbol.tags.find(t => t.title === 'requirements') || { description: '' };
+    const canonical = symbol.tags.find(t => t.title === 'canonical') || false;
 
     const symbolWithRelatedType = {
       ...symbol,
@@ -142,6 +143,7 @@ function mapConnectors(connectors, symbols, files) {
       withHeadings: true,
       editable: true,
       githubSource: getGithubSource(symbolWithRelatedType),
+      canonical: createCanonicalURL(canonical),
     };
   });
 }

--- a/docgen/src/connectors.md
+++ b/docgen/src/connectors.md
@@ -7,6 +7,7 @@ withHeadings: true
 navWeight: 100
 editable: true
 githubSource: docgen/src/connectors.md
+canonical: https://www.algolia.com/doc/guides/building-search-ui/widgets/customize-an-existing-widget/js/
 ---
 
 ## Introduction to connectors

--- a/docgen/src/examples.md
+++ b/docgen/src/examples.md
@@ -20,6 +20,7 @@ examples: [{
 examplesEndpoint: examples
 editable: true
 githubSource: docgen/src/examples.md
+canonical: https://www.algolia.com/doc/guides/building-search-ui/resources/demos/js/
 ---
 
 ## Demos

--- a/docgen/src/getting-started.md.hbs
+++ b/docgen/src/getting-started.md.hbs
@@ -7,6 +7,7 @@ withHeadings: true
 navWeight: 100
 editable: true
 githubSource: docgen/src/getting-started.md.hbs
+canonical: https://www.algolia.com/doc/guides/building-search-ui/getting-started/js/
 ---
 
 ## Welcome to InstantSearch.js

--- a/docgen/src/guides/custom-backend.md
+++ b/docgen/src/guides/custom-backend.md
@@ -7,6 +7,7 @@ withHeadings: true
 navWeight: 21
 editable: true
 githubSource: docgen/src/guides/custom-backend.md
+canonical: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend-search/in-depth/backend-instantsearch/js/
 ---
 
 > This guide is compatible with InstantSearch.js ≥ 2.8.0.

--- a/docgen/src/guides/custom-widget.md
+++ b/docgen/src/guides/custom-widget.md
@@ -8,6 +8,7 @@ withHeadings: true
 navWeight: 20
 editable: true
 githubSource: docgen/src/guides/custom-widget.md
+canonical: https://www.algolia.com/doc/guides/building-search-ui/widgets/create-your-own-widgets/js/
 ---
 
 ## Creating new widgets

--- a/docgen/src/guides/customization.md
+++ b/docgen/src/guides/customization.md
@@ -8,6 +8,7 @@ withHeadings: true
 navWeight: 20
 editable: true
 githubSource: docgen/src/guides/customization.md
+canonical: https://www.algolia.com/doc/guides/building-search-ui/widgets/customize-an-existing-widget/js/
 ---
 
 ## Customize widgets

--- a/docgen/src/guides/migration.md
+++ b/docgen/src/guides/migration.md
@@ -7,6 +7,7 @@ withHeadings: true
 navWeight: 10
 editable: true
 githubSource: docgen/src/guides/migration.md
+canonical: https://www.algolia.com/doc/guides/building-search-ui/upgrade-guides/js/
 ---
 
 ## The searchBox widget has new default options

--- a/docgen/src/guides/no-result.md
+++ b/docgen/src/guides/no-result.md
@@ -7,6 +7,7 @@ withHeadings: true
 navWeight: 10
 editable: true
 githubSource: docgen/src/guides/no-result.md
+canonical: https://www.algolia.com/doc/guides/building-search-ui/going-further/conditional-display/js/
 ---
 ## Designing the no results page
 

--- a/docgen/src/guides/opensearch.md
+++ b/docgen/src/guides/opensearch.md
@@ -7,6 +7,7 @@ withHeadings: true
 navWeight: 10
 editable: true
 githubSource: docgen/src/guides/opensearch.md
+canonical: https://www.algolia.com/doc/guides/building-search-ui/resources/ui-and-ux-patterns/in-depth/opensearch/js/
 ---
 
 OpenSearch is web standard that makes browsers aware of an underlying search

--- a/docgen/src/guides/routing.md
+++ b/docgen/src/guides/routing.md
@@ -8,6 +8,7 @@ navWeight: 5
 withHeadings: true
 editable: true
 githubSource: docgen/src/guides/routing.md
+canonical: https://www.algolia.com/doc/guides/building-search-ui/going-further/routing-urls/js/
 ---
 
 Via the `routing` option, InstantSearch provides the necessary API entries to allow you to synchronize the state of your search UI (which widget were refined, what is the current search query ..) with any kind of storage. And most probably you want that storage to be the browser url bar.

--- a/docgen/src/guides/usage.md
+++ b/docgen/src/guides/usage.md
@@ -8,6 +8,7 @@ withHeadings: true
 navWeight: 30
 editable: true
 githubSource: docgen/src/guides/usage.md
+canonical: https://www.algolia.com/doc/guides/building-search-ui/installation/js/
 ---
 
 ## Use InstantSearch.js

--- a/docgen/src/index.md
+++ b/docgen/src/index.md
@@ -1,5 +1,6 @@
 ---
 title: InstantSearch.js
 layout: index.pug
+canonical: https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/js/
 ---
 <!-- the content is in layouts/index.pug -->

--- a/docgen/src/widgets.md
+++ b/docgen/src/widgets.md
@@ -7,6 +7,7 @@ withHeadings: true
 navWeight: 100
 editable: true
 githubSource: docgen/src/widgets.md
+canonical: https://www.algolia.com/doc/guides/building-search-ui/widgets/showcase/js/
 ---
 
 ## Introduction to widgets

--- a/src/connectors/autocomplete/connectAutocomplete.js
+++ b/src/connectors/autocomplete/connectAutocomplete.js
@@ -46,6 +46,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/c
  * THere's a complete example available on how to write a custom **Autocomplete** widget:
  * [autocomplete.js](https://github.com/algolia/instantsearch.js/blob/develop/dev/app/custom-widgets/jquery/autocomplete.js)
  * @type {Connector}
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/autocomplete/js/
  * @param {function(AutocompleteRenderingOptions, boolean)} renderFn Rendering function for the custom **Autocomplete** widget.
  * @param {function} unmountFn Unmount function called when the widget is disposed.
  * @return {function(CustomAutocompleteWidgetOptions)} Re-usable widget factory for a custom **Autocomplete** widget.

--- a/src/connectors/breadcrumb/connectBreadcrumb.js
+++ b/src/connectors/breadcrumb/connectBreadcrumb.js
@@ -51,6 +51,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  *
  * This is commonly used in websites that have a large amount of content organized in a hierarchical manner (usually e-commerce websites).
  * @type {Connector}
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/breadcrumb/js/
  * @param {function(BreadcrumbRenderingOptions, boolean)} renderFn Rendering function for the custom **Breadcrumb* widget.
  * @param {function} unmountFn Unmount function called when the widget is disposed.
  * @return {function(CustomBreadcrumbWidgetOptions)} Re-usable widget factory for a custom **Breadcrumb** widget.

--- a/src/connectors/clear-all/connectClearAll.js
+++ b/src/connectors/clear-all/connectClearAll.js
@@ -48,6 +48,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  * prevent certain attributes from being cleared.
  *
  * @type {Connector}
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/clear-refinements/js/
  * @param {function(ClearAllRenderingOptions, boolean)} renderFn Rendering function for the custom **ClearAll** widget.
  * @param {function} unmountFn Unmount function called when the widget is disposed.
  * @return {function(CustomClearAllWidgetOptions)} Re-usable widget factory for a custom **ClearAll** widget.

--- a/src/connectors/configure/connectConfigure.js
+++ b/src/connectors/configure/connectConfigure.js
@@ -31,6 +31,7 @@ var customConfigureWidget = connectConfigure(
  * that will give you ability to override or force some search parameters sent to Algolia API.
  *
  * @type {Connector}
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/configure/js/
  * @param {function(ConfigureRenderingOptions)} renderFn Rendering function for the custom **Configure** Widget.
  * @param {function} unmountFn Unmount function called when the widget is disposed.
  * @return {function(CustomConfigureWidgetOptions)} Re-usable widget factory for a custom **Configure** widget.

--- a/src/connectors/current-refined-values/connectCurrentRefinedValues.js
+++ b/src/connectors/current-refined-values/connectCurrentRefinedValues.js
@@ -88,6 +88,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  * function to clear all the filters. Those functions can see their behaviour change based on
  * the widget options used.
  * @type {Connector}
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/current-refinements/js/
  * @param {function(CurrentRefinedValuesRenderingOptions)} renderFn Rendering function for the custom **CurrentRefinedValues** widget.
  * @param {function} unmountFn Unmount function called when the widget is disposed.
  * @return {function(CustomCurrentRefinedValuesWidgetOptions)} Re-usable widget factory for a custom **CurrentRefinedValues** widget.

--- a/src/connectors/geo-search/connectGeoSearch.js
+++ b/src/connectors/geo-search/connectGeoSearch.js
@@ -83,6 +83,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  * Currently, the feature is not compatible with multiple values in the _geoloc attribute.
  *
  * @type {Connector}
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/geo-search/js/
  * @param {function(GeoSearchRenderingOptions, boolean)} renderFn Rendering function for the custom **GeoSearch** widget.
  * @param {function} unmountFn Unmount function called when the widget is disposed.
  * @return {function(CustomGeoSearchWidgetOptions)} Re-usable widget factory for a custom **GeoSearch** widget.

--- a/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
+++ b/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
@@ -69,6 +69,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  * There's a complete example available on how to write a custom **HierarchicalMenu**:
  *  [hierarchicalMenu.js](https://github.com/algolia/instantsearch.js/blob/develop/dev/app/jquery/widgets/hierarchicalMenu.js)
  * @type {Connector}
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/hierarchical-menu/js/
  * @param {function(HierarchicalMenuRenderingOptions)} renderFn Rendering function for the custom **HierarchicalMenu** widget.
  * @param {function} unmountFn Unmount function called when the widget is disposed.
  * @return {function(CustomHierarchicalMenuWidgetOptions)} Re-usable widget factory for a custom **HierarchicalMenu** widget.

--- a/src/connectors/hits-per-page/connectHitsPerPage.js
+++ b/src/connectors/hits-per-page/connectHitsPerPage.js
@@ -60,6 +60,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  *
  * This connector provides a `refine()` function to change the hits per page configuration and trigger a new search.
  * @type {Connector}
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/hits-per-page/js/
  * @param {function(HitsPerPageRenderingOptions, boolean)} renderFn Rendering function for the custom **HitsPerPage** widget.
  * @param {function} unmountFn Unmount function called when the widget is disposed.
  * @return {function(HitsPerPageWidgetOptions)} Re-usable widget factory for a custom **HitsPerPage** widget.

--- a/src/connectors/hits/connectHits.js
+++ b/src/connectors/hits/connectHits.js
@@ -35,6 +35,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
 /**
  * **Hits** connector provides the logic to create custom widgets that will render the results retrieved from Algolia.
  * @type {Connector}
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/hits/js/
  * @param {function(HitsRenderingOptions, boolean)} renderFn Rendering function for the custom **Hits** widget.
  * @param {function} unmountFn Unmount function called when the widget is disposed.
  * @return {function(CustomHitsWidgetOptions)} Re-usable widget factory for a custom **Hits** widget.

--- a/src/connectors/infinite-hits/connectInfiniteHits.js
+++ b/src/connectors/infinite-hits/connectInfiniteHits.js
@@ -41,6 +41,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  *
  * This connector provides a `InfiniteHitsRenderingOptions.showMore()` function to load next page of matched results.
  * @type {Connector}
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/infinite-hits/js/
  * @param {function(InfiniteHitsRenderingOptions, boolean)} renderFn Rendering function for the custom **InfiniteHits** widget.
  * @param {function} unmountFn Unmount function called when the widget is disposed.
  * @return {function(CustomInfiniteHitsWidgetOptions)} Re-usable widget factory for a custom **InfiniteHits** widget.

--- a/src/connectors/menu/connectMenu.js
+++ b/src/connectors/menu/connectMenu.js
@@ -66,6 +66,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  *
  * **Requirement:** the attribute passed as `attributeName` must be present in "attributes for faceting" on the Algolia dashboard or configured as attributesForFaceting via a set settings call to the Algolia API.
  * @type {Connector}
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/menu/js/
  * @param {function(MenuRenderingOptions, boolean)} renderFn Rendering function for the custom **Menu** widget. widget.
  * @param {function} unmountFn Unmount function called when the widget is disposed.
  * @return {function(CustomMenuWidgetOptions)} Re-usable widget factory for a custom **Menu** widget.

--- a/src/connectors/numeric-refinement-list/connectNumericRefinementList.js
+++ b/src/connectors/numeric-refinement-list/connectNumericRefinementList.js
@@ -63,6 +63,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  * **Requirement:** the attribute passed as `attributeName` must be present in "attributes for faceting" on the Algolia dashboard or configured as attributesForFaceting via a set settings call to the Algolia API.
  * @function connectNumericRefinementList
  * @type {Connector}
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/numeric-menu/js/
  * @param {function(NumericRefinementListRenderingOptions, boolean)} renderFn Rendering function for the custom **NumericRefinementList** widget.
  * @param {function} unmountFn Unmount function called when the widget is disposed.
  * @return {function(CustomNumericRefinementListWidgetOptions)} Re-usable widget factory for a custom **NumericRefinementList** widget.

--- a/src/connectors/pagination/connectPagination.js
+++ b/src/connectors/pagination/connectPagination.js
@@ -49,6 +49,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  * beyond the 1000th hits by default. You can find more information on the [Algolia documentation](https://www.algolia.com/doc/guides/searching/pagination/#pagination-limitations).
  *
  * @type {Connector}
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/pagination/js/
  * @param {function(PaginationRenderingOptions, boolean)} renderFn Rendering function for the custom **Pagination** widget.
  * @param {function} unmountFn Unmount function called when the widget is disposed.
  * @return {function(CustomPaginationWidgetOptions)} Re-usable widget factory for a custom **Pagination** widget.

--- a/src/connectors/range/connectRange.js
+++ b/src/connectors/range/connectRange.js
@@ -52,6 +52,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  * This connectors provides a `refine()` function that accepts bounds. It will also provide
  * information about the min and max bounds for the current result set.
  * @type {Connector}
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/range-input/js/
  * @param {function(RangeRenderingOptions, boolean)} renderFn Rendering function for the custom **Range** widget.
  * @param {function} unmountFn Unmount function called when the widget is disposed.
  * @return {function(CustomRangeWidgetOptions)} Re-usable widget factory for a custom **Range** widget.

--- a/src/connectors/refinement-list/connectRefinementList.js
+++ b/src/connectors/refinement-list/connectRefinementList.js
@@ -95,6 +95,7 @@ export const checkUsage = ({
  * This connector provides a `toggleShowMore()` function to display more or less items and a `refine()`
  * function to select an item.
  * @type {Connector}
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/refinement-list/js/
  * @param {function(RefinementListRenderingOptions, boolean)} renderFn Rendering function for the custom **RefinementList** widget.
  * @param {function} unmountFn Unmount function called when the widget is disposed.
  * @return {function(CustomRefinementListWidgetOptions)} Re-usable widget factory for a custom **RefinementList** widget.

--- a/src/connectors/search-box/connectSearchBox.js
+++ b/src/connectors/search-box/connectSearchBox.js
@@ -46,6 +46,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  * The connector provides to the rendering: `refine()` to set the query. The behaviour of this function
  * may be impacted by the `queryHook` widget parameter.
  * @type {Connector}
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/search-box/js/
  * @param {function(SearchBoxRenderingOptions, boolean)} renderFn Rendering function for the custom **SearchBox** widget.
  * @param {function} unmountFn Unmount function called when the widget is disposed.
  * @return {function(CustomSearchBoxWidgetOptions)} Re-usable widget factory for a custom **SearchBox** widget.

--- a/src/connectors/sort-by-selector/connectSortBySelector.js
+++ b/src/connectors/sort-by-selector/connectSortBySelector.js
@@ -52,6 +52,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  * `options` that are the values that can be selected. `refine` should be used
  * with `options.value`.
  * @type {Connector}
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
  * @param {function(SortBySelectorRenderingOptions, boolean)} renderFn Rendering function for the custom **SortBySelector** widget.
  * @param {function} unmountFn Unmount function called when the widget is disposed.
  * @return {function(CustomSortBySelectorWidgetOptions)} Re-usable widget factory for a custom **SortBySelector** widget.

--- a/src/connectors/star-rating/connectStarRating.js
+++ b/src/connectors/star-rating/connectStarRating.js
@@ -54,6 +54,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  * `items` that are the values that can be selected. `refine` should be used
  * with `items.value`.
  * @type {Connector}
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/rating-menu/js/
  * @param {function(StarRatingRenderingOptions, boolean)} renderFn Rendering function for the custom **StarRating** widget.
  * @param {function} unmountFn Unmount function called when the widget is disposed.
  * @return {function(CustomStarRatingWidgetOptions)} Re-usable widget factory for a custom **StarRating** widget.

--- a/src/connectors/stats/connectStats.js
+++ b/src/connectors/stats/connectStats.js
@@ -32,6 +32,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  * search statistics (hits number and processing time).
  *
  * @type {Connector}
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/stats/js/
  * @param {function(StatsRenderingOptions, boolean)} renderFn Rendering function for the custom **Stats** widget.
  * @param {function} unmountFn Unmount function called when the widget is disposed.
  * @return {function} Re-usable widget factory for a custom **Stats** widget.

--- a/src/connectors/toggle/connectToggle.js
+++ b/src/connectors/toggle/connectToggle.js
@@ -59,6 +59,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  *  - switch between two values.
  *
  * @type {Connector}
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/toggle-refinement/js/
  * @param {function(ToggleRenderingOptions, boolean)} renderFn Rendering function for the custom **Toggle** widget.
  * @param {function} unmountFn Unmount function called when the widget is disposed.
  * @return {function(CustomToggleWidgetOptions)} Re-usable widget factory for a custom **Toggle** widget.

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -167,6 +167,7 @@ import * as stateMappings from './stateMappings/index.js';
  * look at the [getting started](getting-started.html).
  *
  * @function instantsearch
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/
  * @param {InstantSearchOptions} $0 The options
  * @return {InstantSearch} the instantsearch instance
  */

--- a/src/widgets/analytics/analytics.js
+++ b/src/widgets/analytics/analytics.js
@@ -26,6 +26,7 @@ analytics({
  * UI.
  * @type {WidgetFactory}
  * @devNovel Analytics
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/analytics/js/
  * @category analytics
  * @param {AnalyticsWidgetOptions} $0 The Analytics widget options.
  * @return {Widget} A new instance of the Analytics widget.

--- a/src/widgets/breadcrumb/breadcrumb.js
+++ b/src/widgets/breadcrumb/breadcrumb.js
@@ -135,6 +135,7 @@ breadcrumb({
  * ```
  * @type {WidgetFactory}
  * @devNovel Breadcrumb
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/breadcrumb/js/
  * @category navigation
  * @param {BreadcrumbWidgetOptions} $0 The Breadcrumb widget options.
  * @return {Widget} A new Breadcrumb widget instance.

--- a/src/widgets/clear-all/clear-all.js
+++ b/src/widgets/clear-all/clear-all.js
@@ -95,6 +95,7 @@ clearAll({
  * The current refined values widget can display a button that has the same behavior.
  * @type {WidgetFactory}
  * @devNovel ClearAll
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/clear-refinements/js/
  * @category clear-filter
  * @param {ClearAllWidgetOptions} $0 The ClearAll widget options.
  * @returns {Widget} A new instance of the ClearAll widget.

--- a/src/widgets/configure/configure.js
+++ b/src/widgets/configure/configure.js
@@ -19,6 +19,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  *
  * @type {WidgetFactory}
  * @category filter
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/configure/js/
  * @param {SearchParameters} searchParameters The Configure widget options are search parameters
  * @returns {Object} A new Configure widget instance.
  * @example

--- a/src/widgets/current-refined-values/current-refined-values.js
+++ b/src/widgets/current-refined-values/current-refined-values.js
@@ -161,6 +161,7 @@ currentRefinedValues({
  * This widget is usually in the top part of the search UI.
  * @type {WidgetFactory}
  * @devNovel CurrentRefinedValues
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/current-refinements/js/
  * @category clear-filter
  * @param {CurrentRefinedValuesWidgetOptions} $0 The CurrentRefinedValues widget options.
  * @returns {Object} A new CurrentRefinedValues widget instance.

--- a/src/widgets/geo-search/geo-search.js
+++ b/src/widgets/geo-search/geo-search.js
@@ -130,6 +130,7 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  *
  * @type {WidgetFactory}
  * @devNovel GeoSearch
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/geo-search/js/
  * @param {GeoSearchWidgetOptions} $0 Options of the GeoSearch widget.
  * @return {Widget} A new instance of GeoSearch widget.
  * @staticExample

--- a/src/widgets/hierarchical-menu/hierarchical-menu.js
+++ b/src/widgets/hierarchical-menu/hierarchical-menu.js
@@ -175,6 +175,7 @@ hierarchicalMenu({
  * ```
  * @type {WidgetFactory}
  * @devNovel HierarchicalMenu
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/hierarchical-menu/js/
  * @category filter
  * @param {HierarchicalMenuWidgetOptions} $0 The HierarchicalMenu widget options.
  * @return {Widget} A new HierarchicalMenu widget instance.

--- a/src/widgets/hits-per-page-selector/hits-per-page-selector.js
+++ b/src/widgets/hits-per-page-selector/hits-per-page-selector.js
@@ -70,6 +70,7 @@ hitsPerPageSelector({
  * You can specify the default hits per page using a boolean in the items[] array. If none is specified, this first hits per page option will be picked.
  * @type {WidgetFactory}
  * @devNovel HitsPerPageSelector
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/hits-per-page/js/
  * @category basic
  * @param {HitsPerPageSelectorWidgetOptions} $0 The options of the HitPerPageSelector widget.
  * @return {Widget} A new instance of the HitPerPageSelector widget.

--- a/src/widgets/hits/hits.js
+++ b/src/widgets/hits/hits.js
@@ -92,6 +92,7 @@ hits({
  * beyond the first page.
  * @type {WidgetFactory}
  * @devNovel Hits
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/hits/js/
  * @category basic
  * @param {HitsWidgetOptions} $0 Options of the Hits widget.
  * @return {Widget} A new instance of Hits widget.

--- a/src/widgets/infinite-hits/infinite-hits.js
+++ b/src/widgets/infinite-hits/infinite-hits.js
@@ -100,6 +100,7 @@ infiniteHits({
  * handy on mobile implementations.
  * @type {WidgetFactory}
  * @devNovel InfiniteHits
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/infinite-hits/js/
  * @category basic
  * @param {InfiniteHitsWidgetOptions} $0 The options for the InfiniteHits widget.
  * @return {Widget} Creates a new instance of the InfiniteHits widget.

--- a/src/widgets/menu-select/menu-select.js
+++ b/src/widgets/menu-select/menu-select.js
@@ -103,6 +103,7 @@ menuSelect({
  * Create a menu select out of a facet
  * @type {WidgetFactory}
  * @category filter
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/menu-select/js/
  * @param {MenuSelectWidgetOptions} $0 The Menu select widget options.
  * @return {Widget} Creates a new instance of the Menu select widget.
  * @example

--- a/src/widgets/menu/menu.js
+++ b/src/widgets/menu/menu.js
@@ -150,6 +150,7 @@ menu({
  * in your Algolia settings.
  * @type {WidgetFactory}
  * @devNovel Menu
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/menu/js/
  * @category filter
  * @param {MenuWidgetOptions} $0 The Menu widget options.
  * @return {Widget} Creates a new instance of the Menu widget.

--- a/src/widgets/numeric-refinement-list/numeric-refinement-list.js
+++ b/src/widgets/numeric-refinement-list/numeric-refinement-list.js
@@ -119,6 +119,7 @@ numericRefinementList({
  *
  * @type {WidgetFactory}
  * @devNovel NumericRefinementList
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/numeric-menu/js/
  * @category filter
  * @param {NumericRefinementListWidgetOptions} $0 The NumericRefinementList widget options
  * @return {Widget} Creates a new instance of the NumericRefinementList widget.

--- a/src/widgets/pagination/pagination.js
+++ b/src/widgets/pagination/pagination.js
@@ -127,6 +127,7 @@ pagination({
  *
  * @type {WidgetFactory}
  * @devNovel Pagination
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/pagination/js/
  * @category navigation
  * @param {PaginationWidgetOptions} $0 Options for the Pagination widget.
  * @return {Widget} A new instance of Pagination widget.

--- a/src/widgets/range-input/range-input.js
+++ b/src/widgets/range-input/range-input.js
@@ -128,6 +128,7 @@ rangeInput({
  * The values inside this attribute must be JavaScript numbers (not strings).
  * @type {WidgetFactory}
  * @devNovel RangeInput
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/range-input/js/
  * @category filter
  * @param {RangeInputWidgetOptions} $0 The RangeInput widget options.
  * @return {Widget} A new instance of RangeInput widget.

--- a/src/widgets/range-slider/range-slider.js
+++ b/src/widgets/range-slider/range-slider.js
@@ -145,6 +145,7 @@ rangeSlider({
  *
  * @type {WidgetFactory}
  * @devNovel RangeSlider
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/range-slider/js/
  * @category filter
  * @param {RangeSliderWidgetOptions} $0 RangeSlider widget options.
  * @return {Widget} A new RangeSlider widget instance.

--- a/src/widgets/refinement-list/refinement-list.js
+++ b/src/widgets/refinement-list/refinement-list.js
@@ -211,6 +211,7 @@ refinementList({
  *
  * @type {WidgetFactory}
  * @devNovel RefinementList
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/refinement-list/js/
  * @category filter
  * @param {RefinementListWidgetOptions} $0 The RefinementList widget options that you use to customize the widget.
  * @return {Widget} Creates a new instance of the RefinementList widget.

--- a/src/widgets/search-box/search-box.js
+++ b/src/widgets/search-box/search-box.js
@@ -235,6 +235,7 @@ searchBox({
  *
  * @type {WidgetFactory}
  * @devNovel SearchBox
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/search-box/js/
  * @category basic
  * @param {SearchBoxWidgetOptions} $0 Options used to configure a SearchBox widget.
  * @return {Widget} Creates a new instance of the SearchBox widget.

--- a/src/widgets/sort-by-selector/sort-by-selector.js
+++ b/src/widgets/sort-by-selector/sort-by-selector.js
@@ -65,6 +65,7 @@ sortBySelector({
  * For the users it is like they are selecting a new sort order.
  * @type {WidgetFactory}
  * @devNovel SortBySelector
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
  * @category sort
  * @param {SortByWidgetOptions} $0 Options for the SortBySelector widget
  * @return {Widget} Creates a new instance of the SortBySelector widget.

--- a/src/widgets/star-rating/star-rating.js
+++ b/src/widgets/star-rating/star-rating.js
@@ -131,6 +131,7 @@ starRating({
  *
  * @type {WidgetFactory}
  * @devNovel StarRating
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/rating-menu/js/
  * @category filter
  * @param {StarWidgetOptions} $0 StarRating widget options.
  * @return {Widget} A new StarRating widget instance.

--- a/src/widgets/stats/stats.js
+++ b/src/widgets/stats/stats.js
@@ -122,6 +122,7 @@ stats({
  * results inside the engine.
  * @type {WidgetFactory}
  * @devNovel Stats
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/stats/js/
  * @category metadata
  * @param {StatsWidgetOptions} $0 Stats widget options. Some keys are mandatory: `container`,
  * @return {Widget} A new stats widget instance

--- a/src/widgets/toggle/toggle.js
+++ b/src/widgets/toggle/toggle.js
@@ -137,6 +137,7 @@ toggle({
  *
  * @type {WidgetFactory}
  * @devNovel Toggle
+ * @canonical https://www.algolia.com/doc/api-reference/widgets/toggle-refinement/js/
  * @category filter
  * @param {ToggleWidgetOptions} $0 Options for the Toggle widget.
  * @return {Widget} A new instance of the Toggle widget


### PR DESCRIPTION
**Summary**

This PR setup the meta `canonical` for all the pages of the website. If no meta `canonical` is found for the page we fallback to an `noindex, nofollow` meta. Here is the list of changes:

- allow `canonical` meta or fallback on each pages
- setup `canonical` meta tags for top level pages & guides
- setup `canonical` meta tags for the API Ref