### PR TITLE
refactor(RoutingManager): remove dead code

### DIFF
--- a/src/lib/RoutingManager.js
+++ b/src/lib/RoutingManager.js
@@ -63,13 +63,6 @@ export default class RoutingManager {
         uiState,
       });
 
-      const fullHelperState = {
-        ...this.originalConfig,
-        ...searchParameters,
-      };
-
-      if (isEqual(fullHelperState, searchParameters)) return;
-
       helper
         .overrideStateWithoutTriggeringChangeEvent(searchParameters)
         .search();

--- a/src/lib/RoutingManager.js
+++ b/src/lib/RoutingManager.js
@@ -3,7 +3,6 @@ import isEqual from 'lodash/isEqual';
 
 export default class RoutingManager {
   constructor({ instantSearchInstance, router, stateMapping } = {}) {
-    this.originalConfig = null;
     this.firstRender = true;
 
     this.router = router;
@@ -23,19 +22,16 @@ export default class RoutingManager {
   }
 
   getConfiguration(currentConfiguration) {
-    // we need to create a REAL helper to then get its state. Because some parameters
-    // like hierarchicalFacet.rootPath are then triggering a default refinement that would
-    // be not present if it was not going trough the SearchParameters constructor
-    this.originalConfig = algoliasearchHelper(
-      {},
-      currentConfiguration.index,
+    // We have to create a `SearchParameters` because `getAllSearchParameters`
+    // expect an instance of `SearchParameters` and not a plain object.
+    const currentSearchParameters = algoliasearchHelper.SearchParameters.make(
       currentConfiguration
-    ).state;
-    // The content of getAllSearchParameters is destructured to return a plain object
+    );
+
     return {
       ...this.getAllSearchParameters({
-        currentSearchParameters: this.originalConfig,
         uiState: this.originalUIState,
+        currentSearchParameters,
       }),
     };
   }

--- a/src/lib/RoutingManager.js
+++ b/src/lib/RoutingManager.js
@@ -157,12 +157,7 @@ export default class RoutingManager {
         uiState,
       });
 
-      const fullSearchParameters = {
-        ...this.originalConfig,
-        ...searchParameters,
-      };
-
-      fn(fullSearchParameters);
+      fn({ ...searchParameters });
     });
     return;
   }

--- a/src/lib/RoutingManager.js
+++ b/src/lib/RoutingManager.js
@@ -23,7 +23,7 @@ export default class RoutingManager {
 
   getConfiguration(currentConfiguration) {
     // We have to create a `SearchParameters` because `getAllSearchParameters`
-    // expect an instance of `SearchParameters` and not a plain object.
+    // expects an instance of `SearchParameters` and not a plain object.
     const currentSearchParameters = algoliasearchHelper.SearchParameters.make(
       currentConfiguration
     );


### PR DESCRIPTION
**Summary**

This PR removes dead code inside the `RoutingManager`. Here is the changes:

- [L66-72](https://github.com/algolia/instantsearch.js/blob/ca8ae5018b93b98e663b623c2ba829b01a7f2861/src/lib/RoutingManager.js#L66-L71): It was previously used inside the [`URLSync`](https://github.com/algolia/instantsearch.js/blob/v2.10.4/src/lib/url-sync.js#L164-L169) implementation to avoid useless search + render. Inside the previous implementation, it was working fine because both values were objects ([`getState`](https://github.com/algolia/algoliasearch-helper-js/blob/eafd4cfd3e78b49bb5425784bab413f0702cbc04/src/algoliasearch.helper.js#L819-L821) with a filter function returns a plain object). With the `routing` system it's not the case. We compare a plain object with an instance of `SearchParameters`, even with the same parameters the two values [are different](https://codesandbox.io/s/n0m90108op). It means that with the new implementation the condition never worked. I removed the condition because we never had an issue related to performance in that part of the code since the release of the feature.

- [L167-172](https://github.com/algolia/instantsearch.js/blob/ca8ae5018b93b98e663b623c2ba829b01a7f2861/src/lib/RoutingManager.js#L167-L172): It was previously used inside the [`URLSync`](https://github.com/algolia/instantsearch.js/blob/48a8d66746eb51fc0bc135f38182f84bc92ced37/src/lib/url-sync.js#L220-L224) implementation to provide the full state to the callback. It was required because the `URLSync` was not able to restore a full state from the URL. With the `routing` system it's not the case. We compute the `SearchParameters` directly from the current `helper.state` which means that it already contains the "configuration" part (which is `disjunctiveFacets`, etc... crafted at `getConfiguration`).

- [L26-37](https://github.com/algolia/instantsearch.js/blob/ca8ae5018b93b98e663b623c2ba829b01a7f2861/src/lib/RoutingManager.js#L26-L37): We got rid of the usage of `this.originalConfig` inside the manager at the two previous steps which means that we can drop it completely. The call to `algoliasearchHelper` is replaced with `SearchParameters.make` because we only use the `state` of the helper. You can take a look at the [constructor implementation](https://github.com/algolia/algoliasearch-helper-js/blob/eafd4cfd3e78b49bb5425784bab413f0702cbc04/src/algoliasearch.helper.js#L121-L135), the replacement call is equivalent.
