### PR TITLE
docs(connectCurrentRefinedValues): fix example with find method

### DIFF
--- a/src/connectors/current-refined-values/connectCurrentRefinedValues.js
+++ b/src/connectors/current-refined-values/connectCurrentRefinedValues.js
@@ -127,8 +127,8 @@ Full documentation available at https://community.algolia.com/instantsearch.js/v
  *         + refinement.computedLabel + ' ' + refinement.count + '</a></li>';
  *     });
  *
- *     CurrentRefinedValuesRenderingOptions.find('ul').html(list);
- *     CurrentRefinedValuesRenderingOptions.find('li > a').each(function(index) {
+ *     CurrentRefinedValuesRenderingOptions.containerNode.find('ul').html(list);
+ *     CurrentRefinedValuesRenderingOptions.containerNode.find('li > a').each(function(index) {
  *       $(this).on('click', function(event) {
  *         event.preventDefault();
  *


### PR DESCRIPTION
Closes #3237.

This documentation fix only targets the v2 documentation website. Will be fixed when we decide to deploy it.