### PR TITLE
fix(stories): remove custom separator from breadcrumb.

### DIFF
--- a/stories/breadcrumb.stories.js
+++ b/stories/breadcrumb.stories.js
@@ -135,7 +135,6 @@ storiesOf('Breadcrumb', module)
       search.addWidget(
         instantsearch.widgets.breadcrumb({
           container: breadcrumb,
-          separator: ' / ',
           attributes: [
             'hierarchicalCategories.lvl0',
             'hierarchicalCategories.lvl1',


### PR DESCRIPTION
If a separator is chosen which isn't the same as the corresponding hierarchical menu on the page, it will cause a conflict between those, and it will no longer be split correctly.

spotted by @tkrugg initially

Check [story →](https://deploy-preview-3696--instantsearchjs.netlify.com/stories/?path=/story/breadcrumb--with-hierarchical-menu) (vs [before this change →](https://instantsearchjs.netlify.com/stories/?path=/story/breadcrumb--with-hierarchical-menu))