### PR TITLE
feat(queryRules): add context features to connectQueryRules

### DIFF
--- a/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
+++ b/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
@@ -211,6 +211,25 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
         expect(priceFilterSpy).toHaveBeenCalledWith([500, 400, 100]);
       });
 
+      test('adds ruleContexts to search parameters if transformRuleContexts is provided', () => {
+        const helper = createFakeHelper({
+          disjunctiveFacets: ['brand'],
+        });
+        const brandFilterSpy = jest.fn(values => values);
+        const widget = makeWidget({
+          trackedFilters: {
+            brand: brandFilterSpy,
+          },
+          transformRuleContexts: () => ['overriden-rule'],
+        });
+
+        widget.init({ helper, state: helper.state, instantSearchInstance: {} });
+
+        expect(helper.getState().ruleContexts).toEqual(['overriden-rule']);
+        expect(brandFilterSpy).toHaveBeenCalledTimes(1);
+        expect(brandFilterSpy).toHaveBeenCalledWith([]);
+      });
+
       test('adds all ruleContexts to search parameters from dynamically added facet and numeric refinements', () => {
         const helper = createFakeHelper({
           disjunctiveFacets: ['brand'],
@@ -611,6 +630,9 @@ Consider using \`transformRuleContexts\` to minimize the number of rules sent to
       test('transform all rule contexts before passing them to search parameters, except the initial ones', () => {
         const helper = createFakeHelper({
           disjunctiveFacets: ['brand'],
+          disjunctiveFacetsRefinements: {
+            brand: ['Samsung', 'Apple'],
+          },
           ruleContexts: ['initial-rule'],
         });
         const transformRuleContextsSpy = jest.fn((rules: string[]) =>
@@ -624,12 +646,6 @@ Consider using \`transformRuleContexts\` to minimize the number of rules sent to
         });
 
         widget.init({ helper, state: helper.state, instantSearchInstance: {} });
-
-        helper.setState({
-          disjunctiveFacetsRefinements: {
-            brand: ['Samsung', 'Apple'],
-          },
-        });
 
         widget.render({
           helper,

--- a/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
+++ b/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
@@ -571,6 +571,40 @@ Consider using \`transformRuleContexts\` to minimize the number of rules sent to
 
         expect(nextState.ruleContexts).toEqual(['initial-rule']);
       });
+
+      test('stops tracking filters after dispose', () => {
+        const helper = createFakeHelper({
+          disjunctiveFacets: ['brand'],
+          disjunctiveFacetsRefinements: {
+            brand: ['Samsung'],
+          },
+        });
+        const brandFilterSpy = jest.fn(values => values);
+        const widget = makeWidget({
+          trackedFilters: {
+            brand: brandFilterSpy,
+          },
+        });
+
+        expect(helper.getState().ruleContexts).toEqual(undefined);
+
+        widget.init({ helper, state: helper.state, instantSearchInstance: {} });
+
+        expect(helper.getState().ruleContexts).toEqual(['ais-brand-Samsung']);
+        expect(brandFilterSpy).toHaveBeenCalledTimes(1);
+        expect(brandFilterSpy).toHaveBeenCalledWith(['Samsung']);
+
+        widget.dispose({ helper, state: helper.state });
+
+        helper.setState({
+          disjunctiveFacetsRefinements: {
+            brand: ['Samsung', 'Apple'],
+          },
+        });
+
+        expect(helper.getState().ruleContexts).toEqual(undefined);
+        expect(brandFilterSpy).toHaveBeenCalledTimes(1);
+      });
     });
 
     describe('transformRuleContexts', () => {

--- a/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
+++ b/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
@@ -137,24 +137,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
       const widget = makeWidget({});
 
       widget.init({ helper, state: helper.state, instantSearchInstance: {} });
-      widget.dispose({ state: helper.getState() });
-
-      expect(unmountFn).toHaveBeenCalledTimes(1);
-    });
-
-    test('calls the unmount function even when returning early in the dispose step', () => {
-      const helper = createFakeHelper();
-      const widget = makeWidget({
-        // `trackedFilter` creates another path in the code that returns the
-        // next helper state early. We make sure that we call the `unmount` function
-        // even with this option set.
-        trackedFilters: {
-          brand: values => values,
-        },
-      });
-
-      widget.init({ helper, state: helper.state, instantSearchInstance: {} });
-      widget.dispose({ state: helper.getState() });
+      widget.dispose({ helper, state: helper.getState() });
 
       expect(unmountFn).toHaveBeenCalledTimes(1);
     });
@@ -545,7 +528,7 @@ Consider using \`transformRuleContexts\` to minimize the number of rules sent to
           'ais-brand-Apple',
         ]);
 
-        const nextState = widget.dispose({ state: helper.getState() });
+        const nextState = widget.dispose({ helper, state: helper.getState() });
 
         expect(nextState.ruleContexts).toEqual(['initial-rule']);
       });

--- a/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
+++ b/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
@@ -172,7 +172,46 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
     });
 
     describe('trackedFilters', () => {
-      test('adds all ruleContexts to search parameters from facets and numeric refinements', () => {
+      test('adds ruleContexts to search parameters from initial facet and numeric refinements', () => {
+        const helper = createFakeHelper({
+          disjunctiveFacets: ['brand'],
+          disjunctiveFacetsRefinements: {
+            brand: ['Samsung', 'Apple'],
+          },
+          numericRefinements: {
+            price: {
+              '<=': [500, 400],
+              '>=': [100],
+            },
+          },
+        });
+        const brandFilterSpy = jest.fn(values => values);
+        const priceFilterSpy = jest.fn(values => values);
+        const widget = makeWidget({
+          trackedFilters: {
+            brand: brandFilterSpy,
+            price: priceFilterSpy,
+          },
+        });
+
+        widget.init({ helper, state: helper.state, instantSearchInstance: {} });
+
+        // Query parameters are initially set in the helper.
+        // Therefore, `ruleContexts` should be set.
+        expect(helper.getState().ruleContexts).toEqual([
+          'ais-brand-Samsung',
+          'ais-brand-Apple',
+          'ais-price-500',
+          'ais-price-400',
+          'ais-price-100',
+        ]);
+        expect(brandFilterSpy).toHaveBeenCalledTimes(1);
+        expect(brandFilterSpy).toHaveBeenCalledWith(['Samsung', 'Apple']);
+        expect(priceFilterSpy).toHaveBeenCalledTimes(1);
+        expect(priceFilterSpy).toHaveBeenCalledWith([500, 400, 100]);
+      });
+
+      test('adds all ruleContexts to search parameters from dynamically added facet and numeric refinements', () => {
         const helper = createFakeHelper({
           disjunctiveFacets: ['brand'],
         });

--- a/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
+++ b/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
@@ -41,6 +41,21 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
         connectQueryRules(() => {})({});
       }).not.toThrow();
     });
+
+    test('throws with a non-functon tracked filter', () => {
+      expect(() => {
+        makeWidget({
+          // @ts-ignore
+          trackedFilters: {
+            brand: ['Samsung'],
+          },
+        });
+      }).toThrowErrorMatchingInlineSnapshot(`
+"'The \\"brand\\" filter value in the \`trackedFilters\` option expects a function.
+
+See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules/js/#connector"
+`);
+    });
   });
 
   describe('lifecycle', () => {
@@ -126,6 +141,23 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
 
       expect(unmountFn).toHaveBeenCalledTimes(1);
     });
+
+    test('calls the unmount function even when returning early in the dispose step', () => {
+      const helper = createFakeHelper();
+      const widget = makeWidget({
+        // `trackedFilter` creates another path in the code that returns the
+        // next helper state early. We make sure that we call the `unmount` function
+        // even with this option set.
+        trackedFilters: {
+          brand: values => values,
+        },
+      });
+
+      widget.init({ helper, state: helper.state, instantSearchInstance: {} });
+      widget.dispose({ state: helper.getState() });
+
+      expect(unmountFn).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('options', () => {
@@ -153,6 +185,423 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
         const { items } = renderingParameters;
 
         expect(items).toEqual({ banner: 'image1.png' });
+      });
+    });
+
+    describe('trackedFilters', () => {
+      test('adds all ruleContexts to search parameters from facets and numeric refinements', () => {
+        const helper = createFakeHelper({
+          disjunctiveFacets: ['brand'],
+        });
+        const brandFilterSpy = jest.fn(values => values);
+        const priceFilterSpy = jest.fn(values => values);
+        const widget = makeWidget({
+          trackedFilters: {
+            brand: brandFilterSpy,
+            price: priceFilterSpy,
+          },
+        });
+
+        widget.init({ helper, state: helper.state, instantSearchInstance: {} });
+
+        // There's no results yet, so no `ruleContexts` should be set.
+        expect(helper.getState().ruleContexts).toEqual([]);
+        expect(brandFilterSpy).toHaveBeenCalledTimes(0);
+        expect(priceFilterSpy).toHaveBeenCalledTimes(0);
+
+        widget.render({
+          helper,
+          results: new SearchResults(helper.getState(), [
+            {},
+            {
+              facets: {
+                brand: {
+                  Samsung: 100,
+                  Apple: 100,
+                },
+              },
+            },
+          ]),
+          instantSearchInstance: {},
+        });
+
+        // There are some results with the facets that we track in the
+        // widget but the query parameters are not set in the helper.
+        // Therefore, no `ruleContexts` should be set.
+        expect(helper.getState().ruleContexts).toEqual([]);
+        expect(brandFilterSpy).toHaveBeenCalledTimes(0);
+        expect(priceFilterSpy).toHaveBeenCalledTimes(0);
+
+        // Updating the helper state in a single method call
+        // calls the tracked filters only once.
+        helper.setState({
+          disjunctiveFacetsRefinements: {
+            brand: ['Samsung', 'Apple'],
+          },
+          numericRefinements: {
+            price: {
+              '<=': [500, 400],
+              '>=': [100],
+            },
+          },
+        });
+
+        widget.render({
+          helper,
+          results: new SearchResults(helper.getState(), [
+            {},
+            {
+              facets: {
+                brand: {
+                  Samsung: 100,
+                  Apple: 100,
+                },
+              },
+            },
+          ]),
+          instantSearchInstance: {},
+        });
+
+        // The search state contains the facets that we track,
+        // therefore the `ruleContexts` should finally be set.
+        expect(helper.getState().ruleContexts).toEqual([
+          'ais-brand-Samsung',
+          'ais-brand-Apple',
+          'ais-price-500',
+          'ais-price-400',
+          'ais-price-100',
+        ]);
+        expect(brandFilterSpy).toHaveBeenCalledTimes(1);
+        expect(brandFilterSpy).toHaveBeenCalledWith(['Samsung', 'Apple']);
+        expect(priceFilterSpy).toHaveBeenCalledTimes(1);
+        expect(priceFilterSpy).toHaveBeenCalledWith([500, 400, 100]);
+      });
+
+      test('can filter trackedFilters with facets refinements', () => {
+        const helper = createFakeHelper({
+          disjunctiveFacets: ['brand'],
+        });
+        const brandFilterSpy = jest.fn(() => ['Samsung']);
+        const widget = makeWidget({
+          trackedFilters: {
+            brand: brandFilterSpy,
+          },
+        });
+
+        widget.init({ helper, state: helper.state, instantSearchInstance: {} });
+
+        expect(helper.getState().ruleContexts).toEqual([]);
+        expect(brandFilterSpy).toHaveBeenCalledTimes(0);
+
+        widget.render({
+          helper,
+          results: new SearchResults(helper.getState(), [
+            {},
+            {
+              facets: {
+                brand: {
+                  Samsung: 100,
+                  Apple: 100,
+                },
+              },
+            },
+          ]),
+          instantSearchInstance: {},
+        });
+
+        expect(helper.getState().ruleContexts).toEqual([]);
+        expect(brandFilterSpy).toHaveBeenCalledTimes(0);
+
+        helper.setState({
+          disjunctiveFacetsRefinements: {
+            brand: ['Samsung', 'Apple'],
+          },
+        });
+
+        widget.render({
+          helper,
+          results: new SearchResults(helper.getState(), [
+            {},
+            {
+              facets: {
+                brand: {
+                  Samsung: 100,
+                  Apple: 100,
+                },
+              },
+            },
+          ]),
+          instantSearchInstance: {},
+        });
+
+        expect(helper.getState().ruleContexts).toEqual(['ais-brand-Samsung']);
+        expect(brandFilterSpy).toHaveBeenCalledTimes(1);
+        expect(brandFilterSpy).toHaveBeenCalledWith(['Samsung', 'Apple']);
+      });
+
+      test('can filter tracked filters from numeric refinements', () => {
+        const helper = createFakeHelper();
+        const priceFilterSpy = jest.fn(() => [500]);
+        const widget = makeWidget({
+          trackedFilters: {
+            price: priceFilterSpy,
+          },
+        });
+
+        widget.init({ helper, state: helper.state, instantSearchInstance: {} });
+
+        expect(helper.getState().ruleContexts).toEqual([]);
+        expect(priceFilterSpy).toHaveBeenCalledTimes(0);
+
+        widget.render({
+          helper,
+          results: new SearchResults(helper.getState(), [{}, {}]),
+          instantSearchInstance: {},
+        });
+
+        expect(helper.getState().ruleContexts).toEqual([]);
+        expect(priceFilterSpy).toHaveBeenCalledTimes(0);
+
+        helper.setState({
+          numericRefinements: {
+            price: {
+              '<=': [500, 400],
+              '>=': [100],
+            },
+          },
+        });
+
+        widget.render({
+          helper,
+          results: new SearchResults(helper.getState(), [{}, {}]),
+          instantSearchInstance: {},
+        });
+
+        expect(helper.getState().ruleContexts).toEqual(['ais-price-500']);
+        expect(priceFilterSpy).toHaveBeenCalledTimes(1);
+        expect(priceFilterSpy).toHaveBeenCalledWith([500, 400, 100]);
+      });
+
+      test('escapes all ruleContexts before passing them to search parameters', () => {
+        const helper = createFakeHelper({
+          disjunctiveFacets: ['brand'],
+        });
+        const widget = makeWidget({
+          trackedFilters: {
+            brand: values => values,
+          },
+        });
+
+        widget.init({ helper, state: helper.state, instantSearchInstance: {} });
+
+        helper.setState({
+          disjunctiveFacetsRefinements: {
+            brand: ['Insignia™', '© Apple'],
+          },
+        });
+
+        widget.render({
+          helper,
+          results: new SearchResults(helper.getState(), [
+            {},
+            {
+              facets: {
+                brand: {
+                  'Insignia™': 100,
+                  '© Apple': 100,
+                },
+              },
+            },
+          ]),
+          instantSearchInstance: {},
+        });
+
+        expect(helper.getState().ruleContexts).toEqual([
+          'ais-brand-Insignia_',
+          'ais-brand-_Apple',
+        ]);
+      });
+
+      test('slices and warns when more than 10 ruleContexts are applied', () => {
+        const brandFacetRefinements = [
+          'Insignia',
+          'Canon',
+          'Dynex',
+          'LG',
+          'Metra',
+          'Sony',
+          'HP',
+          'Apple',
+          'Samsung',
+          'Speck',
+          'PNY',
+        ];
+
+        expect(brandFacetRefinements).toHaveLength(11);
+
+        const helper = createFakeHelper({
+          disjunctiveFacets: ['brand'],
+        });
+        const widget = makeWidget({
+          trackedFilters: {
+            brand: values => values,
+          },
+        });
+
+        widget.init({
+          helper,
+          state: helper.state,
+          instantSearchInstance: {},
+        });
+
+        expect(() => {
+          helper.setState({
+            disjunctiveFacetsRefinements: {
+              brand: brandFacetRefinements,
+            },
+          });
+        })
+          .toWarnDev(`[InstantSearch.js]: The maximum number of \`ruleContexts\` is 10. They have been sliced to that limit.
+Consider using \`transformRuleContexts\` to minimize the number of rules sent to Algolia.`);
+
+        widget.render({
+          helper,
+          results: new SearchResults(helper.getState(), [
+            {},
+            {
+              facets: {
+                brand: {
+                  Insignia: 100,
+                  Canon: 100,
+                  Dynex: 100,
+                  LG: 100,
+                  Metra: 100,
+                  Sony: 100,
+                  HP: 100,
+                  Apple: 100,
+                  Samsung: 100,
+                  Speck: 100,
+                  PNY: 100,
+                },
+              },
+            },
+          ]),
+          instantSearchInstance: {},
+        });
+
+        expect(helper.getState().ruleContexts).toHaveLength(10);
+        expect(helper.getState().ruleContexts).toEqual([
+          'ais-brand-Insignia',
+          'ais-brand-Canon',
+          'ais-brand-Dynex',
+          'ais-brand-LG',
+          'ais-brand-Metra',
+          'ais-brand-Sony',
+          'ais-brand-HP',
+          'ais-brand-Apple',
+          'ais-brand-Samsung',
+          'ais-brand-Speck',
+        ]);
+      });
+
+      test('reinitializes the rule contexts on dispose', () => {
+        const helper = createFakeHelper({
+          disjunctiveFacets: ['brand'],
+          ruleContexts: ['initial-rule'],
+        });
+        const widget = makeWidget({
+          trackedFilters: {
+            brand: values => values,
+          },
+        });
+
+        widget.init({ helper, state: helper.state, instantSearchInstance: {} });
+
+        helper.setState({
+          disjunctiveFacetsRefinements: {
+            brand: ['Samsung', 'Apple'],
+          },
+        });
+
+        widget.render({
+          helper,
+          results: new SearchResults(helper.getState(), [
+            {},
+            {
+              facets: {
+                brand: {
+                  Samsung: 100,
+                  Apple: 100,
+                },
+              },
+            },
+          ]),
+          instantSearchInstance: {},
+        });
+
+        expect(helper.getState().ruleContexts).toEqual([
+          'initial-rule',
+          'ais-brand-Samsung',
+          'ais-brand-Apple',
+        ]);
+
+        const nextState = widget.dispose({ state: helper.getState() });
+
+        expect(nextState.ruleContexts).toEqual(['initial-rule']);
+      });
+    });
+
+    describe('transformRuleContexts', () => {
+      test('transform all rule contexts before passing them to search parameters, except the initial ones', () => {
+        const helper = createFakeHelper({
+          disjunctiveFacets: ['brand'],
+          ruleContexts: ['initial-rule'],
+        });
+        const transformRuleContextsSpy = jest.fn((rules: string[]) =>
+          rules.map(rule => rule.replace('ais-', 'transformed-'))
+        );
+        const widget = makeWidget({
+          trackedFilters: {
+            brand: values => values,
+          },
+          transformRuleContexts: transformRuleContextsSpy,
+        });
+
+        widget.init({ helper, state: helper.state, instantSearchInstance: {} });
+
+        helper.setState({
+          disjunctiveFacetsRefinements: {
+            brand: ['Samsung', 'Apple'],
+          },
+        });
+
+        widget.render({
+          helper,
+          results: new SearchResults(helper.getState(), [
+            {},
+            {
+              facets: {
+                brand: {
+                  Samsung: 100,
+                  Apple: 100,
+                },
+              },
+            },
+          ]),
+          instantSearchInstance: {},
+        });
+
+        expect(transformRuleContextsSpy).toHaveBeenCalledTimes(1);
+        expect(transformRuleContextsSpy).toHaveBeenCalledWith([
+          'initial-rule',
+          'ais-brand-Samsung',
+          'ais-brand-Apple',
+        ]);
+        expect(helper.getState().ruleContexts).toEqual([
+          'initial-rule',
+          'transformed-brand-Samsung',
+          'transformed-brand-Apple',
+        ]);
       });
     });
   });

