### PR TITLE
refactor(helper): update query usage [PART-6]

### DIFF
--- a/src/connectors/autocomplete/connectAutocomplete.js
+++ b/src/connectors/autocomplete/connectAutocomplete.js
@@ -121,7 +121,7 @@ export default function connectAutocomplete(renderFn, unmountFn) {
       },
 
       renderWithAllIndices({ isFirstRendering = false } = {}) {
-        const currentRefinement = this.indices[0].helper.state.query;
+        const currentRefinement = this.indices[0].helper.state.query || '';
 
         renderFn(
           {

--- a/src/connectors/search-box/__tests__/connectSearchBox-test.js
+++ b/src/connectors/search-box/__tests__/connectSearchBox-test.js
@@ -44,7 +44,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
     // should provide good values for the first rendering
     expect(rendering).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        query: helper.state.query,
+        query: '',
         widgetParams: { foo: 'bar' },
       }),
       true
@@ -63,7 +63,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
     // should provide good values after the first search
     expect(rendering).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        query: helper.state.query,
+        query: '',
         widgetParams: { foo: 'bar' },
       }),
       false
@@ -88,8 +88,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
 
     {
       // first rendering
-      expect(helper.state.query).toBe('');
-      const { refine } = rendering.mock.calls[0][0];
+      const { refine, query } = rendering.mock.calls[0][0];
+      expect(helper.state.query).toBeUndefined();
+      expect(query).toBe('');
       refine('bip');
       expect(helper.state.query).toBe('bip');
       expect(helper.search).toHaveBeenCalledTimes(1);
@@ -105,8 +106,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
 
     {
       // Second rendering
-      expect(helper.state.query).toBe('bip');
       const { refine, query } = rendering.mock.calls[1][0];
+      expect(helper.state.query).toBe('bip');
       expect(query).toBe('bip');
       refine('bop');
       expect(helper.state.query).toBe('bop');
@@ -191,10 +192,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
 
       refine('bip');
       expect(queryHook).toHaveBeenCalledTimes(1);
-      expect(helper.state.query).toBe('');
+      expect(helper.state.query).toBeUndefined();
       expect(helper.search).not.toHaveBeenCalled();
 
       letSearchThrough = true;
+
       refine('bip');
       expect(queryHook).toHaveBeenCalledTimes(2);
       expect(helper.state.query).toBe('bip');

--- a/src/connectors/search-box/connectSearchBox.js
+++ b/src/connectors/search-box/connectSearchBox.js
@@ -149,7 +149,7 @@ export default function connectSearchBox(renderFn, unmountFn) {
       },
 
       getWidgetSearchParameters(searchParameters, { uiState }) {
-        return searchParameters.setQuery(uiState.query);
+        return searchParameters.setQueryParameter('query', uiState.query);
       },
     };
   };

--- a/src/connectors/search-box/connectSearchBox.js
+++ b/src/connectors/search-box/connectSearchBox.js
@@ -103,7 +103,7 @@ export default function connectSearchBox(renderFn, unmountFn) {
 
         renderFn(
           {
-            query: helper.state.query,
+            query: helper.state.query || '',
             refine: this._refine,
             clear: this._cachedClear,
             widgetParams,
@@ -118,7 +118,7 @@ export default function connectSearchBox(renderFn, unmountFn) {
 
         renderFn(
           {
-            query: helper.state.query,
+            query: helper.state.query || '',
             refine: this._refine,
             clear: this._cachedClear,
             widgetParams,
@@ -131,11 +131,12 @@ export default function connectSearchBox(renderFn, unmountFn) {
 
       dispose({ state }) {
         unmountFn();
+
         return state.setQuery('');
       },
 
       getWidgetState(uiState, { searchParameters }) {
-        const query = searchParameters.query;
+        const query = searchParameters.query || '';
 
         if (query === '' || (uiState && uiState.query === query)) {
           return uiState;
@@ -148,7 +149,7 @@ export default function connectSearchBox(renderFn, unmountFn) {
       },
 
       getWidgetSearchParameters(searchParameters, { uiState }) {
-        return searchParameters.setQuery(uiState.query || '');
+        return searchParameters.setQuery(uiState.query);
       },
     };
   };

--- a/src/connectors/stats/__tests__/connectStats-test.js
+++ b/src/connectors/stats/__tests__/connectStats-test.js
@@ -60,7 +60,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/stats/js/#c
       expect(nbPages).toBe(0);
       expect(page).toBe(0);
       expect(processingTimeMS).toBe(-1);
-      expect(query).toBe(helper.state.query);
+      expect(query).toBe('');
       expect(widgetParams).toEqual({ foo: 'bar' });
     }
 
@@ -72,7 +72,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/stats/js/#c
           nbHits: 1,
           hitsPerPage: helper.state.hitsPerPage,
           page: helper.state.page,
-          query: helper.state.query,
+          query: '',
           processingTimeMS: 12,
         },
       ]),
@@ -102,7 +102,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/stats/js/#c
       expect(nbPages).toBe(1);
       expect(page).toBe(helper.state.page);
       expect(processingTimeMS).toBe(12);
-      expect(query).toBe(helper.state.query);
+      expect(query).toBe('');
     }
   });
 });

--- a/src/connectors/stats/connectStats.js
+++ b/src/connectors/stats/connectStats.js
@@ -59,7 +59,7 @@ export default function connectStats(renderFn, unmountFn) {
           nbPages: 0,
           page: helper.state.page || 0,
           processingTimeMS: -1,
-          query: helper.state.query,
+          query: helper.state.query || '',
           widgetParams,
         },
         true

--- a/src/connectors/voice-search/__tests__/connectVoiceSearch-test.js
+++ b/src/connectors/voice-search/__tests__/connectVoiceSearch-test.js
@@ -188,7 +188,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/voice-searc
         searchParametersBefore,
         { uiState }
       );
