### PR TITLE
feat(connectSearchBox): clear the state on dispose

### DIFF
--- a/src/connectors/search-box/__tests__/connectSearchBox-test.js
+++ b/src/connectors/search-box/__tests__/connectSearchBox-test.js
@@ -297,6 +297,23 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
     expect(helper.search).toHaveBeenCalledTimes(1);
   });
 
+  describe('dispose', () => {
+    it('calls the unmount function', () => {
+      const helper = jsHelper({}, '');
+
+      const renderFn = () => {};
+      const unmountFn = jest.fn();
+      const makeWidget = connectSearchBox(renderFn, unmountFn);
+      const widget = makeWidget();
+
+      expect(unmountFn).toHaveBeenCalledTimes(0);
+
+      widget.dispose({ helper, state: helper.state });
+
+      expect(unmountFn).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('routing', () => {
     const getInitializedWidget = (config = {}) => {
       const rendering = jest.fn();

--- a/src/connectors/search-box/__tests__/connectSearchBox-test.js
+++ b/src/connectors/search-box/__tests__/connectSearchBox-test.js
@@ -312,6 +312,18 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
 
       expect(unmountFn).toHaveBeenCalledTimes(1);
     });
+
+    it('does not throw without the unmount function', () => {
+      const helper = jsHelper({}, '');
+
+      const renderFn = () => {};
+      const makeWidget = connectSearchBox(renderFn);
+      const widget = makeWidget();
+
+      expect(() =>
+        widget.dispose({ helper, state: helper.state })
+      ).not.toThrow();
+    });
   });
 
   describe('routing', () => {

--- a/src/connectors/search-box/__tests__/connectSearchBox-test.js
+++ b/src/connectors/search-box/__tests__/connectSearchBox-test.js
@@ -324,6 +324,22 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
         widget.dispose({ helper, state: helper.state })
       ).not.toThrow();
     });
+
+    it('removes the `query` from the `SearchParameters`', () => {
+      const helper = jsHelper({}, '', {
+        query: 'Apple',
+      });
+
+      const renderFn = () => {};
+      const makeWidget = connectSearchBox(renderFn);
+      const widget = makeWidget();
+
+      expect(helper.state.query).toBe('Apple');
+
+      const nextState = widget.dispose({ helper, state: helper.state });
+
+      expect(nextState.query).toBeUndefined();
+    });
   });
 
   describe('routing', () => {

--- a/src/connectors/search-box/__tests__/connectSearchBox-test.js
+++ b/src/connectors/search-box/__tests__/connectSearchBox-test.js
@@ -1,4 +1,4 @@
-import jsHelper, {
+import algoliasearchHelper, {
   SearchResults,
   SearchParameters,
 } from 'algoliasearch-helper';
@@ -29,7 +29,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
 
     expect(widget.getConfiguration).toBe(undefined);
 
-    const helper = jsHelper({});
+    const helper = algoliasearchHelper({});
     helper.search = () => {};
 
     widget.init({
@@ -76,7 +76,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
 
     const widget = makeWidget();
 
-    const helper = jsHelper({});
+    const helper = algoliasearchHelper({});
     helper.search = jest.fn();
 
     widget.init({
@@ -121,7 +121,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
 
     const widget = makeWidget();
 
-    const helper = jsHelper({}, '', {
+    const helper = algoliasearchHelper({}, '', {
       query: 'bup',
     });
     helper.search = jest.fn();
@@ -176,7 +176,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
       queryHook,
     });
 
-    const helper = jsHelper({});
+    const helper = algoliasearchHelper({});
     helper.search = jest.fn();
 
     widget.init({
@@ -237,7 +237,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
 
     const widget = makeWidget();
 
-    const helper = jsHelper({});
+    const helper = algoliasearchHelper({});
     helper.search = () => {};
 
     widget.init({
@@ -277,7 +277,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
 
     const widget = makeWidget();
 
-    const helper = jsHelper({});
+    const helper = algoliasearchHelper({});
     helper.search = jest.fn();
     helper.setQuery('foobar');
 
@@ -299,7 +299,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
 
   describe('dispose', () => {
     it('calls the unmount function', () => {
-      const helper = jsHelper({}, '');
+      const helper = algoliasearchHelper({}, '');
 
       const renderFn = () => {};
       const unmountFn = jest.fn();
@@ -314,7 +314,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
     });
 
     it('does not throw without the unmount function', () => {
-      const helper = jsHelper({}, '');
+      const helper = algoliasearchHelper({}, '');
 
       const renderFn = () => {};
       const makeWidget = connectSearchBox(renderFn);
@@ -326,7 +326,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
     });
 
     it('removes the `query` from the `SearchParameters`', () => {
-      const helper = jsHelper({}, '', {
+      const helper = algoliasearchHelper({}, '', {
         query: 'Apple',
       });
 
@@ -352,7 +352,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
       });
 
       const initialConfig = {};
-      const helper = jsHelper({}, '', initialConfig);
+      const helper = algoliasearchHelper({}, '', initialConfig);
       helper.search = jest.fn();
 
       widget.init({

--- a/src/connectors/search-box/__tests__/connectSearchBox-test.js
+++ b/src/connectors/search-box/__tests__/connectSearchBox-test.js
@@ -18,13 +18,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
   });
 
   it('Renders during init and render', () => {
-    // test that the dummyRendering is called with the isFirstRendering
-    // flag set accordingly
-    const rendering = jest.fn();
-    const makeWidget = connectSearchBox(rendering);
-
+    const renderFn = jest.fn();
+    const makeWidget = connectSearchBox(renderFn);
     const widget = makeWidget({
-      foo: 'bar', // dummy param passed to `renderFn`
+      foo: 'bar',
     });
 
     expect(widget.getConfiguration).toBe(undefined);
@@ -39,10 +36,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
       onHistoryChange: () => {},
     });
 
-    // should call the rendering once with isFirstRendering to true
-    expect(rendering).toHaveBeenCalledTimes(1);
-    // should provide good values for the first rendering
-    expect(rendering).toHaveBeenLastCalledWith(
+    expect(renderFn).toHaveBeenCalledTimes(1);
+    expect(renderFn).toHaveBeenLastCalledWith(
       expect.objectContaining({
         query: '',
         widgetParams: { foo: 'bar' },
@@ -58,10 +53,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
       searchMetadata: { isSearchStalled: false },
     });
 
-    // Should call the rendering a second time, with isFirstRendering to false
-    expect(rendering).toHaveBeenCalledTimes(2);
-    // should provide good values after the first search
-    expect(rendering).toHaveBeenLastCalledWith(
+    expect(renderFn).toHaveBeenCalledTimes(2);
+    expect(renderFn).toHaveBeenLastCalledWith(
       expect.objectContaining({
         query: '',
         widgetParams: { foo: 'bar' },
@@ -71,9 +64,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
   });
 
   it('Provides a function to update the refinements at each step', () => {
-    const rendering = jest.fn();
-    const makeWidget = connectSearchBox(rendering);
-
+    const renderFn = jest.fn();
+    const makeWidget = connectSearchBox(renderFn);
     const widget = makeWidget();
 
     const helper = algoliasearchHelper({});
@@ -87,8 +79,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
     });
 
     {
-      // first rendering
-      const { refine, query } = rendering.mock.calls[0][0];
+      const { refine, query } = renderFn.mock.calls[0][0];
       expect(helper.state.query).toBeUndefined();
       expect(query).toBe('');
       refine('bip');
@@ -105,8 +96,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
     });
 
     {
-      // Second rendering
-      const { refine, query } = rendering.mock.calls[1][0];
+      const { refine, query } = renderFn.mock.calls[1][0];
       expect(helper.state.query).toBe('bip');
       expect(query).toBe('bip');
       refine('bop');
@@ -116,9 +106,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
   });
 
   it('provides a function to clear the query and perform new search', () => {
-    const rendering = jest.fn();
-    const makeWidget = connectSearchBox(rendering);
-
+    const renderFn = jest.fn();
+    const makeWidget = connectSearchBox(renderFn);
     const widget = makeWidget();
 
     const helper = algoliasearchHelper({}, '', {
@@ -134,9 +123,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
     });
 
     {
-      // first rendering
       expect(helper.state.query).toBe('bup');
-      const { refine, clear } = rendering.mock.calls[0][0];
+      const { refine, clear } = renderFn.mock.calls[0][0];
       clear(); // triggers a search
       expect(helper.state.query).toBe('');
       expect(helper.search).toHaveBeenCalledTimes(1);
@@ -152,26 +140,22 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
     });
 
     {
-      // Second rendering
       expect(helper.state.query).toBe('bip');
-      const { clear } = rendering.mock.calls[1][0];
-      clear(); // triggers a search
+      const { clear } = renderFn.mock.calls[1][0];
+      clear();
       expect(helper.state.query).toBe('');
-      // refine and clear functions trigger searches. clear + refine + clear
       expect(helper.search).toHaveBeenCalledTimes(3);
     }
   });
 
   it('queryHook parameter let the dev control the behavior of the search', () => {
-    const rendering = jest.fn();
-    const makeWidget = connectSearchBox(rendering);
-
-    // letSearchThrough will control if the provided function should be called
     let letSearchThrough = false;
     const queryHook = jest.fn((q, search) => {
       if (letSearchThrough) search(q);
     });
 
+    const renderFn = jest.fn();
+    const makeWidget = connectSearchBox(renderFn);
     const widget = makeWidget({
       queryHook,
     });
@@ -187,8 +171,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
     });
 
     {
-      // first rendering
-      const { refine } = rendering.mock.calls[0][0];
+      const { refine } = renderFn.mock.calls[0][0];
 
       refine('bip');
       expect(queryHook).toHaveBeenCalledTimes(1);
@@ -203,7 +186,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
       expect(helper.search).toHaveBeenCalledTimes(1);
     }
 
-    // reset the hook behavior
     letSearchThrough = false;
 
     widget.render({
@@ -215,8 +197,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
     });
 
     {
-      // Second rendering
-      const { refine } = rendering.mock.calls[1][0];
+      const { refine } = renderFn.mock.calls[1][0];
 
       refine('bop');
       expect(queryHook).toHaveBeenCalledTimes(3);
@@ -232,9 +213,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
   });
 
   it('should always provide the same refine() and clear() function reference', () => {
-    const rendering = jest.fn();
-    const makeWidget = connectSearchBox(rendering);
-
+    const renderFn = jest.fn();
+    const makeWidget = connectSearchBox(renderFn);
     const widget = makeWidget();
 
     const helper = algoliasearchHelper({});
@@ -255,7 +235,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
       searchMetadata: { isSearchStalled: false },
     });
 
-    const firstRenderOptions = rendering.mock.calls[0][0];
+    const firstRenderOptions = renderFn.mock.calls[0][0];
 
     widget.render({
       results: new SearchResults(helper.state, [{}]),
@@ -265,16 +245,15 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
       searchMetadata: { isSearchStalled: false },
     });
 
-    const secondRenderOptions = rendering.mock.calls[1][0];
+    const secondRenderOptions = renderFn.mock.calls[1][0];
 
     expect(firstRenderOptions.clear).toBe(secondRenderOptions.clear);
     expect(firstRenderOptions.refine).toBe(secondRenderOptions.refine);
   });
 
   it('should clear on init as well', () => {
-    const rendering = jest.fn();
-    const makeWidget = connectSearchBox(rendering);
-
+    const renderFn = jest.fn();
+    const makeWidget = connectSearchBox(renderFn);
     const widget = makeWidget();
 
     const helper = algoliasearchHelper({});
@@ -290,7 +269,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
       onHistoryChange: () => {},
     });
 
-    const { clear } = rendering.mock.calls[0][0];
+    const { clear } = renderFn.mock.calls[0][0];
     clear();
 
     expect(helper.state.query).toBe('');
@@ -344,9 +323,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
 
   describe('routing', () => {
     const getInitializedWidget = (config = {}) => {
-      const rendering = jest.fn();
-      const makeWidget = connectSearchBox(rendering);
-
+      const renderFn = jest.fn();
+      const makeWidget = connectSearchBox(renderFn);
       const widget = makeWidget({
         ...config,
       });
@@ -362,7 +340,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
         onHistoryChange: () => {},
       });
 
-      const { refine } = rendering.mock.calls[0][0];
+      const { refine } = renderFn.mock.calls[0][0];
 
       return [widget, helper, refine];
     };

--- a/src/connectors/search-box/connectSearchBox.js
+++ b/src/connectors/search-box/connectSearchBox.js
@@ -133,7 +133,7 @@ export default function connectSearchBox(renderFn, unmountFn = noop) {
       dispose({ state }) {
         unmountFn();
 
-        return state.setQuery('');
+        return state.setQueryParameter('query', undefined);
       },
 
       getWidgetState(uiState, { searchParameters }) {

--- a/src/connectors/search-box/connectSearchBox.js
+++ b/src/connectors/search-box/connectSearchBox.js
@@ -1,6 +1,7 @@
 import {
   checkRendering,
   createDocumentationMessageGenerator,
+  noop,
 } from '../../lib/utils';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -63,7 +64,7 @@ const withUsage = createDocumentationMessageGenerator({
  *   })
  * );
  */
-export default function connectSearchBox(renderFn, unmountFn) {
+export default function connectSearchBox(renderFn, unmountFn = noop) {
   checkRendering(renderFn, withUsage());
 
   return (widgetParams = {}) => {


### PR DESCRIPTION
This PR fix the implementation of the `dispose` method for the connector `connectSearchBox`. It omits `query` once the widget is removed. I also cover the rest of the `dispose` function with tests.