--- a/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
+++ b/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
@@ -205,7 +205,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
         widget.init({ helper, state: helper.state, instantSearchInstance: {} });
 
         // There's no results yet, so no `ruleContexts` should be set.
-        expect(helper.getState().ruleContexts).toEqual([]);
+        expect(helper.getState().ruleContexts).toEqual(undefined);
         expect(brandFilterSpy).toHaveBeenCalledTimes(0);
         expect(priceFilterSpy).toHaveBeenCalledTimes(0);
 
@@ -228,7 +228,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
         // There are some results with the facets that we track in the
         // widget but the query parameters are not set in the helper.
         // Therefore, no `ruleContexts` should be set.
-        expect(helper.getState().ruleContexts).toEqual([]);
+        expect(helper.getState().ruleContexts).toEqual(undefined);
         expect(brandFilterSpy).toHaveBeenCalledTimes(0);
         expect(priceFilterSpy).toHaveBeenCalledTimes(0);
 
@@ -290,7 +290,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
 
         widget.init({ helper, state: helper.state, instantSearchInstance: {} });
 
-        expect(helper.getState().ruleContexts).toEqual([]);
+        expect(helper.getState().ruleContexts).toEqual(undefined);
         expect(brandFilterSpy).toHaveBeenCalledTimes(0);
 
         widget.render({
@@ -309,7 +309,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
           instantSearchInstance: {},
         });
 
