### PR TITLE
fix(rangeSlider): round the slider pit value

### DIFF
--- a/src/components/Slider/Pit.js
+++ b/src/components/Slider/Pit.js
@@ -10,7 +10,7 @@ const Pit = ({ style, children }) => {
   // Children could be an array, unwrap the value if it's the case
   // see: https://github.com/developit/preact-compat/issues/436
   const value = Array.isArray(children) ? children[0] : children;
-  const pitValue = Math.round(parseFloat(value) * 100) / 100;
+  const pitValue = Math.round(parseInt(value) * 100) / 100;
 
   return (
     <div

--- a/src/components/Slider/Pit.js
+++ b/src/components/Slider/Pit.js
@@ -10,7 +10,7 @@ const Pit = ({ style, children }) => {
   // Children could be an array, unwrap the value if it's the case
   // see: https://github.com/developit/preact-compat/issues/436
   const value = Array.isArray(children) ? children[0] : children;
-  const pitValue = Math.round(parseInt(value) * 100) / 100;
+  const pitValue = Math.round(parseInt(value, 10) * 100) / 100;
 
   return (
     <div


### PR DESCRIPTION
**Summary**

This adds a missing base to the [`parseInt`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt) function.

**Result**

Before:

![image](https://user-images.githubusercontent.com/6137112/57235417-1c271380-7023-11e9-84ce-62c5a8f6d90e.png)

After:

![image](https://user-images.githubusercontent.com/6137112/57235436-2517e500-7023-11e9-8ea0-148a356d685b.png)
