### PR TITLE
chore: disable canonical link

### DIFF
--- a/docgen/layouts/common/meta.pug
+++ b/docgen/layouts/common/meta.pug
@@ -34,9 +34,6 @@ html
     link(rel='stylesheet', href="stylesheets/style.css")
     link(rel="stylesheet", href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css")
 
-    if canonical
-      link(rel='canonical', href=canonical)
-    else
-      meta(name="robots", content="noindex, nofollow")
+    meta(name="robots", content="noindex, nofollow")
 
     block head


### PR DESCRIPTION
**Summary**

We introduce [the canonical URLs](https://github.com/algolia/instantsearch.js/pull/3576) to keep backlinks to the algolia.com/doc. But it's not enough to make the Community website disappear from the search results. We have to hide them from the search results otherwise it's confusing for users.