### PR TITLE
fix(getRefinements): check for facet before accessing its data

### DIFF
--- a/src/lib/utils/__tests__/index-test.js
+++ b/src/lib/utils/__tests__/index-test.js
@@ -699,6 +699,37 @@ describe('utils.getRefinements', () => {
     );
   });
 
+  it('should retrieve hierarchicalFacetsRefinements on multiple levels without any data', () => {
+    helper.toggleRefinement(
+      'hierarchicalFacet2',
+      'hierarchicalFacet2lvl0val1 > lvl1val1'
+    );
+
+    results = {
+      hierarchicalFacets: [
+        {
+          count: null,
+          data: null,
+          isRefined: true,
+          name: 'hierarchicalFacet2',
+          path: null,
+        },
+      ],
+    };
+
+    const expected = {
+      type: 'hierarchical',
+      attributeName: 'hierarchicalFacet2',
+      name: 'hierarchicalFacet2lvl0val1 > lvl1val1',
+      count: null,
+      exhaustive: null,
+    };
+
+    expect(utils.getRefinements(results, helper.state)).toContainEqual(
+      expected
+    );
+  });
+
   it('should have a count for a hierarchicalFacetRefinement if available', () => {
     helper.toggleRefinement('hierarchicalFacet1', 'hierarchicalFacet1val1');
     results = {

--- a/src/lib/utils/getRefinements.ts
+++ b/src/lib/utils/getRefinements.ts
@@ -65,6 +65,7 @@ function getRefinement(
 
     for (let i = 0; facet !== undefined && i < nameParts.length; ++i) {
       facet =
+        facet &&
         facet.data &&
         find(
           Object.keys(facet.data).map(getFacetRefinement(facet.data)),


### PR DESCRIPTION
This regression was introduced while removing Lodash from the codebase. We need to check that `facet` is defined before accessing `facet.data`, otherwise some query might fail and break InstantSearch lifecycle.

Steps to reproduce the issue:

- Select "Cameras & Camcorders" from the HierarchicalMenu
- Select "Cameras & Camcorders > Binoculars" from the HierarchicalMenu
- Type the query: "pokem"

Example on [this deployment](https://deploy-preview-3802--instantsearchjs.netlify.com/examples/e-commerce).