### PR TITLE
refactor(lodash): remove first and last usage

### DIFF
--- a/src/connectors/geo-search/__tests__/connectGeoSearch-test.js
+++ b/src/connectors/geo-search/__tests__/connectGeoSearch-test.js
@@ -1,5 +1,3 @@
-import last from 'lodash/last';
-import first from 'lodash/first';
 import algoliasearchHelper, {
   SearchParameters,
   SearchResults,
@@ -35,8 +33,8 @@ describe('connectGeoSearch', () => {
     return [widget, helper, refine];
   };
 
-  const firstRenderArgs = fn => first(fn.mock.calls)[0];
-  const lastRenderArgs = fn => last(fn.mock.calls)[0];
+  const firstRenderArgs = fn => fn.mock.calls[0][0];
+  const lastRenderArgs = fn => fn.mock.calls[fn.mock.calls.length - 1][0];
 
   describe('Usage', () => {
     it('throws without render function', () => {

--- a/src/widgets/geo-search/__tests__/geo-search-test.js
+++ b/src/widgets/geo-search/__tests__/geo-search-test.js
@@ -1,4 +1,3 @@
-import last from 'lodash/last';
 import { render, unmountComponentAtNode } from 'preact-compat';
 import algoliasearchHelper from 'algoliasearch-helper';
 import createHTMLMarker from '../createHTMLMarker';
@@ -115,7 +114,7 @@ describe('GeoSearch', () => {
       'indexName'
     );
 
-  const lastRenderArgs = fn => last(fn.mock.calls)[0];
+  const lastRenderArgs = fn => fn.mock.calls[fn.mock.calls.length - 1][0];
   const lastRenderState = fn => lastRenderArgs(fn).widgetParams.renderState;
 
   const simulateMapReadyEvent = google => {


### PR DESCRIPTION
This removes the `lodash/first` and `lodash/last` usage.