### PR TITLE
chore(types): add basic InstantSearch types

### DIFF
--- a/src/types/connector.ts
+++ b/src/types/connector.ts
@@ -1,0 +1,11 @@
+import { InstantSearch } from './instantsearch';
+
+export type RenderOptions<T = unknown> = {
+  widgetParams: T;
+  instantSearchInstance: InstantSearch;
+};
+
+export type Renderer<T extends RenderOptions> = (
+  renderOptions: T,
+  isFirstRender: boolean
+) => void;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,3 @@
+export * from './instantsearch';
+export * from './connector';
+export * from './widget';

--- a/src/types/instantsearch.ts
+++ b/src/types/instantsearch.ts
@@ -1,0 +1,16 @@
+export type InstantSearch = {
+  templatesConfig?: object;
+};
+
+export type Helper = any;
+
+export type HelperState = any;
+
+export type SearchParameters = any;
+
+export type SearchResults = any;
+
+export type FacetRefinement = {
+  value: string;
+  type: string;
+};

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -1,0 +1,23 @@
+import {
+  Helper,
+  HelperState,
+  SearchResults,
+  InstantSearch,
+  SearchParameters,
+} from './instantsearch';
+
+interface WidgetArgs {
+  helper: Helper;
+  state?: HelperState;
+  results?: SearchResults;
+  instantSearchInstance: InstantSearch;
+}
+
+export interface Widget {
+  init(options: WidgetArgs): void;
+  render(options: WidgetArgs): void;
+  dispose(options: any): SearchParameters;
+  getConfiguration?(previousConfiguration: SearchParameters): SearchParameters;
+}
+
+export type WidgetFactory<T> = (widgetParams: T) => Widget;


### PR DESCRIPTION
> This is the 1st PR in the series "Merchandized Query Rules".

This adds basic InstantSearch types necessary for the `connectQueryRules` connector.

These types are meant to be completed over time.