### PR TITLE
feat(Insights): expose `insights`  helper on instantsearch instance

### DIFF
--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -2,3 +2,4 @@ export * from './highlight';
 export * from './snippet';
 export { default as highlight } from './highlight';
 export { default as snippet } from './snippet';
+export { default as insights } from './insights';

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -129,5 +129,6 @@ instantsearch.widgets = widgets;
 instantsearch.version = version;
 instantsearch.highlight = helpers.highlight;
 instantsearch.snippet = helpers.snippet;
+instantsearch.insights = helpers.insights;
 
 export default instantsearch;


### PR DESCRIPTION
**Summary**

This is mimicking the way we allow usage for `highlight` and `snippet`.

**Result**

```js
  Instantsearch.widgets.hits({
    // ...
    templates: {
      item(hit) {
        return `
          <h2> ${hit.name} </h2>
          <button ${
            Instantsearch.insights('clickedObjectIDsAfterSearch', {
              eventName: "Add to favorite",
              objectIDs: [hit.objectID]
            })
          }>
            Add to favorite
          </button>
        `;
      },
    },
  });
```

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->


<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

