### PR TITLE
fix(connectSortBy): do not throw with wrong indexes

### DIFF
--- a/src/connectors/sort-by/__tests__/connectSortBy-test.js
+++ b/src/connectors/sort-by/__tests__/connectSortBy-test.js
@@ -218,6 +218,74 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
     }
   });
 
+  describe('options', () => {
+    describe('items', () => {
+      test('uses the helper index by default', () => {
+        const renderFn = jest.fn();
+        const customSortBy = connectSortBy(renderFn);
+        const instantSearchInstance = instantSearch({
+          indexName: '',
+          searchClient: { search() {} },
+        });
+        const helper = jsHelper({}, 'index_featured');
+        helper.search = jest.fn();
+
+        const items = [
+          { label: 'Featured', value: 'index_featured' },
+          { label: 'Price asc.', value: 'index_price_asc' },
+          { label: 'Price desc.', value: 'index_price_desc' },
+        ];
+        const widget = customSortBy({ items });
+
+        widget.init({
+          helper,
+          state: helper.state,
+          createURL: () => '#',
+          instantSearchInstance,
+        });
+
+        expect(renderFn).toHaveBeenCalledTimes(1);
+        const [renderOptions] = renderFn.mock.calls[0];
+
+        expect(renderOptions.currentRefinement).toBe('index_featured');
+      });
+
+      test('warns and falls back to the helper index if not present in the items', () => {
+        const renderFn = jest.fn();
+        const customSortBy = connectSortBy(renderFn);
+        const instantSearchInstance = instantSearch({
+          indexName: '',
+          searchClient: { search() {} },
+        });
+        const helper = jsHelper({}, 'index_initial');
+        helper.search = jest.fn();
+
+        const items = [
+          { label: 'Featured', value: 'index_featured' },
+          { label: 'Price asc.', value: 'index_price_asc' },
+          { label: 'Price desc.', value: 'index_price_desc' },
+        ];
+        const widget = customSortBy({ items });
+
+        expect(() => {
+          widget.init({
+            helper,
+            state: helper.state,
+            createURL: () => '#',
+            instantSearchInstance,
+          });
+        }).toWarnDev(
+          '[InstantSearch.js]: The index named "index_initial" is not listed in the `items` of `sortBy`.'
+        );
+
+        expect(renderFn).toHaveBeenCalledTimes(1);
+        const [firstRenderOptions] = renderFn.mock.calls[0];
+
+        expect(firstRenderOptions.currentRefinement).toBe('index_initial');
+      });
+    });
+  });
+
   describe('routing', () => {
     const getInitializedWidget = (config = {}) => {
       const rendering = jest.fn();

--- a/src/connectors/sort-by/connectSortBy.js
+++ b/src/connectors/sort-by/connectSortBy.js
@@ -2,6 +2,7 @@ import {
   checkRendering,
   createDocumentationMessageGenerator,
   find,
+  warning,
 } from '../../lib/utils';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -100,21 +101,25 @@ export default function connectSortBy(renderFn, unmountFn) {
 
     return {
       init({ helper, instantSearchInstance }) {
-        const currentIndex = helper.getIndex();
-        const isIndexInList = find(items, item => item.value === currentIndex);
+        const initialIndex = helper.getIndex();
+        const isInitialIndexInItems = find(
+          items,
+          item => item.value === initialIndex
+        );
 
-        if (!isIndexInList) {
-          throw new Error(
-            `[sortBy]: Index ${currentIndex} not present in \`items\``
-          );
-        }
+        this.initialIndex = initialIndex;
+        this.setIndex = indexName => {
+          helper.setIndex(indexName).search();
+        };
 
-        this.initialIndex = instantSearchInstance.indexName;
-        this.setIndex = indexName => helper.setIndex(indexName).search();
+        warning(
+          isInitialIndexInItems,
+          `The index named "${initialIndex}" is not listed in the \`items\` of \`sortBy\`.`
+        );
 
         renderFn(
           {
-            currentRefinement: currentIndex,
+            currentRefinement: initialIndex,
             options: transformItems(items),
             refine: this.setIndex,
             hasNoResults: true,
@@ -141,6 +146,7 @@ export default function connectSortBy(renderFn, unmountFn) {
 
       dispose({ state }) {
         unmountFn();
+
         return state.setIndex(this.initialIndex);
       },
 

--- a/src/connectors/sort-by/connectSortBy.js
+++ b/src/connectors/sort-by/connectSortBy.js
@@ -133,7 +133,7 @@ export default function connectSortBy(renderFn, unmountFn) {
       render({ helper, results, instantSearchInstance }) {
         renderFn(
           {
-            currentRefinement: helper.getIndex(),
+            currentRefinement: helper.state.index,
             options: transformItems(items),
             refine: this.setIndex,
             hasNoResults: results.nbHits === 0,

--- a/src/connectors/sort-by/connectSortBy.js
+++ b/src/connectors/sort-by/connectSortBy.js
@@ -101,7 +101,7 @@ export default function connectSortBy(renderFn, unmountFn) {
 
     return {
       init({ helper, instantSearchInstance }) {
-        const initialIndex = helper.getIndex();
+        const initialIndex = helper.state.index;
         const isInitialIndexInItems = find(
           items,
           item => item.value === initialIndex

--- a/src/widgets/sort-by/__tests__/sort-by-test.js
+++ b/src/widgets/sort-by/__tests__/sort-by-test.js
@@ -35,7 +35,7 @@ describe('sortBy()', () => {
     render.mockClear();
 
     const instantSearchInstance = instantSearch({
-      indexName: 'defaultIndex',
+      indexName: '',
       searchClient: {
         search() {},
       },
@@ -53,8 +53,7 @@ describe('sortBy()', () => {
     };
     widget = sortBy({ container, items, cssClasses });
 
-    helper = algoliasearchHelper({}, '');
-    helper.getIndex = jest.fn().mockReturnValue('index-a');
+    helper = algoliasearchHelper({}, 'index-a');
     helper.setIndex = jest.fn().mockReturnThis();
     helper.search = jest.fn();
 

--- a/src/widgets/sort-by/__tests__/sort-by-test.js
+++ b/src/widgets/sort-by/__tests__/sort-by-test.js
@@ -1,4 +1,5 @@
 import { render } from 'preact-compat';
+import algoliasearchHelper from 'algoliasearch-helper';
 import sortBy from '../sort-by';
 import instantSearch from '../../../lib/main';
 
@@ -51,11 +52,11 @@ describe('sortBy()', () => {
       item: 'custom-item',
     };
     widget = sortBy({ container, items, cssClasses });
-    helper = {
-      getIndex: jest.fn().mockReturnValue('index-a'),
-      setIndex: jest.fn().mockReturnThis(),
-      search: jest.fn(),
-    };
+
+    helper = algoliasearchHelper({}, '');
+    helper.getIndex = jest.fn().mockReturnValue('index-a');
+    helper.setIndex = jest.fn().mockReturnThis();
+    helper.search = jest.fn();
 
     results = {
       hits: [],

--- a/src/widgets/sort-by/__tests__/sort-by-test.js
+++ b/src/widgets/sort-by/__tests__/sort-by-test.js
@@ -99,21 +99,4 @@ describe('sortBy()', () => {
     expect(helper.setIndex).toHaveBeenCalledTimes(1);
     expect(helper.search).toHaveBeenCalledTimes(1);
   });
-
-  it('should throw if there is no name attribute in a passed object', () => {
-    items.length = 0;
-    items.push({ label: 'Label without a name' });
-
-    expect(() => {
-      widget.init({ helper });
-    }).toThrow(/Index index-a not present/);
-  });
-
-  it('must include the current index at initialization time', () => {
-    helper.getIndex = jest.fn().mockReturnValue('non-existing-index');
-
-    expect(() => {
-      widget.init({ helper });
-    }).toThrow(/Index non-existing-index not present/);
-  });
 });


### PR DESCRIPTION
> This PR closes #3397.

The `sortBy` connector used to throw an error when the current index wasn't listed in the `items` of the widget.

This broke some users' apps when using `routing`. If users type a URL with a wrong index name for the `sortBy` widget, it will throw straight away and break the InstantSearch lifecycle.

This PR removes the error thrown and rathers warns only in development. The initial index (from the helper) is used if that happens.

I slightly changed the implementation because we were relying on the InstantSearch instance index (`instantSearch.indexName`) and now use the helper index (`helper.getIndex()`). This shouldn't break anything and is more consistent within the connector.

The deleted tests in the widget are now covered in the connector.