### PR TITLE
refactor(lodash): remove reduce usage

### DIFF
--- a/src/lib/escape-highlight.ts
+++ b/src/lib/escape-highlight.ts
@@ -1,4 +1,3 @@
-import reduce from 'lodash/reduce';
 import escape from 'lodash/escape';
 import isPlainObject from 'lodash/isPlainObject';
 import { Hit, FacetHit } from '../types';
@@ -27,11 +26,10 @@ function replaceTagsAndEscape(value: string): string {
 
 function recursiveEscape(input: any): any {
   if (isPlainObject(input) && typeof input.value !== 'string') {
-    return reduce(
-      input,
-      (acc, item, key) => ({
+    return Object.keys(input).reduce(
+      (acc, key) => ({
         ...acc,
-        [key]: recursiveEscape(item),
+        [key]: recursiveEscape(input[key]),
       }),
       {}
     );

--- a/src/lib/utils/prepareTemplateProps.js
+++ b/src/lib/utils/prepareTemplateProps.js
@@ -1,12 +1,10 @@
-import reduce from 'lodash/reduce';
 import keys from 'lodash/keys';
 import uniq from 'lodash/uniq';
 
 function prepareTemplates(defaultTemplates = {}, templates = {}) {
   const allKeys = uniq([...keys(defaultTemplates), ...keys(templates)]);
 
-  return reduce(
-    allKeys,
+  return allKeys.reduce(
     (config, key) => {
       const defaultTemplate = defaultTemplates[key];
       const customTemplate = templates[key];


### PR DESCRIPTION
This removes `lodash/reduce` usage and uses the native `Array.prototype.reduce` method.