### PR TITLE
refactor(currentRefinements): update stories

### DIFF
--- a/stories/current-refinements.stories.js
+++ b/stories/current-refinements.stories.js
@@ -56,7 +56,7 @@ storiesOf('CurrentRefinements', module)
       search.addWidget(
         instantsearch.widgets.configure({
           hierarchicalFacetsRefinements: {
-            brand: ['Samsung'],
+            categories: ['Audio'],
           },
         })
       );
@@ -64,7 +64,7 @@ storiesOf('CurrentRefinements', module)
       search.addWidget(
         instantsearch.widgets.menu({
           container: menuContainer,
-          attribute: 'brand',
+          attribute: 'categories',
         })
       );
 

--- a/stories/current-refinements.stories.js
+++ b/stories/current-refinements.stories.js
@@ -49,6 +49,7 @@ storiesOf('CurrentRefinements', module)
     'with menu',
     withHits(({ search, container, instantsearch }) => {
       const currentRefinementsContainer = document.createElement('div');
+      currentRefinementsContainer.style.marginBottom = '10px';
       container.appendChild(currentRefinementsContainer);
       const menuContainer = document.createElement('div');
       container.appendChild(menuContainer);
@@ -79,6 +80,7 @@ storiesOf('CurrentRefinements', module)
     'with hierarchicalMenu',
     withHits(({ search, container, instantsearch }) => {
       const currentRefinementsContainer = document.createElement('div');
+      currentRefinementsContainer.style.marginBottom = '10px';
       container.appendChild(currentRefinementsContainer);
       const hierarchicalMenuContainer = document.createElement('div');
       container.appendChild(hierarchicalMenuContainer);
@@ -114,6 +116,7 @@ storiesOf('CurrentRefinements', module)
     'with toggleRefinement',
     withHits(({ search, container, instantsearch }) => {
       const currentRefinementsContainer = document.createElement('div');
+      currentRefinementsContainer.style.marginBottom = '10px';
       container.appendChild(currentRefinementsContainer);
       const toggleRefinementContainer = document.createElement('div');
       container.appendChild(toggleRefinementContainer);
@@ -158,6 +161,7 @@ storiesOf('CurrentRefinements', module)
     'with rangeInput',
     withHits(({ search, container, instantsearch }) => {
       const currentRefinementsContainer = document.createElement('div');
+      currentRefinementsContainer.style.marginBottom = '10px';
       container.appendChild(currentRefinementsContainer);
       const rangeInputContainer = document.createElement('div');
       container.appendChild(rangeInputContainer);

--- a/stories/current-refinements.stories.js
+++ b/stories/current-refinements.stories.js
@@ -7,10 +7,6 @@ storiesOf('CurrentRefinements', module)
     withHits(({ search, container, instantsearch }) => {
       const currentRefinementsContainer = document.createElement('div');
       container.appendChild(currentRefinementsContainer);
-      const refinementListContainer = document.createElement('div');
-      container.appendChild(refinementListContainer);
-      const numericMenuContainer = document.createElement('div');
-      container.appendChild(numericMenuContainer);
 
       search.addWidget(
         instantsearch.widgets.configure({
@@ -25,27 +21,6 @@ storiesOf('CurrentRefinements', module)
           container: currentRefinementsContainer,
         })
       );
-
-      search.addWidget(
-        instantsearch.widgets.refinementList({
-          container: refinementListContainer,
-          attribute: 'brand',
-        })
-      );
-
-      search.addWidget(
-        instantsearch.widgets.numericMenu({
-          container: numericMenuContainer,
-          attribute: 'price',
-          items: [
-            { label: 'All' },
-            { end: 10, label: '≤ $10' },
-            { start: 10, end: 100, label: '$10–$100' },
-            { start: 100, end: 500, label: '$100–$500' },
-            { start: 500, label: '≥ $500' },
-          ],
-        })
-      );
     })
   )
   .add(
@@ -53,8 +28,6 @@ storiesOf('CurrentRefinements', module)
     withHits(({ search, container, instantsearch }) => {
       const currentRefinementsContainer = document.createElement('div');
       container.appendChild(currentRefinementsContainer);
-      const refinementListContainer = document.createElement('div');
-      container.appendChild(refinementListContainer);
 
       search.addWidget(
         instantsearch.widgets.configure({
@@ -62,13 +35,6 @@ storiesOf('CurrentRefinements', module)
             brand: ['Google', 'Apple', 'Samsung'],
           },
           disjunctiveFacets: ['brand'],
-        })
-      );
-
-      search.addWidget(
-        instantsearch.widgets.refinementList({
-          container: refinementListContainer,
-          attribute: 'brand',
         })
       );
 
@@ -174,26 +140,10 @@ storiesOf('CurrentRefinements', module)
     withHits(({ search, container, instantsearch }) => {
       const currentRefinementsContainer = document.createElement('div');
       container.appendChild(currentRefinementsContainer);
-      const numericMenuContainer = document.createElement('div');
-      container.appendChild(numericMenuContainer);
 
       search.addWidget(
         instantsearch.widgets.configure({
           numericRefinements: { price: { '<=': [10] } },
-        })
-      );
-
-      search.addWidget(
-        instantsearch.widgets.numericMenu({
-          container: numericMenuContainer,
-          attribute: 'price',
-          items: [
-            { label: 'All' },
-            { end: 10, label: '≤ $10' },
-            { start: 10, end: 100, label: '$10–$100' },
-            { start: 100, end: 500, label: '$100–$500' },
-            { start: 500, label: '≥ $500' },
-          ],
         })
       );
 
@@ -237,38 +187,10 @@ storiesOf('CurrentRefinements', module)
     withHits(({ search, container, instantsearch }) => {
       const currentRefinementsContainer = document.createElement('div');
       container.appendChild(currentRefinementsContainer);
-      const toggleRefinementContainer = document.createElement('div');
-      container.appendChild(toggleRefinementContainer);
-      const numericMenuContainer = document.createElement('div');
-      container.appendChild(numericMenuContainer);
 
       search.addWidget(
         instantsearch.widgets.configure({
           numericRefinements: { price: { '<=': [10] } },
-        })
-      );
-
-      search.addWidget(
-        instantsearch.widgets.numericMenu({
-          container: numericMenuContainer,
-          attribute: 'price',
-          items: [
-            { label: 'All' },
-            { end: 10, label: '≤ $10' },
-            { start: 10, end: 100, label: '$10–$100' },
-            { start: 100, end: 500, label: '$100–$500' },
-            { start: 500, label: '≥ $500' },
-          ],
-        })
-      );
-
-      search.addWidget(
-        instantsearch.widgets.toggleRefinement({
-          container: toggleRefinementContainer,
-          attribute: 'free_shipping',
-          templates: {
-            labelText: 'Free Shipping',
-          },
         })
       );
 
@@ -285,10 +207,6 @@ storiesOf('CurrentRefinements', module)
     withHits(({ search, container, instantsearch }) => {
       const currentRefinementsContainer = document.createElement('div');
       container.appendChild(currentRefinementsContainer);
-      const refinementListContainer = document.createElement('div');
-      container.appendChild(refinementListContainer);
-      const numericMenuContainer = document.createElement('div');
-      container.appendChild(numericMenuContainer);
 
       search.addWidget(
         instantsearch.widgets.configure({
@@ -304,27 +222,6 @@ storiesOf('CurrentRefinements', module)
           excludedAttributes: ['query', 'price'],
         })
       );
-
-      search.addWidget(
-        instantsearch.widgets.refinementList({
-          container: refinementListContainer,
-          attribute: 'brand',
-        })
-      );
-
-      search.addWidget(
-        instantsearch.widgets.numericMenu({
-          container: numericMenuContainer,
-          attribute: 'price',
-          items: [
-            { label: 'All' },
-            { end: 10, label: '≤ $10' },
-            { start: 10, end: 100, label: '$10–$100' },
-            { start: 100, end: 500, label: '$100–$500' },
-            { start: 500, label: '≥ $500' },
-          ],
-        })
-      );
     })
   )
   .add(
@@ -332,10 +229,6 @@ storiesOf('CurrentRefinements', module)
     withHits(({ search, container, instantsearch }) => {
       const currentRefinementsContainer = document.createElement('div');
       container.appendChild(currentRefinementsContainer);
-      const refinementListContainer = document.createElement('div');
-      container.appendChild(refinementListContainer);
-      const numericMenuContainer = document.createElement('div');
-      container.appendChild(numericMenuContainer);
 
       search.addWidget(
         instantsearch.widgets.configure({
@@ -351,27 +244,6 @@ storiesOf('CurrentRefinements', module)
           excludedAttributes: [],
         })
       );
-
-      search.addWidget(
-        instantsearch.widgets.refinementList({
-          container: refinementListContainer,
-          attribute: 'brand',
-        })
-      );
-
-      search.addWidget(
-        instantsearch.widgets.numericMenu({
-          container: numericMenuContainer,
-          attribute: 'price',
-          items: [
-            { label: 'All' },
-            { end: 10, label: '≤ $10' },
-            { start: 10, end: 100, label: '$10–$100' },
-            { start: 100, end: 500, label: '$100–$500' },
-            { start: 500, label: '≥ $500' },
-          ],
-        })
-      );
     })
   )
   .add(
@@ -379,10 +251,6 @@ storiesOf('CurrentRefinements', module)
     withHits(({ search, container, instantsearch }) => {
       const currentRefinementsContainer = document.createElement('div');
       container.appendChild(currentRefinementsContainer);
-      const refinementListContainer = document.createElement('div');
-      container.appendChild(refinementListContainer);
-      const numericMenuContainer = document.createElement('div');
-      container.appendChild(numericMenuContainer);
 
       search.addWidget(
         instantsearch.widgets.configure({
@@ -403,27 +271,6 @@ storiesOf('CurrentRefinements', module)
                 label: item.label.toUpperCase(),
               })),
             })),
-        })
-      );
-
-      search.addWidget(
-        instantsearch.widgets.refinementList({
-          container: refinementListContainer,
-          attribute: 'brand',
-        })
-      );
-
-      search.addWidget(
-        instantsearch.widgets.numericMenu({
-          container: numericMenuContainer,
-          attribute: 'price',
-          items: [
-            { label: 'All' },
-            { end: 10, label: '≤ $10' },
-            { start: 10, end: 100, label: '$10–$100' },
-            { start: 100, end: 500, label: '$100–$500' },
-            { start: 500, label: '≥ $500' },
-          ],
         })
       );
     })


### PR DESCRIPTION
**Summary**

This PR clean the `currentRefinements` stories.

- remove the duplicated widgets
- change the attribute of menu to avoid collision with the `refinementList`

**Result**

Check out the example inside [Storybook](https://deploy-preview-3781--instantsearchjs.netlify.com/stories/?path=/story/currentrefinements--default).