### PR TITLE
feat(connectPagination): add default value on getConfiguration

### DIFF
--- a/src/connectors/pagination/__tests__/connectPagination-test.js
+++ b/src/connectors/pagination/__tests__/connectPagination-test.js
@@ -25,8 +25,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/pagination/
       foo: 'bar',
     });
 
-    expect(widget.getConfiguration).toBe(undefined);
-
     const helper = algoliasearchHelper({});
     helper.search = jest.fn();
 
@@ -252,6 +250,18 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/pagination/
       const { pages } = renderOptions;
       expect(pages).toEqual([39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49]);
     }
+  });
+
+  describe('getConfiguration', () => {
+    it('adds a `page` to the `SearchParameters`', () => {
+      const renderFn = () => {};
+      const makeWidget = connectPagination(renderFn);
+      const widget = makeWidget();
+
+      const nextConfiguation = widget.getConfiguration();
+
+      expect(nextConfiguation.page).toBe(0);
+    });
   });
 
   describe('dispose', () => {

--- a/src/connectors/pagination/connectPagination.js
+++ b/src/connectors/pagination/connectPagination.js
@@ -98,6 +98,12 @@ export default function connectPagination(renderFn, unmountFn = noop) {
     });
 
     return {
+      getConfiguration() {
+        return {
+          page: 0,
+        };
+      },
+
       init({ helper, createURL, instantSearchInstance }) {
         this.refine = page => {
           helper.setPage(page);

--- a/src/widgets/pagination/__tests__/pagination-test.js
+++ b/src/widgets/pagination/__tests__/pagination-test.js
@@ -72,10 +72,6 @@ describe('pagination()', () => {
     widget.init({ helper });
   });
 
-  it('configures nothing', () => {
-    expect(widget.getConfiguration).toEqual(undefined);
-  });
-
   it('sets the page', () => {
     widget.refine(helper, 42);
     expect(helper.setPage).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
This PR updates the implementation for `getConfiguration` inside `connectAutocomplete`. It adds a default `page` once the widget is mounted. This default value is useful for federated search, without the widget is **always** controlled by its parent.