### PR TITLE
fix(getTag): use object version of toString

### DIFF
--- a/src/lib/utils/isPlainObject.ts
+++ b/src/lib/utils/isPlainObject.ts
@@ -8,7 +8,7 @@ function getTag(value: any): string {
     return value === undefined ? '[object Undefined]' : '[object Null]';
   }
 
-  return toString.call(value);
+  return Object.prototype.toString.call(value);
 }
 
 function isObjectLike(value: any): boolean {


### PR DESCRIPTION
IE11: global `toString` can not be called as `Object.prototype.toString`, so we need to use the Object version, like done in lodash (not doing this initially was likely a simple omission)

fixes #3814 

references: 

- https://github.com/lodash/lodash/pull/4115 (remove core-js to test more regular code)
- https://github.com/lodash/lodash/blob/master/.internal/getTag.js#L1

<img width="279" alt="Screenshot 2019-05-27 at 17 23 43" src="https://user-images.githubusercontent.com/6270048/58428994-9982f880-80a4-11e9-8ecf-60a2916955a3.png">
<img width="805" alt="Screenshot 2019-05-27 at 15 49 22" src="https://user-images.githubusercontent.com/6270048/58428995-9982f880-80a4-11e9-895c-17b15ef37fec.png">
