### PR TITLE
feat(queryRules): add queryRuleContext widget

### DIFF
--- a/src/lib/utils/checkRendering.ts
+++ b/src/lib/utils/checkRendering.ts
@@ -1,6 +1,6 @@
 import { Renderer } from '../../types/connector';
 
-function checkRendering(rendering: Renderer<any>, usage: string) {
+function checkRendering(rendering: Renderer, usage: string) {
   if (rendering === undefined || typeof rendering !== 'function') {
     throw new Error(`The render function is not valid (got type "${typeof rendering}").
 

--- a/src/lib/utils/checkRendering.ts
+++ b/src/lib/utils/checkRendering.ts
@@ -1,6 +1,6 @@
 import { Renderer } from '../../types/connector';
 
-function checkRendering(rendering: Renderer, usage: string) {
+function checkRendering(rendering: Renderer<any>, usage: string) {
   if (rendering === undefined || typeof rendering !== 'function') {
     throw new Error(`The render function is not valid (got type "${typeof rendering}").
 

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -40,3 +40,6 @@ export { default as panel } from './panel/panel';
 export {
   default as queryRuleCustomData,
 } from './query-rule-custom-data/query-rule-custom-data';
+export {
+  default as queryRuleContext,
+} from './query-rule-context/query-rule-context';

--- a/src/widgets/query-rule-context/__tests__/query-rule-context-test.ts
+++ b/src/widgets/query-rule-context/__tests__/query-rule-context-test.ts
@@ -1,0 +1,18 @@
+import queryRuleContext from '../query-rule-context';
+
+describe('queryRuleContext', () => {
+  describe('Usage', () => {
+    test('does not throw without options', () => {
+      expect(() => {
+        // @ts-ignore
+        queryRuleContext();
+      }).not.toThrow();
+    });
+
+    test('does not throw with empty options', () => {
+      expect(() => {
+        queryRuleContext({});
+      }).not.toThrow();
+    });
+  });
+});

--- a/src/widgets/query-rule-context/__tests__/query-rule-context-test.ts
+++ b/src/widgets/query-rule-context/__tests__/query-rule-context-test.ts
@@ -2,17 +2,26 @@ import queryRuleContext from '../query-rule-context';
 
 describe('queryRuleContext', () => {
   describe('Usage', () => {
-    test('does not throw without options', () => {
+    test('throws trackedFilters error without options', () => {
       expect(() => {
         // @ts-ignore
         queryRuleContext();
-      }).not.toThrow();
+      }).toThrowErrorMatchingInlineSnapshot(`
+"The \`trackedFilters\` option is required.
+
+See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rule-context/js/"
+`);
     });
 
-    test('does not throw with empty options', () => {
+    test('throws trackedFilters error with empty options', () => {
       expect(() => {
+        // @ts-ignore
         queryRuleContext({});
-      }).not.toThrow();
+      }).toThrowErrorMatchingInlineSnapshot(`
+"The \`trackedFilters\` option is required.
+
+See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rule-context/js/"
+`);
     });
   });
 });

--- a/src/widgets/query-rule-context/query-rule-context.tsx
+++ b/src/widgets/query-rule-context/query-rule-context.tsx
@@ -1,20 +1,29 @@
 import noop from 'lodash/noop';
 import { WidgetFactory } from '../../types';
+import { createDocumentationMessageGenerator } from '../../lib/utils';
 import connectQueryRules, {
-  QueryRulesConnectorParams,
+  ParamTrackedFilters,
+  ParamTransformRuleContexts,
 } from '../../connectors/query-rules/connectQueryRules';
 
-type QueryRulesWidgetParams = Pick<
-  QueryRulesConnectorParams,
-  'trackedFilters' | 'transformRuleContexts'
->;
+type QueryRulesWidgetParams = {
+  trackedFilters: ParamTrackedFilters;
+  transformRuleContexts?: ParamTransformRuleContexts;
+};
 
 type QueryRuleContext = WidgetFactory<QueryRulesWidgetParams>;
 
-const queryRuleContext: QueryRuleContext = ({
-  trackedFilters,
-  transformRuleContexts,
-} = {}) => {
+const withUsage = createDocumentationMessageGenerator({
+  name: 'query-rule-context',
+});
+
+const queryRuleContext: QueryRuleContext = (
+  { trackedFilters, transformRuleContexts } = {} as QueryRulesWidgetParams
+) => {
+  if (!trackedFilters) {
+    throw new Error(withUsage('The `trackedFilters` option is required.'));
+  }
+
   return connectQueryRules(noop)({
     trackedFilters,
     transformRuleContexts,

--- a/src/widgets/query-rule-context/query-rule-context.tsx
+++ b/src/widgets/query-rule-context/query-rule-context.tsx
@@ -1,0 +1,24 @@
+import noop from 'lodash/noop';
+import { WidgetFactory } from '../../types';
+import connectQueryRules, {
+  QueryRulesConnectorParams,
+} from '../../connectors/query-rules/connectQueryRules';
+
+type QueryRulesWidgetParams = Pick<
+  QueryRulesConnectorParams,
+  'trackedFilters' | 'transformRuleContexts'
+>;
+
+type QueryRuleContext = WidgetFactory<QueryRulesWidgetParams>;
+
+const queryRuleContext: QueryRuleContext = ({
+  trackedFilters,
+  transformRuleContexts,
+} = {}) => {
+  return connectQueryRules(noop)({
+    trackedFilters,
+    transformRuleContexts,
+  });
+};
+
+export default queryRuleContext;

--- a/stories/query-rule-context.stories.ts
+++ b/stories/query-rule-context.stories.ts
@@ -15,48 +15,102 @@ const searchOptions = {
   playground: moviesPlayground,
 };
 
-storiesOf('QueryRuleContext', module).add(
-  'default',
-  withHits(({ search, container, instantsearch }) => {
-    const widgetContainer = document.createElement('div');
-    const description = document.createElement('ul');
-    description.innerHTML = `
+storiesOf('QueryRuleContext', module)
+  .add(
+    'default',
+    withHits(({ search, container, instantsearch }) => {
+      const widgetContainer = document.createElement('div');
+      const description = document.createElement('ul');
+      description.innerHTML = `
         <li>Select the "Drama" category and The Shawshank Redemption appears</li>
         <li>Select the "Thriller" category and Pulp Fiction appears</li>
         <li>Type <q>music</q> and a banner will appear.</li>
       `;
 
-    container.appendChild(description);
-    container.appendChild(widgetContainer);
+      container.appendChild(description);
+      container.appendChild(widgetContainer);
 
-    search.addWidget(
-      instantsearch.widgets.queryRuleContext({
-        trackedFilters: {
-          genre: () => ['Thriller', 'Drama'],
-        },
-      })
-    );
+      search.addWidget(
+        instantsearch.widgets.queryRuleContext({
+          trackedFilters: {
+            genre: () => ['Thriller', 'Drama'],
+          },
+        })
+      );
 
-    search.addWidget(
-      instantsearch.widgets.queryRuleCustomData({
-        container: widgetContainer,
-        transformItems: (items: CustomDataItem[]) => items[0],
-        templates: {
-          default({ title, banner, link }: CustomDataItem) {
-            if (!banner) {
-              return '';
-            }
+      search.addWidget(
+        instantsearch.widgets.queryRuleCustomData({
+          container: widgetContainer,
+          transformItems: (items: CustomDataItem[]) => items[0],
+          templates: {
+            default({ title, banner, link }: CustomDataItem) {
+              if (!banner) {
+                return '';
+              }
 
-            return `
+              return `
               <h2>${title}</h2>
 
               <a href="${link}">
                 <img src="${banner}" alt="${title}">
               </a>
             `;
+            },
           },
-        },
-      })
-    );
-  }, searchOptions)
-);
+        })
+      );
+    }, searchOptions)
+  )
+  .add(
+    'with initial filter',
+    withHits(({ search, container, instantsearch }) => {
+      const widgetContainer = document.createElement('div');
+      const description = document.createElement('ul');
+      description.innerHTML = `
+        <li>Select the "Drama" category and The Shawshank Redemption appears</li>
+        <li>Select the "Thriller" category and Pulp Fiction appears</li>
+        <li>Type <q>music</q> and a banner will appear.</li>
+      `;
+
+      container.appendChild(description);
+      container.appendChild(widgetContainer);
+
+      search.addWidget(
+        instantsearch.widgets.configure({
+          disjunctiveFacetsRefinements: {
+            genre: ['Drama'],
+          },
+        })
+      );
+
+      search.addWidget(
+        instantsearch.widgets.queryRuleContext({
+          trackedFilters: {
+            genre: () => ['Thriller', 'Drama'],
+          },
+        })
+      );
+
+      search.addWidget(
+        instantsearch.widgets.queryRuleCustomData({
+          container: widgetContainer,
+          transformItems: (items: CustomDataItem[]) => items[0],
+          templates: {
+            default({ title, banner, link }: CustomDataItem) {
+              if (!banner) {
+                return '';
+              }
+
+              return `
+              <h2>${title}</h2>
+
+              <a href="${link}">
+                <img src="${banner}" alt="${title}">
+              </a>
+            `;
+            },
+          },
+        })
+      );
+    }, searchOptions)
+  );

