### PR TITLE
fix(infiniteHits): clear cache on query or refinement changes

### DIFF
--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.js
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.js
@@ -219,6 +219,54 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     expect(thirdRenderingOptions.results).toEqual(previousResults);
   });
 
+  it('Provides the hits and flush hists cache on query changes', () => {
+    const rendering = jest.fn();
+    const makeWidget = connectInfiniteHits(rendering);
+    const widget = makeWidget();
+
+    const helper = jsHelper({}, '', {});
+    helper.search = jest.fn();
+
+    widget.init({
+      helper,
+      state: helper.state,
+      createURL: () => '#',
+      onHistoryChange: () => {},
+    });
+
+    const firstRenderingOptions = rendering.mock.calls[0][0];
+    expect(firstRenderingOptions.hits).toEqual([]);
+    expect(firstRenderingOptions.results).toBe(undefined);
+
+    const hits = [{ fake: 'data' }, { sample: 'infos' }];
+    const results = new SearchResults(helper.state, [{ hits }]);
+    widget.render({
+      results,
+      state: helper.state,
+      helper,
+      createURL: () => '#',
+    });
+
+    const secondRenderingOptions = rendering.mock.calls[1][0];
+    expect(secondRenderingOptions.hits).toEqual(hits);
+    expect(secondRenderingOptions.results).toEqual(results);
+
+    helper.setQuery('data');
+
+    // If the query changes, the hits cache should be flushed
+    const otherHits = [{ fake: 'data 2' }, { sample: 'infos 2' }];
+    const otherResults = new SearchResults(helper.state, [{ hits: otherHits }]);
+    widget.render({
+      results: otherResults,
+      state: helper.state,
+      helper,
+      createURL: () => '#',
+    });
+    const thirdRenderingOptions = rendering.mock.calls[2][0];
+    expect(thirdRenderingOptions.hits).toEqual(otherHits);
+    expect(thirdRenderingOptions.results).toEqual(otherResults);
+  });
+
   it('escape highlight properties if requested', () => {
     const rendering = jest.fn();
     const makeWidget = connectInfiniteHits(rendering);


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

In https://github.com/algolia/instantsearch.js/pull/3645 we removed [a condition](https://github.com/algolia/instantsearch.js/blob/db9b91e140f3172545d76b37e1c153421ca20799/src/connectors/infinite-hits/connectInfiniteHits.js#L99-L102) that reseted the widget internal cache when reaching the first page. It was removed since it was conflicting with the new previous button feature.

Sadly, this reset step was essential to reset the widget internal cache on any refinement or query update so we don't append the new results with the ones from the previous search.

This fix re-introduces this code but with a different condition: since we can not rely on the page index anymore we now compare the full search state for any difference, and reset the cache if any difference (except for the page) is found.

While working correctly this fix is not very clean IMHO (it serialize the full state to do the comparison :nauseated_face: ), so if anyone has a better idea I am open to any suggestion :hugs: )

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

