### PR TITLE
fix(voiceSearch): remove event listeners on dispose

### DIFF
--- a/src/connectors/voice-search/__tests__/connectVoiceSearch-test.js
+++ b/src/connectors/voice-search/__tests__/connectVoiceSearch-test.js
@@ -78,14 +78,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/voice-searc
       );
     });
 
-    it('calls unmount on disposal', () => {
+    it('calls unmount on `dispose`', () => {
       const { unmountFn, widget, helper } = getDefaultSetup();
       widget.init({ helper });
       widget.dispose({ helper, state: helper.state });
       expect(unmountFn).toHaveBeenCalledTimes(1);
     });
 
-    it('removes event listeners on disposal', () => {
+    it('removes event listeners on `dispose`', () => {
       const { widget, helper } = getDefaultSetup();
       widget.init({ helper });
       widget.dispose({ helper, state: helper.state });

--- a/src/connectors/voice-search/__tests__/connectVoiceSearch-test.js
+++ b/src/connectors/voice-search/__tests__/connectVoiceSearch-test.js
@@ -8,7 +8,7 @@ jest.mock('../../../lib/voiceSearchHelper', () => {
       isBrowserSupported: () => true,
       isListening: () => false,
       toggleListening: () => {},
-      removeEventListeners: jest.fn(),
+      dispose: jest.fn(),
       // ⬇️ for test
       changeState: () => onStateChange(),
       changeQuery: query => onQueryChange(query),
@@ -78,20 +78,18 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/voice-searc
       );
     });
 
-    it('calls unmount on dispose', () => {
+    it('calls unmount on disposal', () => {
       const { unmountFn, widget, helper } = getDefaultSetup();
       widget.init({ helper });
       widget.dispose({ helper, state: helper.state });
       expect(unmountFn).toHaveBeenCalledTimes(1);
     });
 
-    it('remove event listeners on dispose', () => {
+    it('removes event listeners on disposal', () => {
       const { widget, helper } = getDefaultSetup();
       widget.init({ helper });
       widget.dispose({ helper, state: helper.state });
-      expect(
-        widget._voiceSearchHelper.removeEventListeners
-      ).toHaveBeenCalledTimes(1);
+      expect(widget._voiceSearchHelper.dispose).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/connectors/voice-search/__tests__/connectVoiceSearch-test.js
+++ b/src/connectors/voice-search/__tests__/connectVoiceSearch-test.js
@@ -8,6 +8,7 @@ jest.mock('../../../lib/voiceSearchHelper', () => {
       isBrowserSupported: () => true,
       isListening: () => false,
       toggleListening: () => {},
+      removeEventListeners: jest.fn(),
       // ⬇️ for test
       changeState: () => onStateChange(),
       changeQuery: query => onQueryChange(query),
@@ -82,6 +83,15 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/voice-searc
       widget.init({ helper });
       widget.dispose({ helper, state: helper.state });
       expect(unmountFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('remove event listeners on dispose', () => {
+      const { widget, helper } = getDefaultSetup();
+      widget.init({ helper });
+      widget.dispose({ helper, state: helper.state });
+      expect(
+        widget._voiceSearchHelper.removeEventListeners
+      ).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/connectors/voice-search/connectVoiceSearch.ts
+++ b/src/connectors/voice-search/connectVoiceSearch.ts
@@ -116,8 +116,8 @@ const connectVoiceSearch: VoiceSearchConnector = (
         });
       },
       dispose({ state }) {
+        (this as any)._voiceSearchHelper.dispose();
         unmountFn();
-        (this as any)._voiceSearchHelper.removeEventListeners();
         return state.setQuery('');
       },
       getWidgetState(uiState, { searchParameters }) {

--- a/src/connectors/voice-search/connectVoiceSearch.ts
+++ b/src/connectors/voice-search/connectVoiceSearch.ts
@@ -4,7 +4,7 @@ import {
   noop,
 } from '../../lib/utils';
 import { Renderer, RenderOptions, WidgetFactory } from '../../types';
-import voiceSearchHelper, {
+import createVoiceSearchHelper, {
   VoiceListeningState,
   ToggleListening,
 } from '../../lib/voiceSearchHelper';
@@ -91,7 +91,7 @@ const connectVoiceSearch: VoiceSearchConnector = (
           };
           return setQueryAndSearch;
         })();
-        (this as any)._voiceSearchHelper = voiceSearchHelper({
+        (this as any)._voiceSearchHelper = createVoiceSearchHelper({
           searchAsYouSpeak,
           onQueryChange: query => (this as any)._refine(query),
           onStateChange: () => {

--- a/src/connectors/voice-search/connectVoiceSearch.ts
+++ b/src/connectors/voice-search/connectVoiceSearch.ts
@@ -117,6 +117,7 @@ const connectVoiceSearch: VoiceSearchConnector = (
       },
       dispose({ state }) {
         unmountFn();
+        (this as any)._voiceSearchHelper.removeEventListeners();
         return state.setQuery('');
       },
       getWidgetState(uiState, { searchParameters }) {

--- a/src/lib/voiceSearchHelper/__tests__/index-test.ts
+++ b/src/lib/voiceSearchHelper/__tests__/index-test.ts
@@ -8,11 +8,14 @@ declare global {
   }
 }
 
+const start = jest.fn();
+const stop = jest.fn();
+
 const createFakeSpeechRecognition = (): jest.Mock => {
   const listeners: any = {};
   const mock = jest.fn().mockImplementation(() => ({
-    start() {},
-    stop() {},
+    start,
+    stop,
     addEventListener(eventName: string, callback: () => void) {
       listeners[eventName] = callback;
     },
@@ -189,6 +192,6 @@ describe('VoiceSearchHelper', () => {
     });
     voiceSearchHelper.toggleListening();
     voiceSearchHelper.dispose();
-    expect(voiceSearchHelper.isListening()).toBe(false);
+    expect(stop).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/voiceSearchHelper/__tests__/index-test.ts
+++ b/src/lib/voiceSearchHelper/__tests__/index-test.ts
@@ -97,6 +97,7 @@ describe('VoiceSearchHelper', () => {
     listeners.start(); // This way, we're simulating `start` event of the SpeechRecognition.
     expect(voiceSearchHelper.getState().status).toEqual('waiting');
     listeners.result({
+      // Simulating `result` event of the SpeechRecognition.
       results: [
         (() => {
           const obj = [
@@ -113,7 +114,7 @@ describe('VoiceSearchHelper', () => {
     expect(voiceSearchHelper.getState().transcript).toEqual('Hello World');
     expect(voiceSearchHelper.getState().isSpeechFinal).toBe(true);
     expect(onQueryChange).toHaveBeenCalledTimes(0);
-    listeners.end();
+    listeners.end(); // Simulating `end` event of the SpeechRecognition.
     expect(onQueryChange).toHaveBeenCalledWith('Hello World');
     expect(voiceSearchHelper.getState().status).toEqual('finished');
   });
@@ -132,9 +133,10 @@ describe('VoiceSearchHelper', () => {
     voiceSearchHelper.toggleListening();
     expect(onStateChange).toHaveBeenCalledTimes(1);
     expect(voiceSearchHelper.getState().status).toEqual('askingPermission');
-    listeners.start();
+    listeners.start(); // Simulating `start` event of the SpeechRecognition.
     expect(voiceSearchHelper.getState().status).toEqual('waiting');
     listeners.result({
+      // Simulating `result` event of the SpeechRecognition.
       results: [
         (() => {
           const obj = [
@@ -151,7 +153,7 @@ describe('VoiceSearchHelper', () => {
     expect(voiceSearchHelper.getState().transcript).toEqual('Hello World');
     expect(voiceSearchHelper.getState().isSpeechFinal).toBe(true);
     expect(onQueryChange).toHaveBeenCalledWith('Hello World');
-    listeners.end();
+    listeners.end(); // Simulating `end` event of the SpeechRecognition.
     expect(onQueryChange).toHaveBeenCalledTimes(1);
     expect(voiceSearchHelper.getState().status).toEqual('finished');
   });
@@ -169,11 +171,12 @@ describe('VoiceSearchHelper', () => {
     voiceSearchHelper.toggleListening();
     expect(voiceSearchHelper.getState().status).toEqual('askingPermission');
     listeners.error({
+      // Simulating `error` event of the SpeechRecognition.
       error: 'not-allowed',
     });
     expect(voiceSearchHelper.getState().status).toEqual('error');
     expect(voiceSearchHelper.getState().errorCode).toEqual('not-allowed');
-    listeners.end();
+    listeners.end(); // Simulating `end` event of the SpeechRecognition.
     expect(onQueryChange).toHaveBeenCalledTimes(0);
   });
 

--- a/src/lib/voiceSearchHelper/__tests__/index-test.ts
+++ b/src/lib/voiceSearchHelper/__tests__/index-test.ts
@@ -61,11 +61,11 @@ describe('VoiceSearchHelper', () => {
   });
 
   it('works with mock SpeechRecognition (searchAsYouSpeak:false)', () => {
-    let recognition;
+    const listeners: any = {};
     window.SpeechRecognition = jest.fn().mockImplementation(() => ({
-      start() {
-        /* eslint-disable-next-line consistent-this */
-        recognition = this;
+      start() {},
+      addEventListener(eventName: string, callback: () => void) {
+        listeners[eventName] = callback;
       },
     }));
     const onQueryChange = jest.fn();
@@ -79,9 +79,9 @@ describe('VoiceSearchHelper', () => {
     voiceSearchHelper.toggleListening();
     expect(onStateChange).toHaveBeenCalledTimes(1);
     expect(voiceSearchHelper.getState().status).toEqual('askingPermission');
-    recognition.onstart();
+    listeners.start();
     expect(voiceSearchHelper.getState().status).toEqual('waiting');
-    recognition.onresult({
+    listeners.result({
       results: [
         (() => {
           const obj = [
@@ -98,17 +98,17 @@ describe('VoiceSearchHelper', () => {
     expect(voiceSearchHelper.getState().transcript).toEqual('Hello World');
     expect(voiceSearchHelper.getState().isSpeechFinal).toBe(true);
     expect(onQueryChange).toHaveBeenCalledTimes(0);
-    recognition.onend();
+    listeners.end();
     expect(onQueryChange).toHaveBeenCalledWith('Hello World');
     expect(voiceSearchHelper.getState().status).toEqual('finished');
   });
 
   it('works with mock SpeechRecognition (searchAsYouSpeak:true)', () => {
-    let recognition;
+    const listeners: any = {};
     window.SpeechRecognition = jest.fn().mockImplementation(() => ({
-      start() {
-        /* eslint-disable-next-line consistent-this */
-        recognition = this;
+      start() {},
+      addEventListener(eventName: string, callback: () => void) {
+        listeners[eventName] = callback;
       },
     }));
     const onQueryChange = jest.fn();
@@ -122,9 +122,9 @@ describe('VoiceSearchHelper', () => {
     voiceSearchHelper.toggleListening();
     expect(onStateChange).toHaveBeenCalledTimes(1);
     expect(voiceSearchHelper.getState().status).toEqual('askingPermission');
-    recognition.onstart();
+    listeners.start();
     expect(voiceSearchHelper.getState().status).toEqual('waiting');
-    recognition.onresult({
+    listeners.result({
       results: [
         (() => {
           const obj = [
@@ -141,17 +141,17 @@ describe('VoiceSearchHelper', () => {
     expect(voiceSearchHelper.getState().transcript).toEqual('Hello World');
     expect(voiceSearchHelper.getState().isSpeechFinal).toBe(true);
     expect(onQueryChange).toHaveBeenCalledWith('Hello World');
-    recognition.onend();
+    listeners.end();
     expect(onQueryChange).toHaveBeenCalledTimes(1);
     expect(voiceSearchHelper.getState().status).toEqual('finished');
   });
 
   it('works with onerror', () => {
-    let recognition;
+    const listeners: any = {};
     window.SpeechRecognition = jest.fn().mockImplementation(() => ({
-      start() {
-        /* eslint-disable-next-line consistent-this */
-        recognition = this;
+      start() {},
+      addEventListener(eventName: string, callback: () => void) {
+        listeners[eventName] = callback;
       },
     }));
     const onQueryChange = jest.fn();
@@ -163,12 +163,12 @@ describe('VoiceSearchHelper', () => {
     });
     voiceSearchHelper.toggleListening();
     expect(voiceSearchHelper.getState().status).toEqual('askingPermission');
-    recognition.onerror({
+    listeners.error({
       error: 'not-allowed',
     });
     expect(voiceSearchHelper.getState().status).toEqual('error');
     expect(voiceSearchHelper.getState().errorCode).toEqual('not-allowed');
-    recognition.onend();
+    listeners.end();
     expect(onQueryChange).toHaveBeenCalledTimes(0);
   });
 });

--- a/src/lib/voiceSearchHelper/__tests__/index-test.ts
+++ b/src/lib/voiceSearchHelper/__tests__/index-test.ts
@@ -12,16 +12,18 @@ const createFakeSpeechRecognition = () => {
   const listeners: any = {};
   const mock = jest.fn().mockImplementation(() => ({
     start() {},
+    stop() {},
     addEventListener(eventName: string, callback: () => void) {
       listeners[eventName] = callback;
     },
+    removeEventListener() {},
   }));
   (mock as any).listeners = listeners;
   return mock;
 };
 
 describe('VoiceSearchHelper', () => {
-  beforeEach(() => {
+  afterEach(() => {
     delete window.webkitSpeechRecognition;
     delete window.SpeechRecognition;
   });
@@ -173,5 +175,17 @@ describe('VoiceSearchHelper', () => {
     expect(voiceSearchHelper.getState().errorCode).toEqual('not-allowed');
     listeners.end();
     expect(onQueryChange).toHaveBeenCalledTimes(0);
+  });
+
+  it('stops listening on disposal', () => {
+    window.SpeechRecognition = createFakeSpeechRecognition();
+    const voiceSearchHelper = createVoiceSearchHelper({
+      searchAsYouSpeak: false,
+      onQueryChange: () => {},
+      onStateChange: () => {},
+    });
+    voiceSearchHelper.toggleListening();
+    voiceSearchHelper.dispose();
+    expect(voiceSearchHelper.isListening()).toBe(false);
   });
 });

--- a/src/lib/voiceSearchHelper/__tests__/index-test.ts
+++ b/src/lib/voiceSearchHelper/__tests__/index-test.ts
@@ -183,7 +183,7 @@ describe('VoiceSearchHelper', () => {
     expect(onQueryChange).toHaveBeenCalledTimes(0);
   });
 
-  it('stops listening on disposal', () => {
+  it('stops listening on `dispose`', () => {
     window.SpeechRecognition = createFakeSpeechRecognition();
     const voiceSearchHelper = createVoiceSearchHelper({
       searchAsYouSpeak: false,

--- a/src/lib/voiceSearchHelper/__tests__/index-test.ts
+++ b/src/lib/voiceSearchHelper/__tests__/index-test.ts
@@ -85,7 +85,7 @@ describe('VoiceSearchHelper', () => {
     voiceSearchHelper.toggleListening();
     expect(onStateChange).toHaveBeenCalledTimes(1);
     expect(voiceSearchHelper.getState().status).toEqual('askingPermission');
-    listeners.start();
+    listeners.start(); // This way, we're simulating `start` event of the SpeechRecognition.
     expect(voiceSearchHelper.getState().status).toEqual('waiting');
     listeners.result({
       results: [

--- a/src/lib/voiceSearchHelper/__tests__/index-test.ts
+++ b/src/lib/voiceSearchHelper/__tests__/index-test.ts
@@ -8,6 +8,18 @@ declare global {
   }
 }
 
+const createFakeSpeechRecognition = () => {
+  const listeners: any = {};
+  const mock = jest.fn().mockImplementation(() => ({
+    start() {},
+    addEventListener(eventName: string, callback: () => void) {
+      listeners[eventName] = callback;
+    },
+  }));
+  (mock as any).listeners = listeners;
+  return mock;
+};
+
 describe('VoiceSearchHelper', () => {
   beforeEach(() => {
     delete window.webkitSpeechRecognition;
@@ -57,7 +69,7 @@ describe('VoiceSearchHelper', () => {
   });
 
   it('is supported with SpeechRecognition', () => {
-    window.SpeechRecognition = () => {};
+    window.SpeechRecognition = createFakeSpeechRecognition();
     const voiceSearchHelper = createVoiceSearchHelper({
       searchAsYouSpeak: false,
       onQueryChange: () => {},
@@ -67,13 +79,8 @@ describe('VoiceSearchHelper', () => {
   });
 
   it('works with mock SpeechRecognition (searchAsYouSpeak:false)', () => {
-    const listeners: any = {};
-    window.SpeechRecognition = jest.fn().mockImplementation(() => ({
-      start() {},
-      addEventListener(eventName: string, callback: () => void) {
-        listeners[eventName] = callback;
-      },
-    }));
+    window.SpeechRecognition = createFakeSpeechRecognition();
+    const { listeners } = window.SpeechRecognition as any;
     const onQueryChange = jest.fn();
     const onStateChange = jest.fn();
     const voiceSearchHelper = createVoiceSearchHelper({
@@ -110,13 +117,8 @@ describe('VoiceSearchHelper', () => {
   });
 
   it('works with mock SpeechRecognition (searchAsYouSpeak:true)', () => {
-    const listeners: any = {};
-    window.SpeechRecognition = jest.fn().mockImplementation(() => ({
-      start() {},
-      addEventListener(eventName: string, callback: () => void) {
-        listeners[eventName] = callback;
-      },
-    }));
+    window.SpeechRecognition = createFakeSpeechRecognition();
+    const { listeners } = window.SpeechRecognition as any;
     const onQueryChange = jest.fn();
     const onStateChange = jest.fn();
     const voiceSearchHelper = createVoiceSearchHelper({
@@ -153,13 +155,8 @@ describe('VoiceSearchHelper', () => {
   });
 
   it('works with onerror', () => {
-    const listeners: any = {};
-    window.SpeechRecognition = jest.fn().mockImplementation(() => ({
-      start() {},
-      addEventListener(eventName: string, callback: () => void) {
-        listeners[eventName] = callback;
-      },
-    }));
+    window.SpeechRecognition = createFakeSpeechRecognition();
+    const { listeners } = window.SpeechRecognition as any;
     const onQueryChange = jest.fn();
     const onStateChange = jest.fn();
     const voiceSearchHelper = createVoiceSearchHelper({

--- a/src/lib/voiceSearchHelper/__tests__/index-test.ts
+++ b/src/lib/voiceSearchHelper/__tests__/index-test.ts
@@ -12,16 +12,16 @@ const start = jest.fn();
 const stop = jest.fn();
 
 const createFakeSpeechRecognition = (): jest.Mock => {
-  const listeners: any = {};
+  const simulateListener: any = {};
   const mock = jest.fn().mockImplementation(() => ({
     start,
     stop,
     addEventListener(eventName: string, callback: () => void) {
-      listeners[eventName] = callback;
+      simulateListener[eventName] = callback;
     },
     removeEventListener() {},
   }));
-  (mock as any).listeners = listeners;
+  (mock as any).simulateListener = simulateListener;
   return mock;
 };
 
@@ -85,7 +85,7 @@ describe('VoiceSearchHelper', () => {
 
   it('works with mock SpeechRecognition (searchAsYouSpeak:false)', () => {
     window.SpeechRecognition = createFakeSpeechRecognition();
-    const { listeners } = window.SpeechRecognition as any;
+    const { simulateListener } = window.SpeechRecognition as any;
     const onQueryChange = jest.fn();
     const onStateChange = jest.fn();
     const voiceSearchHelper = createVoiceSearchHelper({
@@ -97,10 +97,9 @@ describe('VoiceSearchHelper', () => {
     voiceSearchHelper.toggleListening();
     expect(onStateChange).toHaveBeenCalledTimes(1);
     expect(voiceSearchHelper.getState().status).toEqual('askingPermission');
-    listeners.start(); // This way, we're simulating `start` event of the SpeechRecognition.
+    simulateListener.start();
     expect(voiceSearchHelper.getState().status).toEqual('waiting');
-    listeners.result({
-      // Simulating `result` event of the SpeechRecognition.
+    simulateListener.result({
       results: [
         (() => {
           const obj = [
@@ -117,14 +116,14 @@ describe('VoiceSearchHelper', () => {
     expect(voiceSearchHelper.getState().transcript).toEqual('Hello World');
     expect(voiceSearchHelper.getState().isSpeechFinal).toBe(true);
     expect(onQueryChange).toHaveBeenCalledTimes(0);
-    listeners.end(); // Simulating `end` event of the SpeechRecognition.
+    simulateListener.end();
     expect(onQueryChange).toHaveBeenCalledWith('Hello World');
     expect(voiceSearchHelper.getState().status).toEqual('finished');
   });
 
   it('works with mock SpeechRecognition (searchAsYouSpeak:true)', () => {
     window.SpeechRecognition = createFakeSpeechRecognition();
-    const { listeners } = window.SpeechRecognition as any;
+    const { simulateListener } = window.SpeechRecognition as any;
     const onQueryChange = jest.fn();
     const onStateChange = jest.fn();
     const voiceSearchHelper = createVoiceSearchHelper({
@@ -136,10 +135,9 @@ describe('VoiceSearchHelper', () => {
     voiceSearchHelper.toggleListening();
     expect(onStateChange).toHaveBeenCalledTimes(1);
     expect(voiceSearchHelper.getState().status).toEqual('askingPermission');
-    listeners.start(); // Simulating `start` event of the SpeechRecognition.
+    simulateListener.start();
     expect(voiceSearchHelper.getState().status).toEqual('waiting');
-    listeners.result({
-      // Simulating `result` event of the SpeechRecognition.
+    simulateListener.result({
       results: [
         (() => {
           const obj = [
@@ -156,14 +154,14 @@ describe('VoiceSearchHelper', () => {
     expect(voiceSearchHelper.getState().transcript).toEqual('Hello World');
     expect(voiceSearchHelper.getState().isSpeechFinal).toBe(true);
     expect(onQueryChange).toHaveBeenCalledWith('Hello World');
-    listeners.end(); // Simulating `end` event of the SpeechRecognition.
+    simulateListener.end();
     expect(onQueryChange).toHaveBeenCalledTimes(1);
     expect(voiceSearchHelper.getState().status).toEqual('finished');
   });
 
   it('works with onerror', () => {
     window.SpeechRecognition = createFakeSpeechRecognition();
-    const { listeners } = window.SpeechRecognition as any;
+    const { simulateListener } = window.SpeechRecognition as any;
     const onQueryChange = jest.fn();
     const onStateChange = jest.fn();
     const voiceSearchHelper = createVoiceSearchHelper({
@@ -173,13 +171,12 @@ describe('VoiceSearchHelper', () => {
     });
     voiceSearchHelper.toggleListening();
     expect(voiceSearchHelper.getState().status).toEqual('askingPermission');
-    listeners.error({
-      // Simulating `error` event of the SpeechRecognition.
+    simulateListener.error({
       error: 'not-allowed',
     });
     expect(voiceSearchHelper.getState().status).toEqual('error');
     expect(voiceSearchHelper.getState().errorCode).toEqual('not-allowed');
-    listeners.end(); // Simulating `end` event of the SpeechRecognition.
+    simulateListener.end();
     expect(onQueryChange).toHaveBeenCalledTimes(0);
   });
 

--- a/src/lib/voiceSearchHelper/__tests__/index-test.ts
+++ b/src/lib/voiceSearchHelper/__tests__/index-test.ts
@@ -1,18 +1,4 @@
-import createVoiceSearchHelper, {
-  VoiceSearchHelper,
-  VoiceSearchHelperParams,
-} from '..';
-
-const getVoiceSearchHelper = (
-  opts?: VoiceSearchHelperParams
-): VoiceSearchHelper =>
-  createVoiceSearchHelper(
-    opts || {
-      searchAsYouSpeak: false,
-      onQueryChange: () => {},
-      onStateChange: () => {},
-    }
-  );
+import createVoiceSearchHelper from '..';
 
 type DummySpeechRecognition = () => void;
 declare global {
@@ -29,7 +15,11 @@ describe('VoiceSearchHelper', () => {
   });
 
   it('has initial state correctly', () => {
-    const voiceSearchHelper = getVoiceSearchHelper();
+    const voiceSearchHelper = createVoiceSearchHelper({
+      searchAsYouSpeak: false,
+      onQueryChange: () => {},
+      onStateChange: () => {},
+    });
     expect(voiceSearchHelper.getState()).toEqual({
       errorCode: undefined,
       isSpeechFinal: false,
@@ -39,24 +29,40 @@ describe('VoiceSearchHelper', () => {
   });
 
   it('is not supported', () => {
-    const voiceSearchHelper = getVoiceSearchHelper();
+    const voiceSearchHelper = createVoiceSearchHelper({
+      searchAsYouSpeak: false,
+      onQueryChange: () => {},
+      onStateChange: () => {},
+    });
     expect(voiceSearchHelper.isBrowserSupported()).toBe(false);
   });
 
   it('is not listening', () => {
-    const voiceSearchHelper = getVoiceSearchHelper();
+    const voiceSearchHelper = createVoiceSearchHelper({
+      searchAsYouSpeak: false,
+      onQueryChange: () => {},
+      onStateChange: () => {},
+    });
     expect(voiceSearchHelper.isListening()).toBe(false);
   });
 
   it('is supported with webkitSpeechRecognition', () => {
     window.webkitSpeechRecognition = () => {};
-    const voiceSearchHelper = getVoiceSearchHelper();
+    const voiceSearchHelper = createVoiceSearchHelper({
+      searchAsYouSpeak: false,
+      onQueryChange: () => {},
+      onStateChange: () => {},
+    });
     expect(voiceSearchHelper.isBrowserSupported()).toBe(true);
   });
 
   it('is supported with SpeechRecognition', () => {
     window.SpeechRecognition = () => {};
-    const voiceSearchHelper = getVoiceSearchHelper();
+    const voiceSearchHelper = createVoiceSearchHelper({
+      searchAsYouSpeak: false,
+      onQueryChange: () => {},
+      onStateChange: () => {},
+    });
     expect(voiceSearchHelper.isBrowserSupported()).toBe(true);
   });
 
@@ -70,7 +76,7 @@ describe('VoiceSearchHelper', () => {
     }));
     const onQueryChange = jest.fn();
     const onStateChange = jest.fn();
-    const voiceSearchHelper = getVoiceSearchHelper({
+    const voiceSearchHelper = createVoiceSearchHelper({
       searchAsYouSpeak: false,
       onQueryChange,
       onStateChange,
@@ -113,7 +119,7 @@ describe('VoiceSearchHelper', () => {
     }));
     const onQueryChange = jest.fn();
     const onStateChange = jest.fn();
-    const voiceSearchHelper = getVoiceSearchHelper({
+    const voiceSearchHelper = createVoiceSearchHelper({
       searchAsYouSpeak: true,
       onQueryChange,
       onStateChange,
@@ -156,7 +162,7 @@ describe('VoiceSearchHelper', () => {
     }));
     const onQueryChange = jest.fn();
     const onStateChange = jest.fn();
-    const voiceSearchHelper = getVoiceSearchHelper({
+    const voiceSearchHelper = createVoiceSearchHelper({
       searchAsYouSpeak: true,
       onQueryChange,
       onStateChange,

--- a/src/lib/voiceSearchHelper/__tests__/index-test.ts
+++ b/src/lib/voiceSearchHelper/__tests__/index-test.ts
@@ -8,7 +8,7 @@ declare global {
   }
 }
 
-const createFakeSpeechRecognition = () => {
+const createFakeSpeechRecognition = (): jest.Mock => {
   const listeners: any = {};
   const mock = jest.fn().mockImplementation(() => ({
     start() {},

--- a/src/lib/voiceSearchHelper/index.ts
+++ b/src/lib/voiceSearchHelper/index.ts
@@ -23,7 +23,7 @@ export type VoiceSearchHelper = {
   isBrowserSupported: () => boolean;
   isListening: () => boolean;
   toggleListening: () => void;
-  removeEventListeners: () => void;
+  dispose: () => void;
 };
 
 export type ToggleListening = () => void;
@@ -119,14 +119,17 @@ export default function voiceSearchHelper({
     recognition.start();
   };
 
-  const removeEventListeners = (): void => {
+  const dispose = (): void => {
     if (!recognition) {
       return;
     }
+    recognition.stop();
     recognition.removeEventListener('start', onStart);
     recognition.removeEventListener('error', onError);
     recognition.removeEventListener('result', onResult);
     recognition.removeEventListener('end', onEnd);
+    recognition = undefined;
+    resetState();
   };
 
   const toggleListening = (): void => {
@@ -145,6 +148,6 @@ export default function voiceSearchHelper({
     isBrowserSupported,
     isListening,
     toggleListening,
-    removeEventListeners,
+    dispose,
   };
 }

--- a/src/lib/voiceSearchHelper/index.ts
+++ b/src/lib/voiceSearchHelper/index.ts
@@ -129,7 +129,6 @@ export default function voiceSearchHelper({
     recognition.removeEventListener('result', onResult);
     recognition.removeEventListener('end', onEnd);
     recognition = undefined;
-    resetState();
   };
 
   const toggleListening = (): void => {

--- a/src/lib/voiceSearchHelper/index.ts
+++ b/src/lib/voiceSearchHelper/index.ts
@@ -28,7 +28,7 @@ export type VoiceSearchHelper = {
 
 export type ToggleListening = () => void;
 
-export default function voiceSearchHelper({
+export default function createVoiceSearchHelper({
   searchAsYouSpeak,
   onQueryChange,
   onStateChange,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This removes event listeners attached to SpeechRecognition instance when the widget is disposed.
The related discussion is [here](https://github.com/algolia/react-instantsearch/pull/2316#discussion_r283821410).

**Result**

It shouldn't change any user behaviour.