### PR TITLE
refactor(lodash): remove forEach usage

### DIFF
--- a/src/lib/__tests__/main-test.js
+++ b/src/lib/__tests__/main-test.js
@@ -1,9 +1,6 @@
 import instantsearch from '../main';
-import forEach from 'lodash/forEach';
 
 describe('instantsearch()', () => {
-  // to ensure the global.window is set
-
   it('includes a version', () => {
     expect(instantsearch.version).toMatch(
       /^(\d+\.)?(\d+\.)?(\*|\d+)(-beta.\d+)?$/
@@ -11,24 +8,18 @@ describe('instantsearch()', () => {
   });
 
   it('includes the widget functions', () => {
-    forEach(instantsearch.widgets, widget => {
-      expect(typeof widget).toEqual('function', 'A widget must be a function');
+    Object.values(instantsearch.widgets).forEach(widget => {
+      expect(widget).toBeInstanceOf(Function);
     });
   });
 
   it('includes the connectors functions', () => {
-    forEach(instantsearch.connectors, connector => {
-      expect(typeof connector).toEqual(
-        'function',
-        'A connector must be a function'
-      );
+    Object.values(instantsearch.connectors).forEach(connector => {
+      expect(connector).toBeInstanceOf(Function);
     });
   });
 
   it('includes the highlight helper function', () => {
-    expect(typeof instantsearch.highlight).toEqual(
-      'function',
-      'THe highlight helper must be a function'
-    );
+    expect(instantsearch.highlight).toBeInstanceOf(Function);
   });
 });

--- a/src/lib/utils/getRefinements.ts
+++ b/src/lib/utils/getRefinements.ts
@@ -96,9 +96,9 @@ function getRefinements(
   Object.keys(facetsRefinements).forEach(attributeName => {
     const refinements = facetsRefinements[attributeName];
 
-    refinements.forEach(name => {
+    refinements.forEach(refinement => {
       res.push(
-        getRefinement(state, 'facet', attributeName, name, results.facets)
+        getRefinement(state, 'facet', attributeName, refinement, results.facets)
       );
     });
   });
@@ -106,8 +106,13 @@ function getRefinements(
   Object.keys(facetsExcludes).forEach(attributeName => {
     const refinements = facetsExcludes[attributeName];
 
-    refinements.forEach(name => {
-      res.push({ type: 'exclude', attributeName, name, exclude: true });
+    refinements.forEach(refinement => {
+      res.push({
+        type: 'exclude',
+        attributeName,
+        name: refinement,
+        exclude: true,
+      });
     });
   });
 
@@ -120,8 +125,8 @@ function getRefinements(
           state,
           'disjunctive',
           attributeName,
-          // we unescapeRefinement any disjunctive refined value since they can be escaped
-          // when negative numeric values search `escapeRefinement` usage in code
+          // We unescape any disjunctive refined values with `unescapeRefinement` because
+          // they can be escaped on negative numeric values with `escapeRefinement`.
           unescapeRefinement(refinement),
           results.disjunctiveFacets
         )
@@ -166,8 +171,8 @@ function getRefinements(
     });
   });
 
-  tagRefinements.forEach(name => {
-    res.push({ type: 'tag', attributeName: '_tags', name });
+  tagRefinements.forEach(refinement => {
+    res.push({ type: 'tag', attributeName: '_tags', name: refinement });
   });
 
   if (clearsQuery && state.query && state.query.trim()) {

--- a/src/lib/utils/getRefinements.ts
+++ b/src/lib/utils/getRefinements.ts
@@ -1,6 +1,5 @@
 import find from 'lodash/find';
 import get from 'lodash/get';
-import forEach from 'lodash/forEach';
 import { SearchParameters, SearchResults } from '../../types';
 import unescapeRefinement from './unescapeRefinement';
 
@@ -85,23 +84,37 @@ function getRefinements(
   clearsQuery: boolean = false
 ): Refinement[] {
   const res: Refinement[] = [];
+  const {
+    facetsRefinements = {},
+    facetsExcludes = {},
+    disjunctiveFacetsRefinements = {},
+    hierarchicalFacetsRefinements = {},
+    numericRefinements = {},
+    tagRefinements = [],
+  } = state;
 
-  forEach(state.facetsRefinements, (refinements, attributeName) => {
-    forEach(refinements, name => {
+  Object.keys(facetsRefinements).forEach(attributeName => {
+    const refinements = facetsRefinements[attributeName];
+
+    refinements.forEach(name => {
       res.push(
         getRefinement(state, 'facet', attributeName, name, results.facets)
       );
     });
   });
 
-  forEach(state.facetsExcludes, (refinements, attributeName) => {
-    forEach(refinements, name => {
+  Object.keys(facetsExcludes).forEach(attributeName => {
+    const refinements = facetsExcludes[attributeName];
+
+    refinements.forEach(name => {
       res.push({ type: 'exclude', attributeName, name, exclude: true });
     });
   });
 
-  forEach(state.disjunctiveFacetsRefinements, (refinements, attributeName) => {
-    forEach(refinements, name => {
+  Object.keys(disjunctiveFacetsRefinements).forEach(attributeName => {
+    const refinements = disjunctiveFacetsRefinements[attributeName];
+
+    refinements.forEach(refinement => {
       res.push(
         getRefinement(
           state,
@@ -109,42 +122,51 @@ function getRefinements(
           attributeName,
           // we unescapeRefinement any disjunctive refined value since they can be escaped
           // when negative numeric values search `escapeRefinement` usage in code
-          unescapeRefinement(name),
+          unescapeRefinement(refinement),
           results.disjunctiveFacets
         )
       );
     });
   });
 
-  forEach(state.hierarchicalFacetsRefinements, (refinements, attributeName) => {
-    forEach(refinements, name => {
+  Object.keys(hierarchicalFacetsRefinements).forEach(attributeName => {
+    const refinements = hierarchicalFacetsRefinements[attributeName];
+
+    refinements.forEach(refinement => {
       res.push(
         getRefinement(
           state,
           'hierarchical',
           attributeName,
-          name,
+          refinement,
           results.hierarchicalFacets
         )
       );
     });
   });
 
-  forEach(state.numericRefinements, (operators, attributeName) => {
-    forEach(operators, (values, operator) => {
-      forEach(values, value => {
+  Object.keys(numericRefinements).forEach(attributeName => {
+    const operators = numericRefinements[attributeName];
+
+    Object.keys(operators).forEach(operator => {
+      const valueOrValues = operators[operator];
+      const refinements = Array.isArray(valueOrValues)
+        ? valueOrValues
+        : [valueOrValues];
+
+      refinements.forEach(refinement => {
         res.push({
           type: 'numeric',
           attributeName,
-          name: `${value}`,
-          numericValue: value,
+          name: `${refinement}`,
+          numericValue: refinement,
           operator,
         });
       });
     });
   });
 
-  forEach(state.tagRefinements, name => {
+  tagRefinements.forEach(name => {
     res.push({ type: 'tag', attributeName: '_tags', name });
   });
 

--- a/src/widgets/clear-refinements/__tests__/clear-refinements-test.js
+++ b/src/widgets/clear-refinements/__tests__/clear-refinements-test.js
@@ -90,7 +90,7 @@ describe('clearRefinements()', () => {
 
   describe('with refinements', () => {
     beforeEach(() => {
-      helper.state.facetsRefinements = ['something'];
+      helper.state.facetsRefinements = { something: ['something'] };
     });
 
     it('calls twice render(<ClearAll props />, container)', () => {


### PR DESCRIPTION
This removes `lodash/forEach` for the native `Array.prototype.forEach` method.