### PR TITLE
refactor(lodash): remove isEqual usage

### DIFF
--- a/src/components/Pagination/PaginationLink.js
+++ b/src/components/Pagination/PaginationLink.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'preact-compat';
 import PropTypes from 'prop-types';
-import isEqual from 'lodash/isEqual';
+import { isEqual } from '../../lib/utils';
 
 class PaginationLink extends Component {
   componentWillMount() {

--- a/src/components/RefinementList/RefinementList.js
+++ b/src/components/RefinementList/RefinementList.js
@@ -1,8 +1,7 @@
 import React, { Component } from 'preact-compat';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import isEqual from 'lodash/isEqual';
-import { isSpecialClick } from '../../lib/utils';
+import { isSpecialClick, isEqual } from '../../lib/utils';
 import Template from '../Template/Template';
 import RefinementListItem from './RefinementListItem';
 import SearchBox from '../SearchBox/SearchBox';

--- a/src/components/RefinementList/RefinementListItem.js
+++ b/src/components/RefinementList/RefinementListItem.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'preact-compat';
-import isEqual from 'lodash/isEqual';
+import { isEqual } from '../../lib/utils';
 import Template from '../Template/Template';
 
 class RefinementListItem extends Component {

--- a/src/components/Template/Template.js
+++ b/src/components/Template/Template.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'preact-compat';
 import PropTypes from 'prop-types';
-import isEqual from 'lodash/isEqual';
-import { renderTemplate } from '../../lib/utils';
+import { renderTemplate, isEqual } from '../../lib/utils';
 
 class Template extends Component {
   shouldComponentUpdate(nextProps) {

--- a/src/connectors/breadcrumb/connectBreadcrumb.js
+++ b/src/connectors/breadcrumb/connectBreadcrumb.js
@@ -1,9 +1,9 @@
 import find from 'lodash/find';
-import isEqual from 'lodash/isEqual';
 import {
   checkRendering,
   warning,
   createDocumentationMessageGenerator,
+  isEqual,
 } from '../../lib/utils';
 
 const withUsage = createDocumentationMessageGenerator({

--- a/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
+++ b/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
@@ -1,9 +1,9 @@
 import find from 'lodash/find';
-import isEqual from 'lodash/isEqual';
 import {
   checkRendering,
   warning,
   createDocumentationMessageGenerator,
+  isEqual,
 } from '../../lib/utils';
 
 const withUsage = createDocumentationMessageGenerator({

--- a/src/connectors/infinite-hits/connectInfiniteHits.js
+++ b/src/connectors/infinite-hits/connectInfiniteHits.js
@@ -1,9 +1,8 @@
-import isEqual from 'lodash/isEqual';
-
 import escapeHits, { TAG_PLACEHOLDER } from '../../lib/escape-highlight';
 import {
   checkRendering,
   createDocumentationMessageGenerator,
+  isEqual,
   addAbsolutePosition,
   addQueryID,
 } from '../../lib/utils';

--- a/src/connectors/query-rules/connectQueryRules.ts
+++ b/src/connectors/query-rules/connectQueryRules.ts
@@ -1,4 +1,3 @@
-import isEqual from 'lodash/isEqual';
 import {
   Renderer,
   RenderOptions,
@@ -11,6 +10,7 @@ import {
   createDocumentationMessageGenerator,
   warning,
   getRefinements,
+  isEqual,
   noop,
 } from '../../lib/utils';
 import {

--- a/src/connectors/refinement-list/connectRefinementList.js
+++ b/src/connectors/refinement-list/connectRefinementList.js
@@ -1,13 +1,13 @@
 import {
   checkRendering,
   createDocumentationMessageGenerator,
+  isEqual,
 } from '../../lib/utils';
 import {
   escapeFacets,
   TAG_PLACEHOLDER,
   TAG_REPLACEMENT,
 } from '../../lib/escape-highlight';
-import isEqual from 'lodash/isEqual';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'refinement-list',

--- a/src/lib/RoutingManager.js
+++ b/src/lib/RoutingManager.js
@@ -1,5 +1,5 @@
 import algoliasearchHelper from 'algoliasearch-helper';
-import isEqual from 'lodash/isEqual';
+import { isEqual } from './utils';
 
 export default class RoutingManager {
   constructor({ instantSearchInstance, router, stateMapping } = {}) {

--- a/src/lib/utils/__tests__/isEqual-test.ts
+++ b/src/lib/utils/__tests__/isEqual-test.ts
@@ -73,6 +73,22 @@ describe('isEqual', () => {
     });
   });
 
+  describe('with functions', () => {
+    test('with same functions should be true', () => {
+      const first = function a() {};
+      const second = first;
+
+      expect(isEqual(first, second)).toBe(true);
+    });
+
+    test('with different functions should be false', () => {
+      const first = function a() {};
+      const second = function a() {};
+
+      expect(isEqual(first, second)).toBe(false);
+    });
+  });
+
   describe('with arrays', () => {
     test('with same array values should be true', () => {
       const first = ['Alphonse', 'Fred'];

--- a/src/lib/utils/__tests__/isEqual-test.ts
+++ b/src/lib/utils/__tests__/isEqual-test.ts
@@ -74,7 +74,7 @@ describe('isEqual', () => {
   });
 
   describe('with arrays', () => {
-    test('with same array values should be false', () => {
+    test('with same array values should be true', () => {
       const first = ['Alphonse', 'Fred'];
       const second = ['Alphonse', 'Fred'];
 

--- a/src/lib/utils/__tests__/isEqual-test.ts
+++ b/src/lib/utils/__tests__/isEqual-test.ts
@@ -1,0 +1,186 @@
+import isEqual from '../isEqual';
+
+describe('isEqual', () => {
+  describe('with primitives', () => {
+    test('with null should be true', () => {
+      const first = null;
+      const second = null;
+
+      expect(isEqual(first, second)).toBe(true);
+    });
+
+    test('with undefined should be true', () => {
+      const first = undefined;
+      const second = undefined;
+
+      expect(isEqual(first, second)).toBe(true);
+    });
+
+    test('with same booleans should be true', () => {
+      const first = true;
+      const second = true;
+
+      expect(isEqual(first, second)).toBe(true);
+    });
+
+    test('with different booleans should be false', () => {
+      const first = true;
+      const second = false;
+
+      expect(isEqual(first, second)).toBe(false);
+    });
+
+    test('with same numbers should be true', () => {
+      const first = 1;
+      const second = 1;
+
+      expect(isEqual(first, second)).toBe(true);
+    });
+
+    test('with different numbers should be false', () => {
+      const first = 1;
+      const second = 2;
+
+      expect(isEqual(first, second)).toBe(false);
+    });
+
+    test('with same strings should be true', () => {
+      const first = 'string';
+      const second = 'string';
+
+      expect(isEqual(first, second)).toBe(true);
+    });
+
+    test('with different strings should be false', () => {
+      const first = 'string1';
+      const second = 'string2';
+
+      expect(isEqual(first, second)).toBe(false);
+    });
+
+    test('with same symbols should be true', () => {
+      const first = Symbol('42');
+      const second = first;
+
+      expect(isEqual(first, second)).toBe(true);
+    });
+
+    test('with different symbols should be false', () => {
+      const first = Symbol('42');
+      const second = Symbol('42');
+
+      expect(isEqual(first, second)).toBe(false);
+    });
+  });
+
+  describe('with arrays', () => {
+    test('with same array values should be false', () => {
+      const first = ['Alphonse', 'Fred'];
+      const second = ['Alphonse', 'Fred'];
+
+      expect(isEqual(first, second)).toBe(true);
+    });
+
+    test('with different array values should be false', () => {
+      const first = ['Alphonse', 'Fred'];
+      const second = ['Adeline', 'Fred'];
+
+      expect(isEqual(first, second)).toBe(false);
+    });
+  });
+
+  describe('with objects', () => {
+    test('with same reference should be true', () => {
+      const first = { name: 'Alfred' };
+      const second = first;
+
+      expect(isEqual(first, second)).toBe(true);
+    });
+
+    test('with different number of keys should be false', () => {
+      const first = { name: 'Alfred' };
+      const second = { name: 'Alfred', age: 33 };
+
+      expect(isEqual(first, second)).toBe(false);
+    });
+
+    test('with different keys types should be false', () => {
+      const first = { name: 'Alfred', age: 33 };
+      const second = { name: 'Alfred', age: '33' };
+
+      expect(isEqual(first, second)).toBe(false);
+    });
+
+    test('with different keys should be false', () => {
+      const first = { name: 'Alfred' };
+      const second = { firstName: 'Alfred' };
+
+      expect(isEqual(first, second)).toBe(false);
+    });
+
+    test('with different values should be false', () => {
+      const first = { name: 'Alfred' };
+      const second = { name: 'Georges' };
+
+      expect(isEqual(first, second)).toBe(false);
+    });
+
+    test('with equal nested objects should be true', () => {
+      const first = { name: { first: 'John', last: 'Doe' } };
+      const second = { name: { first: 'John', last: 'Doe' } };
+
+      expect(isEqual(first, second)).toBe(true);
+    });
+
+    test('with different nested objects should be false', () => {
+      const first = { name: { first: 'John', last: 'Doe' } };
+      const second = { name: { first: 'Jane', last: 'Doe' } };
+
+      expect(isEqual(first, second)).toBe(false);
+    });
+
+    test('with full equal objets should be true', () => {
+      const first = {
+        index: '',
+        query: '',
+        facets: [],
+        facetsRefinements: {},
+        tagRefinements: [],
+        numericFilters: undefined,
+      };
+
+      const second = {
+        index: '',
+        query: '',
+        facets: [],
+        facetsRefinements: {},
+        tagRefinements: [],
+        numericFilters: undefined,
+      };
+
+      expect(isEqual(first, second)).toBe(true);
+    });
+
+    test('with full different objets should be false', () => {
+      const first = {
+        index: '',
+        query: 'first query',
+        facets: [],
+        facetsRefinements: {},
+        tagRefinements: [],
+        numericFilters: undefined,
+      };
+
+      const second = {
+        index: '',
+        query: '',
+        facets: ['brand'],
+        facetsRefinements: {},
+        tagRefinements: [],
+        numericFilters: undefined,
+      };
+
+      expect(isEqual(first, second)).toBe(false);
+    });
+  });
+});

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -15,6 +15,7 @@ export { default as isFiniteNumber } from './isFiniteNumber';
 export { default as isPlainObject } from './isPlainObject';
 export { default as uniq } from './uniq';
 export { default as range } from './range';
+export { default as isEqual } from './isEqual';
 export { warning, deprecate } from './logger';
 export {
   createDocumentationLink,

--- a/src/lib/utils/isEqual.ts
+++ b/src/lib/utils/isEqual.ts
@@ -1,0 +1,31 @@
+function isPrimitive(obj: any): boolean {
+  return obj !== Object(obj);
+}
+
+function isEqual(first: any, second: any): boolean {
+  if (first === second) {
+    return true;
+  }
+
+  if (isPrimitive(first) || isPrimitive(second)) {
+    return first === second;
+  }
+
+  if (Object.keys(first).length !== Object.keys(second).length) {
+    return false;
+  }
+
+  for (const key of Object.keys(first)) {
+    if (!(key in second)) {
+      return false;
+    }
+
+    if (!isEqual(first[key], second[key])) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export default isEqual;

--- a/src/lib/utils/isEqual.ts
+++ b/src/lib/utils/isEqual.ts
@@ -7,7 +7,12 @@ function isEqual(first: any, second: any): boolean {
     return true;
   }
 
-  if (isPrimitive(first) || isPrimitive(second)) {
+  if (
+    isPrimitive(first) ||
+    isPrimitive(second) ||
+    typeof first === 'function' ||
+    typeof second === 'function'
+  ) {
     return first === second;
   }
 


### PR DESCRIPTION
This removes `lodash/isEqual` usage for our own custom `isEqual` function.

The `isEqual` function takes into account object references, primitive objects and nested objects. This covers all our usages.