-        expect(helper.getState().ruleContexts).toEqual([]);
+        expect(helper.getState().ruleContexts).toEqual(undefined);
         expect(brandFilterSpy).toHaveBeenCalledTimes(0);
 
         helper.setState({
@@ -350,7 +350,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
 
         widget.init({ helper, state: helper.state, instantSearchInstance: {} });
 
-        expect(helper.getState().ruleContexts).toEqual([]);
+        expect(helper.getState().ruleContexts).toEqual(undefined);
         expect(priceFilterSpy).toHaveBeenCalledTimes(0);
 
         widget.render({
@@ -359,7 +359,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
           instantSearchInstance: {},
         });
 
-        expect(helper.getState().ruleContexts).toEqual([]);
+        expect(helper.getState().ruleContexts).toEqual(undefined);
         expect(priceFilterSpy).toHaveBeenCalledTimes(0);
 
         helper.setState({

--- a/src/connectors/query-rules/connectQueryRules.ts
+++ b/src/connectors/query-rules/connectQueryRules.ts
@@ -202,15 +202,7 @@ const connectQueryRules: QueryRulesConnector = (render, unmount = noop) => {
           if (hasStateRefinements(state)) {
             // If some filters are applied on the first load (e.g. using `configure`),
             // we need to apply the `ruleContexts` based on the `trackedFilters`.
-            applyRuleContexts.call(
-              {
-                helper,
-                initialRuleContexts,
-                trackedFilters,
-                transformRuleContexts,
-              },
-              state
-            );
+            onHelperChange(state);
           }
 
           // We track every change in the helper to override its state and add

--- a/src/connectors/query-rules/connectQueryRules.ts
+++ b/src/connectors/query-rules/connectQueryRules.ts
@@ -199,9 +199,14 @@ const connectQueryRules: QueryRulesConnector = (render, unmount = noop) => {
         });
 
         if (hasTrackedFilters) {
-          if (hasStateRefinements(state)) {
-            // If some filters are applied on the first load (e.g. using `configure`),
-            // we need to apply the `ruleContexts` based on the `trackedFilters`.
+          // We need to apply the `ruleContexts` based on the `trackedFilters`
+          // before the helper changes state in some cases:
+          //   - Some filters are applied on the first load (e.g. using `configure`)
+          //   - The `transformRuleContexts` option sets initial `ruleContexts`.
+          if (
+            hasStateRefinements(state) ||
+            Boolean(widgetParams.transformRuleContexts)
+          ) {
             onHelperChange(state);
           }
 

--- a/src/connectors/query-rules/connectQueryRules.ts
+++ b/src/connectors/query-rules/connectQueryRules.ts
@@ -186,9 +186,6 @@ const connectQueryRules: QueryRulesConnector = (render, unmount = noop) => {
     // We store the initial rule contexts applied before creating the widget
     // so that we do not override them with the rules created from `trackedFilters`.
     let initialRuleContexts: string[] = [];
-
-    // This callback function is attached to helper and stored because
-    // it needs to be removed on `dipose`.
     let onHelperChange: (state: HelperState) => void;
 
     return {

--- a/src/connectors/query-rules/connectQueryRules.ts
+++ b/src/connectors/query-rules/connectQueryRules.ts
@@ -139,17 +139,6 @@ const connectQueryRules: QueryRulesConnector = (render, unmount = noop) => {
         initialRuleContexts = state.ruleContexts || [];
 
         if (hasTrackedFilters) {
-          // The helper's `ruleContexts` value is by default `undefined`.
-          // We want to set it to an empty array to process the same
-          // data type both internally and externally (= when passing the
-          // `ruleContexts` to the option `transformRuleContexts`).
-          if (initialRuleContexts.length === 0) {
-            helper.overrideStateWithoutTriggeringChangeEvent({
-              ...helper,
-              ruleContexts: initialRuleContexts,
-            });
-          }
-
           helper.on('change', (sharedHelperState: HelperState) => {
             const previousRuleContexts = sharedHelperState.ruleContexts;
             const nextRuleContexts = getRuleContextsFromTrackedFilters({

--- a/src/connectors/query-rules/connectQueryRules.ts
+++ b/src/connectors/query-rules/connectQueryRules.ts
@@ -141,7 +141,7 @@ const connectQueryRules: QueryRulesConnector = (render, unmount = noop) => {
         if (hasTrackedFilters) {
           // The helper's `ruleContexts` value is by default `undefined`.
           // We want to set it to an empty array to process the same
-          // data type both internal and externally (= when passing the
+          // data type both internally and externally (= when passing the
           // `ruleContexts` to the option `transformRuleContexts`).
           if (initialRuleContexts.length === 0) {
             helper.overrideStateWithoutTriggeringChangeEvent({

--- a/src/connectors/query-rules/connectQueryRules.ts
+++ b/src/connectors/query-rules/connectQueryRules.ts
@@ -1,18 +1,39 @@
 import noop from 'lodash/noop';
-import { Renderer, RenderOptions, WidgetFactory } from '../../types';
+import isEqual from 'lodash/isEqual';
+import {
+  Renderer,
+  RenderOptions,
+  WidgetFactory,
+  Helper,
+  HelperState,
+} from '../../types';
 import {
   checkRendering,
   createDocumentationMessageGenerator,
+  warning,
+  getRefinements,
 } from '../../lib/utils';
+import {
+  Refinement as InternalRefinement,
+  NumericRefinement as InternalNumericRefinement,
+} from '../../lib/utils/getRefinements';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'query-rules',
   connector: true,
 });
 
+export type ParamTrackedFilters = {
+  [facetName: string]: (
+    facetValues: Array<string | number>
+  ) => Array<string | number>;
+};
+export type ParamTransformRuleContexts = (ruleContexts: string[]) => string[];
 type ParamTransformItems = (items: object[]) => any;
 
 export type QueryRulesConnectorParams = {
+  trackedFilters?: ParamTrackedFilters;
+  transformRuleContexts?: ParamTransformRuleContexts;
   transformItems?: ParamTransformItems;
 };
 
@@ -33,15 +54,138 @@ export type QueryRulesConnector = <T>(
   unmount?: () => void
 ) => QueryRulesWidgetFactory<T>;
 
+// A context rule must consist only of alphanumeric characters, hyphens, and underscores.
+// See https://www.algolia.com/doc/guides/managing-results/refine-results/merchandising-and-promoting/in-depth/implementing-query-rules/#context
+function escapeRuleContext(ruleName: string) {
+  return ruleName.replace(/[^a-z0-9-_]+/gi, '_');
+}
+
+function getRuleContextsFromTrackedFilters({
+  helper,
+  sharedHelperState,
+  trackedFilters,
+}: {
+  helper: Helper;
+  sharedHelperState: HelperState;
+  trackedFilters: ParamTrackedFilters;
+}) {
+  const ruleContexts = Object.keys(trackedFilters).reduce<string[]>(
+    (facets, facetName) => {
+      const facetRefinements: Array<string | number> = getRefinements(
+        helper.lastResults || {},
+        sharedHelperState
+      )
+        .filter(
+          (refinement: InternalRefinement) =>
+            refinement.attributeName === facetName
+        )
+        .map(
+          (refinement: InternalRefinement) =>
+            (refinement as InternalNumericRefinement).numericValue ||
+            refinement.name
+        );
+
+      const getTrackedFacetValues = trackedFilters[facetName];
+      const trackedFacetValues = getTrackedFacetValues(facetRefinements);
+
+      return [
+        ...facets,
+        ...facetRefinements
+          .filter(facetRefinement =>
+            trackedFacetValues.includes(facetRefinement)
+          )
+          .map(facetValue =>
+            escapeRuleContext(`ais-${facetName}-${facetValue}`)
+          ),
+      ];
+    },
+    []
+  );
+
+  return ruleContexts;
+}
+
 const connectQueryRules: QueryRulesConnector = (render, unmount = noop) => {
   checkRendering(render, withUsage());
 
+  // We store the initial rule contexts applied before creating the widget
+  // so that we do not override them with the rules created from `trackedFilters`.
+  let initialRuleContexts: string[] = [];
+
+  // We track the added rule contexts to remove them when the widget is disposed.
+  let addedRuleContexts: string[] = [];
+
   return widgetParams => {
-    const { transformItems = (items => items) as ParamTransformItems } =
-      widgetParams || {};
+    const {
+      trackedFilters = {} as ParamTrackedFilters,
+      transformRuleContexts = (rules => rules) as ParamTransformRuleContexts,
+      transformItems = (items => items) as ParamTransformItems,
+    } = widgetParams || {};
+
+    Object.keys(trackedFilters).forEach(facetName => {
+      if (typeof trackedFilters[facetName] !== 'function') {
+        throw new Error(
+          withUsage(
+            `'The "${facetName}" filter value in the \`trackedFilters\` option expects a function.`
+          )
+        );
+      }
+    });
+
+    const hasTrackedFilters = Object.keys(trackedFilters).length > 0;
 
     return {
-      init({ instantSearchInstance }) {
+      init({ helper, state, instantSearchInstance }) {
+        initialRuleContexts = state.ruleContexts || [];
+
+        if (hasTrackedFilters) {
+          // The helper's `ruleContexts` value is by default `undefined`.
+          // We want to set it to an empty array to process the same
+          // data type both internal and externally (= when passing the
+          // `ruleContexts` to the option `transformRuleContexts`).
+          if (initialRuleContexts.length === 0) {
+            helper.overrideStateWithoutTriggeringChangeEvent({
+              ...helper,
+              ruleContexts: initialRuleContexts,
+            });
+          }
+
+          helper.on('change', (sharedHelperState: HelperState) => {
+            const previousRuleContexts = sharedHelperState.ruleContexts;
+            const nextRuleContexts = getRuleContextsFromTrackedFilters({
+              helper,
+              sharedHelperState,
+              trackedFilters,
+            });
+            const newRuleContexts = [
+              ...initialRuleContexts,
+              ...nextRuleContexts,
+            ];
+
+            warning(
+              newRuleContexts.length <= 10,
+              `
+The maximum number of \`ruleContexts\` is 10. They have been sliced to that limit.
+Consider using \`transformRuleContexts\` to minimize the number of rules sent to Algolia.
+`
+            );
+
+            const ruleContexts = transformRuleContexts(newRuleContexts).slice(
+              0,
+              10
+            );
+
+            if (!isEqual(previousRuleContexts, ruleContexts)) {
+              helper.overrideStateWithoutTriggeringChangeEvent({
+                ...sharedHelperState,
+                ruleContexts,
+              });
+            }
+
+            addedRuleContexts = nextRuleContexts;
+          });
+        }
+
         render(
           {
             items: [],
@@ -68,6 +212,18 @@ const connectQueryRules: QueryRulesConnector = (render, unmount = noop) => {
 
       dispose({ state }) {
         unmount();
+
+        if (
+          hasTrackedFilters &&
+          state.ruleContexts &&
+          state.ruleContexts.length > 0
+        ) {
+          const reinitRuleContexts = state.ruleContexts.filter(
+            (rule: string) => !addedRuleContexts.includes(rule)
+          );
+
+          return state.setQueryParameter('ruleContexts', reinitRuleContexts);
+        }
 
         return state;
       },

--- a/src/lib/utils/getRefinements.ts
+++ b/src/lib/utils/getRefinements.ts
@@ -19,7 +19,8 @@ export interface FacetRefinement {
   exhaustive?: boolean;
 }
 
-export interface QueryRefinement extends FacetRefinement {
+export interface QueryRefinement
+  extends Pick<FacetRefinement, 'type' | 'attributeName' | 'name'> {
   type: 'query';
   query: string;
 }
@@ -47,7 +48,7 @@ function getRefinement(
   attributeName: Refinement['attributeName'],
   name: Refinement['name'],
   resultsFacets: string[]
-) {
+): Refinement {
   const res: Refinement = { type, attributeName, name };
   let facet: any = find(resultsFacets, { name: attributeName });
   let count: number;
@@ -82,7 +83,7 @@ function getRefinements(
   results: SearchResults,
   state: HelperState,
   clearsQuery: boolean = false
-) {
+): Refinement[] {
   const res: Refinement[] = [];
 
   forEach(state.facetsRefinements, (refinements, attributeName) => {

--- a/src/lib/utils/getRefinements.ts
+++ b/src/lib/utils/getRefinements.ts
@@ -20,15 +20,18 @@ export interface FacetRefinement {
 }
 
 export interface QueryRefinement extends FacetRefinement {
+  type: 'query';
   query: string;
 }
 
 export interface NumericRefinement extends FacetRefinement {
+  type: 'numeric';
   numericValue: number;
   operator: '<' | '<=' | '=' | '>=' | '>';
 }
 
 export interface FacetExcludeRefinement extends FacetRefinement {
+  type: 'exclude';
   exclude: boolean;
 }
 

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -40,3 +40,6 @@ export { default as panel } from './panel/panel';
 export {
   default as queryRuleCustomData,
 } from './query-rule-custom-data/query-rule-custom-data';
+export {
+  default as queryRuleContext,
+} from './query-rule-context/query-rule-context';

--- a/src/widgets/query-rule-context/__tests__/query-rule-context-test.ts
+++ b/src/widgets/query-rule-context/__tests__/query-rule-context-test.ts
@@ -1,0 +1,27 @@
+import queryRuleContext from '../query-rule-context';
+
+describe('queryRuleContext', () => {
+  describe('Usage', () => {
+    test('throws trackedFilters error without options', () => {
+      expect(() => {
+        // @ts-ignore
+        queryRuleContext();
+      }).toThrowErrorMatchingInlineSnapshot(`
+"The \`trackedFilters\` option is required.
+
+See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rule-context/js/"
+`);
+    });
+
+    test('throws trackedFilters error with empty options', () => {
+      expect(() => {
+        // @ts-ignore
+        queryRuleContext({});
+      }).toThrowErrorMatchingInlineSnapshot(`
+"The \`trackedFilters\` option is required.
+
+See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rule-context/js/"
+`);
+    });
+  });
+});

--- a/src/widgets/query-rule-context/query-rule-context.tsx
+++ b/src/widgets/query-rule-context/query-rule-context.tsx
@@ -1,0 +1,33 @@
+import noop from 'lodash/noop';
+import { WidgetFactory } from '../../types';
+import { createDocumentationMessageGenerator } from '../../lib/utils';
+import connectQueryRules, {
+  ParamTrackedFilters,
+  ParamTransformRuleContexts,
+} from '../../connectors/query-rules/connectQueryRules';
+
+type QueryRulesWidgetParams = {
+  trackedFilters: ParamTrackedFilters;
+  transformRuleContexts?: ParamTransformRuleContexts;
+};
+
+type QueryRuleContext = WidgetFactory<QueryRulesWidgetParams>;
+
+const withUsage = createDocumentationMessageGenerator({
+  name: 'query-rule-context',
+});
+
+const queryRuleContext: QueryRuleContext = (
+  { trackedFilters, transformRuleContexts } = {} as QueryRulesWidgetParams
+) => {
+  if (!trackedFilters) {
+    throw new Error(withUsage('The `trackedFilters` option is required.'));
+  }
+
+  return connectQueryRules(noop)({
+    trackedFilters,
+    transformRuleContexts,
+  });
+};
+
+export default queryRuleContext;

--- a/stories/query-rule-context.stories.ts
+++ b/stories/query-rule-context.stories.ts
@@ -1,0 +1,116 @@
+import { storiesOf } from '@storybook/html';
+import { withHits } from '../.storybook/decorators';
+import moviesPlayground from '../.storybook/playgrounds/movies';
+
+type CustomDataItem = {
+  title: string;
+  banner: string;
+  link: string;
+};
+
+const searchOptions = {
+  appId: 'latency',
+  apiKey: 'af044fb0788d6bb15f807e4420592bc5',
+  indexName: 'instant_search_movies',
+  playground: moviesPlayground,
+};
+
+storiesOf('QueryRuleContext', module)
+  .add(
+    'default',
+    withHits(({ search, container, instantsearch }) => {
+      const widgetContainer = document.createElement('div');
+      const description = document.createElement('ul');
+      description.innerHTML = `
+        <li>Select the "Drama" category and The Shawshank Redemption appears</li>
+        <li>Select the "Thriller" category and Pulp Fiction appears</li>
+        <li>Type <q>music</q> and a banner will appear.</li>
+      `;
+
+      container.appendChild(description);
+      container.appendChild(widgetContainer);
+
+      search.addWidget(
+        instantsearch.widgets.queryRuleContext({
+          trackedFilters: {
+            genre: () => ['Thriller', 'Drama'],
+          },
+        })
+      );
+
+      search.addWidget(
+        instantsearch.widgets.queryRuleCustomData({
+          container: widgetContainer,
+          transformItems: (items: CustomDataItem[]) => items[0],
+          templates: {
+            default({ title, banner, link }: CustomDataItem) {
+              if (!banner) {
+                return '';
+              }
+
+              return `
+              <h2>${title}</h2>
+
+              <a href="${link}">
+                <img src="${banner}" alt="${title}">
+              </a>
+            `;
+            },
+          },
+        })
+      );
+    }, searchOptions)
+  )
+  .add(
+    'with initial filter',
+    withHits(({ search, container, instantsearch }) => {
+      const widgetContainer = document.createElement('div');
+      const description = document.createElement('ul');
+      description.innerHTML = `
+        <li>Select the "Drama" category and The Shawshank Redemption appears</li>
+        <li>Select the "Thriller" category and Pulp Fiction appears</li>
+        <li>Type <q>music</q> and a banner will appear.</li>
+      `;
+
+      container.appendChild(description);
+      container.appendChild(widgetContainer);
+
+      search.addWidget(
+        instantsearch.widgets.configure({
+          disjunctiveFacetsRefinements: {
+            genre: ['Drama'],
+          },
+        })
+      );
+
+      search.addWidget(
+        instantsearch.widgets.queryRuleContext({
+          trackedFilters: {
+            genre: () => ['Thriller', 'Drama'],
+          },
+        })
+      );
+
+      search.addWidget(
+        instantsearch.widgets.queryRuleCustomData({
+          container: widgetContainer,
+          transformItems: (items: CustomDataItem[]) => items[0],
+          templates: {
+            default({ title, banner, link }: CustomDataItem) {
+              if (!banner) {
+                return '';
+              }
+
+              return `
+              <h2>${title}</h2>
+
+              <a href="${link}">
+                <img src="${banner}" alt="${title}">
+              </a>
+            `;
+            },
+          },
+        })
+      );
+    }, searchOptions)
+  );

--- a/stories/query-rule-context.stories.ts
+++ b/stories/query-rule-context.stories.ts
@@ -22,8 +22,8 @@ storiesOf('QueryRuleContext', module)
       const widgetContainer = document.createElement('div');
       const description = document.createElement('ul');
       description.innerHTML = `
-        <li>Select the "Drama" category and The Shawshank Redemption appears</li>
-        <li>Select the "Thriller" category and Pulp Fiction appears</li>
+        <li>On empty query, select the "Drama" category and The Shawshank Redemption appears</li>
+        <li>On empty query, select the "Thriller" category and Pulp Fiction appears</li>
         <li>Type <q>music</q> and a banner will appear.</li>
       `;
 


### PR DESCRIPTION
## Summary

This adds context-related features to the `connectQueryRules` connector. This allows to set rule contexts (called `ruleContexts`) of the search parameters based on active filters.

Query rules are by default _generic_ when not provided any context. If you provide a context, they become _contextual_ and are only triggered when the context is matched.

<p align="center">
  <img src="https://user-images.githubusercontent.com/6137112/53238266-27f87000-3699-11e9-8c6a-0e28cc448996.png" alt="Refinement List" width="200">
</p>

This interface can create the following rules:

- `ais-rating-4`
- `ais-rating-5`
- `ais-brand-Samsung`
- `ais-brand-Apple`

The maximum number of rule contexts handled by the engine is 10. Above that limit, the engine returns an error because it slows down data processing. The connector therefore slices the number of rules created to 10.

The `trackedFilters` option sets rules for the specified filters. If the user refines `"Samsung"` in the "brand" refinement list, it will add `ais-brand-Samsung` to the `ruleContexts` of the search parameters.

Rules are prefixed by `ais-` to detect that they're coming from InstantSearch. Users can modify them with the `transformRuleContexts` option.

## Implementation

This is another take based on the previous work in #3597. This solution _does not_ trigger two requests.

At widget initialization, we attach a callback to the [helper](https://github.com/algolia/algoliasearch-helper-js) [`change`](https://community.algolia.com/algoliasearch-helper-js/reference.html#AlgoliaSearchHelper%23event:change) event. This callback computes the `ruleContexts` based on the helper state. Every time the helper state changes, we update the helper state with the potential new rule contexts, without triggering another change (to avoid infinite loops), with the [`overrideStateWithoutTriggeringChangeEvent`](https://community.algolia.com/algoliasearch-helper-js/reference.html#AlgoliaSearchHelper%23overrideStateWithoutTriggeringChangeEvent) method.

## Related

- [`queryRuleCustomData`](https://github.com/algolia/instantsearch.js/pull/3600)
- [Merchandized Query Rules RFC](https://github.com/algolia/instantsearch-rfcs/blob/master/accepted/merchandized-query-rules.md)