### PR TITLE
fix(normalizeRefinement): remove boolean values passed to `_objectSpread` in normalizeRefinement

### DIFF
--- a/src/connectors/current-refinements/connectCurrentRefinements.js
+++ b/src/connectors/current-refinements/connectCurrentRefinements.js
@@ -254,17 +254,23 @@ function normalizeRefinement(refinement) {
     ? `${getOperatorSymbol(refinement.operator)} ${refinement.name}`
     : refinement.name;
 
-  return {
+  const normalizedRefinement = {
     attribute: refinement.attributeName,
     type: refinement.type,
     value,
     label,
-    ...(refinement.operator !== undefined && { operator: refinement.operator }),
-    ...(refinement.count !== undefined && { count: refinement.count }),
-    ...(refinement.exhaustive !== undefined && {
-      exhaustive: refinement.exhaustive,
-    }),
   };
+
+  if (refinement.operator !== undefined) {
+    normalizedRefinement.operator = refinement.operator;
+  }
+  if (refinement.count !== undefined) {
+    normalizedRefinement.count = refinement.count;
+  }
+  if (refinement.exhaustive !== undefined) {
+    normalizedRefinement.exhaustive = refinement.exhaustive;
+  }
+  return normalizedRefinement;
 }
 
 function groupItemsByRefinements(items, helper) {


### PR DESCRIPTION
**Summary**

_objectSpread polyfill calls Object.keys() under the hood which on IE11
does not support anything other than objects.

Reason: change in spec

ES5: https://www.ecma-international.org/ecma-262/5.1/#sec-15.2.3.14

> If the Type(O) is not Object, throw a TypeError exception.

ES6: https://www.ecma-international.org/ecma-262/6.0/#sec-object.keys

Uses ToObject, which supports booleans

> Return a new Boolean object whose [[BooleanData]] internal slot is set to the value of argument. See 19.3 for a description of Boolean objects





**Result**
No we are avoiding booleans altogether.
Nothing should change. I'll test this out in IE once it's deployed
