### PR TITLE
feat(connectInfiniteHits): clear the state on dispose

### DIFF
--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -44,10 +44,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
   });
 
   it('Renders during init and render', () => {
-    // test that the dummyRendering is called with the isFirstRendering
-    // flag set accordingly
-    const rendering = jest.fn();
-    const makeWidget = connectInfiniteHits(rendering);
+    const renderFn = jest.fn();
+    const makeWidget = connectInfiniteHits(renderFn);
     const widget = makeWidget({
       escapeHTML: true,
     });
@@ -57,8 +55,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       highlightPostTag: TAG_PLACEHOLDER.highlightPostTag,
     });
 
-    // test if widget is not rendered yet at this point
-    expect(rendering).toHaveBeenCalledTimes(0);
+    expect(renderFn).toHaveBeenCalledTimes(0);
 
     const helper = algoliasearchHelper({} as Client, '', {});
     helper.search = jest.fn();
@@ -69,10 +66,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       state: helper.state,
     });
 
-    // test that rendering has been called during init with isFirstRendering = true
-    expect(rendering).toHaveBeenCalledTimes(1);
-    // test if isFirstRendering is true during init
-    expect(rendering).toHaveBeenLastCalledWith(
+    expect(renderFn).toHaveBeenCalledTimes(1);
+    expect(renderFn).toHaveBeenLastCalledWith(
       expect.objectContaining({
         hits: [],
         showPrevious: expect.any(Function),
@@ -102,8 +97,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       helper,
     });
 
-    expect(rendering).toHaveBeenCalledTimes(2);
-    expect(rendering).toHaveBeenLastCalledWith(
+    expect(renderFn).toHaveBeenCalledTimes(2);
+    expect(renderFn).toHaveBeenLastCalledWith(
       expect.objectContaining({
         hits: [],
         showPrevious: expect.any(Function),
@@ -124,8 +119,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
   });
 
   it('sets the default configuration', () => {
-    const rendering = jest.fn();
-    const makeWidget = connectInfiniteHits(rendering);
+    const renderFn = (): void => {};
+    const makeWidget = connectInfiniteHits(renderFn);
     const widget = makeWidget({});
 
     expect(widget.getConfiguration!()).toEqual({
@@ -135,8 +130,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
   });
 
   it('Provides the hits and accumulates results on next page', () => {
-    const rendering = jest.fn();
-    const makeWidget = connectInfiniteHits(rendering);
+    const renderFn = jest.fn();
+    const makeWidget = connectInfiniteHits(renderFn);
     const widget = makeWidget({});
 
     const helper = algoliasearchHelper({} as Client, '', {});
@@ -148,9 +143,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       state: helper.state,
     });
 
-    const firstRenderingOptions = rendering.mock.calls[0][0];
-    expect(firstRenderingOptions.hits).toEqual([]);
-    expect(firstRenderingOptions.results).toBe(undefined);
+    const firstRenderOptions = renderFn.mock.calls[0][0];
+    expect(firstRenderOptions.hits).toEqual([]);
+    expect(firstRenderOptions.results).toBe(undefined);
 
     const hits = [{ fake: 'data' }, { sample: 'infos' }];
     const results = new SearchResults(helper.state, [{ hits }]);
@@ -161,10 +156,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       helper,
     });
 
-    const secondRenderingOptions = rendering.mock.calls[1][0];
-    const { showMore } = secondRenderingOptions;
-    expect(secondRenderingOptions.hits).toEqual(hits);
-    expect(secondRenderingOptions.results).toEqual(results);
+    const secondRenderOptions = renderFn.mock.calls[1][0];
+    const { showMore } = secondRenderOptions;
+    expect(secondRenderOptions.hits).toEqual(hits);
+    expect(secondRenderOptions.results).toEqual(results);
     showMore();
     expect(helper.search).toHaveBeenCalledTimes(1);
 
@@ -182,14 +177,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       helper,
     });
 
-    const thirdRenderingOptions = rendering.mock.calls[2][0];
-    expect(thirdRenderingOptions.hits).toEqual([...hits, ...otherHits]);
-    expect(thirdRenderingOptions.results).toEqual(otherResults);
+    const thirdRenderOptions = renderFn.mock.calls[2][0];
+    expect(thirdRenderOptions.hits).toEqual([...hits, ...otherHits]);
+    expect(thirdRenderOptions.results).toEqual(otherResults);
   });
 
   it('Provides the hits and prepends results on previous page', () => {
-    const rendering = jest.fn();
-    const makeWidget = connectInfiniteHits(rendering);
+    const renderFn = jest.fn();
+    const makeWidget = connectInfiniteHits(renderFn);
     const widget = makeWidget({});
 
     const helper = algoliasearchHelper({} as Client, '', {});
@@ -203,9 +198,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       state: helper.state,
     });
 
