### PR TITLE
fix(voiceSearch): connector handles default value of searchAsYouSpeak

### DIFF
--- a/src/connectors/voice-search/connectVoiceSearch.ts
+++ b/src/connectors/voice-search/connectVoiceSearch.ts
@@ -15,7 +15,7 @@ const withUsage = createDocumentationMessageGenerator({
 });
 
 export type VoiceSearchConnectorParams = {
-  searchAsYouSpeak: boolean;
+  searchAsYouSpeak?: boolean;
 };
 
 export interface VoiceSearchRenderOptions<TVoiceSearchWidgetParams>
@@ -71,7 +71,7 @@ const connectVoiceSearch: VoiceSearchConnector = (
       );
     };
 
-    const { searchAsYouSpeak } = widgetParams;
+    const { searchAsYouSpeak = false } = widgetParams;
 
     return {
       init({ helper, instantSearchInstance }) {

--- a/src/widgets/voice-search/voice-search.tsx
+++ b/src/widgets/voice-search/voice-search.tsx
@@ -79,7 +79,7 @@ const voiceSearch: VoiceSearch = (
     container,
     cssClasses: userCssClasses = {} as VoiceSearchCSSClasses,
     templates,
-    searchAsYouSpeak = false,
+    searchAsYouSpeak,
   } = {} as VoiceSearchWidgetParams
 ) => {
   if (!container) {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR lets the connector handle the default value of `searchAsYouSpeak` when it's not given.
(The default value was given at the widget phase before).

Related to [this](https://github.com/algolia/angular-instantsearch/pull/530#discussion_r286278985)