### PR TITLE
feat(connectAutocomplete): clear the state on dispose

### DIFF
--- a/src/connectors/autocomplete/__tests__/connectAutocomplete-test.js
+++ b/src/connectors/autocomplete/__tests__/connectAutocomplete-test.js
@@ -269,5 +269,30 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/autocomplet
 
       expect(nextState.query).toBeUndefined();
     });
+
+    it('removes the TAG_PLACEHOLDER from the `SearchParameters`', () => {
+      const helper = algoliasearchHelper(fakeClient, 'firstIndex', {
+        ...TAG_PLACEHOLDER,
+      });
+
+      const renderFn = () => {};
+      const makeWidget = connectAutocomplete(renderFn);
+      const widget = makeWidget();
+
+      expect(helper.state.highlightPreTag).toBe(
+        TAG_PLACEHOLDER.highlightPreTag
+      );
+
+      expect(helper.state.highlightPostTag).toBe(
+        TAG_PLACEHOLDER.highlightPostTag
+      );
+
+      widget.init({ helper, instantSearchInstance: {} });
+
+      const nextState = widget.dispose({ helper, state: helper.state });
+
+      expect(nextState.highlightPreTag).toBeUndefined();
+      expect(nextState.highlightPostTag).toBeUndefined();
+    });
   });
 });

--- a/src/connectors/autocomplete/__tests__/connectAutocomplete-test.js
+++ b/src/connectors/autocomplete/__tests__/connectAutocomplete-test.js
@@ -186,14 +186,27 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/autocomplet
       expect(unmountFn).toHaveBeenCalledTimes(1);
     });
 
