### PR TITLE
feat(voice): add additional query parameters

### DIFF
--- a/src/connectors/voice-search/connectVoiceSearch.ts
+++ b/src/connectors/voice-search/connectVoiceSearch.ts
@@ -1,3 +1,4 @@
+import { PlainSearchParameters } from 'algoliasearch-helper';
 import {
   checkRendering,
   createDocumentationMessageGenerator,
@@ -15,7 +16,11 @@ const withUsage = createDocumentationMessageGenerator({
 });
 
 export type VoiceSearchConnectorParams = {
-  searchAsYouSpeak?: boolean;
+  searchAsYouSpeak: boolean;
+  language?: string;
+  additionalQueryParameters?: (params: {
+    query: string;
+  }) => PlainSearchParameters | void;
 };
 
 export interface VoiceSearchRendererOptions<TVoiceSearchWidgetParams>
@@ -71,7 +76,11 @@ const connectVoiceSearch: VoiceSearchConnector = (
       );
     };
 
-    const { searchAsYouSpeak = false } = widgetParams;
+    const {
+      searchAsYouSpeak = false,
+      language,
+      additionalQueryParameters,
+    } = widgetParams;
 
     return {
       $$type: 'ais.voiceSearch',
@@ -79,12 +88,30 @@ const connectVoiceSearch: VoiceSearchConnector = (
       init({ helper, instantSearchInstance }) {
         (this as any)._refine = (query: string): void => {
           if (query !== helper.state.query) {
+            const queryLanguages = language
+              ? [language.split('-')[0]]
+              : undefined;
+            helper.setQueryParameter('queryLanguages', queryLanguages);
+
+            if (typeof additionalQueryParameters === 'function') {
+              helper.setState(
+                helper.state.setQueryParameters({
+                  ignorePlurals: true,
+                  removeStopWords: true,
+                  // @ts-ignore (optionalWords only allows array, while string is also valid)
+                  optionalWords: query,
+                  ...additionalQueryParameters({ query }),
+                })
+              );
+            }
+
             helper.setQuery(query).search();
           }
         };
 
         (this as any)._voiceSearchHelper = createVoiceSearchHelper({
           searchAsYouSpeak,
+          language,
           onQueryChange: query => (this as any)._refine(query),
           onStateChange: () => {
             render({
@@ -115,7 +142,26 @@ const connectVoiceSearch: VoiceSearchConnector = (
 
         unmountFn();
 
-        return state.setQueryParameter('query', undefined);
+        let newState = state;
+        if (typeof additionalQueryParameters === 'function') {
+          const additional = additionalQueryParameters({ query: '' });
+          const toReset = additional
+            ? Object.keys(additional).reduce((acc, current) => {
+                acc[current] = undefined;
+                return acc;
+              }, {})
+            : {};
+          newState = state.setQueryParameters({
+            // @ts-ignore (queryLanguages is not yet added to algoliasearch)
+            queryLanguages: undefined,
+            ignorePlurals: undefined,
+            removeStopWords: undefined,
+            optionalWords: undefined,
+            ...toReset,
+          });
+        }
+
+        return newState.setQueryParameter('query', undefined);
       },
 
       getWidgetState(uiState, { searchParameters }) {

--- a/src/lib/voiceSearchHelper/index.ts
+++ b/src/lib/voiceSearchHelper/index.ts
@@ -1,5 +1,6 @@
 export type VoiceSearchHelperParams = {
   searchAsYouSpeak: boolean;
+  language?: string;
   onQueryChange: (query: string) => void;
   onStateChange: () => void;
 };
@@ -31,6 +32,7 @@ export type ToggleListening = () => void;
 
 export default function createVoiceSearchHelper({
   searchAsYouSpeak,
+  language,
   onQueryChange,
   onStateChange,
 }: VoiceSearchHelperParams): VoiceSearchHelper {
@@ -105,6 +107,11 @@ export default function createVoiceSearchHelper({
     }
     resetState('askingPermission');
     recognition.interimResults = true;
+
+    if (language) {
+      recognition.lang = language;
+    }
+
     recognition.addEventListener('start', onStart);
     recognition.addEventListener('error', onError);
     recognition.addEventListener('result', onResult);

--- a/src/widgets/voice-search/voice-search.tsx
+++ b/src/widgets/voice-search/voice-search.tsx
@@ -1,5 +1,6 @@
 import React, { render, unmountComponentAtNode } from 'preact-compat';
 import cx from 'classnames';
+import { PlainSearchParameters } from 'algoliasearch-helper';
 import {
   getContainerNode,
   createDocumentationMessageGenerator,
@@ -42,6 +43,10 @@ type VoiceSearchWidgetParams = {
   cssClasses?: Partial<VoiceSearchCSSClasses>;
   templates?: Partial<VoiceSearchTemplates>;
   searchAsYouSpeak?: boolean;
+  language?: string;
+  additionalQueryParameters?: (params: {
+    query: string;
+  }) => PlainSearchParameters | void;
 };
 
 interface VoiceSearchRendererWidgetParams extends VoiceSearchWidgetParams {
@@ -79,7 +84,9 @@ const voiceSearch: VoiceSearch = (
     container,
     cssClasses: userCssClasses = {} as VoiceSearchCSSClasses,
     templates,
-    searchAsYouSpeak,
+    searchAsYouSpeak = false,
+    language,
+    additionalQueryParameters,
   } = {} as VoiceSearchWidgetParams
 ) => {
   if (!container) {
@@ -103,6 +110,8 @@ const voiceSearch: VoiceSearch = (
     cssClasses,
     templates: { ...defaultTemplates, ...templates },
     searchAsYouSpeak,
+    language,
+    additionalQueryParameters,
   });
 };
 

--- a/stories/voice-search.stories.ts
+++ b/stories/voice-search.stories.ts
@@ -186,4 +186,24 @@ storiesOf('VoiceSearch', module)
         })
       );
     })
+  )
+  .add(
+    'with additional parameters',
+    withHits(({ search, container }) => {
+      const descContainer = document.createElement('div');
+      const realContainer = document.createElement('div');
+      container.appendChild(descContainer);
+      container.appendChild(realContainer);
+      descContainer.innerHTML = `
+        <p>Sets the default additional parameters, as well as a language</p>
+      `;
+
+      search.addWidget(
+        voiceSearch({
+          container: realContainer,
+          language: 'en-US',
+          additionalQueryParameters: () => {},
+        })
+      );
+    })
   );


### PR DESCRIPTION
Two new arguments:
- `additionalQueryParameters: () => Partial<SearchParameters>` (only applied when voice search is mounted)
- `language: string` (iso 639-1), the parameter sent to Algolia will be always the short version

known limitation: additional query parameters will stay applied as long as the Voice Search widget is mounted, meaning they can cause stale values if you switch input method without unmounting (limitation of the architecture of InstantSearch)

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->
