### PR TITLE
feat(connectInfiniteHits): add default value on getConfiguration

### DIFF
--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -50,11 +50,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       escapeHTML: true,
     });
 
-    expect(widget.getConfiguration!()).toEqual({
-      highlightPreTag: TAG_PLACEHOLDER.highlightPreTag,
-      highlightPostTag: TAG_PLACEHOLDER.highlightPostTag,
-    });
-
     expect(renderFn).toHaveBeenCalledTimes(0);
 
     const helper = algoliasearchHelper({} as Client, '', {});
@@ -116,17 +111,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       }),
       false
     );
-  });
-
-  it('sets the default configuration', () => {
-    const renderFn = (): void => {};
-    const makeWidget = connectInfiniteHits(renderFn);
-    const widget = makeWidget({});
-
-    expect(widget.getConfiguration!()).toEqual({
-      highlightPreTag: TAG_PLACEHOLDER.highlightPreTag,
-      highlightPostTag: TAG_PLACEHOLDER.highlightPostTag,
-    });
   });
 
   it('Provides the hits and accumulates results on next page', () => {
@@ -600,6 +584,37 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     );
   });
 
+  describe('getConfiguration', () => {
+    it('adds the TAG_PLACEHOLDER to the `SearchParameters`', () => {
+      const renderFn = (): void => {};
+      const makeWidget = connectInfiniteHits(renderFn);
+      const widget = makeWidget({});
+
+      const nextConfiguration = widget.getConfiguration!();
+
+      expect(nextConfiguration.highlightPreTag).toBe(
+        TAG_PLACEHOLDER.highlightPreTag
+      );
+
+      expect(nextConfiguration.highlightPostTag).toBe(
+        TAG_PLACEHOLDER.highlightPostTag
+      );
+    });
+
+    it('does not add the TAG_PLACEHOLDER to the `SearchParameters` with `escapeHTML` disabled', () => {
+      const renderFn = (): void => {};
+      const makeWidget = connectInfiniteHits(renderFn);
+      const widget = makeWidget({
+        escapeHTML: false,
+      });
+
+      const nextConfiguration = widget.getConfiguration!();
+
+      expect(nextConfiguration.highlightPreTag).toBeUndefined();
+      expect(nextConfiguration.highlightPostTag).toBeUndefined();
+    });
+  });
+
   describe('dispose', () => {
     it('calls the unmount function', () => {
       const helper = algoliasearchHelper({} as Client, '', {});
@@ -654,7 +669,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       expect(nextState.highlightPostTag).toBeUndefined();
     });
 
-    it('does not remove the TAG_PLACEHOLDER from the `SearchParameters` with `escapeHTML`', () => {
+    it('does not remove the TAG_PLACEHOLDER from the `SearchParameters` with `escapeHTML` disabled', () => {
       const helper = algoliasearchHelper({} as Client, '', {
         highlightPreTag: '<mark>',
         highlightPostTag: '</mark>',

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -585,6 +585,16 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
   });
 
   describe('getConfiguration', () => {
+    it('adds a `page` to the `SearchParameters`', () => {
+      const renderFn = (): void => {};
+      const makeWidget = connectInfiniteHits(renderFn);
+      const widget = makeWidget({});
+
+      const nextConfiguration = widget.getConfiguration!();
+
+      expect(nextConfiguration.page).toBe(0);
+    });
+
     it('adds the TAG_PLACEHOLDER to the `SearchParameters`', () => {
       const renderFn = (): void => {};
       const makeWidget = connectInfiniteHits(renderFn);

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -140,7 +140,18 @@ const connectInfiniteHits: InfiniteHitsConnector = (
 
     return {
       getConfiguration() {
-        return escapeHTML ? TAG_PLACEHOLDER : {};
+        const parameters = {
+          page: 0,
+        };
+
+        if (!escapeHTML) {
+          return parameters;
+        }
+
+        return {
+          ...parameters,
+          ...TAG_PLACEHOLDER,
+        };
       },
 
       init({ instantSearchInstance, helper }) {

--- a/src/widgets/infinite-hits/__tests__/infinite-hits-test.ts
+++ b/src/widgets/infinite-hits/__tests__/infinite-hits-test.ts
@@ -1,6 +1,5 @@
 import { render } from 'preact-compat';
 import algoliasearchHelper from 'algoliasearch-helper';
-import { TAG_PLACEHOLDER } from '../../../lib/escape-highlight';
 import infiniteHits from '../infinite-hits';
 import { Client } from '../../../types';
 
@@ -51,13 +50,6 @@ describe('infiniteHits()', () => {
       hitsPerPage: 2,
       page: 1,
     };
-  });
-
-  it('It does have a specific configuration', () => {
-    expect(widget.getConfiguration()).toEqual({
-      highlightPreTag: TAG_PLACEHOLDER.highlightPreTag,
-      highlightPostTag: TAG_PLACEHOLDER.highlightPostTag,
-    });
   });
 
   it('calls twice render(<Hits props />, container)', () => {


### PR DESCRIPTION
This PR updates the implementation for `getConfiguration` inside `connectInfiniteHits`. It adds a default `page` once the widget is mounted. This default value is useful for federated search, without the widget is **always** controlled by its parent. I also cover the rest of the `getConfiguration` function with tests.