### PR TITLE
chore(build): remove PropTypes from builds

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -31,7 +31,7 @@ module.exports = api => {
   const buildPlugins = clean([
     '@babel/plugin-proposal-class-properties',
     '@babel/plugin-transform-react-constant-elements',
-    'babel-plugin-transform-react-remove-prop-types',
+    ['babel-plugin-transform-react-remove-prop-types', { removeImport: true }],
     'babel-plugin-transform-react-pure-class-to-function',
     (isCJS || isES) && [
       'inline-replace-variables',

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "rollup-plugin-babel": "4.3.2",
     "rollup-plugin-commonjs": "9.3.4",
     "rollup-plugin-filesize": "6.0.1",
+    "rollup-plugin-ignore": "1.0.5",
     "rollup-plugin-node-resolve": "4.2.3",
     "rollup-plugin-replace": "2.2.0",
     "rollup-plugin-uglify": "6.0.2",

--- a/scripts/rollup/config.js
+++ b/scripts/rollup/config.js
@@ -2,6 +2,7 @@ import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
 import babel from 'rollup-plugin-babel';
 import replace from 'rollup-plugin-replace';
+import ignore from 'rollup-plugin-ignore';
 import { uglify } from 'rollup-plugin-uglify';
 import filesize from 'rollup-plugin-filesize';
 
@@ -12,6 +13,7 @@ const link = 'https://github.com/algolia/instantsearch.js';
 const license = `/*! InstantSearch.js ${version} | ${algolia} | ${link} */`;
 
 const plugins = [
+  ignore(['prop-types']),
   resolve({
     browser: true,
     preferBuiltins: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10589,6 +10589,11 @@ rollup-plugin-filesize@6.0.1:
     gzip-size "^5.0.0"
     terser "^3.10.0"
 
+rollup-plugin-ignore@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-ignore/-/rollup-plugin-ignore-1.0.5.tgz#fc16b321b29d054d728dafde808a8a52ec39f024"
+  integrity sha512-fGDl4eRMpEeSNqZ9WFR3piK47rrFgVzAIFRsJhTc9/P5t1qsScuFeEBfbXbHDnv6yh5OUth8dti+f+dswebV+Q==
+
 rollup-plugin-node-resolve@4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-4.2.3.tgz#638a373a54287d19fcc088fdd1c6fd8a58e4d90a"


### PR DESCRIPTION
## Description

PropTypes were still mostly present in the bundles (both UMD and ES/CJS) despite the usage of the plugin `babel-plugin-transform-react-remove-prop-types`. As opposed to React InstantSearch, there's no reasons to expose PropTypes in our bundles. This PR aims at removing those.

- For the UMD bundle, I introduced the `ignore` Rollup plugin to ignore the `prop-types` package.
- For the ES/CJS bundle, I added `{ removeImport: true }`, which defaults to `false`, to remove all traces of `prop-types` imports ([see documentation](https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types#removeimport)).

The PropTypes remaining come from [`preact-rheostat`](https://github.com/algolia/rheostat), which will be addressed in a later PR.

## Result


**Before the change**

```
┌────────────────────────────────────────────────────┐
│                                                    │
│   Destination: dist/instantsearch.development.js   │
│   Bundle Size:  1.03 MB                            │
│   Gzipped Size:  79.8 KB                           │
│                                                    │
└────────────────────────────────────────────────────┘

┌───────────────────────────────────────────────────────┐
│                                                       │
│   Destination: dist/instantsearch.production.min.js   │
│   Bundle Size:  284.36 KB                             │
│   Gzipped Size:  78.96 KB                             │
│                                                       │
└───────────────────────────────────────────────────────┘
```

**After the change**

```
┌────────────────────────────────────────────────────┐
│                                                    │
│   Destination: dist/instantsearch.development.js   │
│   Bundle Size:  1.02 MB                            │
│   Gzipped Size:  78.52 KB                          │
│                                                    │
└────────────────────────────────────────────────────┘

┌───────────────────────────────────────────────────────┐
│                                                       │
│   Destination: dist/instantsearch.production.min.js   │
│   Bundle Size:  280.44 KB                             │
│   Gzipped Size:  77.67 KB                             │
│                                                       │
└───────────────────────────────────────────────────────┘
```

## Related

- IFW-626