### PR TITLE
refactor(lodash): remove isPlainObject usage

### DIFF
--- a/src/connectors/configure/connectConfigure.js
+++ b/src/connectors/configure/connectConfigure.js
@@ -1,5 +1,8 @@
-import isPlainObject from 'lodash/isPlainObject';
-import { createDocumentationMessageGenerator, noop } from '../../lib/utils';
+import {
+  createDocumentationMessageGenerator,
+  noop,
+  isPlainObject,
+} from '../../lib/utils';
 import { enhanceConfiguration } from '../../lib/InstantSearch';
 
 const withUsage = createDocumentationMessageGenerator({

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -1,14 +1,17 @@
 import algoliasearchHelper from 'algoliasearch-helper';
 import mergeWith from 'lodash/mergeWith';
 import union from 'lodash/union';
-import isPlainObject from 'lodash/isPlainObject';
 import EventEmitter from 'events';
 import RoutingManager from './RoutingManager';
 import simpleMapping from './stateMappings/simple';
 import historyRouter from './routers/history';
 import version from './version';
 import createHelpers from './createHelpers';
-import { createDocumentationMessageGenerator, noop } from './utils';
+import {
+  createDocumentationMessageGenerator,
+  noop,
+  isPlainObject,
+} from './utils';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'instantsearch',

--- a/src/lib/escape-highlight.ts
+++ b/src/lib/escape-highlight.ts
@@ -1,7 +1,7 @@
 import reduce from 'lodash/reduce';
 import escape from 'lodash/escape';
-import isPlainObject from 'lodash/isPlainObject';
 import { Hit, FacetHit } from '../types';
+import { isPlainObject } from '../lib/utils';
 
 export const TAG_PLACEHOLDER = {
   highlightPreTag: '__ais-highlight__',

--- a/src/lib/utils/__tests__/isPlainObject-test.ts
+++ b/src/lib/utils/__tests__/isPlainObject-test.ts
@@ -1,0 +1,41 @@
+import isPlainObject from '../isPlainObject';
+
+describe('isPlainObject', () => {
+  test('with primitive should be false', () => {
+    const actual = isPlainObject(1);
+
+    expect(actual).toBe(false);
+  });
+
+  test('with literal object should be true', () => {
+    const actual = isPlainObject({ name: 'John' });
+
+    expect(actual).toBe(true);
+  });
+
+  test('with literal object containing the `constructor` key should be true', () => {
+    const actual = isPlainObject({ constructor: 'present' });
+
+    expect(actual).toBe(true);
+  });
+
+  test('with constructor should be false', () => {
+    function Foo() {}
+
+    const actual = isPlainObject(new Foo());
+
+    expect(actual).toBe(false);
+  });
+
+  test('with array should be false', () => {
+    const actual = isPlainObject([1, 2, 3]);
+
+    expect(actual).toBe(false);
+  });
+
+  test('with Object.create should be true', () => {
+    const actual = isPlainObject(Object.create(null));
+
+    expect(actual).toBe(true);
+  });
+});

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -12,6 +12,7 @@ export { default as checkRendering } from './checkRendering';
 export { default as getPropertyByPath } from './getPropertyByPath';
 export { default as noop } from './noop';
 export { default as isFiniteNumber } from './isFiniteNumber';
+export { default as isPlainObject } from './isPlainObject';
 export { warning, deprecate } from './logger';
 export {
   createDocumentationLink,

--- a/src/lib/utils/isPlainObject.ts
+++ b/src/lib/utils/isPlainObject.ts
@@ -1,0 +1,42 @@
+/**
+ * This implementation is taken from Lodash implementation.
+ * See: https://github.com/lodash/lodash/blob/master/isPlainObject.js
+ */
+
+function getTag(value: any): string {
+  if (value === null) {
+    return value === undefined ? '[object Undefined]' : '[object Null]';
+  }
+
+  return toString.call(value);
+}
+
+function isObjectLike(value: any): boolean {
+  return typeof value === 'object' && value !== null;
+}
+
+/**
+ * Checks if `value` is a plain object.
+ *
+ * A plain object is an object created by the `Object`
+ * constructor or with a `[[Prototype]]` of `null`.
+ */
+function isPlainObject(value: any): boolean {
+  if (!isObjectLike(value) || getTag(value) !== '[object Object]') {
+    return false;
+  }
+
+  if (Object.getPrototypeOf(value) === null) {
+    return true;
+  }
+
+  let proto = value;
+
+  while (Object.getPrototypeOf(proto) !== null) {
+    proto = Object.getPrototypeOf(proto);
+  }
+
+  return Object.getPrototypeOf(value) === proto;
+}
+
+export default isPlainObject;


### PR DESCRIPTION
This removes `lodash/isPlainObject` in favor of our own `isPlainObject` util. I basically copied their implementation because this is the most solid I found while testing it.