### PR TITLE
feat(connectAutocomplete): add default value on getConfiguration

### DIFF
--- a/src/connectors/autocomplete/__tests__/connectAutocomplete-test.js
+++ b/src/connectors/autocomplete/__tests__/connectAutocomplete-test.js
@@ -158,6 +158,16 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/autocomplet
   });
 
   describe('getConfiguration', () => {
+    it('adds a `query` to the `SearchParameters`', () => {
+      const renderFn = () => {};
+      const makeWidget = connectAutocomplete(renderFn);
+      const widget = makeWidget();
+
+      const nextConfiguation = widget.getConfiguration();
+
+      expect(nextConfiguation.query).toBe('');
+    });
+
     it('adds the TAG_PLACEHOLDER to the `SearchParameters`', () => {
       const renderFn = () => {};
       const makeWidget = connectAutocomplete(renderFn);

--- a/src/connectors/autocomplete/__tests__/connectAutocomplete-test.js
+++ b/src/connectors/autocomplete/__tests__/connectAutocomplete-test.js
@@ -43,17 +43,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/autocomplet
     expect(renderFn.mock.calls[1][1]).toBeFalsy();
   });
 
-  it('sets the default configuration', () => {
-    const renderFn = jest.fn();
-    const makeWidget = connectAutocomplete(renderFn);
-    const widget = makeWidget();
-
-    expect(widget.getConfiguration()).toEqual({
-      highlightPreTag: TAG_PLACEHOLDER.highlightPreTag,
-      highlightPostTag: TAG_PLACEHOLDER.highlightPostTag,
-    });
-  });
-
   it('creates DerivedHelper', () => {
     const renderFn = jest.fn();
     const makeWidget = connectAutocomplete(renderFn);
@@ -166,6 +155,37 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/autocomplet
     const rendering = renderFn.mock.calls[1][0];
 
     expect(rendering.indices[0].hits).toEqual(hits);
+  });
+
+  describe('getConfiguration', () => {
+    it('adds the TAG_PLACEHOLDER to the `SearchParameters`', () => {
+      const renderFn = () => {};
+      const makeWidget = connectAutocomplete(renderFn);
+      const widget = makeWidget();
+
+      const nextConfiguation = widget.getConfiguration();
+
+      expect(nextConfiguation.highlightPreTag).toBe(
+        TAG_PLACEHOLDER.highlightPreTag
+      );
+
+      expect(nextConfiguation.highlightPostTag).toBe(
+        TAG_PLACEHOLDER.highlightPostTag
+      );
+    });
+
+    it('does not add the TAG_PLACEHOLDER to the `SearchParameters` with `escapeHTML` disabled', () => {
+      const renderFn = () => {};
+      const makeWidget = connectAutocomplete(renderFn);
+      const widget = makeWidget({
+        escapeHTML: false,
+      });
+
+      const nextConfiguation = widget.getConfiguration();
+
+      expect(nextConfiguation.highlightPreTag).toBeUndefined();
+      expect(nextConfiguation.highlightPostTag).toBeUndefined();
+    });
   });
 
   describe('dispose', () => {
@@ -295,7 +315,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/autocomplet
       expect(nextState.highlightPostTag).toBeUndefined();
     });
 
-    it('does not remove the TAG_PLACEHOLDER from the `SearchParameters` with `escapeHTML`', () => {
+    it('does not remove the TAG_PLACEHOLDER from the `SearchParameters` with `escapeHTML` disabled', () => {
       const helper = algoliasearchHelper(fakeClient, 'firstIndex', {
         highlightPreTag: '<mark>',
         highlightPostTag: '</mark>',

--- a/src/connectors/autocomplete/connectAutocomplete.js
+++ b/src/connectors/autocomplete/connectAutocomplete.js
@@ -57,7 +57,7 @@ export default function connectAutocomplete(renderFn, unmountFn = noop) {
 
     return {
       getConfiguration() {
-        return escapeHTML ? TAG_PLACEHOLDER : undefined;
+        return escapeHTML ? TAG_PLACEHOLDER : {};
       },
 
       init({ instantSearchInstance, helper }) {

--- a/src/connectors/autocomplete/connectAutocomplete.js
+++ b/src/connectors/autocomplete/connectAutocomplete.js
@@ -57,7 +57,18 @@ export default function connectAutocomplete(renderFn, unmountFn = noop) {
 
     return {
       getConfiguration() {
-        return escapeHTML ? TAG_PLACEHOLDER : {};
+        const parameters = {
+          query: '',
+        };
+
+        if (!escapeHTML) {
+          return parameters;
+        }
+
+        return {
+          ...parameters,
+          ...TAG_PLACEHOLDER,
+        };
       },
 
       init({ instantSearchInstance, helper }) {


### PR DESCRIPTION
This PR updates the implementation for `getConfiguration` inside `connectAutocomplete`. It adds a default `query` once the widget is mounted. This default value is useful for federated search, without the widget is **always** controlled by its parent. I also cover the rest of the `getConfiguration` function with tests.