### PR TITLE
refactor(lodash): remove find usage

### DIFF
--- a/src/components/MenuSelect/MenuSelect.js
+++ b/src/components/MenuSelect/MenuSelect.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'preact-compat';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
+import { find } from '../../lib/utils';
 import Template from '../Template/Template';
 
 class MenuSelect extends Component {
@@ -21,7 +22,7 @@ class MenuSelect extends Component {
 
   render() {
     const { cssClasses, templateProps, items } = this.props;
-    const { value: selectedValue } = items.find(item => item.isRefined) || {
+    const { value: selectedValue } = find(items, item => item.isRefined) || {
       value: '',
     };
 

--- a/src/connectors/autocomplete/connectAutocomplete.js
+++ b/src/connectors/autocomplete/connectAutocomplete.js
@@ -2,6 +2,7 @@ import escapeHits, { TAG_PLACEHOLDER } from '../../lib/escape-highlight';
 import {
   checkRendering,
   createDocumentationMessageGenerator,
+  find,
 } from '../../lib/utils';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -96,7 +97,7 @@ export default function connectAutocomplete(renderFn, unmountFn) {
       },
 
       saveResults({ results, label }) {
-        const derivedIndex = this.indices.find(i => i.label === label);
+        const derivedIndex = find(this.indices, i => i.label === label);
 
         if (escapeHTML && results && results.hits && results.hits.length > 0) {
           results.hits = escapeHits(results.hits);

--- a/src/connectors/breadcrumb/connectBreadcrumb.js
+++ b/src/connectors/breadcrumb/connectBreadcrumb.js
@@ -3,6 +3,7 @@ import {
   warning,
   createDocumentationMessageGenerator,
   isEqual,
+  find,
 } from '../../lib/utils';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -64,7 +65,8 @@ export default function connectBreadcrumb(renderFn, unmountFn) {
     return {
       getConfiguration: currentConfiguration => {
         if (currentConfiguration.hierarchicalFacets) {
-          const isFacetSet = currentConfiguration.hierarchicalFacets.find(
+          const isFacetSet = find(
+            currentConfiguration.hierarchicalFacets,
             ({ name }) => name === hierarchicalFacetName
           );
           if (isFacetSet) {

--- a/src/connectors/breadcrumb/connectBreadcrumb.js
+++ b/src/connectors/breadcrumb/connectBreadcrumb.js
@@ -1,4 +1,3 @@
-import find from 'lodash/find';
 import {
   checkRendering,
   warning,
@@ -65,8 +64,7 @@ export default function connectBreadcrumb(renderFn, unmountFn) {
     return {
       getConfiguration: currentConfiguration => {
         if (currentConfiguration.hierarchicalFacets) {
-          const isFacetSet = find(
-            currentConfiguration.hierarchicalFacets,
+          const isFacetSet = currentConfiguration.hierarchicalFacets.find(
             ({ name }) => name === hierarchicalFacetName
           );
           if (isFacetSet) {

--- a/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
+++ b/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
@@ -1,4 +1,3 @@
-import find from 'lodash/find';
 import {
   checkRendering,
   warning,
@@ -115,8 +114,7 @@ export default function connectHierarchicalMenu(renderFn, unmountFn) {
 
       getConfiguration(currentConfiguration) {
         if (currentConfiguration.hierarchicalFacets) {
-          const isFacetSet = find(
-            currentConfiguration.hierarchicalFacets,
+          const isFacetSet = currentConfiguration.hierarchicalFacets.find(
             ({ name }) => name === hierarchicalFacetName
           );
           if (

--- a/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
+++ b/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
@@ -3,6 +3,7 @@ import {
   warning,
   createDocumentationMessageGenerator,
   isEqual,
+  find,
 } from '../../lib/utils';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -114,7 +115,8 @@ export default function connectHierarchicalMenu(renderFn, unmountFn) {
 
       getConfiguration(currentConfiguration) {
         if (currentConfiguration.hierarchicalFacets) {
-          const isFacetSet = currentConfiguration.hierarchicalFacets.find(
+          const isFacetSet = find(
+            currentConfiguration.hierarchicalFacets,
             ({ name }) => name === hierarchicalFacetName
           );
           if (

--- a/src/connectors/hits-per-page/connectHitsPerPage.js
+++ b/src/connectors/hits-per-page/connectHitsPerPage.js
@@ -1,4 +1,3 @@
-import find from 'lodash/find';
 import {
   checkRendering,
   warning,
@@ -114,7 +113,7 @@ export default function connectHitsPerPage(renderFn, unmountFn) {
       );
     }
 
-    const defaultValue = find(userItems, item => item.default === true);
+    const defaultValue = userItems.find(item => item.default === true);
 
     return {
       getConfiguration() {

--- a/src/connectors/hits-per-page/connectHitsPerPage.js
+++ b/src/connectors/hits-per-page/connectHitsPerPage.js
@@ -2,6 +2,7 @@ import {
   checkRendering,
   warning,
   createDocumentationMessageGenerator,
+  find,
 } from '../../lib/utils';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -113,7 +114,7 @@ export default function connectHitsPerPage(renderFn, unmountFn) {
       );
     }
 
-    const defaultValue = userItems.find(item => item.default === true);
+    const defaultValue = find(userItems, item => item.default === true);
 
     return {
       getConfiguration() {

--- a/src/connectors/range/connectRange.js
+++ b/src/connectors/range/connectRange.js
@@ -1,4 +1,3 @@
-import find from 'lodash/find';
 import {
   checkRendering,
   createDocumentationMessageGenerator,
@@ -244,7 +243,9 @@ export default function connectRange(renderFn, unmountFn) {
 
       render({ results, helper, instantSearchInstance }) {
         const facetsFromResults = results.disjunctiveFacets || [];
-        const facet = find(facetsFromResults, { name: attribute });
+        const facet = facetsFromResults.find(
+          facetResult => facetResult.name === attribute
+        );
         const stats = (facet && facet.stats) || {};
 
         const currentRange = this._getCurrentRange(stats);

--- a/src/connectors/range/connectRange.js
+++ b/src/connectors/range/connectRange.js
@@ -2,6 +2,7 @@ import {
   checkRendering,
   createDocumentationMessageGenerator,
   isFiniteNumber,
+  find,
 } from '../../lib/utils';
 
 const withUsage = createDocumentationMessageGenerator(
@@ -243,7 +244,8 @@ export default function connectRange(renderFn, unmountFn) {
 
       render({ results, helper, instantSearchInstance }) {
         const facetsFromResults = results.disjunctiveFacets || [];
-        const facet = facetsFromResults.find(
+        const facet = find(
+          facetsFromResults,
           facetResult => facetResult.name === attribute
         );
         const stats = (facet && facet.stats) || {};

--- a/src/connectors/sort-by/__tests__/connectSortBy-test.js
+++ b/src/connectors/sort-by/__tests__/connectSortBy-test.js
@@ -27,6 +27,16 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
 See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/#connector"
 `);
     });
+
+    it('throws with non-array items', () => {
+      expect(() => {
+        connectSortBy(() => {})({ items: 'items' });
+      }).toThrowErrorMatchingInlineSnapshot(`
+"The \`items\` option expects an array of objects.
+
+See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/#connector"
+`);
+    });
   });
 
   it('Renders during init and render', () => {

--- a/src/connectors/sort-by/connectSortBy.js
+++ b/src/connectors/sort-by/connectSortBy.js
@@ -1,6 +1,7 @@
 import {
   checkRendering,
   createDocumentationMessageGenerator,
+  find,
 } from '../../lib/utils';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -100,7 +101,7 @@ export default function connectSortBy(renderFn, unmountFn) {
     return {
       init({ helper, instantSearchInstance }) {
         const currentIndex = helper.getIndex();
-        const isIndexInList = items.find(item => item.value === currentIndex);
+        const isIndexInList = find(items, item => item.value === currentIndex);
 
         if (!isIndexInList) {
           throw new Error(

--- a/src/connectors/sort-by/connectSortBy.js
+++ b/src/connectors/sort-by/connectSortBy.js
@@ -91,7 +91,7 @@ export default function connectSortBy(renderFn, unmountFn) {
   return (widgetParams = {}) => {
     const { items, transformItems = x => x } = widgetParams;
 
-    if (!items) {
+    if (!Array.isArray(items)) {
       throw new Error(
         withUsage('The `items` option expects an array of objects.')
       );

--- a/src/connectors/sort-by/connectSortBy.js
+++ b/src/connectors/sort-by/connectSortBy.js
@@ -1,4 +1,3 @@
-import find from 'lodash/find';
 import {
   checkRendering,
   createDocumentationMessageGenerator,
@@ -101,7 +100,7 @@ export default function connectSortBy(renderFn, unmountFn) {
     return {
       init({ helper, instantSearchInstance }) {
         const currentIndex = helper.getIndex();
-        const isIndexInList = find(items, item => item.value === currentIndex);
+        const isIndexInList = items.find(item => item.value === currentIndex);
 
         if (!isIndexInList) {
           throw new Error(

--- a/src/connectors/toggleRefinement/connectToggleRefinement.js
+++ b/src/connectors/toggleRefinement/connectToggleRefinement.js
@@ -3,6 +3,7 @@ import {
   escapeRefinement,
   unescapeRefinement,
   createDocumentationMessageGenerator,
+  find,
 } from '../../lib/utils';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -191,7 +192,8 @@ export default function connectToggleRefinement(renderFn, unmountFn) {
         const offValue = off === undefined ? false : off;
         const allFacetValues = results.getFacetValues(attribute);
 
-        const onData = allFacetValues.find(
+        const onData = find(
+          allFacetValues,
           ({ name }) => name === unescapeRefinement(on)
         );
         const onFacetValue = {
@@ -200,7 +202,8 @@ export default function connectToggleRefinement(renderFn, unmountFn) {
         };
 
         const offData = hasAnOffValue
-          ? allFacetValues.find(
+          ? find(
+              allFacetValues,
               ({ name }) => name === unescapeRefinement(offValue)
             )
           : undefined;

--- a/src/connectors/toggleRefinement/connectToggleRefinement.js
+++ b/src/connectors/toggleRefinement/connectToggleRefinement.js
@@ -1,4 +1,3 @@
-import find from 'lodash/find';
 import {
   checkRendering,
   escapeRefinement,
@@ -192,8 +191,7 @@ export default function connectToggleRefinement(renderFn, unmountFn) {
         const offValue = off === undefined ? false : off;
         const allFacetValues = results.getFacetValues(attribute);
 
-        const onData = find(
-          allFacetValues,
+        const onData = allFacetValues.find(
           ({ name }) => name === unescapeRefinement(on)
         );
         const onFacetValue = {
@@ -202,8 +200,7 @@ export default function connectToggleRefinement(renderFn, unmountFn) {
         };
 
         const offData = hasAnOffValue
-          ? find(
-              allFacetValues,
+          ? allFacetValues.find(
               ({ name }) => name === unescapeRefinement(offValue)
             )
           : undefined;

--- a/src/lib/insights/client.ts
+++ b/src/lib/insights/client.ts
@@ -1,4 +1,4 @@
-import { uniq } from '../utils';
+import { uniq, find } from '../utils';
 import {
   Hits,
   InsightsClient,
@@ -15,7 +15,7 @@ import {
 
 const getSelectedHits = (hits: Hits, selectedObjectIDs: string[]) => {
   return selectedObjectIDs.map(objectID => {
-    const hit = hits.find(h => h.objectID === objectID);
+    const hit = find(hits, h => h.objectID === objectID);
     if (typeof hit === 'undefined') {
       throw new Error(
         `Could not find objectID "${objectID}" passed to \`clickedObjectIDsAfterSearch\` in the returned hits. This is necessary to infer the absolute position and the query ID.`

--- a/src/lib/insights/client.ts
+++ b/src/lib/insights/client.ts
@@ -1,4 +1,3 @@
-import find from 'lodash/find';
 import { uniq } from '../utils';
 import {
   Hits,
@@ -16,7 +15,7 @@ import {
 
 const getSelectedHits = (hits: Hits, selectedObjectIDs: string[]) => {
   return selectedObjectIDs.map(objectID => {
-    const hit = find(hits, h => h.objectID === objectID);
+    const hit = hits.find(h => h.objectID === objectID);
     if (typeof hit === 'undefined') {
       throw new Error(
         `Could not find objectID "${objectID}" passed to \`clickedObjectIDsAfterSearch\` in the returned hits. This is necessary to infer the absolute position and the query ID.`

--- a/src/lib/utils/__tests__/find-test.ts
+++ b/src/lib/utils/__tests__/find-test.ts
@@ -2,6 +2,20 @@ import find from '../find';
 
 describe('find', () => {
   describe('with native array method', () => {
+    test('with empty array', () => {
+      const items = [];
+      const actual = find(items, item => item === 'hello');
+
+      expect(actual).toEqual(undefined);
+    });
+
+    test('with unknown item in array', () => {
+      const items = ['hey'];
+      const actual = find(items, item => item === 'hello');
+
+      expect(actual).toEqual(undefined);
+    });
+
     test('with an array of strings', () => {
       const items = ['hello', 'goodbye'];
       const actual = find(items, item => item === 'hello');
@@ -26,6 +40,20 @@ describe('find', () => {
 
     afterAll(() => {
       Array.prototype.find = originalArrayFind;
+    });
+
+    test('with empty array', () => {
+      const items = [];
+      const actual = find(items, item => item === 'hello');
+
+      expect(actual).toEqual(undefined);
+    });
+
+    test('with unknown item in array', () => {
+      const items = ['hey'];
+      const actual = find(items, item => item === 'hello');
+
+      expect(actual).toEqual(undefined);
     });
 
     test('with an array of strings', () => {

--- a/src/lib/utils/__tests__/find-test.ts
+++ b/src/lib/utils/__tests__/find-test.ts
@@ -1,0 +1,45 @@
+import find from '../find';
+
+describe('find', () => {
+  describe('with native array method', () => {
+    test('with an array of strings', () => {
+      const items = ['hello', 'goodbye'];
+      const actual = find(items, item => item === 'hello');
+
+      expect(actual).toEqual('hello');
+    });
+
+    test('with an array of objects', () => {
+      const items = [{ name: 'John' }, { name: 'Jane' }];
+      const actual = find(items, item => item.name === 'John');
+
+      expect(actual).toEqual(items[0]);
+    });
+  });
+
+  describe('with polyfill', () => {
+    const originalArrayFind = Array.prototype.find;
+
+    beforeAll(() => {
+      delete Array.prototype.find;
+    });
+
+    afterAll(() => {
+      Array.prototype.find = originalArrayFind;
+    });
+
+    test('with an array of strings', () => {
+      const items = ['hello', 'goodbye'];
+      const actual = find(items, item => item === 'hello');
+
+      expect(actual).toEqual('hello');
+    });
+
+    test('with an array of objects', () => {
+      const items = [{ name: 'John' }, { name: 'Jane' }];
+      const actual = find(items, item => item.name === 'John');
+
+      expect(actual).toEqual(items[0]);
+    });
+  });
+});

--- a/src/lib/utils/find.ts
+++ b/src/lib/utils/find.ts
@@ -1,3 +1,9 @@
+// We aren't using the native `Array.prototype.find` because the refactor away from Lodash is not
+// published as a major version.
+// Relying on the `find` polyfillon user-land, which before was only required for niche use-cases,
+// was decided as too risky.
+// @MAJOR Replace with the native `Array.prototype.find` method
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find
 function find<TItem>(
   items: TItem[],
   predicate: (value: TItem, index: number, obj: TItem[]) => boolean,

--- a/src/lib/utils/find.ts
+++ b/src/lib/utils/find.ts
@@ -1,6 +1,6 @@
 // We aren't using the native `Array.prototype.find` because the refactor away from Lodash is not
 // published as a major version.
-// Relying on the `find` polyfillon user-land, which before was only required for niche use-cases,
+// Relying on the `find` polyfill on user-land, which before was only required for niche use-cases,
 // was decided as too risky.
 // @MAJOR Replace with the native `Array.prototype.find` method
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find

--- a/src/lib/utils/find.ts
+++ b/src/lib/utils/find.ts
@@ -1,0 +1,13 @@
+function find<TItem>(
+  items: TItem[],
+  predicate: (value: TItem, index: number, obj: TItem[]) => boolean,
+  thisArg?: any
+): TItem | undefined {
+  if (!Array.prototype.find) {
+    return items.filter(predicate, thisArg)[0];
+  }
+
+  return items.find(predicate, thisArg);
+}
+
+export default find;

--- a/src/lib/utils/getRefinements.ts
+++ b/src/lib/utils/getRefinements.ts
@@ -1,4 +1,5 @@
 import { SearchParameters, SearchResults } from '../../types';
+import find from './find';
 import unescapeRefinement from './unescapeRefinement';
 
 export interface FacetRefinement {
@@ -47,7 +48,8 @@ function getRefinement(
   resultsFacets: SearchResults['facets' | 'hierarchicalFacets'] = []
 ): Refinement {
   const res: Refinement = { type, attributeName, name };
-  let facet: any = (resultsFacets as Array<{ name: string }>).find(
+  let facet: any = find(
+    resultsFacets as Array<{ name: string }>,
     resultsFacet => resultsFacet.name === attributeName
   );
   let count: number;
@@ -59,9 +61,12 @@ function getRefinement(
     for (let i = 0; facet !== undefined && i < nameParts.length; ++i) {
       facet =
         facet.data &&
-        Object.keys(facet.data)
-          .map(refinementKey => facet.data[refinementKey])
-          .find(refinement => refinement.name === nameParts[i]);
+        find(
+          Object.keys(facet.data).map(
+            refinementKey => facet.data[refinementKey]
+          ),
+          refinement => refinement.name === nameParts[i]
+        );
     }
 
     count = facet && facet.count;

--- a/src/lib/utils/getRefinements.ts
+++ b/src/lib/utils/getRefinements.ts
@@ -56,10 +56,12 @@ function getRefinement(
     const facetDeclaration = state.getHierarchicalFacetByName(attributeName);
     const nameParts = name.split(facetDeclaration.separator);
 
-    for (let i = 0; facet !== undefined && i < nameParts.length; ++i) {
-      facet = Object.keys(facet.data)
-        .map(refinementKey => facet.data[refinementKey])
-        .find(refinement => refinement.name === nameParts[i]);
+    if (facet) {
+      nameParts.forEach(namePart => {
+        facet = Object.keys(facet.data)
+          .map(refinementKey => facet.data[refinementKey])
+          .find(refinement => refinement.name === namePart);
+      });
     }
 
     count = facet && facet.count;

--- a/src/lib/utils/getRefinements.ts
+++ b/src/lib/utils/getRefinements.ts
@@ -1,4 +1,3 @@
-import find from 'lodash/find';
 import { SearchParameters, SearchResults } from '../../types';
 import unescapeRefinement from './unescapeRefinement';
 
@@ -45,18 +44,22 @@ function getRefinement(
   type: Refinement['type'],
   attributeName: Refinement['attributeName'],
   name: Refinement['name'],
-  resultsFacets: SearchResults['facets' | 'hierarchicalFacets']
+  resultsFacets: SearchResults['facets' | 'hierarchicalFacets'] = []
 ): Refinement {
   const res: Refinement = { type, attributeName, name };
-  let facet: any = find(resultsFacets, { name: attributeName });
+  let facet: any = (resultsFacets as Array<{ name: string }>).find(
+    resultsFacet => resultsFacet.name === attributeName
+  );
   let count: number;
 
   if (type === 'hierarchical') {
     const facetDeclaration = state.getHierarchicalFacetByName(attributeName);
-    const split = name.split(facetDeclaration.separator);
+    const nameParts = name.split(facetDeclaration.separator);
 
-    for (let i = 0; facet !== undefined && i < split.length; ++i) {
-      facet = find(facet.data, { name: split[i] });
+    for (let i = 0; facet !== undefined && i < nameParts.length; ++i) {
+      facet = Object.keys(facet.data)
+        .map(refinementKey => facet.data[refinementKey])
+        .find(refinement => refinement.name === nameParts[i]);
     }
 
     count = facet && facet.count;

--- a/src/lib/utils/getRefinements.ts
+++ b/src/lib/utils/getRefinements.ts
@@ -57,9 +57,11 @@ function getRefinement(
     const nameParts = name.split(facetDeclaration.separator);
 
     for (let i = 0; facet !== undefined && i < nameParts.length; ++i) {
-      facet = Object.keys(facet.data)
-        .map(refinementKey => facet.data[refinementKey])
-        .find(refinement => refinement.name === nameParts[i]);
+      facet =
+        facet.data &&
+        Object.keys(facet.data)
+          .map(refinementKey => facet.data[refinementKey])
+          .find(refinement => refinement.name === nameParts[i]);
     }
 
     count = facet && facet.count;

--- a/src/lib/utils/getRefinements.ts
+++ b/src/lib/utils/getRefinements.ts
@@ -56,12 +56,10 @@ function getRefinement(
     const facetDeclaration = state.getHierarchicalFacetByName(attributeName);
     const nameParts = name.split(facetDeclaration.separator);
 
-    if (facet) {
-      nameParts.forEach(namePart => {
-        facet = Object.keys(facet.data)
-          .map(refinementKey => facet.data[refinementKey])
-          .find(refinement => refinement.name === namePart);
-      });
+    for (let i = 0; facet !== undefined && i < nameParts.length; ++i) {
+      facet = Object.keys(facet.data)
+        .map(refinementKey => facet.data[refinementKey])
+        .find(refinement => refinement.name === nameParts[i]);
     }
 
     count = facet && facet.count;

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -17,6 +17,7 @@ export { default as uniq } from './uniq';
 export { default as range } from './range';
 export { default as isEqual } from './isEqual';
 export { default as escape } from './escape';
+export { default as find } from './find';
 export { warning, deprecate } from './logger';
 export {
   createDocumentationLink,

--- a/src/widgets/hits-per-page/hits-per-page.js
+++ b/src/widgets/hits-per-page/hits-per-page.js
@@ -5,6 +5,7 @@ import connectHitsPerPage from '../../connectors/hits-per-page/connectHitsPerPag
 import {
   getContainerNode,
   createDocumentationMessageGenerator,
+  find,
 } from '../../lib/utils';
 import { component } from '../../lib/suit';
 
@@ -20,7 +21,7 @@ const renderer = ({ containerNode, cssClasses }) => (
   if (isFirstRendering) return;
 
   const { value: currentValue } =
-    items.find(({ isRefined }) => isRefined) || {};
+    find(items, ({ isRefined }) => isRefined) || {};
 
   render(
     <div className={cssClasses.root}>

--- a/src/widgets/hits-per-page/hits-per-page.js
+++ b/src/widgets/hits-per-page/hits-per-page.js
@@ -1,6 +1,5 @@
 import React, { render, unmountComponentAtNode } from 'preact-compat';
 import cx from 'classnames';
-import find from 'lodash/find';
 import Selector from '../../components/Selector/Selector';
 import connectHitsPerPage from '../../connectors/hits-per-page/connectHitsPerPage';
 import {
@@ -21,7 +20,7 @@ const renderer = ({ containerNode, cssClasses }) => (
   if (isFirstRendering) return;
 
   const { value: currentValue } =
-    find(items, ({ isRefined }) => isRefined) || {};
+    items.find(({ isRefined }) => isRefined) || {};
 
   render(
     <div className={cssClasses.root}>


### PR DESCRIPTION
This removes all `lodash/find` usages. We need to be careful with `undefined` collections being loop over since Lodash used to deal with that for us.

Note that we already use `Array.prototype.find` in the codebase and that we document [using a polyfill to support browsers](https://www.algolia.com/doc/guides/building-search-ui/installation/js/#browser-support).