### PR TITLE
docs(connectRange): tag `precision` option for next major

### DIFF
--- a/src/connectors/range/connectRange.js
+++ b/src/connectors/range/connectRange.js
@@ -49,7 +49,7 @@ export default function connectRange(renderFn, unmountFn) {
       attribute,
       min: minBound,
       max: maxBound,
-      precision = 2,
+      precision = 2, // @MAJOR: the `precision` default value should be 0
     } = widgetParams;
 
     if (!attribute) {


### PR DESCRIPTION
We forgot to change the `connectRange` `precision` default value to `0` in v3. This adds a major tag so that we do not forget to update it in the next major version.