### PR TITLE
fix(hitsPerPage): improve warning for missing state value

### DIFF
--- a/src/connectors/hits-per-page/connectHitsPerPage.js
+++ b/src/connectors/hits-per-page/connectHitsPerPage.js
@@ -144,7 +144,7 @@ Learn more: https://community.algolia.com/instantsearch.js/v2/widgets/configure.
           warning(
             false,
             `
-The \`hitsPerPage\` widget \`items\` option does not contain the "hits per page" value coming from the state: ${
+The \`items\` option of \`hitsPerPage\` does not contain the "hits per page" value coming from the state: ${
               state.hitsPerPage
             }.
 

--- a/src/connectors/hits-per-page/connectHitsPerPage.js
+++ b/src/connectors/hits-per-page/connectHitsPerPage.js
@@ -143,9 +143,12 @@ Learn more: https://community.algolia.com/instantsearch.js/v2/widgets/configure.
 
           warning(
             false,
-            `No items in HitsPerPage \`items\` with \`value: hitsPerPage\` (hitsPerPage: ${
+            `
+The \`hitsPerPage\` widget \`items\` option does not contain the "hits per page" value coming from the state: ${
               state.hitsPerPage
-            })`
+            }.
+
+You may want to add another entry to the \`items\` option with this value.`
           );
 
           items = [{ value: '', label: '' }, ...items];

--- a/src/widgets/hits-per-page/__tests__/hits-per-page-test.js
+++ b/src/widgets/hits-per-page/__tests__/hits-per-page-test.js
@@ -121,7 +121,9 @@ describe('hitsPerPage()', () => {
     expect(() => {
       widget.init({ state: helper.state, helper });
     }).toWarnDev(
-      '[InstantSearch.js]: No items in HitsPerPage `items` with `value: hitsPerPage` (hitsPerPage: 20)'
+      `[InstantSearch.js]: The \`hitsPerPage\` widget \`items\` option does not contain the "hits per page" value coming from the state: 20.
+
+You may want to add another entry to the \`items\` option with this value.`
     );
   });
 
@@ -131,7 +133,9 @@ describe('hitsPerPage()', () => {
     expect(() => {
       widget.init({ state: helper.state, helper });
     }).toWarnDev(
-      '[InstantSearch.js]: No items in HitsPerPage `items` with `value: hitsPerPage` (hitsPerPage: -1)'
+      `[InstantSearch.js]: The \`hitsPerPage\` widget \`items\` option does not contain the "hits per page" value coming from the state: -1.
+
+You may want to add another entry to the \`items\` option with this value.`
     );
   });
 

--- a/src/widgets/hits-per-page/__tests__/hits-per-page-test.js
+++ b/src/widgets/hits-per-page/__tests__/hits-per-page-test.js
@@ -121,7 +121,7 @@ describe('hitsPerPage()', () => {
     expect(() => {
       widget.init({ state: helper.state, helper });
     }).toWarnDev(
-      `[InstantSearch.js]: The \`hitsPerPage\` widget \`items\` option does not contain the "hits per page" value coming from the state: 20.
+      `[InstantSearch.js]: The \`items\` option of \`hitsPerPage\` does not contain the "hits per page" value coming from the state: 20.
 
 You may want to add another entry to the \`items\` option with this value.`
     );
@@ -133,7 +133,7 @@ You may want to add another entry to the \`items\` option with this value.`
     expect(() => {
       widget.init({ state: helper.state, helper });
     }).toWarnDev(
-      `[InstantSearch.js]: The \`hitsPerPage\` widget \`items\` option does not contain the "hits per page" value coming from the state: -1.
+      `[InstantSearch.js]: The \`items\` option of \`hitsPerPage\` does not contain the "hits per page" value coming from the state: -1.
 
 You may want to add another entry to the \`items\` option with this value.`
     );

--- a/stories/hits-per-page.stories.js
+++ b/stories/hits-per-page.stories.js
@@ -10,6 +10,7 @@ storiesOf('HitsPerPage', module)
           container,
           items: [
             { value: 3, label: '3 per page' },
+            { value: 4, label: '4 per page' },
             { value: 5, label: '5 per page' },
             { value: 10, label: '10 per page' },
           ],
@@ -39,7 +40,7 @@ storiesOf('HitsPerPage', module)
         instantsearch.widgets.hitsPerPage({
           container,
           items: [
-            { value: 3, label: '3 per page' },
+            { value: 3, label: '3 per page', default: true },
             { value: 5, label: '5 per page' },
             { value: 10, label: '10 per page' },
           ],


### PR DESCRIPTION
I stumbled across this development warning message and couldn't understand it. I tried to rephrase it.