### PR TITLE
refactor(lodash): remove uniq usage

### DIFF
--- a/src/lib/insights/client.ts
+++ b/src/lib/insights/client.ts
@@ -1,6 +1,5 @@
 import find from 'lodash/find';
-import uniq from 'lodash/uniq';
-
+import { uniq } from '../utils';
 import {
   Hits,
   InsightsClient,

--- a/src/lib/utils/__tests__/uniq-test.ts
+++ b/src/lib/utils/__tests__/uniq-test.ts
@@ -1,0 +1,21 @@
+import uniq from '../uniq';
+
+describe('uniq', () => {
+  test('with empty array', () => {
+    const actual = uniq([]);
+
+    expect(actual).toEqual([]);
+  });
+
+  test('with duplicate items in array', () => {
+    const actual = uniq([1, 1, 2, 3, 4, 5, 6, 5, 5]);
+
+    expect(actual).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  test('with already unique items in array', () => {
+    const actual = uniq([1, 2, 3, 4, 5, 6]);
+
+    expect(actual).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+});

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -13,6 +13,7 @@ export { default as getPropertyByPath } from './getPropertyByPath';
 export { default as noop } from './noop';
 export { default as isFiniteNumber } from './isFiniteNumber';
 export { default as isPlainObject } from './isPlainObject';
+export { default as uniq } from './uniq';
 export { warning, deprecate } from './logger';
 export {
   createDocumentationLink,

--- a/src/lib/utils/prepareTemplateProps.js
+++ b/src/lib/utils/prepareTemplateProps.js
@@ -1,5 +1,5 @@
 import keys from 'lodash/keys';
-import uniq from 'lodash/uniq';
+import uniq from './uniq';
 
 function prepareTemplates(defaultTemplates = {}, templates = {}) {
   const allKeys = uniq([...keys(defaultTemplates), ...keys(templates)]);

--- a/src/lib/utils/uniq.ts
+++ b/src/lib/utils/uniq.ts
@@ -1,0 +1,5 @@
+function uniq(array: any[]): any[] {
+  return array.filter((value, index, self) => self.indexOf(value) === index);
+}
+
+export default uniq;


### PR DESCRIPTION
This removes `lodash/uniq` for our own `uniq` util.