### PR TITLE
refactor(helper): replace .getState() by .state

### DIFF
--- a/src/connectors/autocomplete/__tests__/connectAutocomplete-test.js
+++ b/src/connectors/autocomplete/__tests__/connectAutocomplete-test.js
@@ -85,7 +85,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/autocomplet
 
     expect(refine).toBe(widget._refine);
     expect(helper.search).toHaveBeenCalledTimes(1);
-    expect(helper.getState().query).toBe('foo');
+    expect(helper.state.query).toBe('foo');
   });
 
   it('with escapeHTML should escape the hits', () => {

--- a/src/connectors/clear-refinements/__tests__/connectClearRefinements-test.js
+++ b/src/connectors/clear-refinements/__tests__/connectClearRefinements-test.js
@@ -341,7 +341,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/clear-refin
       });
 
       expect(helper.hasRefinements('facet1')).toBe(true);
-      expect(helper.getState().query).toBe('not empty');
+      expect(helper.state.query).toBe('not empty');
 
       const refine = rendering.mock.calls[0][0].refine;
       refine();
@@ -352,7 +352,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/clear-refin
       });
 
       expect(helper.hasRefinements('facet1')).toBe(false);
-      expect(helper.getState().query).toBe('');
+      expect(helper.state.query).toBe('');
       expect(rendering.mock.calls[1][0].hasRefinements).toBe(false);
     });
 
@@ -446,7 +446,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/clear-refin
       expect(helper.hasRefinements('facet1')).toBe(true);
       expect(helper.hasRefinements('facet2')).toBe(true);
       expect(helper.hasRefinements('facet3')).toBe(true);
-      expect(helper.getState().query).toBe('not empty');
+      expect(helper.state.query).toBe('not empty');
 
       const refine = rendering.mock.calls[0][0].refine;
       refine();
@@ -459,7 +459,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/clear-refin
       expect(helper.hasRefinements('facet1')).toBe(true);
       expect(helper.hasRefinements('facet2')).toBe(true);
       expect(helper.hasRefinements('facet3')).toBe(false);
-      expect(helper.getState().query).toBe('');
+      expect(helper.state.query).toBe('');
       expect(rendering.mock.calls[1][0].hasRefinements).toBe(false);
     });
 

--- a/src/connectors/configure/__tests__/connectConfigure-test.js
+++ b/src/connectors/configure/__tests__/connectConfigure-test.js
@@ -89,7 +89,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
     widget.init({ helper });
 
     expect(widget.getConfiguration()).toEqual({ analytics: true });
-    expect(helper.getState().analytics).toEqual(true);
+    expect(helper.state.analytics).toEqual(true);
 
     const { refine } = renderFn.mock.calls[0][0];
     expect(refine).toBe(widget._refine);
@@ -97,8 +97,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
     refine({ hitsPerPage: 3 });
 
     expect(widget.getConfiguration()).toEqual({ hitsPerPage: 3 });
-    expect(helper.getState().analytics).toBe(undefined);
-    expect(helper.getState().hitsPerPage).toBe(3);
+    expect(helper.state.analytics).toBe(undefined);
+    expect(helper.state.hitsPerPage).toBe(3);
   });
 
   it('should dispose all the state set by configure', () => {
@@ -109,9 +109,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
     widget.init({ helper });
 
     expect(widget.getConfiguration()).toEqual({ analytics: true });
-    expect(helper.getState().analytics).toBe(true);
+    expect(helper.state.analytics).toBe(true);
 
-    const nextState = widget.dispose({ state: helper.getState() });
+    const nextState = widget.dispose({ state: helper.state });
 
     expect(nextState.analytics).toBe(undefined);
   });

