### PR TITLE
refactor: simplify logic to setQuery & search

### DIFF
--- a/src/connectors/search-box/connectSearchBox.js
+++ b/src/connectors/search-box/connectSearchBox.js
@@ -87,16 +87,10 @@ export default function connectSearchBox(renderFn, unmountFn) {
         this._clear = clear(helper);
 
         this._refine = (() => {
-          let previousQuery;
-
           const setQueryAndSearch = q => {
             if (q !== helper.state.query) {
-              previousQuery = helper.state.query;
-              helper.setQuery(q);
+              helper.setQuery(q).search();
             }
-
-            if (previousQuery !== undefined && previousQuery !== q)
-              helper.search();
           };
 
           return queryHook

--- a/src/connectors/search-box/connectSearchBox.js
+++ b/src/connectors/search-box/connectSearchBox.js
@@ -86,17 +86,20 @@ export default function connectSearchBox(renderFn, unmountFn) {
         this._cachedClear = this._cachedClear.bind(this);
         this._clear = clear(helper);
 
-        this._refine = (() => {
-          const setQueryAndSearch = q => {
-            if (q !== helper.state.query) {
-              helper.setQuery(q).search();
-            }
-          };
+        const setQueryAndSearch = query => {
+          if (query !== helper.state.query) {
+            helper.setQuery(query).search();
+          }
+        };
 
-          return queryHook
-            ? q => queryHook(q, setQueryAndSearch)
-            : setQueryAndSearch;
-        })();
+        this._refine = query => {
+          if (queryHook) {
+            queryHook(query, setQueryAndSearch);
+            return;
+          }
+
+          setQueryAndSearch(query);
+        };
 
         renderFn(
           {

--- a/src/connectors/search-box/connectSearchBox.js
+++ b/src/connectors/search-box/connectSearchBox.js
@@ -89,12 +89,13 @@ export default function connectSearchBox(renderFn, unmountFn) {
         this._refine = (() => {
           let previousQuery;
 
-          const setQueryAndSearch = (q, doSearch = true) => {
+          const setQueryAndSearch = q => {
             if (q !== helper.state.query) {
               previousQuery = helper.state.query;
               helper.setQuery(q);
             }
-            if (doSearch && previousQuery !== undefined && previousQuery !== q)
+
+            if (previousQuery !== undefined && previousQuery !== q)
               helper.search();
           };
 

--- a/src/connectors/voice-search/connectVoiceSearch.ts
+++ b/src/connectors/voice-search/connectVoiceSearch.ts
@@ -76,17 +76,9 @@ const connectVoiceSearch: VoiceSearchConnector = (
     return {
       init({ helper, instantSearchInstance }) {
         (this as any)._refine = (() => {
-          let previousQuery: string | undefined;
           const setQueryAndSearch = (query: string): void => {
             if (query !== helper.state.query) {
-              previousQuery = helper.state.query;
-              helper.setQuery(query);
-            }
-            if (
-              typeof previousQuery !== 'undefined' &&
-              previousQuery !== query
-            ) {
-              helper.search();
+              helper.setQuery(query).search();
             }
           };
           return setQueryAndSearch;

--- a/src/connectors/voice-search/connectVoiceSearch.ts
+++ b/src/connectors/voice-search/connectVoiceSearch.ts
@@ -75,14 +75,12 @@ const connectVoiceSearch: VoiceSearchConnector = (
 
     return {
       init({ helper, instantSearchInstance }) {
-        (this as any)._refine = (() => {
-          const setQueryAndSearch = (query: string): void => {
-            if (query !== helper.state.query) {
-              helper.setQuery(query).search();
-            }
-          };
-          return setQueryAndSearch;
-        })();
+        (this as any)._refine = (query: string): void => {
+          if (query !== helper.state.query) {
+            helper.setQuery(query).search();
+          }
+        };
+
         (this as any)._voiceSearchHelper = createVoiceSearchHelper({
           searchAsYouSpeak,
           onQueryChange: query => (this as any)._refine(query),
@@ -94,6 +92,7 @@ const connectVoiceSearch: VoiceSearchConnector = (
             });
           },
         });
+
         render({
           isFirstRendering: true,
           instantSearchInstance,


### PR DESCRIPTION
This PR simplify the flow to set a query and trigger a search inside `connectSearchBox` (inside `connectVoiceSearch` too because the implementation is duplicated). Here are the changes:

- drop the usage of `previousQuery`: the value used inside the closure wasn't very useful since it was the value of the previous, previous render. The feature has been introduced [a while ago](https://github.com/algolia/instantsearch.js/pull/1127) when the widget was responsible to manage both: `searchAsYouType` & `searchOnEnter`. We don't support this behavior inside the connector anymore, it's at the renderer level.
- drop support of `doSearch`: the second argument of the `refine` function isn't used anymore, it's not documented either. It has been introduced with [the first connector implementation](https://github.com/algolia/instantsearch.js/commit/618dca2a42cc878c5038356ce15a4e367f5781ac) for the same reason described above.

None of the changes broke the test. I've tested both implementations side-by-side with & without `queryHook`. AFAICT they have the same behavior. The PR targets `next` and not `develop` because it's a BC. The support of `doSearch` is removed.