-      expect(searchParametersAfter.query).toBe('');
+      expect(searchParametersAfter.query).toBeUndefined();
     });
   });
 });

--- a/src/connectors/voice-search/connectVoiceSearch.ts
+++ b/src/connectors/voice-search/connectVoiceSearch.ts
@@ -112,7 +112,7 @@ const connectVoiceSearch: VoiceSearchConnector = (
         return state.setQuery('');
       },
       getWidgetState(uiState, { searchParameters }) {
-        const query = searchParameters.query;
+        const query = searchParameters.query || '';
 
         if (query === '' || (uiState && uiState.query === query)) {
           return uiState;
@@ -124,7 +124,7 @@ const connectVoiceSearch: VoiceSearchConnector = (
         };
       },
       getWidgetSearchParameters(searchParameters, { uiState }) {
-        return searchParameters.setQuery(uiState.query || '');
+        return searchParameters.setQuery(uiState.query);
       },
     };
   };

--- a/src/connectors/voice-search/connectVoiceSearch.ts
+++ b/src/connectors/voice-search/connectVoiceSearch.ts
@@ -124,7 +124,7 @@ const connectVoiceSearch: VoiceSearchConnector = (
         };
       },
       getWidgetSearchParameters(searchParameters, { uiState }) {
-        return searchParameters.setQuery(uiState.query);
+        return searchParameters.setQueryParameter('query', uiState.query);
       },
     };
   };

--- a/src/lib/__tests__/RoutingManager-test.ts
+++ b/src/lib/__tests__/RoutingManager-test.ts
@@ -363,7 +363,7 @@ describe('RoutingManager', () => {
       search.once('render', () => {
         // initialization is done at this point
 
-        expect(search.helper.state.query).toEqual('');
+        expect(search.helper.state.query).toBeUndefined();
 
         // this simulates a router update with a uiState of {q: 'a'}
         onRouterUpdateCallback({

--- a/src/lib/__tests__/search-client-test.js
+++ b/src/lib/__tests__/search-client-test.js
@@ -28,7 +28,7 @@ describe('InstantSearch Search Client', () => {
 
       search.start();
 
-      expect(search.helper.state.query).toBe('');
+      expect(search.helper.state.query).toBeUndefined();
       expect(searchClientSpy.search).toHaveBeenCalledTimes(1);
       expect(searchClientSpy.search.mock.calls[0][0]).toMatchSnapshot();
     });

--- a/src/types/instantsearch.ts
+++ b/src/types/instantsearch.ts
@@ -14,6 +14,7 @@ export type InstantSearchOptions = any;
 // documented or wrongly typed.
 export type SearchParameters = AlgoliaSearchHelperSearchParameters & {
   ruleContexts?: string[];
+  setQuery(value?: string): SearchParameters;
 };
 
 export type SearchResults = AlgoliaSearchHelperSearchResults;

--- a/src/types/instantsearch.ts
+++ b/src/types/instantsearch.ts
@@ -14,7 +14,6 @@ export type InstantSearchOptions = any;
 // documented or wrongly typed.
 export type SearchParameters = AlgoliaSearchHelperSearchParameters & {
   ruleContexts?: string[];
-  setQuery(value?: string): SearchParameters;
 };
 
 export type SearchResults = AlgoliaSearchHelperSearchResults;

--- a/src/widgets/analytics/analytics.js
+++ b/src/widgets/analytics/analytics.js
@@ -147,7 +147,7 @@ function analytics({
 
     formattedParams = formattedParams.join('&');
 
-    let dataToSend = `Query: ${state.state.query}, ${formattedParams}`;
+    let dataToSend = `Query: ${state.state.query || ''}, ${formattedParams}`;
     if (pushPagination === true) {
       dataToSend += `, Page: ${state.state.page || 0}`;
     }

--- a/stories/panel.stories.js
+++ b/stories/panel.stories.js
@@ -88,7 +88,7 @@ storiesOf('Panel', module)
     withHits(({ search, container, instantsearch }) => {
       const brandList = instantsearch.widgets.panel({
         collapsed: options => {
-          return options && options.state && options.state.query.length === 0;
+          return !((options && options.state && options.state.query) || '');
         },
         templates: {
           header: 'Brand (collapsible)',
@@ -109,7 +109,7 @@ storiesOf('Panel', module)
     withHits(({ search, container, instantsearch }) => {
       const brandList = instantsearch.widgets.panel({
         collapsed: options => {
-          return options && options.state && options.state.query.length === 0;
+          return !((options && options.state && options.state.query) || '');
         },
         templates: {
           header: 'Collapsible panel',

--- a/stories/panel.stories.js
+++ b/stories/panel.stories.js
@@ -88,7 +88,7 @@ storiesOf('Panel', module)
     withHits(({ search, container, instantsearch }) => {
       const brandList = instantsearch.widgets.panel({
         collapsed: options => {
-          return !((options && options.state && options.state.query) || '');
+          return options && options.state && !options.state.query;
         },
         templates: {
           header: 'Brand (collapsible)',
@@ -109,7 +109,7 @@ storiesOf('Panel', module)
     withHits(({ search, container, instantsearch }) => {
       const brandList = instantsearch.widgets.panel({
         collapsed: options => {
-          return !((options && options.state && options.state.query) || '');
+          return options && options.state && !options.state.query;
         },
         templates: {
           header: 'Collapsible panel',


### PR DESCRIPTION
This PR updates the usage of the `query` attribute from the `SearchParameters`. Its value is now optional which implies that we have to fall back on a default value at the connector level. The default value is not always required though, it depends on the use case. I've tried to make as few changes as possible to stick with the current behavior.