### PR TITLE
feat(connectVoiceSearch): add default value on getConfiguration

### DIFF
--- a/src/connectors/voice-search/__tests__/connectVoiceSearch-test.js
+++ b/src/connectors/voice-search/__tests__/connectVoiceSearch-test.js
@@ -113,6 +113,18 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/voice-searc
     expect(helper.search).toHaveBeenCalledTimes(1);
   });
 
+  describe('getConfiguration', () => {
+    it('adds a `query` to the `SearchParameters`', () => {
+      const renderFn = () => {};
+      const makeWidget = connectVoiceSearch(renderFn);
+      const widget = makeWidget({});
+
+      const nextConfiguration = widget.getConfiguration();
+
+      expect(nextConfiguration.query).toBe('');
+    });
+  });
+
   describe('dispose', () => {
     it('calls the unmount function', () => {
       const helper = algoliasearchHelper({}, '');

--- a/src/connectors/voice-search/connectVoiceSearch.ts
+++ b/src/connectors/voice-search/connectVoiceSearch.ts
@@ -74,6 +74,12 @@ const connectVoiceSearch: VoiceSearchConnector = (
     const { searchAsYouSpeak } = widgetParams;
 
     return {
+      getConfiguration() {
+        return {
+          query: '',
+        };
+      },
+
       init({ helper, instantSearchInstance }) {
         (this as any)._refine = (query: string): void => {
           if (query !== helper.state.query) {


### PR DESCRIPTION
This PR updates the implementation for `getConfiguration` inside `connectVoiceSearch`. It adds a default `query` once the widget is mounted. This default value is useful for federated search, without the widget is **always** controlled by its parent.