-    const firstRenderingOptions = rendering.mock.calls[0][0];
-    expect(firstRenderingOptions.hits).toEqual([]);
-    expect(firstRenderingOptions.results).toBe(undefined);
+    const firstRenderOptions = renderFn.mock.calls[0][0];
+    expect(firstRenderOptions.hits).toEqual([]);
+    expect(firstRenderOptions.results).toBe(undefined);
 
     const hits = [{ fake: 'data' }, { sample: 'infos' }];
     const results = new SearchResults(helper.state, [
@@ -220,10 +215,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       helper,
     });
 
-    const secondRenderingOptions = rendering.mock.calls[1][0];
-    const { showPrevious } = secondRenderingOptions;
-    expect(secondRenderingOptions.hits).toEqual(hits);
-    expect(secondRenderingOptions.results).toEqual(results);
+    const secondRenderOptions = renderFn.mock.calls[1][0];
+    const { showPrevious } = secondRenderOptions;
+    expect(secondRenderOptions.hits).toEqual(hits);
+    expect(secondRenderOptions.results).toEqual(results);
     showPrevious();
     expect(helper.state.page).toBe(0);
     expect(helper.emit).not.toHaveBeenCalled();
@@ -243,14 +238,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       helper,
     });
 
-    const thirdRenderingOptions = rendering.mock.calls[2][0];
-    expect(thirdRenderingOptions.hits).toEqual([...previousHits, ...hits]);
-    expect(thirdRenderingOptions.results).toEqual(previousResults);
+    const thirdRenderOptions = renderFn.mock.calls[2][0];
+    expect(thirdRenderOptions.hits).toEqual([...previousHits, ...hits]);
+    expect(thirdRenderOptions.results).toEqual(previousResults);
   });
 
   it('Provides the hits and flush hists cache on query changes', () => {
-    const rendering = jest.fn();
-    const makeWidget = connectInfiniteHits(rendering);
+    const renderFn = jest.fn();
+    const makeWidget = connectInfiniteHits(renderFn);
     const widget = makeWidget({});
 
     const helper = algoliasearchHelper({} as Client, '', {});
@@ -262,9 +257,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       state: helper.state,
     });
 
-    const firstRenderingOptions = rendering.mock.calls[0][0];
-    expect(firstRenderingOptions.hits).toEqual([]);
-    expect(firstRenderingOptions.results).toBe(undefined);
+    const firstRenderOptions = renderFn.mock.calls[0][0];
+    expect(firstRenderOptions.hits).toEqual([]);
+    expect(firstRenderOptions.results).toBe(undefined);
 
     const hits = [{ fake: 'data' }, { sample: 'infos' }];
     const results = new SearchResults(helper.state, [{ hits }]);
@@ -275,9 +270,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       helper,
     });
 
-    const secondRenderingOptions = rendering.mock.calls[1][0];
-    expect(secondRenderingOptions.hits).toEqual(hits);
-    expect(secondRenderingOptions.results).toEqual(results);
+    const secondRenderOptions = renderFn.mock.calls[1][0];
+    expect(secondRenderOptions.hits).toEqual(hits);
+    expect(secondRenderOptions.results).toEqual(results);
 
     helper.setQuery('data');
 
@@ -290,14 +285,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       state: helper.state,
       helper,
     });
-    const thirdRenderingOptions = rendering.mock.calls[2][0];
-    expect(thirdRenderingOptions.hits).toEqual(otherHits);
-    expect(thirdRenderingOptions.results).toEqual(otherResults);
+    const thirdRenderOptions = renderFn.mock.calls[2][0];
+    expect(thirdRenderOptions.hits).toEqual(otherHits);
+    expect(thirdRenderOptions.results).toEqual(otherResults);
   });
 
   it('escape highlight properties if requested', () => {
-    const rendering = jest.fn();
-    const makeWidget = connectInfiniteHits(rendering);
+    const renderFn = jest.fn();
+    const makeWidget = connectInfiniteHits(renderFn);
     const widget = makeWidget({ escapeHTML: true });
 
     const helper = algoliasearchHelper({} as Client, '', {});
@@ -309,9 +304,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       state: helper.state,
     });
 
