### PR TITLE
refactor(helper): update listeners [PART-4]

### DIFF
--- a/src/connectors/autocomplete/connectAutocomplete.js
+++ b/src/connectors/autocomplete/connectAutocomplete.js
@@ -121,7 +121,7 @@ export default function connectAutocomplete(renderFn, unmountFn) {
       },
 
       renderWithAllIndices({ isFirstRendering = false } = {}) {
-        const currentRefinement = this.indices[0].helper.state.query;
+        const currentRefinement = this.indices[0].helper.state.query || '';
 
         renderFn(
           {

--- a/src/connectors/autocomplete/connectAutocomplete.js
+++ b/src/connectors/autocomplete/connectAutocomplete.js
@@ -87,7 +87,7 @@ export default function connectAutocomplete(renderFn, unmountFn) {
           });
 
           // update results then trigger render after a search from any helper
-          derivedHelper.on('result', results =>
+          derivedHelper.on('result', ({ results }) =>
             this.saveResults({ results, label })
           );
         });

--- a/src/connectors/geo-search/connectGeoSearch.js
+++ b/src/connectors/geo-search/connectGeoSearch.js
@@ -212,7 +212,7 @@ http://community.algolia.com/instantsearch.js/migration-guide
     };
 
     const clearMapRefinement = helper => () => {
-      helper.setQueryParameter('insideBoundingBox').search();
+      helper.setQueryParameter('insideBoundingBox', undefined).search();
     };
 
     const isRefinedWithMap = state => () => Boolean(state.insideBoundingBox);
@@ -338,7 +338,7 @@ http://community.algolia.com/instantsearch.js/migration-guide
       dispose({ state }) {
         unmountFn();
 
-        return state.setQueryParameter('insideBoundingBox');
+        return state.setQueryParameter('insideBoundingBox', undefined);
       },
 
       getWidgetState(uiState, { searchParameters }) {
@@ -363,7 +363,10 @@ http://community.algolia.com/instantsearch.js/migration-guide
 
       getWidgetSearchParameters(searchParameters, { uiState }) {
         if (!uiState || !uiState.geoSearch) {
-          return searchParameters.setQueryParameter('insideBoundingBox');
+          return searchParameters.setQueryParameter(
+            'insideBoundingBox',
+            undefined
+          );
         }
 
         return searchParameters.setQueryParameter(

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -225,7 +225,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     expect(secondRenderingOptions.hits).toEqual(hits);
     expect(secondRenderingOptions.results).toEqual(results);
     showPrevious();
-    expect(helper.getPage()).toBe(0);
+    expect(helper.state.page).toBe(0);
     expect(helper.emit).not.toHaveBeenCalled();
     expect(helper.search).toHaveBeenCalledTimes(1);
 
@@ -708,6 +708,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
           searchParametersBefore,
           { uiState }
         );
+
         // Applying the same values should not return a new object
         expect(searchParametersAfter).toBe(searchParametersBefore);
       });
@@ -741,7 +742,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
         );
         // Applying an empty state, should force back to page 0
         expect(searchParametersAfter).toMatchSnapshot();
