### PR TITLE
feat(connectHits): clear the state on dispose

### DIFF
--- a/src/connectors/hits/__tests__/connectHits-test.js
+++ b/src/connectors/hits/__tests__/connectHits-test.js
@@ -348,4 +348,19 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
       expect.anything()
     );
   });
+
+  describe('dispose', () => {
+    it('calls the unmount function', () => {
+      const renderFn = () => {};
+      const unmountFn = jest.fn();
+      const makeWidget = connectHits(renderFn, unmountFn);
+      const widget = makeWidget();
+
+      expect(unmountFn).toHaveBeenCalledTimes(0);
+
+      widget.dispose();
+
+      expect(unmountFn).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/connectors/hits/__tests__/connectHits-test.js
+++ b/src/connectors/hits/__tests__/connectHits-test.js
@@ -1,4 +1,4 @@
-import jsHelper, { SearchResults } from 'algoliasearch-helper';
+import algoliasearchHelper, { SearchResults } from 'algoliasearch-helper';
 import { TAG_PLACEHOLDER } from '../../../lib/escape-highlight';
 import connectHits from '../connectHits';
 
@@ -32,7 +32,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
     // test if widget is not rendered yet at this point
     expect(rendering).toHaveBeenCalledTimes(0);
 
-    const helper = jsHelper({}, '', {});
+    const helper = algoliasearchHelper({}, '', {});
     helper.search = jest.fn();
 
     widget.init({
@@ -80,7 +80,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
     const makeWidget = connectHits(rendering);
     const widget = makeWidget({});
 
-    const helper = jsHelper({}, '', {});
+    const helper = algoliasearchHelper({}, '', {});
     helper.search = jest.fn();
 
     widget.init({
@@ -125,7 +125,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
     const makeWidget = connectHits(rendering);
     const widget = makeWidget({ escapeHTML: true });
 
-    const helper = jsHelper({}, '', {});
+    const helper = algoliasearchHelper({}, '', {});
     helper.search = jest.fn();
 
     widget.init({
@@ -191,7 +191,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
       transformItems: items => items.map(() => ({ name: 'transformed' })),
     });
 
-    const helper = jsHelper({}, '', {});
+    const helper = algoliasearchHelper({}, '', {});
     helper.search = jest.fn();
 
     widget.init({
@@ -232,7 +232,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
     const makeWidget = connectHits(rendering);
     const widget = makeWidget({});
 
-    const helper = jsHelper({}, '', {});
+    const helper = algoliasearchHelper({}, '', {});
     helper.search = jest.fn();
 
     widget.init({
@@ -282,7 +282,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
       escapeHTML: true,
     });
 
-    const helper = jsHelper({}, '', {});
+    const helper = algoliasearchHelper({}, '', {});
     helper.search = jest.fn();
 
     widget.init({

--- a/src/connectors/hits/__tests__/connectHits-test.js
+++ b/src/connectors/hits/__tests__/connectHits-test.js
@@ -361,6 +361,18 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
       expect(unmountFn).toHaveBeenCalledTimes(1);
     });
 
+    it('does not throw without the unmount function', () => {
+      const helper = algoliasearchHelper({}, '');
+
+      const renderFn = () => {};
+      const makeWidget = connectHits(renderFn);
+      const widget = makeWidget();
+
+      expect(() =>
+        widget.dispose({ helper, state: helper.state })
+      ).not.toThrow();
+    });
+
     it('removes the TAG_PLACEHOLDER from the `SearchParameters`', () => {
       const helper = algoliasearchHelper({}, '', {
         ...TAG_PLACEHOLDER,

--- a/src/connectors/hits/__tests__/connectHits-test.js
+++ b/src/connectors/hits/__tests__/connectHits-test.js
@@ -379,8 +379,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
       });
 
       const renderFn = () => {};
-      const unmountFn = jest.fn();
-      const makeWidget = connectHits(renderFn, unmountFn);
+      const makeWidget = connectHits(renderFn);
       const widget = makeWidget();
 
       expect(helper.state.highlightPreTag).toBe(
@@ -395,6 +394,27 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
 
       expect(nextState.highlightPreTag).toBeUndefined();
       expect(nextState.highlightPostTag).toBeUndefined();
+    });
+
+    it('removes the TAG_PLACEHOLDER from the `SearchParameters` only with `escapeHTML`', () => {
+      const helper = algoliasearchHelper({}, '', {
+        highlightPreTag: '<mark>',
+        highlightPostTag: '</mark>',
+      });
+
+      const renderFn = () => {};
+      const makeWidget = connectHits(renderFn);
+      const widget = makeWidget({
+        escapeHTML: false,
+      });
+
+      expect(helper.state.highlightPreTag).toBe('<mark>');
+      expect(helper.state.highlightPostTag).toBe('</mark>');
+
+      const nextState = widget.dispose({ helper, state: helper.state });
+
+      expect(nextState.highlightPreTag).toBe('<mark>');
+      expect(nextState.highlightPostTag).toBe('</mark>');
     });
   });
 });

--- a/src/connectors/hits/__tests__/connectHits-test.js
+++ b/src/connectors/hits/__tests__/connectHits-test.js
@@ -347,6 +347,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
 
   describe('dispose', () => {
     it('calls the unmount function', () => {
+      const helper = algoliasearchHelper({}, '');
+
       const renderFn = () => {};
       const unmountFn = jest.fn();
       const makeWidget = connectHits(renderFn, unmountFn);
@@ -354,9 +356,33 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
 
       expect(unmountFn).toHaveBeenCalledTimes(0);
 
-      widget.dispose();
+      widget.dispose({ helper, state: helper.state });
 
       expect(unmountFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('removes the TAG_PLACEHOLDER from the `SearchParameters`', () => {
+      const helper = algoliasearchHelper({}, '', {
+        ...TAG_PLACEHOLDER,
+      });
+
+      const renderFn = () => {};
+      const unmountFn = jest.fn();
+      const makeWidget = connectHits(renderFn, unmountFn);
+      const widget = makeWidget();
+
+      expect(helper.state.highlightPreTag).toBe(
+        TAG_PLACEHOLDER.highlightPreTag
+      );
+
+      expect(helper.state.highlightPostTag).toBe(
+        TAG_PLACEHOLDER.highlightPostTag
+      );
+
+      const nextState = widget.dispose({ helper, state: helper.state });
+
+      expect(nextState.highlightPreTag).toBeUndefined();
+      expect(nextState.highlightPostTag).toBeUndefined();
     });
   });
 });

--- a/src/connectors/hits/__tests__/connectHits-test.js
+++ b/src/connectors/hits/__tests__/connectHits-test.js
@@ -18,10 +18,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
   });
 
   it('Renders during init and render', () => {
-    // test that the dummyRendering is called with the isFirstRendering
-    // flag set accordingly
-    const rendering = jest.fn();
-    const makeWidget = connectHits(rendering);
+    const renderFn = jest.fn();
+    const makeWidget = connectHits(renderFn);
     const widget = makeWidget({ escapeHTML: true });
 
     expect(widget.getConfiguration()).toEqual({
@@ -30,7 +28,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
     });
 
     // test if widget is not rendered yet at this point
-    expect(rendering).toHaveBeenCalledTimes(0);
+    expect(renderFn).toHaveBeenCalledTimes(0);
 
     const helper = algoliasearchHelper({}, '', {});
     helper.search = jest.fn();
@@ -42,9 +40,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
       onHistoryChange: () => {},
     });
 
-    expect(rendering).toHaveBeenCalledTimes(1);
-    // test that rendering has been called during init with isFirstRendering = true
-    expect(rendering).toHaveBeenLastCalledWith(
+    expect(renderFn).toHaveBeenCalledTimes(1);
+    expect(renderFn).toHaveBeenLastCalledWith(
       expect.objectContaining({ widgetParams: { escapeHTML: true } }),
       true
     );
@@ -56,17 +53,16 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
       createURL: () => '#',
     });
 
-    expect(rendering).toHaveBeenCalledTimes(2);
-    // test that rendering has been called during init with isFirstRendering = false
-    expect(rendering).toHaveBeenLastCalledWith(
+    expect(renderFn).toHaveBeenCalledTimes(2);
+    expect(renderFn).toHaveBeenLastCalledWith(
       expect.objectContaining({ widgetParams: { escapeHTML: true } }),
       false
     );
   });
 
   it('sets the default configuration', () => {
-    const rendering = jest.fn();
-    const makeWidget = connectHits(rendering);
+    const renderFn = jest.fn();
+    const makeWidget = connectHits(renderFn);
     const widget = makeWidget();
 
     expect(widget.getConfiguration()).toEqual({
@@ -76,8 +72,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
   });
 
   it('Provides the hits and the whole results', () => {
-    const rendering = jest.fn();
-    const makeWidget = connectHits(rendering);
+    const renderFn = jest.fn();
+    const makeWidget = connectHits(renderFn);
     const widget = makeWidget({});
 
     const helper = algoliasearchHelper({}, '', {});
@@ -90,7 +86,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
       onHistoryChange: () => {},
     });
 
-    expect(rendering).toHaveBeenLastCalledWith(
+    expect(renderFn).toHaveBeenLastCalledWith(
       expect.objectContaining({
         hits: [],
         results: undefined,
@@ -111,7 +107,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
       createURL: () => '#',
     });
 
-    expect(rendering).toHaveBeenLastCalledWith(
+    expect(renderFn).toHaveBeenLastCalledWith(
       expect.objectContaining({
         hits,
         results,
@@ -121,8 +117,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
   });
 
   it('escape highlight properties if requested', () => {
-    const rendering = jest.fn();
-    const makeWidget = connectHits(rendering);
+    const renderFn = jest.fn();
+    const makeWidget = connectHits(renderFn);
     const widget = makeWidget({ escapeHTML: true });
 
     const helper = algoliasearchHelper({}, '', {});
@@ -135,7 +131,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
       onHistoryChange: () => {},
     });
 
-    expect(rendering).toHaveBeenLastCalledWith(
+    expect(renderFn).toHaveBeenLastCalledWith(
       expect.objectContaining({
         hits: [],
         results: undefined,
@@ -175,7 +171,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
 
     escapedHits.__escaped = true;
 
-    expect(rendering).toHaveBeenLastCalledWith(
+    expect(renderFn).toHaveBeenLastCalledWith(
       expect.objectContaining({
         hits: escapedHits,
         results,
@@ -185,8 +181,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
   });
 
   it('transform items if requested', () => {
-    const rendering = jest.fn();
-    const makeWidget = connectHits(rendering);
+    const renderFn = jest.fn();
+    const makeWidget = connectHits(renderFn);
     const widget = makeWidget({
       transformItems: items => items.map(() => ({ name: 'transformed' })),
     });
@@ -201,7 +197,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
       onHistoryChange: () => {},
     });
 
-    expect(rendering).toHaveBeenNthCalledWith(
+    expect(renderFn).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({ hits: [], results: undefined }),
       expect.anything()
@@ -217,7 +213,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
       createURL: () => '#',
     });
 
-    expect(rendering).toHaveBeenNthCalledWith(
+    expect(renderFn).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
         hits: [{ name: 'transformed' }, { name: 'transformed' }],
@@ -228,8 +224,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
   });
 
   it('adds queryID if provided to results', () => {
-    const rendering = jest.fn();
-    const makeWidget = connectHits(rendering);
+    const renderFn = jest.fn();
+    const makeWidget = connectHits(renderFn);
     const widget = makeWidget({});
 
     const helper = algoliasearchHelper({}, '', {});
@@ -254,7 +250,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
       createURL: () => '#',
     });
 
-    expect(rendering).toHaveBeenNthCalledWith(
+    expect(renderFn).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
         hits: [
@@ -267,8 +263,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
   });
 
   it('transform items after escaping', () => {
-    const rendering = jest.fn();
-    const makeWidget = connectHits(rendering);
+    const renderFn = jest.fn();
+    const makeWidget = connectHits(renderFn);
     const widget = makeWidget({
       transformItems: items =>
         items.map(item => ({
@@ -322,7 +318,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
       createURL: () => '#',
     });
 
-    expect(rendering).toHaveBeenNthCalledWith(
+    expect(renderFn).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
         hits: [

--- a/src/connectors/hits/__tests__/connectHits-test.js
+++ b/src/connectors/hits/__tests__/connectHits-test.js
@@ -396,7 +396,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
       expect(nextState.highlightPostTag).toBeUndefined();
     });
 
-    it('removes the TAG_PLACEHOLDER from the `SearchParameters` only with `escapeHTML`', () => {
+    it('does not remove the TAG_PLACEHOLDER from the `SearchParameters` with `escapeHTML`', () => {
       const helper = algoliasearchHelper({}, '', {
         highlightPreTag: '<mark>',
         highlightPostTag: '</mark>',

--- a/src/connectors/hits/connectHits.js
+++ b/src/connectors/hits/connectHits.js
@@ -99,8 +99,18 @@ export default function connectHits(renderFn, unmountFn) {
         );
       },
 
-      dispose() {
+      dispose({ state }) {
         unmountFn();
+
+        return state.setQueryParameters(
+          Object.keys(TAG_PLACEHOLDER).reduce(
+            (acc, key) => ({
+              ...acc,
+              [key]: undefined,
+            }),
+            {}
+          )
+        );
       },
     };
   };

--- a/src/connectors/hits/connectHits.js
+++ b/src/connectors/hits/connectHits.js
@@ -103,6 +103,10 @@ export default function connectHits(renderFn, unmountFn = noop) {
       dispose({ state }) {
         unmountFn();
 
+        if (!escapeHTML) {
+          return state;
+        }
+
         return state.setQueryParameters(
           Object.keys(TAG_PLACEHOLDER).reduce(
             (acc, key) => ({

--- a/src/connectors/hits/connectHits.js
+++ b/src/connectors/hits/connectHits.js
@@ -4,6 +4,7 @@ import {
   createDocumentationMessageGenerator,
   addAbsolutePosition,
   addQueryID,
+  noop,
 } from '../../lib/utils';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -50,7 +51,7 @@ const withUsage = createDocumentationMessageGenerator({
  *   })
  * );
  */
-export default function connectHits(renderFn, unmountFn) {
+export default function connectHits(renderFn, unmountFn = noop) {
   checkRendering(renderFn, withUsage());
 
   return (widgetParams = {}) => {


### PR DESCRIPTION
This PR fix the implementation of the `dispose` method for the connector `connectHits`. It omits `highlightTags` once the widget is removed. I also cover the rest of the `dispose` function with tests.