### PR TITLE
fix(RoutingManager): avoid stale uiState

### DIFF
--- a/src/lib/RoutingManager.js
+++ b/src/lib/RoutingManager.js
@@ -9,7 +9,7 @@ export default class RoutingManager {
     this.stateMapping = stateMapping;
     this.instantSearchInstance = instantSearchInstance;
 
-    this.originalUIState = this.stateMapping.routeToState(this.router.read());
+    this.currentUIState = this.stateMapping.routeToState(this.router.read());
   }
 
   init({ state }) {
@@ -30,7 +30,7 @@ export default class RoutingManager {
 
     return {
       ...this.getAllSearchParameters({
-        uiState: this.originalUIState,
+        uiState: this.currentUIState,
         currentSearchParameters,
       }),
     };
@@ -65,12 +65,15 @@ export default class RoutingManager {
     });
 
     this.renderURLFromState = searchParameters => {
-      const uiState = this.getAllUIStates({
+      this.currentUIState = this.getAllUIStates({
         searchParameters,
       });
-      const route = this.stateMapping.stateToRoute(uiState);
+
+      const route = this.stateMapping.stateToRoute(this.currentUIState);
+
       this.router.write(route);
     };
+
     helper.on('change', this.renderURLFromState);
 
     // Compare initial state and post first render state, in order

--- a/src/lib/RoutingManager.js
+++ b/src/lib/RoutingManager.js
@@ -47,13 +47,15 @@ export default class RoutingManager {
     const { helper } = this.instantSearchInstance;
 
     this.router.onUpdate(route => {
-      this.currentUIState = this.stateMapping.routeToState(route);
+      const nextUiState = this.stateMapping.routeToState(route);
 
       const widgetsUIState = this.getAllUIStates({
         searchParameters: helper.state,
       });
 
-      if (isEqual(this.currentUIState, widgetsUIState)) return;
+      if (isEqual(nextUiState, widgetsUIState)) return;
+
+      this.currentUIState = nextUiState;
 
       const searchParameters = this.getAllSearchParameters({
         currentSearchParameters: state,
@@ -83,15 +85,17 @@ export default class RoutingManager {
     // helper of the `searchFunction` does not trigger change event (not the
     // same instance).
 
-    this.currentUIState = this.getAllUIStates({
+    const firstRenderState = this.getAllUIStates({
       searchParameters: state,
     });
 
-    if (!isEqual(this.initState, this.currentUIState)) {
+    if (!isEqual(this.initState, firstRenderState)) {
       // Force update the URL, if the state has changed since the initial read.
       // We do this in order to make the URL update when there is `searchFunction`
       // that prevent the search of the initial rendering.
       // See: https://github.com/algolia/instantsearch.js/issues/2523#issuecomment-339356157
+      this.currentUIState = firstRenderState;
+
       const route = this.stateMapping.stateToRoute(this.currentUIState);
 
       this.router.write(route);
@@ -149,13 +153,15 @@ export default class RoutingManager {
     const { helper } = this.instantSearchInstance;
 
     this.router.onUpdate(route => {
-      this.currentUIState = this.stateMapping.routeToState(route);
+      const nextUiState = this.stateMapping.routeToState(route);
 
       const widgetsUIState = this.getAllUIStates({
         searchParameters: helper.state,
       });
 
-      if (isEqual(this.currentUIState, widgetsUIState)) return;
+      if (isEqual(nextUiState, widgetsUIState)) return;
+
+      this.currentUIState = nextUiState;
 
       const searchParameters = this.getAllSearchParameters({
         currentSearchParameters: helper.state,

--- a/src/lib/RoutingManager.js
+++ b/src/lib/RoutingManager.js
@@ -45,18 +45,20 @@ export default class RoutingManager {
 
   setupRouting(state) {
     const { helper } = this.instantSearchInstance;
+
     this.router.onUpdate(route => {
-      const uiState = this.stateMapping.routeToState(route);
-      const currentUIState = this.getAllUIStates({
+      this.currentUIState = this.stateMapping.routeToState(route);
+
+      const widgetsUIState = this.getAllUIStates({
         searchParameters: helper.state,
       });
 
-      if (isEqual(uiState, currentUIState)) return;
+      if (isEqual(this.currentUIState, widgetsUIState)) return;
 
       const searchParameters = this.getAllSearchParameters({
         currentSearchParameters: state,
         instantSearchInstance: this.instantSearchInstance,
-        uiState,
+        uiState: this.currentUIState,
       });
 
       helper
@@ -145,22 +147,23 @@ export default class RoutingManager {
 
   onHistoryChange(fn) {
     const { helper } = this.instantSearchInstance;
+
     this.router.onUpdate(route => {
-      const uiState = this.stateMapping.routeToState(route);
-      const currentUIState = this.getAllUIStates({
+      this.currentUIState = this.stateMapping.routeToState(route);
+
+      const widgetsUIState = this.getAllUIStates({
         searchParameters: helper.state,
       });
 
-      if (isEqual(uiState, currentUIState)) return;
+      if (isEqual(this.currentUIState, widgetsUIState)) return;
 
       const searchParameters = this.getAllSearchParameters({
         currentSearchParameters: helper.state,
         instantSearchInstance: this.instantSearchInstance,
-        uiState,
+        uiState: this.currentUIState,
       });
 
       fn({ ...searchParameters });
     });
-    return;
   }
 }

--- a/src/lib/RoutingManager.js
+++ b/src/lib/RoutingManager.js
@@ -76,19 +76,22 @@ export default class RoutingManager {
 
     helper.on('change', this.renderURLFromState);
 
-    // Compare initial state and post first render state, in order
-    // to see if the query has been changed by a searchFunction
+    // Compare initial state and first render state, in order to see if the
+    // query has been changed by a `searchFunction`. It's required because the
+    // helper of the `searchFunction` does not trigger change event (not the
+    // same instance).
 
-    const firstRenderState = this.getAllUIStates({
+    this.currentUIState = this.getAllUIStates({
       searchParameters: state,
     });
 
-    if (!isEqual(this.initState, firstRenderState)) {
-      // force update the URL, if the state has changed since the initial URL read
-      // We do this in order to make a URL update when there is search function
-      // that prevent the search of the initial rendering
+    if (!isEqual(this.initState, this.currentUIState)) {
+      // Force update the URL, if the state has changed since the initial read.
+      // We do this in order to make the URL update when there is `searchFunction`
+      // that prevent the search of the initial rendering.
       // See: https://github.com/algolia/instantsearch.js/issues/2523#issuecomment-339356157
-      const route = this.stateMapping.stateToRoute(firstRenderState);
+      const route = this.stateMapping.stateToRoute(this.currentUIState);
+
       this.router.write(route);
     }
   }

--- a/src/lib/__tests__/RoutingManager-test.js
+++ b/src/lib/__tests__/RoutingManager-test.js
@@ -1,18 +1,18 @@
-import algoliasearch from 'algoliasearch';
 import instantsearch from '../main';
 import RoutingManager from '../RoutingManager';
 import simpleMapping from '../stateMappings/simple';
 
-const fakeAlgoliaClient = {
+const createFakeSearchClient = () => ({
   search: () => Promise.resolve({ results: [{}] }),
-};
+});
 
 describe('RoutingManager', () => {
   describe('getAllUIStates', () => {
     test('reads the state of widgets with a getWidgetState implementation', () => {
+      const searchClient = createFakeSearchClient();
       const search = instantsearch({
         indexName: '',
-        searchClient: fakeAlgoliaClient,
+        searchClient,
       });
 
       const widgetState = {
@@ -54,9 +54,10 @@ describe('RoutingManager', () => {
     });
 
     test('Does not read UI state from widgets without an implementation of getWidgetState', () => {
+      const searchClient = createFakeSearchClient();
       const search = instantsearch({
         indexName: '',
-        searchClient: fakeAlgoliaClient,
+        searchClient,
       });
 
       search.addWidget({
@@ -86,9 +87,10 @@ describe('RoutingManager', () => {
 
   describe('getAllSearchParameters', () => {
     test('should get searchParameters from widget that implements getWidgetSearchParameters', () => {
+      const searchClient = createFakeSearchClient();
       const search = instantsearch({
         indexName: '',
-        searchClient: fakeAlgoliaClient,
+        searchClient,
       });
 
       const widget = {
@@ -127,9 +129,10 @@ describe('RoutingManager', () => {
     });
 
     test('should not change the searchParameters if no widget has a getWidgetSearchParameters', () => {
+      const searchClient = createFakeSearchClient();
       const search = instantsearch({
         indexName: '',
-        searchClient: fakeAlgoliaClient,
+        searchClient,
       });
 
       const widget = {
@@ -157,20 +160,17 @@ describe('RoutingManager', () => {
 
   describe('within instantsearch', () => {
     test('should write in the router on searchParameters change', done => {
-      let onUpdateCallback; // eslint-disable-line
+      const searchClient = createFakeSearchClient();
+
       const router = {
         write: jest.fn(),
         read: jest.fn(),
-        onUpdate: fn => {
-          onUpdateCallback = fn;
-        },
+        onUpdate: () => {},
       };
+
       const search = instantsearch({
         indexName: 'instant_search',
-        searchClient: algoliasearch(
-          'latency',
-          '6be0576ff61c053d5f9a3225e2a90f76'
-        ),
+        searchClient,
         routing: {
           router,
         },
@@ -207,6 +207,8 @@ describe('RoutingManager', () => {
     });
 
     test('should update the searchParameters on router state update', done => {
+      const searchClient = createFakeSearchClient();
+
       let onRouterUpdateCallback;
       const router = {
         write: jest.fn(),
@@ -215,12 +217,10 @@ describe('RoutingManager', () => {
           onRouterUpdateCallback = fn;
         },
       };
+
       const search = instantsearch({
         indexName: 'instant_search',
-        searchClient: algoliasearch(
-          'latency',
-          '6be0576ff61c053d5f9a3225e2a90f76'
-        ),
+        searchClient,
         routing: {
           router,
         },
@@ -256,11 +256,14 @@ describe('RoutingManager', () => {
     });
 
     test('should apply state mapping on differences after searchfunction', done => {
+      const searchClient = createFakeSearchClient();
+
       const router = {
         write: jest.fn(),
         read: jest.fn(() => ({})),
         onUpdate: jest.fn(),
       };
+
       const stateMapping = {
         stateToRoute(uiState) {
           return {
@@ -271,18 +274,16 @@ describe('RoutingManager', () => {
           return routeState;
         },
       };
+
       const search = instantsearch({
         indexName: 'instant_search',
-        searchClient: algoliasearch(
-          'latency',
-          '6be0576ff61c053d5f9a3225e2a90f76'
-        ),
-        routing: {
-          router,
-          stateMapping,
-        },
         searchFunction: helper => {
           helper.setQuery('test').search();
+        },
+        searchClient,
+        routing: {
+          stateMapping,
+          router,
         },
       });
 

--- a/src/lib/__tests__/RoutingManager-test.js
+++ b/src/lib/__tests__/RoutingManager-test.js
@@ -1,6 +1,5 @@
 import instantsearch from '../main';
 import RoutingManager from '../RoutingManager';
-import simpleMapping from '../stateMappings/simple';
 
 const runAllMicroTasks = () => new Promise(setImmediate);
 
@@ -112,7 +111,7 @@ describe('RoutingManager', () => {
 
       const router = new RoutingManager({
         instantSearchInstance: search,
-        stateMapping: simpleMapping(),
+        stateMapping: createFakeStateMapping(),
         router: {
           read: () => actualInitialState,
         },
@@ -152,7 +151,7 @@ describe('RoutingManager', () => {
 
       const router = new RoutingManager({
         instantSearchInstance: search,
-        stateMapping: simpleMapping(),
+        stateMapping: createFakeStateMapping(),
         router: {
           read: () => actualInitialState,
         },
@@ -187,7 +186,7 @@ describe('RoutingManager', () => {
 
       const router = new RoutingManager({
         instantSearchInstance: search,
-        stateMapping: simpleMapping(),
+        stateMapping: createFakeStateMapping(),
         router: {
           read: () => actualInitialState,
         },
@@ -224,7 +223,7 @@ describe('RoutingManager', () => {
 
       const router = new RoutingManager({
         instantSearchInstance: search,
-        stateMapping: simpleMapping(),
+        stateMapping: createFakeStateMapping(),
         router: {
           read: () => {},
         },
@@ -337,16 +336,13 @@ describe('RoutingManager', () => {
         write: jest.fn(),
       });
 
-      const stateMapping = {
+      const stateMapping = createFakeStateMapping({
         stateToRoute(uiState) {
           return {
             query: uiState.query && uiState.query.toUpperCase(),
           };
         },
-        routeToState(routeState) {
-          return routeState;
-        },
-      };
+      });
 
       const search = instantsearch({
         indexName: 'instant_search',

--- a/src/lib/__tests__/RoutingManager-test.js
+++ b/src/lib/__tests__/RoutingManager-test.js
@@ -241,12 +241,9 @@ describe('RoutingManager', () => {
   describe('within instantsearch', () => {
     test('should write in the router on searchParameters change', done => {
       const searchClient = createFakeSearchClient();
-
-      const router = {
+      const router = createFakeRouter({
         write: jest.fn(),
-        read: jest.fn(),
-        onUpdate: () => {},
-      };
+      });
 
       const search = instantsearch({
         indexName: 'instant_search',
@@ -290,13 +287,11 @@ describe('RoutingManager', () => {
       const searchClient = createFakeSearchClient();
 
       let onRouterUpdateCallback;
-      const router = {
-        write: jest.fn(),
-        read: jest.fn(() => ({})),
+      const router = createFakeRouter({
         onUpdate: fn => {
           onRouterUpdateCallback = fn;
         },
-      };
+      });
 
       const search = instantsearch({
         indexName: 'instant_search',
@@ -338,11 +333,9 @@ describe('RoutingManager', () => {
     test('should apply state mapping on differences after searchfunction', done => {
       const searchClient = createFakeSearchClient();
 
-      const router = {
+      const router = createFakeRouter({
         write: jest.fn(),
-        read: jest.fn(() => ({})),
-        onUpdate: jest.fn(),
-      };
+      });
 
       const stateMapping = {
         stateToRoute(uiState) {

--- a/src/lib/__tests__/RoutingManager-test.js
+++ b/src/lib/__tests__/RoutingManager-test.js
@@ -419,7 +419,7 @@ describe('RoutingManager', () => {
 
       await runAllMicroTasks();
 
-      // Trigger getConfigurartion
+      // Trigger getConfiguration
       search.removeWidget(fakeHitsPerPage);
 
       await runAllMicroTasks();
@@ -466,7 +466,7 @@ describe('RoutingManager', () => {
         query: 'Apple iPhone',
       });
 
-      // Trigger getConfigurartion
+      // Trigger getConfiguration
       search.removeWidget(fakeHitsPerPage);
 
       await runAllMicroTasks();
@@ -534,7 +534,7 @@ describe('RoutingManager', () => {
 
       await runAllMicroTasks();
 
-      // Trigger getConfigurartion
+      // Trigger getConfiguration
       search.removeWidget(fakeHitsPerPage);
 
       await runAllMicroTasks();


### PR DESCRIPTION
**Summary**

Closes https://github.com/algolia/instantsearch.js/issues/3497

This PR aims to fix the issue related to the stale `uiState` inside the `RoutingManager` (see the issue for more information). Previously the state was only captured at the creation of the manager and never updated. Now we update it each time an update occurs (state change, router update). It means that now once a widget is added/removed the lifecycle read the up to date `uiState`.

**Before**

![before](https://user-images.githubusercontent.com/6513513/55146418-d71ae200-5144-11e9-9643-7f4cae457973.gif)

**After**

![after](https://user-images.githubusercontent.com/6513513/55146435-df731d00-5144-11e9-90bd-41978b9ac30c.gif)