### PR TITLE
fix(types): fix wrong typing in getWidgetState

### DIFF
--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -44,7 +44,7 @@ export interface Widget {
   getWidgetState?(
     uiState: UiState,
     widgetStateOptions: {
-      state: SearchParameters;
+      searchParameters: SearchParameters;
       helper: Helper;
     }
   ): UiState;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This fixes the wrong typing of `getWidgetState`.

**Result**

`state` -> `searchParameters` in `widgetStateOptions`.
(https://www.algolia.com/doc/guides/building-search-ui/widgets/create-your-own-widgets/js/?language=javascript#the-widget-lifecycle-and-api)