-    const firstRenderingOptions = rendering.mock.calls[0][0];
-    expect(firstRenderingOptions.hits).toEqual([]);
-    expect(firstRenderingOptions.results).toBe(undefined);
+    const firstRenderOptions = renderFn.mock.calls[0][0];
+    expect(firstRenderOptions.hits).toEqual([]);
+    expect(firstRenderOptions.results).toBe(undefined);
 
     const hits = [
       {
@@ -343,14 +338,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       },
     ];
 
-    const secondRenderingOptions = rendering.mock.calls[1][0];
-    expect(secondRenderingOptions.hits).toEqual(escapedHits);
-    expect(secondRenderingOptions.results).toEqual(results);
+    const secondRenderOptions = renderFn.mock.calls[1][0];
+    expect(secondRenderOptions.hits).toEqual(escapedHits);
+    expect(secondRenderOptions.results).toEqual(results);
   });
 
   it('transform items if requested', () => {
-    const rendering = jest.fn();
-    const makeWidget = connectInfiniteHits(rendering);
+    const renderFn = jest.fn();
+    const makeWidget = connectInfiniteHits(renderFn);
     const widget = makeWidget({
       transformItems: items => items.map(() => ({ name: 'transformed' })),
     });
@@ -364,9 +359,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       state: helper.state,
     });
 
-    const firstRenderingOptions = rendering.mock.calls[0][0];
-    expect(firstRenderingOptions.hits).toEqual([]);
-    expect(firstRenderingOptions.results).toBe(undefined);
+    const firstRenderOptions = renderFn.mock.calls[0][0];
+    expect(firstRenderOptions.hits).toEqual([]);
+    expect(firstRenderOptions.results).toBe(undefined);
 
     const hits = [
       {
@@ -394,14 +389,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       },
     ];
 