--- a/stories/query-rule-context.stories.ts
+++ b/stories/query-rule-context.stories.ts
@@ -1,0 +1,63 @@
+import { storiesOf } from '@storybook/html';
+import { withHits } from '../.storybook/decorators';
+import moviesPlayground from '../.storybook/playgrounds/movies';
+
+type CustomDataItem = {
+  title: string;
+  banner: string;
+  link: string;
+};
+
+const searchOptions = {
+  appId: 'latency',
+  apiKey: 'af044fb0788d6bb15f807e4420592bc5',
+  indexName: 'instant_search_movies',
+  playground: moviesPlayground,
+};
+
+storiesOf('QueryRuleContext', module).add(
+  'default',
+  withHits(({ search, container, instantsearch }) => {
+    const widgetContainer = document.createElement('div');
+    const description = document.createElement('ul');
+    description.innerHTML = `
+        <li>Select the "Drama" category and The Shawshank Redemption appears</li>
+        <li>Select the "Thriller" category and Pulp Fiction appears</li>
+        <li>Type <q>music</q> and a banner will appear.</li>
+      `;
+
+    container.appendChild(description);
+    container.appendChild(widgetContainer);
+
+    search.addWidget(
+      instantsearch.widgets.queryRuleContext({
+        container,
+        trackedFilters: {
+          genre: () => ['Thriller', 'Drama'],
+        },
+      })
+    );
+
+    search.addWidget(
+      instantsearch.widgets.queryRuleCustomData({
+        container: widgetContainer,
+        transformItems: (items: CustomDataItem[]) => items[0],
+        templates: {
+          default({ title, banner, link }: CustomDataItem) {
+            if (!banner) {
+              return '';
+            }
+
+            return `
+              <h2>${title}</h2>
+
+              <a href="${link}">
+                <img src="${banner}" alt="${title}">
+              </a>
+            `;
+          },
+        },
+      })
+    );
+  }, searchOptions)
+);

