### PR TITLE
chore(queryRules): update stories

### DIFF
--- a/stories/query-rule-context.stories.ts
+++ b/stories/query-rule-context.stories.ts
@@ -41,20 +41,26 @@ storiesOf('QueryRuleContext', module)
       search.addWidget(
         instantsearch.widgets.queryRuleCustomData({
           container: widgetContainer,
-          transformItems: (items: CustomDataItem[]) => items[0],
+          transformItems(items: CustomDataItem[]) {
+            return items.filter(item => typeof item.banner !== 'undefined');
+          },
           templates: {
-            default({ title, banner, link }: CustomDataItem) {
-              if (!banner) {
-                return '';
+            default(items: CustomDataItem[]) {
+              if (items.length === 0) {
+                return;
               }
 
-              return `
-              <h2>${title}</h2>
+              const { title, banner, link } = items[0];
 
-              <a href="${link}">
-                <img src="${banner}" alt="${title}">
-              </a>
-            `;
+              return `
+                <section>
+                  <h2>${title}</h2>
+
+                  <a href="${link}">
+                    <img src="${banner}" alt="${title}">
+                  </a>
+                </section>
+              `;
             },
           },
         })
@@ -94,20 +100,26 @@ storiesOf('QueryRuleContext', module)
       search.addWidget(
         instantsearch.widgets.queryRuleCustomData({
           container: widgetContainer,
-          transformItems: (items: CustomDataItem[]) => items[0],
+          transformItems(items: CustomDataItem[]) {
+            return items.filter(item => typeof item.banner !== 'undefined');
+          },
           templates: {
-            default({ title, banner, link }: CustomDataItem) {
-              if (!banner) {
-                return '';
+            default(items: CustomDataItem[]) {
+              if (items.length === 0) {
+                return;
               }
 
-              return `
-              <h2>${title}</h2>
+              const { title, banner, link } = items[0];
 
-              <a href="${link}">
-                <img src="${banner}" alt="${title}">
-              </a>
-            `;
+              return `
+                <section>
+                  <h2>${title}</h2>
+
+                  <a href="${link}">
+                    <img src="${banner}" alt="${title}">
+                  </a>
+                </section>
+              `;
             },
           },
         })

--- a/stories/query-rule-custom-data.stories.ts
+++ b/stories/query-rule-custom-data.stories.ts
@@ -29,19 +29,26 @@ storiesOf('QueryRuleCustomData', module)
       search.addWidget(
         instantsearch.widgets.queryRuleCustomData({
           container: widgetContainer,
-          transformItems: (items: CustomDataItem[]) => items[0],
           templates: {
-            default({ title, banner, link }: CustomDataItem) {
+            default(items: CustomDataItem[]) {
+              if (items.length === 0) {
+                return;
+              }
+
+              const { title, banner, link } = items[0];
+
               if (!banner) {
-                return '';
+                return;
               }
 
               return `
-                <h2>${title}</h2>
+                <section>
+                  <h2>${title}</h2>
 
-                <a href="${link}">
-                  <img src="${banner}" alt="${title}">
-                </a>
+                  <a href="${link}">
+                    <img src="${banner}" alt="${title}">
+                  </a>
+                </section>
               `;
             },
           },
@@ -65,20 +72,25 @@ storiesOf('QueryRuleCustomData', module)
           container: widgetContainer,
           transformItems: (items: CustomDataItem[]) => {
             if (items.length > 0) {
-              return items[0];
+              return items.filter(item => typeof item.banner !== 'undefined');
             }
 
-            return {
-              title: 'Kill Bill',
-              banner: 'http://static.bobatv.net/IMovie/mv_2352/poster_2352.jpg',
-              link: 'https://www.netflix.com/title/60031236',
-            };
+            return [
+              {
+                title: 'Kill Bill',
+                banner:
+                  'http://static.bobatv.net/IMovie/mv_2352/poster_2352.jpg',
+                link: 'https://www.netflix.com/title/60031236',
+              },
+            ];
           },
           templates: {
-            default({ title, banner, link }: CustomDataItem) {
-              if (!banner) {
-                return '';
+            default(items: CustomDataItem[]) {
+              if (items.length === 0) {
+                return;
               }
+
+              const { title, banner, link } = items[0];
 
               return `
                 <h2>${title}</h2>


### PR DESCRIPTION
When playing around with Query Rules widgets and writing their documentation (algolia/doc#2896), I saw a few patterns emerging.

That's my proposition for their stories:

- I don't think it's nice to showcase mutating the structure of the items:

```js
transformItems(item[]): item
```

- `transformItems` can be used to filter out custom data to avoid having to add checks to the template

These stories are released to the production storybook once merged to master (when we release a new library version for instance).

If you agree with these changes we can release the new minor version.