### PR TITLE
refactor(lodash): remove range and times usage

### DIFF
--- a/src/components/Slider/Slider.js
+++ b/src/components/Slider/Slider.js
@@ -2,8 +2,7 @@ import React, { Component } from 'preact-compat';
 import Rheostat from 'preact-rheostat';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import times from 'lodash/times';
-import range from 'lodash/range';
+import { range } from '../../lib/utils';
 import Pit from './Pit';
 
 class Slider extends Component {
@@ -42,7 +41,9 @@ class Slider extends Component {
 
     const pitPoints = [
       min,
-      ...times(steps - 1, step => min + stepsLength * (step + 1)),
+      ...range({
+        end: steps - 1,
+      }).map(step => min + stepsLength * (step + 1)),
       max,
     ];
 
@@ -52,7 +53,7 @@ class Slider extends Component {
   // creates an array of values where the slider should snap to
   computeSnapPoints({ min, max, step }) {
     if (!step) return undefined;
-    return [...range(min, max, step), max];
+    return [...range({ start: min, end: max, step }), max];
   }
 
   createHandleComponent = tooltips => props => {

--- a/src/connectors/pagination/Paginator.js
+++ b/src/connectors/pagination/Paginator.js
@@ -1,4 +1,4 @@
-import range from 'lodash/range';
+import { range } from '../../lib/utils';
 
 class Paginator {
   constructor(params) {
@@ -13,7 +13,9 @@ class Paginator {
     if (total === 0) return [0];
 
     const totalDisplayedPages = this.nbPagesDisplayed(padding, total);
-    if (totalDisplayedPages === total) return range(0, total);
+    if (totalDisplayedPages === total) {
+      return range({ start: 0, end: total });
+    }
 
     const paddingLeft = this.calculatePaddingLeft(
       currentPage,
@@ -26,7 +28,7 @@ class Paginator {
     const first = currentPage - paddingLeft;
     const last = currentPage + paddingRight;
 
-    return range(first, last);
+    return range({ start: first, end: last });
   }
 
   nbPagesDisplayed(padding, total) {

--- a/src/connectors/pagination/Paginator.js
+++ b/src/connectors/pagination/Paginator.js
@@ -14,7 +14,7 @@ class Paginator {
 
     const totalDisplayedPages = this.nbPagesDisplayed(padding, total);
     if (totalDisplayedPages === total) {
-      return range({ start: 0, end: total });
+      return range({ end: total });
     }
 
     const paddingLeft = this.calculatePaddingLeft(

--- a/src/connectors/pagination/__tests__/connectPagination-test.js
+++ b/src/connectors/pagination/__tests__/connectPagination-test.js
@@ -115,7 +115,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/pagination/
     }
 
     widget.render({
-      results: new SearchResults(helper.state, [{}]),
+      results: new SearchResults(helper.state, [
+        {
+          nbPages: 250,
+        },
+      ]),
       state: helper.state,
       helper,
       createURL: () => '#',

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -1,5 +1,3 @@
-import range from 'lodash/range';
-import times from 'lodash/times';
 import algoliaSearchHelper from 'algoliasearch-helper';
 import InstantSearch from '../InstantSearch';
 import version from '../version';
@@ -336,7 +334,7 @@ describe('InstantSearch lifecycle', () => {
     let widgets;
 
     beforeEach(() => {
-      widgets = range(5).map((widget, widgetIndex) => ({
+      widgets = Array.from({ length: 5 }, (_widget, widgetIndex) => ({
         init() {},
         getConfiguration: jest.fn().mockReturnValue({ values: [widgetIndex] }),
       }));
@@ -361,7 +359,7 @@ describe('InstantSearch lifecycle', () => {
     const render = jest.fn();
     beforeEach(() => {
       render.mockReset();
-      const widgets = range(5).map(() => ({ render }));
+      const widgets = Array.from({ length: 5 }, () => ({ render }));
 
       widgets.forEach(search.addWidget, search);
 
@@ -671,7 +669,7 @@ describe('InstantSearch lifecycle', () => {
       searchClient: algoliasearch(appId, apiKey),
     });
 
-    const widgets = times(5, () => ({
+    const widgets = Array.from({ length: 5 }, () => ({
       getConfiguration: () => ({}),
       init: jest.fn(),
       render: jest.fn(),

--- a/src/lib/utils/__tests__/range-test.ts
+++ b/src/lib/utils/__tests__/range-test.ts
@@ -1,0 +1,24 @@
+import range from '../range';
+
+describe('range', () => {
+  test('with end', () => {
+    expect(range({ end: 4 })).toEqual([0, 1, 2, 3]);
+  });
+
+  test('with start and end', () => {
+    expect(range({ start: 1, end: 5 })).toEqual([1, 2, 3, 4]);
+  });
+
+  test('with end and step', () => {
+    expect(range({ end: 20, step: 5 })).toEqual([0, 5, 10, 15]);
+  });
+
+  test('with step 0', () => {
+    expect(range({ start: 1, end: 4, step: 0 })).toEqual([1, 1, 1]);
+  });
+
+  test('rounds decimal array lengths', () => {
+    // (5000 - 1) / 500 = 9.998 so we want the array length to be rounded to 10.
+    expect(range({ start: 1, end: 5000, step: 500 })).toHaveLength(10);
+  });
+});

--- a/src/lib/utils/__tests__/range-test.ts
+++ b/src/lib/utils/__tests__/range-test.ts
@@ -16,5 +16,17 @@ describe('range', () => {
   test('rounds decimal array lengths', () => {
     // (5000 - 1) / 500 = 9.998 so we want the array length to be rounded to 10.
     expect(range({ start: 1, end: 5000, step: 500 })).toHaveLength(10);
+    expect(range({ start: 1, end: 5000, step: 500 })).toEqual([
+      500,
+      1000,
+      1500,
+      2000,
+      2500,
+      3000,
+      3500,
+      4000,
+      4500,
+      5000,
+    ]);
   });
 });

--- a/src/lib/utils/__tests__/range-test.ts
+++ b/src/lib/utils/__tests__/range-test.ts
@@ -13,10 +13,6 @@ describe('range', () => {
     expect(range({ end: 20, step: 5 })).toEqual([0, 5, 10, 15]);
   });
 
-  test('with step 0', () => {
-    expect(range({ start: 1, end: 4, step: 0 })).toEqual([1, 1, 1]);
-  });
-
   test('rounds decimal array lengths', () => {
     // (5000 - 1) / 500 = 9.998 so we want the array length to be rounded to 10.
     expect(range({ start: 1, end: 5000, step: 500 })).toHaveLength(10);

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -14,6 +14,7 @@ export { default as noop } from './noop';
 export { default as isFiniteNumber } from './isFiniteNumber';
 export { default as isPlainObject } from './isPlainObject';
 export { default as uniq } from './uniq';
+export { default as range } from './range';
 export { warning, deprecate } from './logger';
 export {
   createDocumentationLink,

--- a/src/lib/utils/range.ts
+++ b/src/lib/utils/range.ts
@@ -1,0 +1,26 @@
+type RangeOptions = {
+  start?: number;
+  end: number;
+  step?: number;
+};
+
+function range({ start = 0, end, step = 1 }: RangeOptions): number[] {
+  // We can't divide by 0 so we re-assign the step to 1 if it happens.
+  const limitStep = step === 0 ? 1 : step;
+
+  // In some cases the array to create has a decimal length.
+  // We therefore need to round the value.
+  // Example:
+  //   { start: 1, end: 5000, step: 500 }
+  //   => Array length = (5000 - 1) / 500 = 9.998
+  const arrayLength = Math.round((end - start) / limitStep);
+
+  return Array.apply(null, Array(arrayLength)).map((_, current) =>
+    // If the step is 0, the values shouldn't get incremented.
+    // Example:
+    //   range({ start: 1, end: 4, step: 0 }) => [1, 1, 1]
+    step === 0 ? start : (start + current) * step
+  );
+}
+
+export default range;

--- a/src/lib/utils/range.ts
+++ b/src/lib/utils/range.ts
@@ -16,7 +16,7 @@ function range({ start = 0, end, step = 1 }: RangeOptions): number[] {
   const arrayLength = Math.round((end - start) / limitStep);
 
   return Array.apply(null, Array(arrayLength)).map(
-    (_, current) => (start + current) * step
+    (_, current) => (start + current) * limitStep
   );
 }
 

--- a/src/lib/utils/range.ts
+++ b/src/lib/utils/range.ts
@@ -15,11 +15,8 @@ function range({ start = 0, end, step = 1 }: RangeOptions): number[] {
   //   => Array length = (5000 - 1) / 500 = 9.998
   const arrayLength = Math.round((end - start) / limitStep);
 
-  return Array.apply(null, Array(arrayLength)).map((_, current) =>
-    // If the step is 0, the values shouldn't get incremented.
-    // Example:
-    //   range({ start: 1, end: 4, step: 0 }) => [1, 1, 1]
-    step === 0 ? start : (start + current) * step
+  return Array.apply(null, Array(arrayLength)).map(
+    (_, current) => (start + current) * step
   );
 }
 


### PR DESCRIPTION
This removes `lodash/range` and `lodash/times` from the codebase.

I created a single custom `range` util for both functions because `lodash/times` is a subset of `lodash/range`.

I decided to change the `range` function signature to something more clear:

**Before**

`start` and `step` are optional, which makes it confusing because arguments change depending on what's given to the function.

```ts
function range(start = 0, end, step = 1): number[] | undefined;
```

**After**

```ts
type RangeOptions = {
  start?: number;
  end: number;
  step?: number;
};

function range({ start = 0, end, step = 1 }: RangeOptions): number[];
```