### PR TITLE
refactor(lodash): remove escape usage

### DIFF
--- a/src/lib/escape-highlight.ts
+++ b/src/lib/escape-highlight.ts
@@ -1,6 +1,5 @@
-import escape from 'lodash/escape';
 import { Hit, FacetHit } from '../types';
-import { isPlainObject } from '../lib/utils';
+import { isPlainObject, escape } from '../lib/utils';
 
 export const TAG_PLACEHOLDER = {
   highlightPreTag: '__ais-highlight__',

--- a/src/lib/utils/__tests__/escape-test.ts
+++ b/src/lib/utils/__tests__/escape-test.ts
@@ -1,0 +1,25 @@
+import escape from '../escape';
+
+describe('escape', () => {
+  test('should escape values', () => {
+    expect(escape('&<>"\'/')).toEqual('&amp;&lt;&gt;&quot;&#39;/');
+  });
+
+  test('should escape values in a sentence', () => {
+    expect(escape('fred, barney, & pebbles')).toEqual(
+      'fred, barney, &amp; pebbles'
+    );
+  });
+
+  test('should handle strings with nothing to escape', () => {
+    expect(escape('abc')).toEqual('abc');
+  });
+
+  test('should not escape the "`" character', () => {
+    expect(escape('`')).toEqual('`');
+  });
+
+  test('should not escape the "/" character', () => {
+    expect(escape('/')).toEqual('/');
+  });
+});

--- a/src/lib/utils/escape.ts
+++ b/src/lib/utils/escape.ts
@@ -1,6 +1,6 @@
 /**
  * This implementation is taken from Lodash implementation.
- * See: https://github.com/lodash/lodash/blob/master/escape.js
+ * See: https://github.com/lodash/lodash/blob/4.17.11-npm/escape.js
  */
 
 // Used to map characters to HTML entities.

--- a/src/lib/utils/escape.ts
+++ b/src/lib/utils/escape.ts
@@ -1,0 +1,29 @@
+/**
+ * This implementation is taken from Lodash implementation.
+ * See: https://github.com/lodash/lodash/blob/master/escape.js
+ */
+
+// Used to map characters to HTML entities.
+const htmlEscapes = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+
+// Used to match HTML entities and HTML characters.
+const regexUnescapedHtml = /[&<>"']/g;
+const regexHasUnescapedHtml = RegExp(regexUnescapedHtml.source);
+
+/**
+ * Converts the characters "&", "<", ">", '"', and "'" in `string` to their
+ * corresponding HTML entities.
+ */
+function escape(value: string): string {
+  return value && regexHasUnescapedHtml.test(value)
+    ? value.replace(regexUnescapedHtml, character => htmlEscapes[character])
+    : value;
+}
+
+export default escape;

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -16,6 +16,7 @@ export { default as isPlainObject } from './isPlainObject';
 export { default as uniq } from './uniq';
 export { default as range } from './range';
 export { default as isEqual } from './isEqual';
+export { default as escape } from './escape';
 export { warning, deprecate } from './logger';
 export {
   createDocumentationLink,


### PR DESCRIPTION
This removes `lodash/escape` usage from our codebase to use our own util. I basically copied their implementation and their test suite.