--- a/src/connectors/configure/connectConfigure.js
+++ b/src/connectors/configure/connectConfigure.js
@@ -58,7 +58,7 @@ export default function connectConfigure(renderFn = noop, unmountFn = noop) {
       refine(helper) {
         return searchParameters => {
           // merge new `searchParameters` with the ones set from other widgets
-          const actualState = this.removeSearchParameters(helper.getState());
+          const actualState = this.removeSearchParameters(helper.state);
           const nextSearchParameters = enhanceConfiguration(
             { ...actualState },
             {

--- a/src/connectors/geo-search/__tests__/connectGeoSearch-test.js
+++ b/src/connectors/geo-search/__tests__/connectGeoSearch-test.js
@@ -104,7 +104,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
     expect(lastRenderArgs(render).isRefinedWithMap()).toBe(false);
 
     widget.render({
-      results: new SearchResults(helper.getState(), [
+      results: new SearchResults(helper.state, [
         {
           hits: [
             { objectID: 123, _geoloc: { lat: 10, lng: 12 } },
@@ -161,7 +161,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
     expect(lastRenderArgs(render).isRefineOnMapMove()).toBe(false);
 
     widget.render({
-      results: new SearchResults(helper.getState(), [
+      results: new SearchResults(helper.state, [
         {
           hits: [{ objectID: 123, _geoloc: { lat: 10, lng: 12 } }],
         },
@@ -183,7 +183,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
     const helper = createFakeHelper({});
 
     widget.render({
-      results: new SearchResults(helper.getState(), [
+      results: new SearchResults(helper.state, [
         {
           hits: [
             { objectID: 123, _geoloc: { lat: 10, lng: 12 } },
@@ -225,7 +225,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
     const helper = createFakeHelper({});
 
     widget.render({
-      results: new SearchResults(helper.getState(), [
+      results: new SearchResults(helper.state, [
         {
           hits: [
             { objectID: 123, _geoloc: { lat: 10, lng: 12 } },
@@ -276,7 +276,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
     );
 
     widget.render({
-      results: new SearchResults(helper.getState(), [
+      results: new SearchResults(helper.state, [
         {
           hits: [],
         },
@@ -299,7 +299,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
     helper.setQueryParameter('aroundLatLng', '12, 14');
 
     widget.render({
-      results: new SearchResults(helper.getState(), [
+      results: new SearchResults(helper.state, [
         {
           hits: [],
         },
@@ -338,7 +338,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
       lng: 42,
     };
 
-    const results = new SearchResults(helper.getState(), [
+    const results = new SearchResults(helper.state, [
       {
         hits: [
           { objectID: 123, _geoloc: { lat: 10, lng: 12 } },
@@ -403,7 +403,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
       lng: 42,
     };
 
-    const results = new SearchResults(helper.getState(), [
+    const results = new SearchResults(helper.state, [
       {
         hits: [
           { objectID: 123, _geoloc: { lat: 10, lng: 12 } },
@@ -468,7 +468,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
       lng: 42,
     };
 
-    const results = new SearchResults(helper.getState(), [
+    const results = new SearchResults(helper.state, [
       {
         hits: [
           { objectID: 123, _geoloc: { lat: 10, lng: 12 } },
@@ -533,7 +533,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
       lng: 42,
     };
 
-    const results = new SearchResults(helper.getState(), [
+    const results = new SearchResults(helper.state, [
       {
         hits: [
           { objectID: 123, _geoloc: { lat: 10, lng: 12 } },
@@ -610,7 +610,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
       });
 
       widget.render({
-        results: new SearchResults(helper.getState(), [
+        results: new SearchResults(helper.state, [
           {
             hits: [],
           },
@@ -635,7 +635,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
       helper.setQueryParameter('insideBoundingBox');
 
       widget.render({
-        results: new SearchResults(helper.getState(), [
+        results: new SearchResults(helper.state, [
           {
             hits: [],
           },
@@ -676,7 +676,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
       });
 
       widget.render({
-        results: new SearchResults(helper.getState(), [
+        results: new SearchResults(helper.state, [
           {
             hits: [],
           },
@@ -701,7 +701,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
       helper.setQueryParameter('insideBoundingBox');
 
       widget.render({
-        results: new SearchResults(helper.getState(), [
+        results: new SearchResults(helper.state, [
           {
             hits: [],
           },
@@ -734,7 +734,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
         lng: 42,
       };
 
-      const results = new SearchResults(helper.getState(), [
+      const results = new SearchResults(helper.state, [
         {
           hits: [{ objectID: 123, _geoloc: { lat: 10, lng: 12 } }],
         },
@@ -748,7 +748,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
       expect(render).toHaveBeenCalledTimes(1);
       expect(lastRenderArgs(render).hasMapMoveSinceLastRefine()).toBe(false);
       expect(lastRenderArgs(render).isRefinedWithMap()).toBe(false);
-      expect(helper.getState().insideBoundingBox).toBe(undefined);
+      expect(helper.state.insideBoundingBox).toBe(undefined);
       expect(helper.search).not.toHaveBeenCalled();
 
       lastRenderArgs(render).refine({ northEast, southWest });
@@ -761,7 +761,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
       expect(render).toHaveBeenCalledTimes(2);
       expect(lastRenderArgs(render).hasMapMoveSinceLastRefine()).toBe(false);
       expect(lastRenderArgs(render).isRefinedWithMap()).toBe(true);
-      expect(helper.getState().insideBoundingBox).toEqual('12,10,40,42');
+      expect(helper.state.insideBoundingBox).toEqual('12,10,40,42');
       expect(helper.search).toHaveBeenCalledTimes(1);
     });
 
@@ -784,7 +784,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
         lng: 42,
       };
 
-      const results = new SearchResults(helper.getState(), [
+      const results = new SearchResults(helper.state, [
         {
           hits: [{ objectID: 123, _geoloc: { lat: 10, lng: 12 } }],
         },
@@ -798,7 +798,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
       expect(render).toHaveBeenCalledTimes(1);
       expect(lastRenderArgs(render).hasMapMoveSinceLastRefine()).toBe(false);
       expect(lastRenderArgs(render).isRefinedWithMap()).toBe(false);
-      expect(helper.getState().insideBoundingBox).toBe(undefined);
+      expect(helper.state.insideBoundingBox).toBe(undefined);
       expect(helper.search).not.toHaveBeenCalled();
 
       lastRenderArgs(render).refine({ northEast, southWest });
@@ -811,7 +811,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
       expect(render).toHaveBeenCalledTimes(2);
       expect(lastRenderArgs(render).hasMapMoveSinceLastRefine()).toBe(false);
       expect(lastRenderArgs(render).isRefinedWithMap()).toBe(true);
-      expect(helper.getState().insideBoundingBox).toEqual('12,10,40,42');
+      expect(helper.state.insideBoundingBox).toEqual('12,10,40,42');
       expect(helper.search).toHaveBeenCalledTimes(1);
     });
   });
@@ -836,7 +836,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
         lng: 42,
       };
 
-      const results = new SearchResults(helper.getState(), [
+      const results = new SearchResults(helper.state, [
         {
           hits: [{ objectID: 123, _geoloc: { lat: 10, lng: 12 } }],
         },
@@ -850,7 +850,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
       expect(render).toHaveBeenCalledTimes(1);
       expect(lastRenderArgs(render).hasMapMoveSinceLastRefine()).toBe(false);
       expect(lastRenderArgs(render).isRefinedWithMap()).toBe(false);
-      expect(helper.getState().insideBoundingBox).toBe(undefined);
+      expect(helper.state.insideBoundingBox).toBe(undefined);
       expect(helper.search).not.toHaveBeenCalled();
 
       lastRenderArgs(render).refine({ northEast, southWest });
@@ -863,7 +863,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
       expect(render).toHaveBeenCalledTimes(2);
       expect(lastRenderArgs(render).hasMapMoveSinceLastRefine()).toBe(false);
       expect(lastRenderArgs(render).isRefinedWithMap()).toBe(true);
-      expect(helper.getState().insideBoundingBox).toEqual('12,10,40,42');
+      expect(helper.state.insideBoundingBox).toEqual('12,10,40,42');
       expect(helper.search).toHaveBeenCalledTimes(1);
 
       lastRenderArgs(render).clearMapRefinement();
@@ -876,7 +876,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
       expect(render).toHaveBeenCalledTimes(3);
       expect(lastRenderArgs(render).hasMapMoveSinceLastRefine()).toBe(false);
       expect(lastRenderArgs(render).isRefinedWithMap()).toBe(false);
-      expect(helper.getState().insideBoundingBox).toBe(undefined);
+      expect(helper.state.insideBoundingBox).toBe(undefined);
       expect(helper.search).toHaveBeenCalledTimes(2);
     });
 
@@ -899,7 +899,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
         lng: 42,
       };
 
-      const results = new SearchResults(helper.getState(), [
+      const results = new SearchResults(helper.state, [
         {
           hits: [{ objectID: 123, _geoloc: { lat: 10, lng: 12 } }],
         },
@@ -913,7 +913,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
       expect(render).toHaveBeenCalledTimes(1);
       expect(lastRenderArgs(render).hasMapMoveSinceLastRefine()).toBe(false);
       expect(lastRenderArgs(render).isRefinedWithMap()).toBe(false);
-      expect(helper.getState().insideBoundingBox).toBe(undefined);
+      expect(helper.state.insideBoundingBox).toBe(undefined);
       expect(helper.search).not.toHaveBeenCalled();
 
       lastRenderArgs(render).refine({ northEast, southWest });
@@ -926,7 +926,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
       expect(render).toHaveBeenCalledTimes(2);
       expect(lastRenderArgs(render).hasMapMoveSinceLastRefine()).toBe(false);
       expect(lastRenderArgs(render).isRefinedWithMap()).toBe(true);
-      expect(helper.getState().insideBoundingBox).toEqual('12,10,40,42');
+      expect(helper.state.insideBoundingBox).toEqual('12,10,40,42');
       expect(helper.search).toHaveBeenCalledTimes(1);
 
       lastRenderArgs(render).clearMapRefinement();
@@ -939,7 +939,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
       expect(render).toHaveBeenCalledTimes(3);
       expect(lastRenderArgs(render).hasMapMoveSinceLastRefine()).toBe(false);
       expect(lastRenderArgs(render).isRefinedWithMap()).toBe(false);
-      expect(helper.getState().insideBoundingBox).toBe(undefined);
+      expect(helper.state.insideBoundingBox).toBe(undefined);
       expect(helper.search).toHaveBeenCalledTimes(2);
     });
   });
@@ -968,7 +968,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
       expect(lastRenderArgs(render).isRefineOnMapMove()).toBe(false);
 
       widget.render({
-        results: new SearchResults(helper.getState(), [
+        results: new SearchResults(helper.state, [
           {
             hits: [{ objectID: 123, _geoloc: { lat: 10, lng: 12 } }],
           },
@@ -993,7 +993,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
       const helper = createFakeHelper({});
 
       widget.render({
-        results: new SearchResults(helper.getState(), [
+        results: new SearchResults(helper.state, [
           {
             hits: [{ objectID: 123, _geoloc: { lat: 10, lng: 12 } }],
           },
@@ -1038,7 +1038,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
       expect(lastRenderArgs(render).hasMapMoveSinceLastRefine()).toBe(true);
 
       widget.render({
-        results: new SearchResults(helper.getState(), [
+        results: new SearchResults(helper.state, [
           {
             hits: [{ objectID: 123, _geoloc: { lat: 10, lng: 12 } }],
           },
@@ -1062,7 +1062,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
 
       const helper = createFakeHelper({});
 
-      const results = new SearchResults(helper.getState(), [
+      const results = new SearchResults(helper.state, [
         {
           hits: [{ objectID: 123, _geoloc: { lat: 10, lng: 12 } }],
         },
@@ -1094,7 +1094,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
 
       const helper = createFakeHelper({});
 
-      const results = new SearchResults(helper.getState(), [
+      const results = new SearchResults(helper.state, [
         {
           hits: [{ objectID: 123, _geoloc: { lat: 10, lng: 12 } }],
         },
@@ -1138,7 +1138,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
         insideBoundingBox: undefined,
       };
 
-      const actual = widget.dispose({ state: helper.getState() });
+      const actual = widget.dispose({ state: helper.state });
 
       expect(unmount).toHaveBeenCalled();
       expect(actual).toMatchObject(expectation);

--- a/src/connectors/geo-search/connectGeoSearch.js
+++ b/src/connectors/geo-search/connectGeoSearch.js
@@ -281,7 +281,7 @@ http://community.algolia.com/instantsearch.js/migration-guide
       const isFirstRendering = false;
       // We don't use the state provided by the render function because we need
       // to be sure that the state is the latest one for the following condition
-      const state = helper.getState();
+      const state = helper.state;
 
       const positionChangedSinceLastRefine =
         Boolean(state.aroundLatLng) &&

--- a/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
+++ b/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
@@ -629,9 +629,9 @@ Consider using \`transformRuleContexts\` to minimize the number of rules sent to
           ]),
         });
 
-        expect(
-          (helper.state as SearchParameters).ruleContexts
-        ).toHaveLength(10);
+        expect((helper.state as SearchParameters).ruleContexts).toHaveLength(
+          10
+        );
         expect((helper.state as SearchParameters).ruleContexts).toEqual([
           'ais-brand-Insignia',
           'ais-brand-Canon',

--- a/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
+++ b/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
@@ -122,8 +122,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
       widget.render!({
         ...defaultRenderOptions,
         helper,
-        state: helper.getState(),
-        results: new SearchResults(helper.getState(), [{ hits: [] }]),
+        state: helper.state,
+        results: new SearchResults(helper.state, [{ hits: [] }]),
       });
 
       {
@@ -147,8 +147,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
       widget.render!({
         ...defaultRenderOptions,
         helper,
-        state: helper.getState(),
-        results: new SearchResults(helper.getState(), [
+        state: helper.state,
+        results: new SearchResults(helper.state, [
           { hits: [], userData: [{ banner: 'image.png' }] },
         ]),
       });
@@ -181,7 +181,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
         helper,
         state: helper.state,
       });
-      widget.dispose!({ helper, state: helper.getState() });
+      widget.dispose!({ helper, state: helper.state });
 
       expect(unmountFn).toHaveBeenCalledTimes(1);
     });
@@ -203,8 +203,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
         widget.render!({
           ...defaultRenderOptions,
           helper,
-          state: helper.getState(),
-          results: new SearchResults(helper.getState(), [
+          state: helper.state,
+          results: new SearchResults(helper.state, [
             {
               hits: [],
               userData: [{ banner: 'image1.png' }, { banner: 'image2.png' }],
@@ -251,7 +251,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
 
         // Query parameters are initially set in the helper.
         // Therefore, `ruleContexts` should be set.
-        expect((helper.getState() as SearchParameters).ruleContexts).toEqual([
+        expect((helper.state as SearchParameters).ruleContexts).toEqual([
           'ais-brand-Samsung',
           'ais-brand-Apple',
           'ais-price-500',
@@ -282,7 +282,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
           state: helper.state,
         });
 
-        expect((helper.getState() as SearchParameters).ruleContexts).toEqual([
+        expect((helper.state as SearchParameters).ruleContexts).toEqual([
           'overriden-rule',
         ]);
         expect(brandFilterSpy).toHaveBeenCalledTimes(1);
@@ -309,7 +309,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
         });
 
         // There's no results yet, so no `ruleContexts` should be set.
-        expect((helper.getState() as SearchParameters).ruleContexts).toEqual(
+        expect((helper.state as SearchParameters).ruleContexts).toEqual(
           undefined
         );
         expect(brandFilterSpy).toHaveBeenCalledTimes(0);
@@ -318,8 +318,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
         widget.render!({
           ...defaultRenderOptions,
           helper,
-          state: helper.getState(),
-          results: new SearchResults(helper.getState(), [
+          state: helper.state,
+          results: new SearchResults(helper.state, [
             {},
             {
               facets: {
@@ -335,7 +335,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
         // There are some results with the facets that we track in the
         // widget but the query parameters are not set in the helper.
         // Therefore, no `ruleContexts` should be set.
-        expect((helper.getState() as SearchParameters).ruleContexts).toEqual(
+        expect((helper.state as SearchParameters).ruleContexts).toEqual(
           undefined
         );
         expect(brandFilterSpy).toHaveBeenCalledTimes(0);
@@ -358,8 +358,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
         widget.render!({
           ...defaultRenderOptions,
           helper,
-          state: helper.getState(),
-          results: new SearchResults(helper.getState(), [
+          state: helper.state,
+          results: new SearchResults(helper.state, [
             {},
             {
               facets: {
@@ -374,7 +374,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
 
         // The search state contains the facets that we track,
         // therefore the `ruleContexts` should finally be set.
-        expect((helper.getState() as SearchParameters).ruleContexts).toEqual([
+        expect((helper.state as SearchParameters).ruleContexts).toEqual([
           'ais-brand-Samsung',
           'ais-brand-Apple',
           'ais-price-500',
@@ -404,7 +404,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
           state: helper.state,
         });
 
-        expect((helper.getState() as SearchParameters).ruleContexts).toEqual(
+        expect((helper.state as SearchParameters).ruleContexts).toEqual(
           undefined
         );
         expect(brandFilterSpy).toHaveBeenCalledTimes(0);
@@ -412,8 +412,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
         widget.render!({
           ...defaultRenderOptions,
           helper,
-          state: helper.getState(),
-          results: new SearchResults(helper.getState(), [
+          state: helper.state,
+          results: new SearchResults(helper.state, [
             {},
             {
               facets: {
@@ -426,7 +426,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
           ]),
         });
 
-        expect((helper.getState() as SearchParameters).ruleContexts).toEqual(
+        expect((helper.state as SearchParameters).ruleContexts).toEqual(
           undefined
         );
         expect(brandFilterSpy).toHaveBeenCalledTimes(0);
@@ -440,8 +440,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
         widget.render!({
           ...defaultRenderOptions,
           helper,
-          state: helper.getState(),
-          results: new SearchResults(helper.getState(), [
+          state: helper.state,
+          results: new SearchResults(helper.state, [
             {},
             {
               facets: {
@@ -454,7 +454,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
           ]),
         });
 
-        expect((helper.getState() as SearchParameters).ruleContexts).toEqual([
+        expect((helper.state as SearchParameters).ruleContexts).toEqual([
           'ais-brand-Samsung',
         ]);
         expect(brandFilterSpy).toHaveBeenCalledTimes(1);
@@ -476,7 +476,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
           state: helper.state,
         });
 
-        expect((helper.getState() as SearchParameters).ruleContexts).toEqual(
+        expect((helper.state as SearchParameters).ruleContexts).toEqual(
           undefined
         );
         expect(priceFilterSpy).toHaveBeenCalledTimes(0);
@@ -484,11 +484,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
         widget.render!({
           ...defaultRenderOptions,
           helper,
-          state: helper.getState(),
-          results: new SearchResults(helper.getState(), [{}, {}]),
+          state: helper.state,
+          results: new SearchResults(helper.state, [{}, {}]),
         });
 
-        expect((helper.getState() as SearchParameters).ruleContexts).toEqual(
+        expect((helper.state as SearchParameters).ruleContexts).toEqual(
           undefined
         );
         expect(priceFilterSpy).toHaveBeenCalledTimes(0);
@@ -505,11 +505,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
         widget.render!({
           ...defaultRenderOptions,
           helper,
-          state: helper.getState(),
-          results: new SearchResults(helper.getState(), [{}, {}]),
+          state: helper.state,
+          results: new SearchResults(helper.state, [{}, {}]),
         });
 
-        expect((helper.getState() as SearchParameters).ruleContexts).toEqual([
+        expect((helper.state as SearchParameters).ruleContexts).toEqual([
           'ais-price-500',
         ]);
         expect(priceFilterSpy).toHaveBeenCalledTimes(1);
@@ -541,8 +541,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
         widget.render!({
           ...defaultRenderOptions,
           helper,
-          state: helper.getState(),
-          results: new SearchResults(helper.getState(), [
+          state: helper.state,
+          results: new SearchResults(helper.state, [
             {},
             {
               facets: {
@@ -555,7 +555,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
           ]),
         });
 
-        expect((helper.getState() as SearchParameters).ruleContexts).toEqual([
+        expect((helper.state as SearchParameters).ruleContexts).toEqual([
           'ais-brand-Insignia_',
           'ais-brand-_Apple',
         ]);
@@ -606,8 +606,8 @@ Consider using \`transformRuleContexts\` to minimize the number of rules sent to
         widget.render!({
           ...defaultRenderOptions,
           helper,
-          state: helper.getState(),
-          results: new SearchResults(helper.getState(), [
+          state: helper.state,
+          results: new SearchResults(helper.state, [
             {},
             {
               facets: {
@@ -630,9 +630,9 @@ Consider using \`transformRuleContexts\` to minimize the number of rules sent to
         });
 
         expect(
-          (helper.getState() as SearchParameters).ruleContexts
+          (helper.state as SearchParameters).ruleContexts
         ).toHaveLength(10);
-        expect((helper.getState() as SearchParameters).ruleContexts).toEqual([
+        expect((helper.state as SearchParameters).ruleContexts).toEqual([
           'ais-brand-Insignia',
           'ais-brand-Canon',
           'ais-brand-Dynex',
@@ -672,8 +672,8 @@ Consider using \`transformRuleContexts\` to minimize the number of rules sent to
         widget.render!({
           ...defaultRenderOptions,
           helper,
-          state: helper.getState(),
-          results: new SearchResults(helper.getState(), [
+          state: helper.state,
+          results: new SearchResults(helper.state, [
             {},
             {
               facets: {
@@ -686,13 +686,13 @@ Consider using \`transformRuleContexts\` to minimize the number of rules sent to
           ]),
         });
 
-        expect((helper.getState() as SearchParameters).ruleContexts).toEqual([
+        expect((helper.state as SearchParameters).ruleContexts).toEqual([
           'initial-rule',
           'ais-brand-Samsung',
           'ais-brand-Apple',
         ]);
 
-        const nextState = widget.dispose!({ helper, state: helper.getState() });
+        const nextState = widget.dispose!({ helper, state: helper.state });
 
         expect((nextState as SearchParameters).ruleContexts).toEqual([
           'initial-rule',
@@ -713,7 +713,7 @@ Consider using \`transformRuleContexts\` to minimize the number of rules sent to
           },
         });
 
-        expect((helper.getState() as SearchParameters).ruleContexts).toEqual(
+        expect((helper.state as SearchParameters).ruleContexts).toEqual(
           undefined
         );
 
@@ -723,7 +723,7 @@ Consider using \`transformRuleContexts\` to minimize the number of rules sent to
           state: helper.state,
         });
 
-        expect((helper.getState() as SearchParameters).ruleContexts).toEqual([
+        expect((helper.state as SearchParameters).ruleContexts).toEqual([
           'ais-brand-Samsung',
         ]);
         expect(brandFilterSpy).toHaveBeenCalledTimes(1);
@@ -737,7 +737,7 @@ Consider using \`transformRuleContexts\` to minimize the number of rules sent to
           },
         });
 
-        expect((helper.getState() as SearchParameters).ruleContexts).toEqual(
+        expect((helper.state as SearchParameters).ruleContexts).toEqual(
           undefined
         );
         expect(brandFilterSpy).toHaveBeenCalledTimes(1);
@@ -772,8 +772,8 @@ Consider using \`transformRuleContexts\` to minimize the number of rules sent to
         widget.render!({
           ...defaultRenderOptions,
           helper,
-          state: helper.getState(),
-          results: new SearchResults(helper.getState(), [
+          state: helper.state,
+          results: new SearchResults(helper.state, [
             {},
             {
               facets: {
@@ -792,7 +792,7 @@ Consider using \`transformRuleContexts\` to minimize the number of rules sent to
           'ais-brand-Samsung',
           'ais-brand-Apple',
         ]);
-        expect((helper.getState() as SearchParameters).ruleContexts).toEqual([
+        expect((helper.state as SearchParameters).ruleContexts).toEqual([
           'initial-rule',
           'transformed-brand-Samsung',
           'transformed-brand-Apple',

--- a/src/connectors/voice-search/__tests__/connectVoiceSearch-test.js
+++ b/src/connectors/voice-search/__tests__/connectVoiceSearch-test.js
@@ -80,7 +80,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/voice-searc
     it('calls unmount on dispose', () => {
       const { unmountFn, widget, helper } = getDefaultSetup();
       widget.init({ helper });
-      widget.dispose({ helper, state: helper.getState() });
+      widget.dispose({ helper, state: helper.state });
       expect(unmountFn).toHaveBeenCalledTimes(1);
     });
   });

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -229,7 +229,7 @@ See: https://www.algolia.com/doc/guides/building-search-ui/widgets/create-your-o
 
       const nextState = widget.dispose({
         helper: this.helper,
-        state: this.helper.getState(),
+        state: this.helper.state,
       });
 
       // re-compute remaining widgets to the state

--- a/src/lib/voiceSearchHelper/__tests__/index-test.ts
+++ b/src/lib/voiceSearchHelper/__tests__/index-test.ts
@@ -1,10 +1,12 @@
-import voiceSearchHelper, {
+import createVoiceSearchHelper, {
   VoiceSearchHelper,
   VoiceSearchHelperParams,
 } from '..';
 
-const getHelper = (opts?: VoiceSearchHelperParams): VoiceSearchHelper =>
-  voiceSearchHelper(
+const getVoiceSearchHelper = (
+  opts?: VoiceSearchHelperParams
+): VoiceSearchHelper =>
+  createVoiceSearchHelper(
     opts || {
       searchAsYouSpeak: false,
       onQueryChange: () => {},
@@ -27,8 +29,8 @@ describe('VoiceSearchHelper', () => {
   });
 
   it('has initial state correctly', () => {
-    const helper = getHelper();
-    expect(helper.getState()).toEqual({
+    const voiceSearchHelper = getVoiceSearchHelper();
+    expect(voiceSearchHelper.getState()).toEqual({
       errorCode: undefined,
       isSpeechFinal: undefined,
       status: 'initial',
@@ -37,25 +39,25 @@ describe('VoiceSearchHelper', () => {
   });
 
   it('is not supported', () => {
-    const helper = getHelper();
-    expect(helper.isBrowserSupported()).toBe(false);
+    const voiceSearchHelper = getVoiceSearchHelper();
+    expect(voiceSearchHelper.isBrowserSupported()).toBe(false);
   });
 
   it('is not listening', () => {
-    const helper = getHelper();
-    expect(helper.isListening()).toBe(false);
+    const voiceSearchHelper = getVoiceSearchHelper();
+    expect(voiceSearchHelper.isListening()).toBe(false);
   });
 
   it('is supported with webkitSpeechRecognition', () => {
     window.webkitSpeechRecognition = () => {};
-    const helper = getHelper();
-    expect(helper.isBrowserSupported()).toBe(true);
+    const voiceSearchHelper = getVoiceSearchHelper();
+    expect(voiceSearchHelper.isBrowserSupported()).toBe(true);
   });
 
   it('is supported with SpeechRecognition', () => {
     window.SpeechRecognition = () => {};
-    const helper = getHelper();
-    expect(helper.isBrowserSupported()).toBe(true);
+    const voiceSearchHelper = getVoiceSearchHelper();
+    expect(voiceSearchHelper.isBrowserSupported()).toBe(true);
   });
 
   it('works with mock SpeechRecognition (searchAsYouSpeak:false)', () => {
@@ -68,17 +70,17 @@ describe('VoiceSearchHelper', () => {
     }));
     const onQueryChange = jest.fn();
     const onStateChange = jest.fn();
-    const helper = getHelper({
+    const voiceSearchHelper = getVoiceSearchHelper({
       searchAsYouSpeak: false,
       onQueryChange,
       onStateChange,
     });
-    const { getState } = helper;
-    helper.toggleListening();
+
+    voiceSearchHelper.toggleListening();
     expect(onStateChange).toHaveBeenCalledTimes(1);
-    expect(getState().status).toEqual('askingPermission');
+    expect(voiceSearchHelper.getState().status).toEqual('askingPermission');
     recognition.onstart();
-    expect(getState().status).toEqual('waiting');
+    expect(voiceSearchHelper.getState().status).toEqual('waiting');
     recognition.onresult({
       results: [
         (() => {
@@ -92,13 +94,13 @@ describe('VoiceSearchHelper', () => {
         })(),
       ],
     });
-    expect(getState().status).toEqual('recognizing');
-    expect(getState().transcript).toEqual('Hello World');
-    expect(getState().isSpeechFinal).toBe(true);
+    expect(voiceSearchHelper.getState().status).toEqual('recognizing');
+    expect(voiceSearchHelper.getState().transcript).toEqual('Hello World');
+    expect(voiceSearchHelper.getState().isSpeechFinal).toBe(true);
     expect(onQueryChange).toHaveBeenCalledTimes(0);
     recognition.onend();
     expect(onQueryChange).toHaveBeenCalledWith('Hello World');
-    expect(getState().status).toEqual('finished');
+    expect(voiceSearchHelper.getState().status).toEqual('finished');
   });
 
   it('works with mock SpeechRecognition (searchAsYouSpeak:true)', () => {
@@ -111,17 +113,17 @@ describe('VoiceSearchHelper', () => {
     }));
     const onQueryChange = jest.fn();
     const onStateChange = jest.fn();
-    const helper = getHelper({
+    const voiceSearchHelper = getVoiceSearchHelper({
       searchAsYouSpeak: true,
       onQueryChange,
       onStateChange,
     });
-    const { getState } = helper;
-    helper.toggleListening();
+
+    voiceSearchHelper.toggleListening();
     expect(onStateChange).toHaveBeenCalledTimes(1);
-    expect(getState().status).toEqual('askingPermission');
+    expect(voiceSearchHelper.getState().status).toEqual('askingPermission');
     recognition.onstart();
-    expect(getState().status).toEqual('waiting');
+    expect(voiceSearchHelper.getState().status).toEqual('waiting');
     recognition.onresult({
       results: [
         (() => {
@@ -135,13 +137,13 @@ describe('VoiceSearchHelper', () => {
         })(),
       ],
     });
-    expect(getState().status).toEqual('recognizing');
-    expect(getState().transcript).toEqual('Hello World');
-    expect(getState().isSpeechFinal).toBe(true);
+    expect(voiceSearchHelper.getState().status).toEqual('recognizing');
+    expect(voiceSearchHelper.getState().transcript).toEqual('Hello World');
+    expect(voiceSearchHelper.getState().isSpeechFinal).toBe(true);
     expect(onQueryChange).toHaveBeenCalledWith('Hello World');
     recognition.onend();
     expect(onQueryChange).toHaveBeenCalledTimes(1);
-    expect(getState().status).toEqual('finished');
+    expect(voiceSearchHelper.getState().status).toEqual('finished');
   });
 
   it('works with onerror', () => {
@@ -154,19 +156,18 @@ describe('VoiceSearchHelper', () => {
     }));
     const onQueryChange = jest.fn();
     const onStateChange = jest.fn();
-    const helper = getHelper({
+    const voiceSearchHelper = getVoiceSearchHelper({
       searchAsYouSpeak: true,
       onQueryChange,
       onStateChange,
     });
-    const { getState } = helper;
-    helper.toggleListening();
-    expect(getState().status).toEqual('askingPermission');
+    voiceSearchHelper.toggleListening();
+    expect(voiceSearchHelper.getState().status).toEqual('askingPermission');
     recognition.onerror({
       error: 'not-allowed',
     });
-    expect(getState().status).toEqual('error');
-    expect(getState().errorCode).toEqual('not-allowed');
+    expect(voiceSearchHelper.getState().status).toEqual('error');
+    expect(voiceSearchHelper.getState().errorCode).toEqual('not-allowed');
     recognition.onend();
     expect(onQueryChange).toHaveBeenCalledTimes(0);
   });

--- a/src/widgets/query-rule-custom-data/__tests__/query-rule-custom-data-test.ts
+++ b/src/widgets/query-rule-custom-data/__tests__/query-rule-custom-data-test.ts
@@ -183,7 +183,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rule-
         });
         widget.dispose!({
           helper,
-          state: helper.getState(),
+          state: helper.state,
         });
 
         expect(unmountComponentAtNode).toHaveBeenCalledTimes(1);


### PR DESCRIPTION

Since https://github.com/algolia/algoliasearch-helper-js/pull/707 getState is the same as fetching state, we decided we want to get rid of it. This makes sure InstantSearch will be ready for that change