### PR TITLE
fix(types): improve types for voiceSearch

### DIFF
--- a/src/components/VoiceSearch/__tests__/VoiceSearch-test.tsx
+++ b/src/components/VoiceSearch/__tests__/VoiceSearch-test.tsx
@@ -14,6 +14,7 @@ const defaultProps: VoiceSearchProps = {
   voiceListeningState: {
     status: 'initial',
     isSpeechFinal: false,
+    transcript: '',
   },
   templates: {
     buttonText: 'button',

--- a/src/components/VoiceSearch/__tests__/VoiceSearch-test.tsx
+++ b/src/components/VoiceSearch/__tests__/VoiceSearch-test.tsx
@@ -13,6 +13,7 @@ const defaultProps: VoiceSearchProps = {
   toggleListening: () => {},
   voiceListeningState: {
     status: 'initial',
+    isSpeechFinal: false,
   },
   templates: {
     buttonText: 'button',

--- a/src/lib/voiceSearchHelper/__tests__/index-test.ts
+++ b/src/lib/voiceSearchHelper/__tests__/index-test.ts
@@ -32,7 +32,7 @@ describe('VoiceSearchHelper', () => {
     const voiceSearchHelper = getVoiceSearchHelper();
     expect(voiceSearchHelper.getState()).toEqual({
       errorCode: undefined,
-      isSpeechFinal: undefined,
+      isSpeechFinal: false,
       status: 'initial',
       transcript: undefined,
     });

--- a/src/lib/voiceSearchHelper/__tests__/index-test.ts
+++ b/src/lib/voiceSearchHelper/__tests__/index-test.ts
@@ -34,7 +34,7 @@ describe('VoiceSearchHelper', () => {
       errorCode: undefined,
       isSpeechFinal: false,
       status: 'initial',
-      transcript: undefined,
+      transcript: '',
     });
   });
 

--- a/src/lib/voiceSearchHelper/index.ts
+++ b/src/lib/voiceSearchHelper/index.ts
@@ -89,9 +89,10 @@ export default function voiceSearchHelper({
       setState({
         status: STATUS_RECOGNIZING,
         transcript:
-          event.results[0] &&
-          event.results[0][0] &&
-          event.results[0][0].transcript,
+          (event.results[0] &&
+            event.results[0][0] &&
+            event.results[0][0].transcript) ||
+          '',
         isSpeechFinal: event.results[0] && event.results[0].isFinal,
       });
       if (searchAsYouSpeak && state.transcript) {

--- a/src/lib/voiceSearchHelper/index.ts
+++ b/src/lib/voiceSearchHelper/index.ts
@@ -13,7 +13,7 @@ export type VoiceSearchHelperParams = {
 
 export type VoiceListeningState = {
   status: string;
-  transcript?: string;
+  transcript: string;
   isSpeechFinal: boolean;
   errorCode?: string;
 };
@@ -37,7 +37,7 @@ export default function voiceSearchHelper({
     (window as any).SpeechRecognition;
   const getDefaultState = (status: string): VoiceListeningState => ({
     status,
-    transcript: undefined,
+    transcript: '',
     isSpeechFinal: false,
     errorCode: undefined,
   });

--- a/src/lib/voiceSearchHelper/index.ts
+++ b/src/lib/voiceSearchHelper/index.ts
@@ -14,7 +14,7 @@ export type VoiceSearchHelperParams = {
 export type VoiceListeningState = {
   status: string;
   transcript?: string;
-  isSpeechFinal?: boolean;
+  isSpeechFinal: boolean;
   errorCode?: string;
 };
 
@@ -38,7 +38,7 @@ export default function voiceSearchHelper({
   const getDefaultState = (status: string): VoiceListeningState => ({
     status,
     transcript: undefined,
-    isSpeechFinal: undefined,
+    isSpeechFinal: false,
     errorCode: undefined,
   });
   let state: VoiceListeningState = getDefaultState(STATUS_INITIAL);

--- a/src/widgets/voice-search/__tests__/__snapshots__/voice-search-test.ts.snap
+++ b/src/widgets/voice-search/__tests__/__snapshots__/voice-search-test.ts.snap
@@ -23,7 +23,7 @@ exports[`voiceSearch() Rendering renders during init() 1`] = `
       "errorCode": undefined,
       "isSpeechFinal": false,
       "status": "initial",
-      "transcript": undefined,
+      "transcript": "",
     }
   }
 />
@@ -52,7 +52,7 @@ exports[`voiceSearch() Rendering renders during render() 1`] = `
       "errorCode": undefined,
       "isSpeechFinal": false,
       "status": "initial",
-      "transcript": undefined,
+      "transcript": "",
     }
   }
 />
@@ -81,7 +81,7 @@ exports[`voiceSearch() Rendering renders during render() 2`] = `
       "errorCode": undefined,
       "isSpeechFinal": false,
       "status": "initial",
-      "transcript": undefined,
+      "transcript": "",
     }
   }
 />

--- a/src/widgets/voice-search/__tests__/__snapshots__/voice-search-test.ts.snap
+++ b/src/widgets/voice-search/__tests__/__snapshots__/voice-search-test.ts.snap
@@ -21,7 +21,7 @@ exports[`voiceSearch() Rendering renders during init() 1`] = `
   voiceListeningState={
     Object {
       "errorCode": undefined,
-      "isSpeechFinal": undefined,
+      "isSpeechFinal": false,
       "status": "initial",
       "transcript": undefined,
     }
@@ -50,7 +50,7 @@ exports[`voiceSearch() Rendering renders during render() 1`] = `
   voiceListeningState={
     Object {
       "errorCode": undefined,
-      "isSpeechFinal": undefined,
+      "isSpeechFinal": false,
       "status": "initial",
       "transcript": undefined,
     }
@@ -79,7 +79,7 @@ exports[`voiceSearch() Rendering renders during render() 2`] = `
   voiceListeningState={
     Object {
       "errorCode": undefined,
-      "isSpeechFinal": undefined,
+      "isSpeechFinal": false,
       "status": "initial",
       "transcript": undefined,
     }

--- a/stories/voice-search.stories.ts
+++ b/stories/voice-search.stories.ts
@@ -171,7 +171,7 @@ storiesOf('VoiceSearch', module)
             status({ isListening, transcript }) {
               return `
                 <div class="layer listening-${isListening}">
-                  <span>${transcript ? transcript : ''}</span>
+                  <span>${transcript}</span>
                 </div>
               `;
             },


### PR DESCRIPTION
**Summary**

This makes the types of the two things non-optional.

* `isSpeechFinal`
* `transcript`

The related discussion is [here](https://github.com/algolia/react-instantsearch/pull/2316#discussion_r283886705)
