### PR TITLE
fix(escape): make sure that __escaped does not get removed

### DIFF
--- a/src/connectors/hits/__tests__/connectHits-test.js
+++ b/src/connectors/hits/__tests__/connectHits-test.js
@@ -219,7 +219,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
 
     const expectedHits = [{ name: 'transformed' }, { name: 'transformed' }];
     expectedHits.__escaped = true;
-    results.hits.__escaped = true;
 
     expect(rendering).toHaveBeenNthCalledWith(
       2,
@@ -348,7 +347,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
       },
     ];
     expectedHits.__escaped = true;
-    results.hits.__escaped = true;
 
     expect(rendering).toHaveBeenNthCalledWith(
       2,

--- a/src/connectors/hits/__tests__/connectHits-test.js
+++ b/src/connectors/hits/__tests__/connectHits-test.js
@@ -3,6 +3,9 @@ import { TAG_PLACEHOLDER } from '../../../lib/escape-highlight';
 import connectHits from '../connectHits';
 
 jest.mock('../../../lib/utils/hits-absolute-position', () => ({
+  // The real implementation creates a new array instance, which can cause bugs,
+  // especially with the __escaped mark, we thus make sure the mock also has the
+  // same behavior regarding the array.
   addAbsolutePosition: hits => hits.map(x => x),
 }));
 

--- a/src/connectors/hits/connectHits.js
+++ b/src/connectors/hits/connectHits.js
@@ -78,7 +78,7 @@ export default function connectHits(renderFn, unmountFn) {
           results.hits = escapeHits(results.hits);
         }
 
-        const oldEscaped = results.hits.__escaped;
+        const initialEscaped = results.hits.__escaped;
 
         results.hits = addAbsolutePosition(
           results.hits,
@@ -93,7 +93,7 @@ export default function connectHits(renderFn, unmountFn) {
         // Make sure the escaped tag stays, even after mapping over the hits.
         // This prevents the hits from being double-escaped if there are multiple
         // hits widgets mounted on the page.
-        results.hits.__escaped = oldEscaped;
+        results.hits.__escaped = initialEscaped;
 
         renderFn(
           {

--- a/src/connectors/hits/connectHits.js
+++ b/src/connectors/hits/connectHits.js
@@ -90,8 +90,8 @@ export default function connectHits(renderFn, unmountFn) {
 
         results.hits = transformItems(results.hits);
 
-        // make sure the escaped tag stays, even after mapping over the hits
-        // this prevents the hits from being double-escaped if there are multiple
+        // Make sure the escaped tag stays, even after mapping over the hits.
+        // This prevents the hits from being double-escaped if there are multiple
         // hits widgets mounted on the page.
         results.hits.__escaped = oldEscaped;
 

--- a/src/connectors/hits/connectHits.js
+++ b/src/connectors/hits/connectHits.js
@@ -74,9 +74,11 @@ export default function connectHits(renderFn, unmountFn) {
       },
 
       render({ results, instantSearchInstance }) {
-        if (escapeHTML && results.hits && results.hits.length > 0) {
+        if (escapeHTML && results.hits.length > 0) {
           results.hits = escapeHits(results.hits);
         }
+
+        const oldEscaped = results.hits.__escaped;
 
         results.hits = addAbsolutePosition(
           results.hits,
@@ -87,6 +89,11 @@ export default function connectHits(renderFn, unmountFn) {
         results.hits = addQueryID(results.hits, results.queryID);
 
         results.hits = transformItems(results.hits);
+
+        // make sure the escaped tag stays, even after mapping over the hits
+        // this prevents the hits from being double-escaped if there are multiple
+        // hits widgets mounted on the page.
+        results.hits.__escaped = oldEscaped;
 
         renderFn(
           {

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -9,6 +9,9 @@ import connectInfiniteHits from '../connectInfiniteHits';
 import { Client } from '../../../types';
 
 jest.mock('../../../lib/utils/hits-absolute-position', () => ({
+  // The real implementation creates a new array instance, which can cause bugs,
+  // especially with the __escaped mark, we thus make sure the mock also has the
+  // same behavior regarding the array.
   addAbsolutePosition: hits => hits.map(x => x),
 }));
 

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -9,7 +9,7 @@ import connectInfiniteHits from '../connectInfiniteHits';
 import { Client } from '../../../types';
 
 jest.mock('../../../lib/utils/hits-absolute-position', () => ({
-  addAbsolutePosition: hits => hits,
+  addAbsolutePosition: hits => hits.map(x => x),
 }));
 
 describe('connectInfiniteHits', () => {
@@ -603,6 +603,33 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       }),
       false
     );
+  });
+
+  it('keeps the __escaped mark', () => {
+    const rendering = jest.fn();
+    const makeWidget = connectInfiniteHits(rendering);
+    const widget = makeWidget({});
+
+    const helper = jsHelper({} as Client, '', {});
+    helper.search = jest.fn();
+
+    widget.init!({
+      ...defaultInitOptions,
+      helper,
+      state: helper.state,
+    });
+
+    const results = new SearchResults(helper.state, [
+      { hits: [{ whatever: 'i like kittens' }] },
+    ]);
+    widget.render!({
+      ...defaultRenderOptions,
+      results,
+      state: helper.state,
+      helper,
+    });
+
+    expect((results.hits as any).__escaped).toBe(true);
   });
 
   describe('routing', () => {

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -182,7 +182,7 @@ const connectInfiniteHits: InfiniteHitsConnector = (
         if (escapeHTML && results.hits.length > 0) {
           results.hits = escapeHits(results.hits);
         }
-        const oldEscaped = (results.hits as any).__escaped;
+        const initialEscaped = (results.hits as any).__escaped;
 
         results.hits = addAbsolutePosition(
           results.hits,
@@ -197,7 +197,7 @@ const connectInfiniteHits: InfiniteHitsConnector = (
         // Make sure the escaped tag stays after mapping over the hits.
         // This prevents the hits from being double-escaped if there are multiple
         // hits widgets mounted on the page.
-        (results.hits as any).__escaped = oldEscaped;
+        (results.hits as any).__escaped = initialEscaped;
 
         if (lastReceivedPage < page! || !hitsCache.length) {
           hitsCache = [...hitsCache, ...results.hits];

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -179,9 +179,10 @@ const connectInfiniteHits: InfiniteHitsConnector = (
           prevState = currentState;
         }
 
-        if (escapeHTML && results.hits && results.hits.length > 0) {
+        if (escapeHTML && results.hits.length > 0) {
           results.hits = escapeHits(results.hits);
         }
+        const oldEscaped = (results.hits as any).__escaped;
 
         results.hits = addAbsolutePosition(
           results.hits,
@@ -192,6 +193,11 @@ const connectInfiniteHits: InfiniteHitsConnector = (
         results.hits = addQueryID(results.hits, results.queryID);
 
         results.hits = transformItems(results.hits);
+
+        // make sure the escaped tag stays, even after mapping over the hits
+        // this prevents the hits from being double-escaped if there are multiple
+        // hits widgets mounted on the page.
+        (results.hits as any).__escaped = oldEscaped;
 
         if (lastReceivedPage < page! || !hitsCache.length) {
           hitsCache = [...hitsCache, ...results.hits];

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -194,8 +194,8 @@ const connectInfiniteHits: InfiniteHitsConnector = (
 
         results.hits = transformItems(results.hits);
 
-        // make sure the escaped tag stays, even after mapping over the hits
-        // this prevents the hits from being double-escaped if there are multiple
+        // Make sure the escaped tag stays after mapping over the hits.
+        // This prevents the hits from being double-escaped if there are multiple
         // hits widgets mounted on the page.
         (results.hits as any).__escaped = oldEscaped;
 


### PR DESCRIPTION
When mapping over an array, extra non-enumerable properties don't get copied into the new array. This means that the `__escaped` gets removed due to transformItems, or addAbsolutePosition.

We fix this by setting that mark back just before calling the render function. We want transformItems to happen after escaping, so it's no option to put the mark before.

Note also that if we would put the escaping before, we would still need to capture the marker, since it will be removed by the earlier transformations.

The new tests I added fail without my modification.

See also https://github.com/algolia/vue-instantsearch/issues/639 which highlighted 😅 this issue.