--- a/stories/query-rule-context.stories.ts
+++ b/stories/query-rule-context.stories.ts
@@ -31,7 +31,6 @@ storiesOf('QueryRuleContext', module).add(
 
     search.addWidget(
       instantsearch.widgets.queryRuleContext({
-        container,
         trackedFilters: {
           genre: () => ['Thriller', 'Drama'],
         },


### PR DESCRIPTION
_This is the 3rd PR in the series "Merchandized Query Rules"._

## Summary

This **headless** widget sets the rule contexts (called [`ruleContexts`](https://www.algolia.com/doc/api-reference/api-parameters/ruleContexts/)) of the search parameters based on the filters.

Query rules are by default _generic_ when not provided any context. If you provide a context, they become _contextual_ and are only triggered when the context is matched.

## Usage

```js
instantsearch.widgets.queryRuleContext({
  container,
  trackedFilters: {
    genre: () => ['Thriller', 'Drama'],
  },
});
```

This will set the following `ruleContexts` dynamically:

- `ais-genre-Thriller`
- `ais-genre-Drama`

## API

### `trackedFilters`

> `object` – no default

The filters to track to add rule contexts.

### `transformRuleContexts`

> `string[] ⇒ string[]` – defaults to identity function

The function to apply to the rule contexts before sending them to Algolia.

## Stories

[See stories →](https://deploy-preview-3602--instantsearchjs.netlify.com/stories/?path=/story/queryrulecontext--default)

## Related

- [`connectQueryRules`](https://github.com/algolia/instantsearch.js/pull/3597)
- [`queryRuleCustomData`](https://github.com/algolia/instantsearch.js/pull/3600)
- [Merchandized Query Rules RFC](https://github.com/algolia/instantsearch-rfcs/blob/master/accepted/merchandized-query-rules.md)