+    it('does not throw without the unmount function', () => {
+      const helper = algoliasearchHelper(fakeClient, 'firstIndex');
+
+      const renderFn = () => {};
+      const makeWidget = connectAutocomplete(renderFn);
+      const widget = makeWidget();
+
+      widget.init({ helper, instantSearchInstance: {} });
+
+      expect(() =>
+        widget.dispose({ helper, state: helper.state })
+      ).not.toThrow();
+    });
+
     it('removes the created DerivedHelper', () => {
       const detachDerivedHelper = jest.fn();
       const helper = algoliasearchHelper(fakeClient, 'firstIndex');
       helper.detachDerivedHelper = detachDerivedHelper;
 
       const renderFn = () => {};
-      const unmountFn = () => {};
-      const makeWidget = connectAutocomplete(renderFn, unmountFn);
+      const makeWidget = connectAutocomplete(renderFn);
       const widget = makeWidget({
         indices: [
           { label: 'Second', value: 'secondIndex' },
@@ -216,8 +229,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/autocomplet
       helper.detachDerivedHelper = detachDerivedHelper;
 
       const renderFn = () => {};
-      const unmountFn = () => {};
-      const makeWidget = connectAutocomplete(renderFn, unmountFn);
+      const makeWidget = connectAutocomplete(renderFn);
       const widget = makeWidget({
         indices: [
           { label: 'Second', value: 'secondIndex' },
@@ -246,8 +258,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/autocomplet
       });
 
       const renderFn = () => {};
-      const unmountFn = () => {};
-      const makeWidget = connectAutocomplete(renderFn, unmountFn);
+      const makeWidget = connectAutocomplete(renderFn);
       const widget = makeWidget();
 
       widget.init({ helper, instantSearchInstance: {} });

--- a/src/connectors/autocomplete/__tests__/connectAutocomplete-test.js
+++ b/src/connectors/autocomplete/__tests__/connectAutocomplete-test.js
@@ -295,7 +295,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/autocomplet
       expect(nextState.highlightPostTag).toBeUndefined();
     });
 
-    it('removes the TAG_PLACEHOLDER from the `SearchParameters` only with `escapeHTML`', () => {
+    it('does not remove the TAG_PLACEHOLDER from the `SearchParameters` with `escapeHTML`', () => {
       const helper = algoliasearchHelper(fakeClient, 'firstIndex', {
         highlightPreTag: '<mark>',
         highlightPostTag: '</mark>',

--- a/src/connectors/autocomplete/__tests__/connectAutocomplete-test.js
+++ b/src/connectors/autocomplete/__tests__/connectAutocomplete-test.js
@@ -54,7 +54,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/autocomplet
     });
   });
 
-  it('creates derived helper', () => {
+  it('creates DerivedHelper', () => {
     const renderFn = jest.fn();
     const makeWidget = connectAutocomplete(renderFn);
     const widget = makeWidget({ indices: [{ label: 'foo', value: 'foo' }] });
@@ -184,6 +184,33 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/autocomplet
       widget.dispose();
 
       expect(unmountFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('removes the created DerivedHelper', () => {
+      const detach = jest.fn();
+      const helper = jsHelper(fakeClient, 'firstIndex');
+      helper.derive = () => ({
+        on() {},
+        detach,
+      });
+
+      const renderFn = () => {};
+      const unmountFn = () => {};
+      const makeWidget = connectAutocomplete(renderFn, unmountFn);
+      const widget = makeWidget({
+        indices: [
+          { label: 'Second', value: 'secondIndex' },
+          { label: 'Third', value: 'thirdIndex' },
+        ],
+      });
+
+      widget.init({ helper, instantSearchInstance: {} });
+
+      expect(detach).toHaveBeenCalledTimes(0);
+
+      widget.dispose();
+
+      expect(detach).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/connectors/autocomplete/__tests__/connectAutocomplete-test.js
+++ b/src/connectors/autocomplete/__tests__/connectAutocomplete-test.js
@@ -1,4 +1,4 @@
-import jsHelper, { SearchResults } from 'algoliasearch-helper';
+import algoliasearchHelper, { SearchResults } from 'algoliasearch-helper';
 import connectAutocomplete from '../connectAutocomplete';
 import { TAG_PLACEHOLDER } from '../../../lib/escape-highlight';
 
@@ -22,7 +22,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/autocomplet
 
     expect(renderFn).toHaveBeenCalledTimes(0);
 
-    const helper = jsHelper(fakeClient, '', {});
+    const helper = algoliasearchHelper(fakeClient, '', {});
     helper.search = jest.fn();
 
     widget.init({
@@ -59,7 +59,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/autocomplet
     const makeWidget = connectAutocomplete(renderFn);
     const widget = makeWidget({ indices: [{ label: 'foo', value: 'foo' }] });
 
-    const helper = jsHelper(fakeClient, '', {});
+    const helper = algoliasearchHelper(fakeClient, '', {});
     helper.search = jest.fn();
 
     widget.init({ helper, instantSearchInstance: {} });
@@ -75,7 +75,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/autocomplet
     const makeWidget = connectAutocomplete(renderFn);
     const widget = makeWidget();
 
-    const helper = jsHelper(fakeClient, '', {});
+    const helper = algoliasearchHelper(fakeClient, '', {});
     helper.search = jest.fn();
 
     widget.init({ helper, instantSearchInstance: {} });
@@ -93,7 +93,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/autocomplet
     const makeWidget = connectAutocomplete(renderFn);
     const widget = makeWidget({ escapeHTML: true });
 
-    const helper = jsHelper(fakeClient, '', {});
+    const helper = algoliasearchHelper(fakeClient, '', {});
     helper.search = jest.fn();
 
     const hits = [
@@ -139,7 +139,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/autocomplet
     const makeWidget = connectAutocomplete(renderFn);
     const widget = makeWidget({ escapeHTML: false });
 
-    const helper = jsHelper(fakeClient, '', {});
+    const helper = algoliasearchHelper(fakeClient, '', {});
     helper.search = jest.fn();
 
     const hits = [
@@ -170,7 +170,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/autocomplet
 
   describe('dispose', () => {
     it('calls the unmount function', () => {
-      const helper = jsHelper(fakeClient, 'firstIndex');
+      const helper = algoliasearchHelper(fakeClient, 'firstIndex');
 
       const renderFn = () => {};
       const unmountFn = jest.fn();
@@ -188,7 +188,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/autocomplet
 
     it('removes the created DerivedHelper', () => {
       const detach = jest.fn();
-      const helper = jsHelper(fakeClient, 'firstIndex');
+      const helper = algoliasearchHelper(fakeClient, 'firstIndex');
       helper.derive = () => ({
         on() {},
         detach,

--- a/src/connectors/autocomplete/__tests__/connectAutocomplete-test.js
+++ b/src/connectors/autocomplete/__tests__/connectAutocomplete-test.js
@@ -167,4 +167,23 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/autocomplet
 
     expect(rendering.indices[0].hits).toEqual(hits);
   });
+
+  describe('dispose', () => {
+    it('calls the unmount function', () => {
+      const helper = jsHelper(fakeClient, 'firstIndex');
+
+      const renderFn = () => {};
+      const unmountFn = jest.fn();
+      const makeWidget = connectAutocomplete(renderFn, unmountFn);
+      const widget = makeWidget();
+
+      widget.init({ helper, instantSearchInstance: {} });
+
+      expect(unmountFn).toHaveBeenCalledTimes(0);
+
+      widget.dispose();
+
+      expect(unmountFn).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/connectors/autocomplete/__tests__/connectAutocomplete-test.js
+++ b/src/connectors/autocomplete/__tests__/connectAutocomplete-test.js
@@ -294,5 +294,28 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/autocomplet
       expect(nextState.highlightPreTag).toBeUndefined();
       expect(nextState.highlightPostTag).toBeUndefined();
     });
+
+    it('removes the TAG_PLACEHOLDER from the `SearchParameters` only with `escapeHTML`', () => {
+      const helper = algoliasearchHelper(fakeClient, 'firstIndex', {
+        highlightPreTag: '<mark>',
+        highlightPostTag: '</mark>',
+      });
+
+      const renderFn = () => {};
+      const makeWidget = connectAutocomplete(renderFn);
+      const widget = makeWidget({
+        escapeHTML: false,
+      });
+
+      expect(helper.state.highlightPreTag).toBe('<mark>');
+      expect(helper.state.highlightPostTag).toBe('</mark>');
+
+      widget.init({ helper, instantSearchInstance: {} });
+
+      const nextState = widget.dispose({ helper, state: helper.state });
+
+      expect(nextState.highlightPreTag).toBe('<mark>');
+      expect(nextState.highlightPostTag).toBe('</mark>');
+    });
   });
 });

--- a/src/connectors/autocomplete/__tests__/connectAutocomplete-test.js
+++ b/src/connectors/autocomplete/__tests__/connectAutocomplete-test.js
@@ -181,7 +181,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/autocomplet
 
       expect(unmountFn).toHaveBeenCalledTimes(0);
 
-      widget.dispose();
+      widget.dispose({ helper, state: helper.state });
 
       expect(unmountFn).toHaveBeenCalledTimes(1);
     });
@@ -208,9 +208,28 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/autocomplet
 
       expect(detach).toHaveBeenCalledTimes(0);
 
-      widget.dispose();
+      widget.dispose({ helper, state: helper.state });
 
       expect(detach).toHaveBeenCalledTimes(2);
+    });
+
+    it('removes the `query` from the `SearchParameters`', () => {
+      const helper = algoliasearchHelper(fakeClient, 'firstIndex', {
+        query: 'Apple',
+      });
+
+      const renderFn = () => {};
+      const unmountFn = () => {};
+      const makeWidget = connectAutocomplete(renderFn, unmountFn);
+      const widget = makeWidget();
+
+      widget.init({ helper, instantSearchInstance: {} });
+
+      expect(helper.state.query).toBe('Apple');
+
+      const nextState = widget.dispose({ helper, state: helper.state });
+
+      expect(nextState.query).toBeUndefined();
     });
   });
 });

--- a/src/connectors/autocomplete/connectAutocomplete.js
+++ b/src/connectors/autocomplete/connectAutocomplete.js
@@ -142,7 +142,6 @@ export default function connectAutocomplete(renderFn, unmountFn) {
       },
 
       dispose() {
-        // detach every derived indices from the main helper instance
         this.indices.slice(1).forEach(({ helper }) => helper.detach());
 
         unmountFn();

--- a/src/connectors/autocomplete/connectAutocomplete.js
+++ b/src/connectors/autocomplete/connectAutocomplete.js
@@ -141,10 +141,12 @@ export default function connectAutocomplete(renderFn, unmountFn) {
         );
       },
 
-      dispose() {
+      dispose({ state }) {
         this.indices.slice(1).forEach(({ helper }) => helper.detach());
 
         unmountFn();
+
+        return state.setQueryParameter('query', undefined);
       },
     };
   };

--- a/src/connectors/autocomplete/connectAutocomplete.js
+++ b/src/connectors/autocomplete/connectAutocomplete.js
@@ -147,7 +147,13 @@ export default function connectAutocomplete(renderFn, unmountFn = noop) {
 
         unmountFn();
 
-        return state.setQueryParameter('query', undefined).setQueryParameters(
+        const stateWithoutQuery = state.setQueryParameter('query', undefined);
+
+        if (!escapeHTML) {
+          return stateWithoutQuery;
+        }
+
+        return stateWithoutQuery.setQueryParameters(
           Object.keys(TAG_PLACEHOLDER).reduce(
             (acc, key) => ({
               ...acc,

--- a/src/connectors/autocomplete/connectAutocomplete.js
+++ b/src/connectors/autocomplete/connectAutocomplete.js
@@ -3,6 +3,7 @@ import {
   checkRendering,
   createDocumentationMessageGenerator,
   find,
+  noop,
 } from '../../lib/utils';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -41,7 +42,7 @@ const withUsage = createDocumentationMessageGenerator({
  * @param {function} unmountFn Unmount function called when the widget is disposed.
  * @return {function(CustomAutocompleteWidgetOptions)} Re-usable widget factory for a custom **Autocomplete** widget.
  */
-export default function connectAutocomplete(renderFn, unmountFn) {
+export default function connectAutocomplete(renderFn, unmountFn = noop) {
   checkRendering(renderFn, withUsage());
 
   return (widgetParams = {}) => {

--- a/src/connectors/autocomplete/connectAutocomplete.js
+++ b/src/connectors/autocomplete/connectAutocomplete.js
@@ -147,7 +147,15 @@ export default function connectAutocomplete(renderFn, unmountFn = noop) {
 
         unmountFn();
 
-        return state.setQueryParameter('query', undefined);
+        return state.setQueryParameter('query', undefined).setQueryParameters(
+          Object.keys(TAG_PLACEHOLDER).reduce(
+            (acc, key) => ({
+              ...acc,
+              [key]: undefined,
+            }),
+            {}
+          )
+        );
       },
     };
   };


### PR DESCRIPTION
This PR fix the implementation of the `dispose` method for the connector `connectAutocomplete`. It omits `query` & `highlightTags` once the widget is removed. I also cover the rest of the `dispose` function with tests.