### PR TITLE
fix(routing): apply windowTitle on first load

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,8 @@
     "inquirer": "6.2.2",
     "jest": "24.7.1",
     "jest-diff": "24.7.0",
+    "jest-environment-jsdom": "24.7.1",
+    "jest-environment-jsdom-global": "1.2.0",
     "jest-watch-typeahead": "0.3.0",
     "jsdom-global": "3.0.2",
     "mversion": "1.13.0",

--- a/scripts/jest/config.js
+++ b/scripts/jest/config.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   rootDir: process.cwd(),
+  testEnvironment: 'jest-environment-jsdom-global',
   testPathIgnorePatterns: [
     '<rootDir>/node_modules/',
     '<rootDir>/dist*',

--- a/src/lib/__tests__/RoutingManager-test.js
+++ b/src/lib/__tests__/RoutingManager-test.js
@@ -549,26 +549,12 @@ describe('RoutingManager', () => {
   });
 
   describe('windowTitle', () => {
-    let setWindowTitle = jest.fn();
-
-    Object.defineProperty(window.document, 'title', {
-      get() {
-        return '';
-      },
-      set(value) {
-        setWindowTitle(value);
-      },
-    });
-
-    beforeEach(() => {
-      setWindowTitle = jest.fn();
-    });
-
     test('should update the window title with URL query params on first render', async () => {
       jsdom.reconfigure({
         url: 'https://website.com/?query=query',
       });
 
+      const setWindowTitle = jest.spyOn(window.document, 'title', 'set');
       const searchClient = createFakeSearchClient();
       const stateMapping = createFakeStateMapping();
       const router = historyRouter({
@@ -595,6 +581,8 @@ describe('RoutingManager', () => {
 
       expect(setWindowTitle).toHaveBeenCalledTimes(1);
       expect(setWindowTitle).toHaveBeenLastCalledWith('Searching for "query"');
+
+      setWindowTitle.mockRestore();
     });
   });
 });

--- a/src/lib/routers/history.js
+++ b/src/lib/routers/history.js
@@ -15,6 +15,12 @@ function defaultParseURL({ qsModule, location }) {
   return qsModule.parse(location.search.slice(1));
 }
 
+function setWindowTitle(title) {
+  if (title) {
+    window.document.title = title;
+  }
+}
+
 class BrowserHistory {
   /**
    * Initializes a new storage provider that will sync the search state in the URL
@@ -44,6 +50,13 @@ class BrowserHistory {
     this.writeDelay = writeDelay;
     this._createURL = createURL;
     this.parseURL = parseURL;
+
+    const routeState = this.parseURL({
+      qsModule: qs,
+      location: window.location,
+    });
+    const title = this.windowTitle && this.windowTitle(routeState);
+    setWindowTitle(title);
   }
 
   /**
@@ -60,7 +73,8 @@ class BrowserHistory {
     }
 
     this.writeTimer = setTimeout(() => {
-      if (title) window.document.title = title;
+      setWindowTitle(title);
+
       window.history.pushState(routeState, title || '', url);
       this.writeTimer = undefined;
     }, this.writeDelay);

--- a/src/lib/routers/history.js
+++ b/src/lib/routers/history.js
@@ -51,11 +51,8 @@ class BrowserHistory {
     this._createURL = createURL;
     this.parseURL = parseURL;
 
-    const routeState = this.parseURL({
-      qsModule: qs,
-      location: window.location,
-    });
-    const title = this.windowTitle && this.windowTitle(routeState);
+    const title = this.windowTitle && this.windowTitle(this.read());
+
     setWindowTitle(title);
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7256,7 +7256,12 @@ jest-each@^24.7.1:
     jest-util "^24.7.1"
     pretty-format "^24.7.0"
 
-jest-environment-jsdom@^24.7.1:
+jest-environment-jsdom-global@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom-global/-/jest-environment-jsdom-global-1.2.0.tgz#dd5b16fe0a0566ee40010d8632be5adf5a5ccb65"
+  integrity sha512-41cDl0OxzmFY/cnW0COUN+lnt2N2ks1r3V4fAKOnlZ9xIrGy0PNPan+Bz8HP+uQy/8bGV6T7J4Oi7X+h43It6g==
+
+jest-environment-jsdom@24.7.1, jest-environment-jsdom@^24.7.1:
   version "24.7.1"
   resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-24.7.1.tgz#a40e004b4458ebeb8a98082df135fd501b9fbbd6"
   integrity sha512-Gnhb+RqE2JuQGb3kJsLF8vfqjt3PHKSstq4Xc8ic+ax7QKo4Z0RWGucU3YV+DwKR3T9SYc+3YCUQEJs8r7+Jxg==


### PR DESCRIPTION
_This PR is a fix for #3667._

The [`windowTitle`](https://www.algolia.com/doc/guides/building-search-ui/going-further/routing-urls/js/#windowtitle-functionroutestate-string) param of the routing option didn't apply on the first page load. 

I fixed this by setting the document title also in the `RoutingManager` constructor, based on the URL query parameters which represent the route state.

This feature remained untested so I added a test for the first page load.

Note that Jest doesn't support updating `window.location` in tests (see facebook/jest#890 and facebook/jest#5124). I therefore needed to introduce two new JSDom dev dependencies to change `window.location` in separate tests, which give access to `jsdom.reconfigure({ url })`. I believe these dependencies will be needed in the feature while we refactor/test/reimplement the routing option.

The [Jest team has at some point considered giving access to `reconfigure`](https://github.com/facebook/jest/issues/890#issuecomment-352585259). This would mean that the new dependencies become unnecessary.

Closes #3667.