### PR TITLE
fix(connectQueryRules): improve tracked refinement type

### DIFF
--- a/src/connectors/query-rules/connectQueryRules.ts
+++ b/src/connectors/query-rules/connectQueryRules.ts
@@ -18,10 +18,12 @@ import {
   NumericRefinement as InternalNumericRefinement,
 } from '../../lib/utils/getRefinements';
 
+type TrackedFilterRefinement = string | number | boolean;
+
 export type ParamTrackedFilters = {
   [facetName: string]: (
-    facetValues: Array<string | number>
-  ) => Array<string | number>;
+    facetValues: TrackedFilterRefinement[]
+  ) => TrackedFilterRefinement[];
 };
 export type ParamTransformRuleContexts = (ruleContexts: string[]) => string[];
 type ParamTransformItems = (items: object[]) => any;
@@ -85,7 +87,7 @@ function getRuleContextsFromTrackedFilters({
 }) {
   const ruleContexts = Object.keys(trackedFilters).reduce<string[]>(
     (facets, facetName) => {
-      const facetRefinements: Array<string | number> = getRefinements(
+      const facetRefinements: TrackedFilterRefinement[] = getRefinements(
         helper.lastResults || {},
         sharedHelperState
       )


### PR DESCRIPTION
The tracked filters assumed a refinement can be a `number` or a `string`. It can also be a `boolean`.

See:

- https://github.com/algolia/react-instantsearch/pull/2258/files#diff-61853eb4221589c33badeb16d8725534R12
- https://github.com/algolia/angular-instantsearch/pull/483#discussion_r271643098