### PR TITLE
refactor(lodash): remove mergeWith usage

### DIFF
--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -1,5 +1,4 @@
 import algoliasearchHelper from 'algoliasearch-helper';
-import mergeWith from 'lodash/mergeWith';
 import EventEmitter from 'events';
 import RoutingManager from './RoutingManager';
 import simpleMapping from './stateMappings/simple';
@@ -10,7 +9,7 @@ import {
   createDocumentationMessageGenerator,
   noop,
   isPlainObject,
-  uniq,
+  mergeDeep,
 } from './utils';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -441,21 +440,7 @@ export function enhanceConfiguration(configuration, widgetDefinition) {
   // Get the relevant partial configuration asked by the widget
   const partialConfiguration = widgetDefinition.getConfiguration(configuration);
 
-  const customizer = (a, b) => {
-    // always create a unified array for facets refinements
-    if (Array.isArray(a)) {
-      return uniq([...a, ...b]);
-    }
-
-    // avoid mutating objects
-    if (isPlainObject(a)) {
-      return mergeWith({}, a, b, customizer);
-    }
-
-    return undefined;
-  };
-
-  return mergeWith({}, configuration, partialConfiguration, customizer);
+  return mergeDeep(configuration, partialConfiguration);
 }
 
 export default InstantSearch;

--- a/src/lib/utils/__tests__/mergeDeep-test.ts
+++ b/src/lib/utils/__tests__/mergeDeep-test.ts
@@ -99,4 +99,18 @@ describe('mergeDeep', () => {
       });
     });
   });
+
+  describe('with different types', () => {
+    test('overrides object with previous boolean value', () => {
+      const actual = mergeDeep({ routing: {} }, { routing: true });
+
+      expect(actual).toEqual({ routing: true });
+    });
+
+    test('overrides array with previous string value', () => {
+      const actual = mergeDeep({ facets: ['brand'] }, { facets: 'brand' });
+
+      expect(actual).toEqual({ facets: 'brand' });
+    });
+  });
 });

--- a/src/lib/utils/__tests__/mergeDeep-test.ts
+++ b/src/lib/utils/__tests__/mergeDeep-test.ts
@@ -1,0 +1,102 @@
+import mergeDeep from '../mergeDeep';
+
+describe('mergeDeep', () => {
+  describe('with primitive values', () => {
+    test('with integers should override previous value', () => {
+      const actual = mergeDeep({ age: 23 }, { age: 24 });
+
+      expect(actual).toEqual({ age: 24 });
+    });
+
+    test('with strings should override previous value', () => {
+      const actual = mergeDeep({ name: 'John' }, { name: 'Jane' });
+
+      expect(actual).toEqual({ name: 'Jane' });
+    });
+  });
+
+  describe('with arrays', () => {
+    test('should concatenate values', () => {
+      const actual = mergeDeep(
+        {
+          children: ['John'],
+        },
+        {
+          children: ['Jane'],
+        }
+      );
+
+      expect(actual).toEqual({
+        children: ['John', 'Jane'],
+      });
+    });
+
+    test('should remove duplicates', () => {
+      const actual = mergeDeep(
+        {
+          children: ['John'],
+        },
+        {
+          children: ['John', 'Jane'],
+        }
+      );
+
+      expect(actual).toEqual({
+        children: ['John', 'Jane'],
+      });
+    });
+  });
+
+  describe('with objects', () => {
+    test('merges properties', () => {
+      const actual = mergeDeep(
+        {
+          age: 23,
+        },
+        {
+          name: 'John',
+        },
+        {
+          children: [1, 2, 3],
+        }
+      );
+
+      expect(actual).toEqual({
+        age: 23,
+        name: 'John',
+        children: [1, 2, 3],
+      });
+    });
+
+    test('with nested objects should merge deeply', () => {
+      const actual = mergeDeep(
+        {
+          child: {
+            child2: {
+              child3: 3,
+            },
+          },
+        },
+        {
+          child: {
+            child2: {
+              child3: {
+                child4: 4,
+              },
+            },
+          },
+        }
+      );
+
+      expect(actual).toEqual({
+        child: {
+          child2: {
+            child3: {
+              child4: 4,
+            },
+          },
+        },
+      });
+    });
+  });
+});

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -18,6 +18,7 @@ export { default as range } from './range';
 export { default as isEqual } from './isEqual';
 export { default as escape } from './escape';
 export { default as find } from './find';
+export { default as mergeDeep } from './mergeDeep';
 export { warning, deprecate } from './logger';
 export {
   createDocumentationLink,

--- a/src/lib/utils/mergeDeep.ts
+++ b/src/lib/utils/mergeDeep.ts
@@ -7,7 +7,7 @@ import isPlainObject from './isPlainObject';
  * - Primitive values are replaced
  * - Arrays a concatenated and their values are made unique
  */
-function mergeDeep(...values: any[]): object {
+function mergeDeep(...values: object[]): object {
   return values.reduce((acc, source = {}) => {
     Object.keys(source).forEach(key => {
       const previousValue = acc[key];

--- a/src/lib/utils/mergeDeep.ts
+++ b/src/lib/utils/mergeDeep.ts
@@ -1,0 +1,29 @@
+import uniq from './uniq';
+import isPlainObject from './isPlainObject';
+
+/**
+ * Deeply merges all the object values in a new object.
+ *
+ * - Primitive values are replaced
+ * - Arrays a concatenated and their values are made unique
+ */
+function mergeDeep(...values: any[]): object {
+  return values.reduce((acc, source = {}) => {
+    Object.keys(source).forEach(key => {
+      const previousValue = acc[key];
+      const nextValue = source[key];
+
+      if (Array.isArray(previousValue) && Array.isArray(nextValue)) {
+        acc[key] = uniq([...previousValue, ...nextValue]);
+      } else if (isPlainObject(previousValue) && isPlainObject(nextValue)) {
+        acc[key] = mergeDeep(previousValue, nextValue);
+      } else {
+        acc[key] = nextValue;
+      }
+    });
+
+    return acc;
+  }, {});
+}
+
+export default mergeDeep;


### PR DESCRIPTION
This removes `lodash/mergeWith` usage and introduces a custom `deepMerge` util. It also simplifies the logic of the `enhanceConfiguration` function.