-        expect(searchParametersAfter.page).toBe(0);
+        expect(searchParametersAfter.page).toBeUndefined();
       });
 
       it('should add the refinements according to the UI state provided', () => {

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -146,8 +146,8 @@ const connectInfiniteHits: InfiniteHitsConnector = (
       init({ instantSearchInstance, helper }) {
         showPrevious = getShowPrevious(helper);
         showMore = getShowMore(helper);
-        firstReceivedPage = helper.state.page!;
-        lastReceivedPage = helper.state.page!;
+        firstReceivedPage = helper.state.page || 0;
+        lastReceivedPage = helper.state.page || 0;
 
         renderFn(
           {
@@ -171,11 +171,12 @@ const connectInfiniteHits: InfiniteHitsConnector = (
         // We're doing this to "reset" the widget if a refinement or the
         // query changes between renders, but we want to keep it as is
         // if we only change pages.
-        const { page, ...currentState } = state;
+        const { page = 0, ...currentState } = state;
+
         if (!isEqual(currentState, prevState)) {
           hitsCache = [];
-          firstReceivedPage = page!;
-          lastReceivedPage = page!;
+          firstReceivedPage = page;
+          lastReceivedPage = page;
           prevState = currentState;
         }
 
@@ -193,12 +194,12 @@ const connectInfiniteHits: InfiniteHitsConnector = (
 
         results.hits = transformItems(results.hits);
 
-        if (lastReceivedPage < page! || !hitsCache.length) {
+        if (lastReceivedPage < page || !hitsCache.length) {
           hitsCache = [...hitsCache, ...results.hits];
-          lastReceivedPage = page!;
-        } else if (firstReceivedPage > page!) {
+          lastReceivedPage = page;
+        } else if (firstReceivedPage > page) {
           hitsCache = [...results.hits, ...hitsCache];
-          firstReceivedPage = page!;
+          firstReceivedPage = page;
         }
 
         const isFirstPage = firstReceivedPage === 0;
@@ -224,7 +225,7 @@ const connectInfiniteHits: InfiniteHitsConnector = (
       },
 
       getWidgetState(uiState, { searchParameters }) {
-        const page = searchParameters.page!;
+        const page = searchParameters.page || 0;
 
         if (!hasShowPrevious || page === 0 || page + 1 === uiState.page) {
           return uiState;
@@ -240,11 +241,14 @@ const connectInfiniteHits: InfiniteHitsConnector = (
         if (!hasShowPrevious) {
           return searchParameters;
         }
+
         const uiPage = uiState.page;
+
         if (uiPage) {
           return searchParameters.setQueryParameter('page', uiPage - 1);
         }
-        return searchParameters.setQueryParameter('page', 0);
+
+        return searchParameters.setQueryParameter('page', undefined);
       },
     };
   };

--- a/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.js
+++ b/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.js
@@ -465,7 +465,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
     expect(secondRenderingOptions.items[0].isRefined).toBe(true);
   });
 
-  it('should reset page on refine()', () => {
+  it('should reset page to 0 on refine() when the page is defined', () => {
     const rendering = jest.fn();
     const makeWidget = connectNumericMenu(rendering);
 
@@ -499,6 +499,41 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
     refine(items[0].value);
 
     expect(helper.state.page).toBe(0);
+  });
+
+  it('should not reset page on refine() when the page is not defined', () => {
+    const rendering = jest.fn();
+    const makeWidget = connectNumericMenu(rendering);
+
+    const widget = makeWidget({
+      attribute: 'numerics',
+      items: [
+        { label: 'below 10', end: 10 },
+        { label: '10 - 20', start: 10, end: 20 },
+        { label: 'more than 20', start: 20 },
+        { label: '42', start: 42, end: 42 },
+        { label: 'void' },
+      ],
+    });
+
+    const helper = jsHelper({});
+    helper.search = jest.fn();
+
+    widget.init({
+      helper,
+      state: helper.state,
+      createURL: () => '#',
+      onHistoryChange: () => {},
+    });
+
+    expect(helper.state.page).toBeUndefined();
+
+    const firstRenderingOptions = rendering.mock.calls[0][0];
+    const { refine, items } = firstRenderingOptions;
+
+    refine(items[0].value);
+
+    expect(helper.state.page).toBeUndefined();
   });
 
   describe('routing', () => {

--- a/src/connectors/numeric-menu/connectNumericMenu.js
+++ b/src/connectors/numeric-menu/connectNumericMenu.js
@@ -340,7 +340,9 @@ function refine(state, attribute, items, facetValue) {
     }
   }
 
-  resolvedState.page = 0;
+  if (typeof resolvedState.page === 'number') {
+    resolvedState.page = 0;
+  }
 
   return resolvedState;
 }

--- a/src/connectors/pagination/__tests__/connectPagination-test.js
+++ b/src/connectors/pagination/__tests__/connectPagination-test.js
@@ -110,7 +110,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/pagination/
         rendering.mock.calls[rendering.mock.calls.length - 1][0];
       const { refine } = renderOptions;
       refine(2);
-      expect(helper.getPage()).toBe(2);
+      expect(helper.state.page).toBe(2);
       expect(helper.search).toHaveBeenCalledTimes(1);
     }
 
@@ -131,7 +131,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/pagination/
         rendering.mock.calls[rendering.mock.calls.length - 1][0];
       const { refine } = renderOptions;
       refine(7);
-      expect(helper.getPage()).toBe(7);
+      expect(helper.state.page).toBe(7);
       expect(helper.search).toHaveBeenCalledTimes(2);
     }
   });
@@ -354,7 +354,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/pagination/
         );
         // Applying an empty state, should force back to page 0
         expect(searchParametersAfter).toMatchSnapshot();
-        expect(searchParametersAfter.page).toBe(0);
+        expect(searchParametersAfter.page).toBeUndefined();
       });
 
       test('should add the refinements according to the UI state provided', () => {

--- a/src/connectors/pagination/connectPagination.js
+++ b/src/connectors/pagination/connectPagination.js
@@ -108,7 +108,7 @@ export default function connectPagination(renderFn, unmountFn) {
         renderFn(
           {
             createURL: this.createURL(helper.state),
-            currentRefinement: helper.getPage() || 0,
+            currentRefinement: helper.state.page || 0,
             nbHits: 0,
             nbPages: 0,
             pages: [],
@@ -129,14 +129,15 @@ export default function connectPagination(renderFn, unmountFn) {
       },
 
       render({ results, state, instantSearchInstance }) {
+        const page = state.page || 0;
         const nbPages = this.getMaxPage(results);
-        pager.currentPage = state.page;
+        pager.currentPage = page;
         pager.total = nbPages;
 
         renderFn(
           {
             createURL: this.createURL(state),
-            currentRefinement: state.page,
+            currentRefinement: page,
             refine: this.refine,
             nbHits: results.nbHits,
             nbPages,
@@ -155,8 +156,12 @@ export default function connectPagination(renderFn, unmountFn) {
       },
 
       getWidgetState(uiState, { searchParameters }) {
-        const page = searchParameters.page;
-        if (page === 0 || page + 1 === uiState.page) return uiState;
+        const page = searchParameters.page || 0;
+
+        if (page === 0 || page + 1 === uiState.page) {
+          return uiState;
+        }
+
         return {
           ...uiState,
           page: page + 1,
@@ -165,9 +170,12 @@ export default function connectPagination(renderFn, unmountFn) {
 
       getWidgetSearchParameters(searchParameters, { uiState }) {
         const uiPage = uiState.page;
-        if (uiPage)
+
+        if (uiPage) {
           return searchParameters.setQueryParameter('page', uiState.page - 1);
-        return searchParameters.setQueryParameter('page', 0);
+        }
+
+        return searchParameters.setQueryParameter('page', undefined);
       },
     };
   };

--- a/src/connectors/query-rules/connectQueryRules.ts
+++ b/src/connectors/query-rules/connectQueryRules.ts
@@ -18,6 +18,10 @@ import {
   NumericRefinement as InternalNumericRefinement,
 } from '../../lib/utils/getRefinements';
 
+type HelperChangeEvent = {
+  state: SearchParameters;
+};
+
 type TrackedFilterRefinement = string | number | boolean;
 
 export type ParamTrackedFilters = {
@@ -126,7 +130,7 @@ function applyRuleContexts(
     trackedFilters: ParamTrackedFilters;
     transformRuleContexts: ParamTransformRuleContexts;
   },
-  sharedHelperState: SearchParameters
+  event: HelperChangeEvent
 ): void {
   const {
     helper,
@@ -135,6 +139,7 @@ function applyRuleContexts(
     transformRuleContexts,
   } = this;
 
+  const sharedHelperState = event.state;
   const previousRuleContexts: string[] = sharedHelperState.ruleContexts || [];
   const newRuleContexts = getRuleContextsFromTrackedFilters({
     helper,
@@ -186,7 +191,7 @@ const connectQueryRules: QueryRulesConnector = (render, unmount = noop) => {
     // We store the initial rule contexts applied before creating the widget
     // so that we do not override them with the rules created from `trackedFilters`.
     let initialRuleContexts: string[] = [];
-    let onHelperChange: (state: SearchParameters) => void;
+    let onHelperChange: (event: HelperChangeEvent) => void;
 
     return {
       init({ helper, state, instantSearchInstance }) {
@@ -207,11 +212,13 @@ const connectQueryRules: QueryRulesConnector = (render, unmount = noop) => {
             hasStateRefinements(state) ||
             Boolean(widgetParams.transformRuleContexts)
           ) {
-            onHelperChange(state);
+            onHelperChange({ state });
           }
 
           // We track every change in the helper to override its state and add
           // any `ruleContexts` needed based on the `trackedFilters`.
+          // @ts-ignore
+          // @TODO: we have to update the definition to make it work
           helper.on('change', onHelperChange);
         }
 

--- a/src/connectors/query-rules/connectQueryRules.ts
+++ b/src/connectors/query-rules/connectQueryRules.ts
@@ -3,6 +3,7 @@ import {
   RenderOptions,
   WidgetFactory,
   Helper,
+  HelperChangeEvent,
   SearchParameters,
 } from '../../types';
 import {
@@ -17,10 +18,6 @@ import {
   Refinement as InternalRefinement,
   NumericRefinement as InternalNumericRefinement,
 } from '../../lib/utils/getRefinements';
-
-type HelperChangeEvent = {
-  state: SearchParameters;
-};
 
 type TrackedFilterRefinement = string | number | boolean;
 

--- a/src/connectors/search-box/__tests__/connectSearchBox-test.js
+++ b/src/connectors/search-box/__tests__/connectSearchBox-test.js
@@ -44,7 +44,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
     // should provide good values for the first rendering
     expect(rendering).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        query: helper.state.query,
+        query: '',
         widgetParams: { foo: 'bar' },
       }),
       true
@@ -63,7 +63,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
     // should provide good values after the first search
     expect(rendering).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        query: helper.state.query,
+        query: '',
         widgetParams: { foo: 'bar' },
       }),
       false
@@ -88,8 +88,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
 
     {
       // first rendering
-      expect(helper.state.query).toBe('');
-      const { refine } = rendering.mock.calls[0][0];
+      const { refine, query } = rendering.mock.calls[0][0];
+      expect(helper.state.query).toBeUndefined();
+      expect(query).toBe('');
       refine('bip');
       expect(helper.state.query).toBe('bip');
       expect(helper.search).toHaveBeenCalledTimes(1);
@@ -105,8 +106,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
 
     {
       // Second rendering
-      expect(helper.state.query).toBe('bip');
       const { refine, query } = rendering.mock.calls[1][0];
+      expect(helper.state.query).toBe('bip');
       expect(query).toBe('bip');
       refine('bop');
       expect(helper.state.query).toBe('bop');
@@ -191,10 +192,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
 
       refine('bip');
       expect(queryHook).toHaveBeenCalledTimes(1);
-      expect(helper.state.query).toBe('');
+      expect(helper.state.query).toBeUndefined();
       expect(helper.search).not.toHaveBeenCalled();
 
       letSearchThrough = true;
+
       refine('bip');
       expect(queryHook).toHaveBeenCalledTimes(2);
       expect(helper.state.query).toBe('bip');

--- a/src/connectors/search-box/connectSearchBox.js
+++ b/src/connectors/search-box/connectSearchBox.js
@@ -103,7 +103,7 @@ export default function connectSearchBox(renderFn, unmountFn) {
 
         renderFn(
           {
-            query: helper.state.query,
+            query: helper.state.query || '',
             refine: this._refine,
             clear: this._cachedClear,
             widgetParams,
@@ -118,7 +118,7 @@ export default function connectSearchBox(renderFn, unmountFn) {
 
         renderFn(
           {
-            query: helper.state.query,
+            query: helper.state.query || '',
             refine: this._refine,
             clear: this._cachedClear,
             widgetParams,
@@ -131,11 +131,12 @@ export default function connectSearchBox(renderFn, unmountFn) {
 
       dispose({ state }) {
         unmountFn();
+
         return state.setQuery('');
       },
 
       getWidgetState(uiState, { searchParameters }) {
-        const query = searchParameters.query;
+        const query = searchParameters.query || '';
 
         if (query === '' || (uiState && uiState.query === query)) {
           return uiState;
@@ -148,7 +149,7 @@ export default function connectSearchBox(renderFn, unmountFn) {
       },
 
       getWidgetSearchParameters(searchParameters, { uiState }) {
-        return searchParameters.setQuery(uiState.query || '');
+        return searchParameters.setQueryParameter('query', uiState.query);
       },
     };
   };

--- a/src/connectors/stats/__tests__/connectStats-test.js
+++ b/src/connectors/stats/__tests__/connectStats-test.js
@@ -58,9 +58,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/stats/js/#c
       expect(hitsPerPage).toBe(helper.state.hitsPerPage);
       expect(nbHits).toBe(0);
       expect(nbPages).toBe(0);
-      expect(page).toBe(helper.state.page);
+      expect(page).toBe(0);
       expect(processingTimeMS).toBe(-1);
-      expect(query).toBe(helper.state.query);
+      expect(query).toBe('');
       expect(widgetParams).toEqual({ foo: 'bar' });
     }
 
@@ -72,7 +72,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/stats/js/#c
           nbHits: 1,
           hitsPerPage: helper.state.hitsPerPage,
           page: helper.state.page,
-          query: helper.state.query,
+          query: '',
           processingTimeMS: 12,
         },
       ]),
@@ -102,7 +102,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/stats/js/#c
       expect(nbPages).toBe(1);
       expect(page).toBe(helper.state.page);
       expect(processingTimeMS).toBe(12);
-      expect(query).toBe(helper.state.query);
+      expect(query).toBe('');
     }
   });
 });

--- a/src/connectors/stats/connectStats.js
+++ b/src/connectors/stats/connectStats.js
@@ -57,9 +57,9 @@ export default function connectStats(renderFn, unmountFn) {
           hitsPerPage: helper.state.hitsPerPage,
           nbHits: 0,
           nbPages: 0,
-          page: helper.state.page,
+          page: helper.state.page || 0,
           processingTimeMS: -1,
-          query: helper.state.query,
+          query: helper.state.query || '',
           widgetParams,
         },
         true

--- a/src/connectors/toggleRefinement/connectToggleRefinement.js
+++ b/src/connectors/toggleRefinement/connectToggleRefinement.js
@@ -150,7 +150,7 @@ export default function connectToggleRefinement(renderFn, unmountFn) {
         if (hasAnOffValue) {
           // Add filtering on the 'off' value if set
           if (!isRefined) {
-            const currentPage = helper.getPage();
+            const currentPage = helper.state.page;
             helper
               .addDisjunctiveFacetRefinement(attribute, off)
               .setPage(currentPage);

--- a/src/connectors/voice-search/__tests__/connectVoiceSearch-test.js
+++ b/src/connectors/voice-search/__tests__/connectVoiceSearch-test.js
@@ -188,7 +188,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/voice-searc
         searchParametersBefore,
         { uiState }
       );
-      expect(searchParametersAfter.query).toBe('');
+      expect(searchParametersAfter.query).toBeUndefined();
     });
   });
 });

--- a/src/connectors/voice-search/connectVoiceSearch.ts
+++ b/src/connectors/voice-search/connectVoiceSearch.ts
@@ -112,7 +112,7 @@ const connectVoiceSearch: VoiceSearchConnector = (
         return state.setQuery('');
       },
       getWidgetState(uiState, { searchParameters }) {
-        const query = searchParameters.query;
+        const query = searchParameters.query || '';
 
         if (query === '' || (uiState && uiState.query === query)) {
           return uiState;
@@ -124,7 +124,7 @@ const connectVoiceSearch: VoiceSearchConnector = (
         };
       },
       getWidgetSearchParameters(searchParameters, { uiState }) {
-        return searchParameters.setQuery(uiState.query || '');
+        return searchParameters.setQueryParameter('query', uiState.query);
       },
     };
   };

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -328,8 +328,13 @@ See: https://www.algolia.com/doc/guides/building-search-ui/widgets/create-your-o
     }
 
     this.helper = helper;
+
     this._init(helper.state, this.helper);
-    this.helper.on('result', this._render.bind(this, this.helper));
+
+    this.helper.on('result', ({ results, state }) => {
+      this._render(this.helper, results, state);
+    });
+
     this.helper.on('error', e => {
       this.emit('error', e);
     });

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -319,7 +319,7 @@ See: https://www.algolia.com/doc/guides/building-search-ui/widgets/create-your-o
           helper.state.index,
           helper.state
         );
-        helperSearchFunction.once('search', state => {
+        helperSearchFunction.once('search', ({ state }) => {
           helper.overrideStateWithoutTriggeringChangeEvent(state);
           this._mainHelperSearch();
         });

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -335,8 +335,10 @@ See: https://www.algolia.com/doc/guides/building-search-ui/widgets/create-your-o
       this._render(this.helper, results, state);
     });
 
-    this.helper.on('error', e => {
-      this.emit('error', e);
+    this.helper.on('error', ({ error }) => {
+      this.emit('error', {
+        error,
+      });
     });
 
     this._searchStalledTimer = null;

--- a/src/lib/RoutingManager.ts
+++ b/src/lib/RoutingManager.ts
@@ -15,6 +15,10 @@ type RoutingManagerProps = {
   stateMapping: StateMapping;
 };
 
+type HelperChangeEvent = {
+  state: SearchParameters;
+};
+
 class RoutingManager implements Widget {
   private readonly instantSearchInstance: InstantSearch;
   private readonly router: Router;
@@ -23,7 +27,7 @@ class RoutingManager implements Widget {
   private isFirstRender: boolean = true;
   private currentUiState: UiState;
   private initState?: UiState;
-  private renderURLFromState?: (searchParameters: SearchParameters) => void;
+  private renderURLFromState?: (event: HelperChangeEvent) => void;
 
   public constructor({
     router,
@@ -98,9 +102,9 @@ class RoutingManager implements Widget {
         .search();
     });
 
-    this.renderURLFromState = searchParameters => {
+    this.renderURLFromState = event => {
       this.currentUiState = this.getAllUiStates({
-        searchParameters,
+        searchParameters: event.state,
       });
 
       const route = this.stateMapping.stateToRoute(this.currentUiState);
@@ -108,6 +112,8 @@ class RoutingManager implements Widget {
       this.router.write(route);
     };
 
+    // @ts-ignore
+    // @TODO: we have to update the definition to make it work
     helper.on('change', this.renderURLFromState);
 
     // Compare initial state and first render state to see if the query has been

--- a/src/lib/__tests__/InstantSearch-test-integration.js
+++ b/src/lib/__tests__/InstantSearch-test-integration.js
@@ -21,9 +21,11 @@ describe('InstantSearch lifecycle', () => {
       reject = r;
     });
 
-    search.on('error', e => {
+    search.on('error', event => {
       try {
-        expect(e).toEqual(expect.any(Error));
+        expect(event).toEqual({
+          error: expect.any(Error),
+        });
       } catch (err) {
         reject(err);
       }

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -303,7 +303,10 @@ describe('InstantSearch lifecycle', () => {
 
         beforeEach(() => {
           results = { some: 'data' };
-          search.helper.emit('result', results, search.helper.state);
+          search.helper.emit('result', {
+            state: search.helper.state,
+            results,
+          });
         });
 
         it('calls widget.render({results, state, helper, templatesConfig, instantSearchInstance})', () => {
@@ -373,12 +376,18 @@ describe('InstantSearch lifecycle', () => {
       expect(render).toHaveBeenCalledTimes(0);
       expect(onRender).toHaveBeenCalledTimes(0);
 
-      search.helper.emit('result', {}, search.helper.state);
+      search.helper.emit('result', {
+        results: null,
+        state: search.helper.state,
+      });
 
       expect(render).toHaveBeenCalledTimes(5);
       expect(onRender).toHaveBeenCalledTimes(1);
 
-      search.helper.emit('result', {}, search.helper.state);
+      search.helper.emit('result', {
+        results: null,
+        state: search.helper.state,
+      });
 
       expect(render).toHaveBeenCalledTimes(10);
       expect(onRender).toHaveBeenCalledTimes(2);
@@ -391,12 +400,18 @@ describe('InstantSearch lifecycle', () => {
       expect(render).toHaveBeenCalledTimes(0);
       expect(onRender).toHaveBeenCalledTimes(0);
 
-      search.helper.emit('result', {}, search.helper.state);
+      search.helper.emit('result', {
+        results: null,
+        state: search.helper.state,
+      });
 
       expect(render).toHaveBeenCalledTimes(5);
       expect(onRender).toHaveBeenCalledTimes(1);
 
-      search.helper.emit('result', {}, search.helper.state);
+      search.helper.emit('result', {
+        results: null,
+        state: search.helper.state,
+      });
 
       expect(render).toHaveBeenCalledTimes(10);
       expect(onRender).toHaveBeenCalledTimes(1);

--- a/src/lib/__tests__/RoutingManager-test.ts
+++ b/src/lib/__tests__/RoutingManager-test.ts
@@ -363,7 +363,7 @@ describe('RoutingManager', () => {
       search.once('render', () => {
         // initialization is done at this point
 
-        expect(search.helper.state.query).toEqual('');
+        expect(search.helper.state.query).toBeUndefined();
 
         // this simulates a router update with a uiState of {q: 'a'}
         onRouterUpdateCallback({

--- a/src/lib/__tests__/search-client-test.js
+++ b/src/lib/__tests__/search-client-test.js
@@ -28,7 +28,7 @@ describe('InstantSearch Search Client', () => {
 
       search.start();
 
-      expect(search.helper.state.query).toBe('');
+      expect(search.helper.state.query).toBeUndefined();
       expect(searchClientSpy.search).toHaveBeenCalledTimes(1);
       expect(searchClientSpy.search.mock.calls[0][0]).toMatchSnapshot();
     });

--- a/src/types/instantsearch.ts
+++ b/src/types/instantsearch.ts
@@ -17,6 +17,10 @@ export type SearchParameters = AlgoliaSearchHelperSearchParameters & {
 
 export type SearchResults = AlgoliaSearchHelperSearchResults;
 
+export type HelperChangeEvent = {
+  state: SearchParameters;
+};
+
 type HitAttributeHighlightResult = {
   value: string;
   matchLevel: 'none' | 'partial' | 'full';

--- a/src/types/instantsearch.ts
+++ b/src/types/instantsearch.ts
@@ -9,8 +9,9 @@ import { Widget, UiState } from './widget';
 
 export type InstantSearchOptions = any;
 
-// That's a proxy to avoid manipulating the original `algoliasearch-helper` SearchParameters
-// typings and to add newer search parameters not yet documented.
+// That's a proxy to avoid manipulating the original `algoliasearch-helper`
+// SearchParameters typings and to add newer search parameters not yet
+// documented or wrongly typed.
 export type SearchParameters = AlgoliaSearchHelperSearchParameters & {
   ruleContexts?: string[];
 };

--- a/src/widgets/analytics/analytics.js
+++ b/src/widgets/analytics/analytics.js
@@ -147,9 +147,9 @@ function analytics({
 
     formattedParams = formattedParams.join('&');
 
-    let dataToSend = `Query: ${state.state.query}, ${formattedParams}`;
+    let dataToSend = `Query: ${state.state.query || ''}, ${formattedParams}`;
     if (pushPagination === true) {
-      dataToSend += `, Page: ${state.state.page}`;
+      dataToSend += `, Page: ${state.state.page || 0}`;
     }
 
     if (lastSentData !== dataToSend) {

--- a/src/widgets/infinite-hits/__tests__/infinite-hits-test.ts
+++ b/src/widgets/infinite-hits/__tests__/infinite-hits-test.ts
@@ -113,7 +113,7 @@ describe('infiniteHits()', () => {
   });
 
   it('updates the search state properly when showMore is called', () => {
-    expect(helper.state.page).toBe(0);
+    expect(helper.state.page).toBeUndefined();
 
     const state = { page: 0 };
     widget.render({ results, state });

--- a/src/widgets/pagination/__tests__/pagination-test.js
+++ b/src/widgets/pagination/__tests__/pagination-test.js
@@ -67,7 +67,7 @@ describe('pagination()', () => {
     helper = {
       setPage: jest.fn(),
       search: jest.fn(),
-      getPage: () => 0,
+      state: {},
     };
     widget.init({ helper });
   });

--- a/stories/panel.stories.js
+++ b/stories/panel.stories.js
@@ -88,7 +88,7 @@ storiesOf('Panel', module)
     withHits(({ search, container, instantsearch }) => {
       const brandList = instantsearch.widgets.panel({
         collapsed: options => {
-          return options && options.state && options.state.query.length === 0;
+          return options && options.state && !options.state.query;
         },
         templates: {
           header: 'Brand (collapsible)',
@@ -109,7 +109,7 @@ storiesOf('Panel', module)
     withHits(({ search, container, instantsearch }) => {
       const brandList = instantsearch.widgets.panel({
         collapsed: options => {
-          return options && options.state && options.state.query.length === 0;
+          return options && options.state && !options.state.query;
         },
         templates: {
           header: 'Collapsible panel',


### PR DESCRIPTION
This PR updates how we subscribe/use the listeners on the Helper. We moved away from [a list of arguments to an object](https://github.com/algolia/algoliasearch-helper-js/pull/700). The PR address those changes on the listeners. It also updates how the `error` event is emitted at the InstantSearch level. It now to match the shape of the Helper.

```js
// With list of arguments
search.on('error', error => {
  console.log(error);
});

// With an object
search.on('error', event => {
  console.log(event.error);
});
```

> The CI does not pass, it's expected. It won't pass until the last PR of the stack.