-    const secondRenderingOptions = rendering.mock.calls[1][0];
-    expect(secondRenderingOptions.hits).toEqual(transformedHits);
-    expect(secondRenderingOptions.results).toEqual(results);
+    const secondRenderOptions = renderFn.mock.calls[1][0];
+    expect(secondRenderOptions.hits).toEqual(transformedHits);
+    expect(secondRenderOptions.results).toEqual(results);
   });
 
   it('transform items after escaping', () => {
-    const rendering = jest.fn();
-    const makeWidget = connectInfiniteHits(rendering);
+    const renderFn = jest.fn();
+    const makeWidget = connectInfiniteHits(renderFn);
     const widget = makeWidget({
       transformItems: items =>
         items.map(item => ({
@@ -455,7 +450,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       helper,
     });
 
-    expect(rendering).toHaveBeenNthCalledWith(
+    expect(renderFn).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
         hits: [
@@ -483,8 +478,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
   });
 
   it('adds queryID if provided to results', () => {
-    const rendering = jest.fn();
-    const makeWidget = connectInfiniteHits(rendering);
+    const renderFn = jest.fn();
+    const makeWidget = connectInfiniteHits(renderFn);
     const widget = makeWidget({});
 
     const helper = algoliasearchHelper({} as Client, '', {});
@@ -515,7 +510,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       helper,
     });
 
-    expect(rendering).toHaveBeenNthCalledWith(
+    expect(renderFn).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
         hits: [
@@ -534,8 +529,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
   });
 
   it('does not render the same page twice', () => {
-    const rendering = jest.fn();
-    const makeWidget = connectInfiniteHits(rendering);
+    const renderFn = jest.fn();
+    const makeWidget = connectInfiniteHits(renderFn);
     const widget = makeWidget({});
 
     const helper = algoliasearchHelper({} as Client, '', {});
@@ -575,8 +570,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       helper,
     });
 
-    expect(rendering).toHaveBeenCalledTimes(3);
-    expect(rendering).toHaveBeenLastCalledWith(
+    expect(renderFn).toHaveBeenCalledTimes(3);
+    expect(renderFn).toHaveBeenLastCalledWith(
       expect.objectContaining({
         hits: [{ objectID: 'a' }, { objectID: 'b' }],
       }),
@@ -596,8 +591,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       helper,
     });
 
-    expect(rendering).toHaveBeenCalledTimes(4);
-    expect(rendering).toHaveBeenLastCalledWith(
+    expect(renderFn).toHaveBeenCalledTimes(4);
+    expect(renderFn).toHaveBeenLastCalledWith(
       expect.objectContaining({
         hits: [{ objectID: 'a' }, { objectID: 'b' }],
       }),
@@ -625,8 +620,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
   describe('routing', () => {
     describe('getWidgetState', () => {
       it('should give back the object unmodified if the default value is selected', () => {
-        const rendering = jest.fn();
-        const makeWidget = connectInfiniteHits(rendering);
+        const renderFn = jest.fn();
+        const makeWidget = connectInfiniteHits(renderFn);
         const widget = makeWidget({ showPrevious: true });
 
         const helper = algoliasearchHelper({} as Client, '', {});
@@ -648,8 +643,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       });
 
       it('should add an entry equal to the refinement', () => {
-        const rendering = jest.fn();
-        const makeWidget = connectInfiniteHits(rendering);
+        const renderFn = jest.fn();
+        const makeWidget = connectInfiniteHits(renderFn);
         const widget = makeWidget({ showPrevious: true });
 
         const helper = algoliasearchHelper({} as Client, '', {});
@@ -661,7 +656,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
           state: helper.state,
         });
 
-        const { showMore } = rendering.mock.calls[0][0];
+        const { showMore } = renderFn.mock.calls[0][0];
 
         showMore();
 
@@ -675,8 +670,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       });
 
       it('should give back the object unmodified if showPrevious is disabled', () => {
-        const rendering = jest.fn();
-        const makeWidget = connectInfiniteHits(rendering);
+        const renderFn = jest.fn();
+        const makeWidget = connectInfiniteHits(renderFn);
         const widget = makeWidget({ showPrevious: false });
 
         const helper = algoliasearchHelper({} as Client, '', {});
@@ -688,7 +683,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
           state: helper.state,
         });
 
-        const { showMore } = rendering.mock.calls[0][0];
+        const { showMore } = renderFn.mock.calls[0][0];
 
         showMore();
 
@@ -704,8 +699,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
 
     describe('getWidgetSearchParameters', () => {
       it('should return the same SP if there are no refinements in the UI state', () => {
-        const rendering = jest.fn();
-        const makeWidget = connectInfiniteHits(rendering);
+        const renderFn = jest.fn();
+        const makeWidget = connectInfiniteHits(renderFn);
         const widget = makeWidget({ showPrevious: true });
 
         const helper = algoliasearchHelper({} as Client, '', {});
@@ -731,8 +726,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       });
 
       it('should enforce the default value if no value is in the UI State', () => {
-        const rendering = jest.fn();
-        const makeWidget = connectInfiniteHits(rendering);
+        const renderFn = jest.fn();
+        const makeWidget = connectInfiniteHits(renderFn);
         const widget = makeWidget({ showPrevious: true });
 
         const helper = algoliasearchHelper({} as Client, '', {});
@@ -744,7 +739,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
           state: helper.state,
         });
 
-        const { showMore } = rendering.mock.calls[0][0];
+        const { showMore } = renderFn.mock.calls[0][0];
 
         // The user presses back (browser), and the URL contains no parameters
         const uiState = {};
@@ -764,8 +759,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
 
       it('should add the refinements according to the UI state provided', () => {
         (global as any).window = { location: { pathname: null } };
-        const rendering = jest.fn();
-        const makeWidget = connectInfiniteHits(rendering);
+        const renderFn = jest.fn();
+        const makeWidget = connectInfiniteHits(renderFn);
         const widget = makeWidget({ showPrevious: true });
 
         const helper = algoliasearchHelper({} as Client, '', {});
@@ -777,7 +772,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
           state: helper.state,
         });
 
-        const { showMore } = rendering.mock.calls[0][0];
+        const { showMore } = renderFn.mock.calls[0][0];
 
         // The user presses back (browser), and the URL contains some parameters
         const uiState = {
@@ -800,8 +795,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
 
     it('should return the same SP if showPrevious is disabled', () => {
       (global as any).window = { location: { pathname: null } };
-      const rendering = jest.fn();
-      const makeWidget = connectInfiniteHits(rendering);
+      const renderFn = jest.fn();
+      const makeWidget = connectInfiniteHits(renderFn);
       const widget = makeWidget({ showPrevious: false });
 
       const helper = algoliasearchHelper({} as Client, '', {});
@@ -813,7 +808,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
         state: helper.state,
       });
 
-      const { showMore } = rendering.mock.calls[0][0];
+      const { showMore } = renderFn.mock.calls[0][0];
 
       // The user presses back (browser), and the URL contains some parameters
       const uiState = {

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -615,6 +615,33 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
 
       expect(unmountFn).toHaveBeenCalledTimes(1);
     });
+
+    it('removes the TAG_PLACEHOLDER from the `SearchParameters`', () => {
+      const helper = algoliasearchHelper({} as Client, '', {
+        ...TAG_PLACEHOLDER,
+      });
+
+      const renderFn = (): void => {};
+      const unmountFn = jest.fn();
+      const makeWidget = connectInfiniteHits(renderFn, unmountFn);
+      const widget = makeWidget({});
+
+      expect(helper.state.highlightPreTag).toBe(
+        TAG_PLACEHOLDER.highlightPreTag
+      );
+
+      expect(helper.state.highlightPostTag).toBe(
+        TAG_PLACEHOLDER.highlightPostTag
+      );
+
+      const nextState = widget.dispose!({
+        helper,
+        state: helper.state,
+      }) as SearchParameters;
+
+      expect(nextState.highlightPreTag).toBeUndefined();
+      expect(nextState.highlightPostTag).toBeUndefined();
+    });
   });
 
   describe('routing', () => {

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -605,6 +605,23 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     );
   });
 
+  describe('dispose', () => {
+    it('calls the unmount function', () => {
+      const helper = jsHelper({} as Client, '', {});
+
+      const renderFn = (): void => {};
+      const unmountFn = jest.fn();
+      const makeWidget = connectInfiniteHits(renderFn, unmountFn);
+      const widget = makeWidget({});
+
+      expect(unmountFn).toHaveBeenCalledTimes(0);
+
+      widget.dispose!({ helper, state: helper.state });
+
+      expect(unmountFn).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('routing', () => {
     describe('getWidgetState', () => {
       it('should give back the object unmodified if the default value is selected', () => {

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -642,6 +642,26 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       expect(nextState.highlightPreTag).toBeUndefined();
       expect(nextState.highlightPostTag).toBeUndefined();
     });
+
+    it('removes the `page` from the `SearchParameters`', () => {
+      const helper = algoliasearchHelper({} as Client, '', {
+        page: 5,
+      });
+
+      const renderFn = (): void => {};
+      const unmountFn = jest.fn();
+      const makeWidget = connectInfiniteHits(renderFn, unmountFn);
+      const widget = makeWidget({});
+
+      expect(helper.state.page).toBe(5);
+
+      const nextState = widget.dispose!({
+        helper,
+        state: helper.state,
+      }) as SearchParameters;
+
+      expect(nextState.page).toBeUndefined();
+    });
   });
 
   describe('routing', () => {

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -1,4 +1,4 @@
-import jsHelper, {
+import algoliasearchHelper, {
   SearchResults,
   SearchParameters,
 } from 'algoliasearch-helper';
@@ -60,7 +60,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     // test if widget is not rendered yet at this point
     expect(rendering).toHaveBeenCalledTimes(0);
 
-    const helper = jsHelper({} as Client, '', {});
+    const helper = algoliasearchHelper({} as Client, '', {});
     helper.search = jest.fn();
 
     widget.init!({
@@ -139,7 +139,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     const makeWidget = connectInfiniteHits(rendering);
     const widget = makeWidget({});
 
-    const helper = jsHelper({} as Client, '', {});
+    const helper = algoliasearchHelper({} as Client, '', {});
     helper.search = jest.fn();
 
     widget.init!({
@@ -192,7 +192,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     const makeWidget = connectInfiniteHits(rendering);
     const widget = makeWidget({});
 
-    const helper = jsHelper({} as Client, '', {});
+    const helper = algoliasearchHelper({} as Client, '', {});
     helper.setPage(1);
     helper.search = jest.fn();
     helper.emit = jest.fn();
@@ -253,7 +253,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     const makeWidget = connectInfiniteHits(rendering);
     const widget = makeWidget({});
 
-    const helper = jsHelper({} as Client, '', {});
+    const helper = algoliasearchHelper({} as Client, '', {});
     helper.search = jest.fn();
 
     widget.init!({
@@ -300,7 +300,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     const makeWidget = connectInfiniteHits(rendering);
     const widget = makeWidget({ escapeHTML: true });
 
-    const helper = jsHelper({} as Client, '', {});
+    const helper = algoliasearchHelper({} as Client, '', {});
     helper.search = jest.fn();
 
     widget.init!({
@@ -355,7 +355,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       transformItems: items => items.map(() => ({ name: 'transformed' })),
     });
 
-    const helper = jsHelper({} as Client, '', {});
+    const helper = algoliasearchHelper({} as Client, '', {});
     helper.search = jest.fn();
 
     widget.init!({
@@ -415,7 +415,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       escapeHTML: true,
     });
 
-    const helper = jsHelper({} as Client, '', {});
+    const helper = algoliasearchHelper({} as Client, '', {});
     helper.search = jest.fn();
 
     widget.init!({
@@ -487,7 +487,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     const makeWidget = connectInfiniteHits(rendering);
     const widget = makeWidget({});
 
-    const helper = jsHelper({} as Client, '', {});
+    const helper = algoliasearchHelper({} as Client, '', {});
     helper.search = jest.fn();
 
     widget.init!({
@@ -538,7 +538,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     const makeWidget = connectInfiniteHits(rendering);
     const widget = makeWidget({});
 
-    const helper = jsHelper({} as Client, '', {});
+    const helper = algoliasearchHelper({} as Client, '', {});
     helper.search = jest.fn();
 
     widget.init!({
@@ -607,7 +607,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
 
   describe('dispose', () => {
     it('calls the unmount function', () => {
-      const helper = jsHelper({} as Client, '', {});
+      const helper = algoliasearchHelper({} as Client, '', {});
 
       const renderFn = (): void => {};
       const unmountFn = jest.fn();
@@ -629,7 +629,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
         const makeWidget = connectInfiniteHits(rendering);
         const widget = makeWidget({ showPrevious: true });
 
-        const helper = jsHelper({} as Client, '', {});
+        const helper = algoliasearchHelper({} as Client, '', {});
         helper.search = jest.fn();
 
         widget.init!({
@@ -652,7 +652,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
         const makeWidget = connectInfiniteHits(rendering);
         const widget = makeWidget({ showPrevious: true });
 
-        const helper = jsHelper({} as Client, '', {});
+        const helper = algoliasearchHelper({} as Client, '', {});
         helper.search = jest.fn();
 
         widget.init!({
@@ -679,7 +679,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
         const makeWidget = connectInfiniteHits(rendering);
         const widget = makeWidget({ showPrevious: false });
 
-        const helper = jsHelper({} as Client, '', {});
+        const helper = algoliasearchHelper({} as Client, '', {});
         helper.search = jest.fn();
 
         widget.init!({
@@ -708,7 +708,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
         const makeWidget = connectInfiniteHits(rendering);
         const widget = makeWidget({ showPrevious: true });
 
-        const helper = jsHelper({} as Client, '', {});
+        const helper = algoliasearchHelper({} as Client, '', {});
         helper.search = jest.fn();
 
         widget.init!({
@@ -735,7 +735,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
         const makeWidget = connectInfiniteHits(rendering);
         const widget = makeWidget({ showPrevious: true });
 
-        const helper = jsHelper({} as Client, '', {});
+        const helper = algoliasearchHelper({} as Client, '', {});
         helper.search = jest.fn();
 
         widget.init!({
@@ -768,7 +768,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
         const makeWidget = connectInfiniteHits(rendering);
         const widget = makeWidget({ showPrevious: true });
 
-        const helper = jsHelper({} as Client, '', {});
+        const helper = algoliasearchHelper({} as Client, '', {});
         helper.search = jest.fn();
 
         widget.init!({
@@ -804,7 +804,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       const makeWidget = connectInfiniteHits(rendering);
       const widget = makeWidget({ showPrevious: false });
 
-      const helper = jsHelper({} as Client, '', {});
+      const helper = algoliasearchHelper({} as Client, '', {});
       helper.search = jest.fn();
 
       widget.init!({

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -654,7 +654,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       expect(nextState.highlightPostTag).toBeUndefined();
     });
 
-    it('removes the TAG_PLACEHOLDER from the `SearchParameters` only with `escapeHTML`', () => {
+    it('does not remove the TAG_PLACEHOLDER from the `SearchParameters` with `escapeHTML`', () => {
       const helper = algoliasearchHelper({} as Client, '', {
         highlightPreTag: '<mark>',
         highlightPostTag: '</mark>',

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -634,8 +634,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       });
 
       const renderFn = (): void => {};
-      const unmountFn = jest.fn();
-      const makeWidget = connectInfiniteHits(renderFn, unmountFn);
+      const makeWidget = connectInfiniteHits(renderFn);
       const widget = makeWidget({});
 
       expect(helper.state.highlightPreTag).toBe(
@@ -655,14 +654,37 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       expect(nextState.highlightPostTag).toBeUndefined();
     });
 
+    it('removes the TAG_PLACEHOLDER from the `SearchParameters` only with `escapeHTML`', () => {
+      const helper = algoliasearchHelper({} as Client, '', {
+        highlightPreTag: '<mark>',
+        highlightPostTag: '</mark>',
+      });
+
+      const renderFn = (): void => {};
+      const makeWidget = connectInfiniteHits(renderFn);
+      const widget = makeWidget({
+        escapeHTML: false,
+      });
+
+      expect(helper.state.highlightPreTag).toBe('<mark>');
+      expect(helper.state.highlightPostTag).toBe('</mark>');
+
+      const nextState = widget.dispose!({
+        helper,
+        state: helper.state,
+      }) as SearchParameters;
+
+      expect(nextState.highlightPreTag).toBe('<mark>');
+      expect(nextState.highlightPostTag).toBe('</mark>');
+    });
+
     it('removes the `page` from the `SearchParameters`', () => {
       const helper = algoliasearchHelper({} as Client, '', {
         page: 5,
       });
 
       const renderFn = (): void => {};
-      const unmountFn = jest.fn();
-      const makeWidget = connectInfiniteHits(renderFn, unmountFn);
+      const makeWidget = connectInfiniteHits(renderFn);
       const widget = makeWidget({});
 
       expect(helper.state.page).toBe(5);

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -616,6 +616,18 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       expect(unmountFn).toHaveBeenCalledTimes(1);
     });
 
+    it('does not throw without the unmount function', () => {
+      const helper = algoliasearchHelper({} as Client, '', {});
+
+      const renderFn = (): void => {};
+      const makeWidget = connectInfiniteHits(renderFn);
+      const widget = makeWidget({});
+
+      expect(() =>
+        widget.dispose!({ helper, state: helper.state })
+      ).not.toThrow();
+    });
+
     it('removes the TAG_PLACEHOLDER from the `SearchParameters`', () => {
       const helper = algoliasearchHelper({} as Client, '', {
         ...TAG_PLACEHOLDER,

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -223,7 +223,7 @@ const connectInfiniteHits: InfiniteHitsConnector = (
       dispose({ state }) {
         unmountFn();
 
-        return state.setQueryParameters(
+        return state.setQueryParameter('page', undefined).setQueryParameters(
           Object.keys(TAG_PLACEHOLDER).reduce(
             (acc, key) => ({
               ...acc,

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -220,8 +220,18 @@ const connectInfiniteHits: InfiniteHitsConnector = (
         );
       },
 
-      dispose() {
+      dispose({ state }) {
         unmountFn();
+
+        return state.setQueryParameters(
+          Object.keys(TAG_PLACEHOLDER).reduce(
+            (acc, key) => ({
+              ...acc,
+              [key]: undefined,
+            }),
+            {}
+          )
+        );
       },
 
       getWidgetState(uiState, { searchParameters }) {

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -223,7 +223,13 @@ const connectInfiniteHits: InfiniteHitsConnector = (
       dispose({ state }) {
         unmountFn();
 
-        return state.setQueryParameter('page', undefined).setQueryParameters(
+        const stateWithoutQuery = state.setQueryParameter('page', undefined);
+
+        if (!escapeHTML) {
+          return stateWithoutQuery;
+        }
+
+        return stateWithoutQuery.setQueryParameters(
           Object.keys(TAG_PLACEHOLDER).reduce(
             (acc, key) => ({
               ...acc,


### PR DESCRIPTION
This PR fix the implementation of the `dispose` method for the connector `connectInfiniteHits`. It omits `page` once the widget is removed. I also cover the rest of the `dispose` function with tests.