### PR TITLE
fix(types): remove unused Without type

### DIFF
--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -1,2 +1,1 @@
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-export type Without<T, K> = Pick<T, Exclude<keyof T, K>>;


### PR DESCRIPTION
The `Without` type is not used and conflicts with `Omit`.