### PR TITLE
refactor(InstantSearch): remove dead variable

### DIFF
--- a/src/connectors/configure/connectConfigure.js
+++ b/src/connectors/configure/connectConfigure.js
@@ -57,7 +57,7 @@ export default function connectConfigure(renderFn = noop, unmountFn = noop) {
         return searchParameters => {
           // merge new `searchParameters` with the ones set from other widgets
           const actualState = this.removeSearchParameters(helper.getState());
-          const nextSearchParameters = enhanceConfiguration({})(
+          const nextSearchParameters = enhanceConfiguration()(
             { ...actualState },
             {
               getConfiguration: () => searchParameters,

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -155,7 +155,7 @@ See: https://www.algolia.com/doc/guides/building-search-ui/widgets/create-your-o
 
     // Init the widget directly if instantsearch has been already started
     if (this.started && Boolean(widgets.length)) {
-      this.searchParameters = this.widgets.reduce(enhanceConfiguration({}), {
+      this.searchParameters = this.widgets.reduce(enhanceConfiguration(), {
         ...this.helper.state,
       });
 
@@ -227,7 +227,7 @@ See: https://www.algolia.com/doc/guides/building-search-ui/widgets/create-your-o
       // re-compute remaining widgets to the state
       // in a case two widgets were using the same configuration but we removed one
       if (nextState) {
-        this.searchParameters = this.widgets.reduce(enhanceConfiguration({}), {
+        this.searchParameters = this.widgets.reduce(enhanceConfiguration(), {
           ...nextState,
         });
 
@@ -273,8 +273,6 @@ See: https://www.algolia.com/doc/guides/building-search-ui/widgets/create-your-o
       );
     }
 
-    let searchParametersFromUrl;
-
     if (this.routing) {
       const routingManager = new RoutingManager({
         ...this.routing,
@@ -293,7 +291,7 @@ See: https://www.algolia.com/doc/guides/building-search-ui/widgets/create-your-o
     }
 
     this.searchParameters = this.widgets.reduce(
-      enhanceConfiguration(searchParametersFromUrl),
+      enhanceConfiguration(),
       this.searchParameters
     );
 
@@ -426,14 +424,13 @@ See: https://www.algolia.com/doc/guides/building-search-ui/widgets/create-your-o
   }
 }
 
-export function enhanceConfiguration(searchParametersFromUrl) {
+export function enhanceConfiguration() {
   return (configuration, widgetDefinition) => {
     if (!widgetDefinition.getConfiguration) return configuration;
 
     // Get the relevant partial configuration asked by the widget
     const partialConfiguration = widgetDefinition.getConfiguration(
-      configuration,
-      searchParametersFromUrl
+      configuration
     );
 
     const customizer = (a, b) => {

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -246,10 +246,7 @@ describe('InstantSearch lifecycle', () => {
       });
 
       it('calls widget.getConfiguration(searchParameters)', () => {
-        expect(widget.getConfiguration).toHaveBeenCalledWith(
-          searchParameters,
-          undefined
-        );
+        expect(widget.getConfiguration).toHaveBeenCalledWith(searchParameters);
       });
 
       it('calls algoliasearchHelper(client, indexName, searchParameters)', () => {

--- a/src/lib/__tests__/enhanceConfiguration-test.js
+++ b/src/lib/__tests__/enhanceConfiguration-test.js
@@ -33,14 +33,11 @@ describe('enhanceConfiguration', () => {
     const widget = { getConfiguration: jest.fn() };
 
     const configuration = {};
-    const searchParametersFromUrl = {};
-    enhanceConfiguration(searchParametersFromUrl)(configuration, widget);
+
+    enhanceConfiguration()(configuration, widget);
 
     expect(widget.getConfiguration).toHaveBeenCalled();
-    expect(widget.getConfiguration).toHaveBeenCalledWith(
-      configuration,
-      searchParametersFromUrl
-    );
+    expect(widget.getConfiguration).toHaveBeenCalledWith(configuration);
   });
 
   it('should replace boolean values', () => {


### PR DESCRIPTION
**Summary**

This PR removes dead code inside `InstantSearch`. Here is the change:

- The `enhanceConfiguration` was previously used with the `SearchParameters` crafted from the URL with the [`URLSync`](https://github.com/algolia/instantsearch.js/blob/48a8d66746eb51fc0bc135f38182f84bc92ced37/src/lib/InstantSearch.js#L333). Under the hood the value was provided to [`getConfiguration`](https://github.com/algolia/instantsearch.js/blob/48a8d66746eb51fc0bc135f38182f84bc92ced37/src/lib/InstantSearch.js#L480-L483) along with the actual configuration. I didn't find any documentation about this argument. We drop the support of `URLSync` with InstantSearch 3.x. Since its introduction, the `routing` system always call the `enhanceConfiguration` function with `undefined` on start and an empty object on add/remove. The behavior is not consistent between the lifecycles. I've dropped the support for the argument which means that now the `getConfiguration` is always called with one argument. The impact should be none: we don't use it internally and it's not documented at all.