### PR TITLE
feat(connectSearchBox): add default value on getConfiguration

### DIFF
--- a/src/connectors/search-box/__tests__/connectSearchBox-test.js
+++ b/src/connectors/search-box/__tests__/connectSearchBox-test.js
@@ -24,8 +24,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
       foo: 'bar',
     });
 
-    expect(widget.getConfiguration).toBe(undefined);
-
     const helper = algoliasearchHelper({});
     helper.search = () => {};
 
@@ -274,6 +272,18 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
 
     expect(helper.state.query).toBe('');
     expect(helper.search).toHaveBeenCalledTimes(1);
+  });
+
+  describe('getConfiguration', () => {
+    it('adds a `query` to the `SearchParameters`', () => {
+      const renderFn = () => {};
+      const makeWidget = connectSearchBox(renderFn);
+      const widget = makeWidget();
+
+      const nextConfiguration = widget.getConfiguration();
+
+      expect(nextConfiguration.query).toBe('');
+    });
   });
 
   describe('dispose', () => {

--- a/src/connectors/search-box/connectSearchBox.js
+++ b/src/connectors/search-box/connectSearchBox.js
@@ -83,6 +83,12 @@ export default function connectSearchBox(renderFn, unmountFn = noop) {
         this._clear();
       },
 
+      getConfiguration() {
+        return {
+          query: '',
+        };
+      },
+
       init({ helper, instantSearchInstance }) {
         this._cachedClear = this._cachedClear.bind(this);
         this._clear = clear(helper);


### PR DESCRIPTION
This PR updates the implementation for `getConfiguration` inside `connectSearchBox`. It adds a default `query` once the widget is mounted. This default value is useful for federated search, without the widget is **always** controlled by its parent.