### PR TITLE
build(travis): fix matrix scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,10 @@ script:
   - '${SCRIPT}'
 env:
   matrix:
-    - SCRIPT=./scripts/ci/functional-test.sh
-    - SCRIPT=yarn run test
-    - SCRIPT=yarn run lint
-    - SCRIPT=yarn run type-check
+    - SCRIPT='./scripts/ci/functional-test.sh'
+    - SCRIPT='yarn run test'
+    - SCRIPT='yarn run lint'
+    - SCRIPT='yarn run type-check'
   global:
     - CXX=g++-4.8
     - SAUCE_USERNAME=isjs

--- a/src/lib/utils/capitalize.ts
+++ b/src/lib/utils/capitalize.ts
@@ -1,9 +1,9 @@
-function capitalize(string: string) {
+function capitalize(text: string) {
   return (
-    string
+    text
       .toString()
       .charAt(0)
-      .toUpperCase() + string.toString().slice(1)
+      .toUpperCase() + text.toString().slice(1)
   );
 }
 

--- a/src/lib/utils/documentation.ts
+++ b/src/lib/utils/documentation.ts
@@ -3,26 +3,28 @@ type WidgetParam = {
   connector?: boolean;
 };
 
-export function createDocumentationLink({
+export const createDocumentationLink = ({
   name,
   connector = false,
-}: WidgetParam) {
+}: WidgetParam) => {
   return [
     'https://www.algolia.com/doc/api-reference/widgets/',
     name,
     '/js/',
     connector ? '#connector' : '',
   ].join('');
-}
+};
 
-export function createDocumentationMessageGenerator(...widgets: WidgetParam[]) {
+export const createDocumentationMessageGenerator = (
+  ...widgets: WidgetParam[]
+) => {
   const links = widgets
     .map(widget => createDocumentationLink(widget))
     .join(', ');
 
-  return function(message: string) {
+  return (message: string) => {
     return [message, `See documentation: ${links}`]
       .filter(Boolean)
       .join('\n\n');
   };
-}
+};

--- a/src/lib/utils/prefixKeys.ts
+++ b/src/lib/utils/prefixKeys.ts
@@ -2,7 +2,7 @@ import mapKeys from 'lodash/mapKeys';
 
 function prefixKeys(prefix: string, obj: object) {
   if (obj) {
-    return mapKeys(obj, (_value, key) => prefix + key);
+    return mapKeys(obj, (_0, key) => prefix + key);
   }
 
   return undefined;


### PR DESCRIPTION
I realized that the CI matrix scripts run with `yarn` were not actually executed since #3481 (for two weeks)... Quotes are needed for the scripts to be run (it ran only `yarn`).

I linted the files that didn't pass at the same time.

Once this PR is merged, please rebase/merge your PRs against `develop` so that CI checks are effective again.

_Lesson to self: always check the CI tests when the configuration changes, even when they pass._

:facepalm: