### PR TITLE
feat(types): rename RenderOptions -> RendererOptions

### DIFF
--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -1,7 +1,7 @@
 import escapeHits, { TAG_PLACEHOLDER } from '../../lib/escape-highlight';
 import {
   Renderer,
-  RenderOptions,
+  RendererOptions,
   WidgetFactory,
   Hits,
   Unmounter,
@@ -22,8 +22,8 @@ export type InfiniteHitsConnectorParams = Partial<
   InfiniteHitsRendererWidgetParams
 >;
 
-export interface InfiniteHitsRenderOptions<TInfiniteHitsWidgetParams>
-  extends RenderOptions<TInfiniteHitsWidgetParams> {
+export interface InfiniteHitsRendererOptions<TInfiniteHitsWidgetParams>
+  extends RendererOptions<TInfiniteHitsWidgetParams> {
   showPrevious: () => void;
   showMore: () => void;
   isFirstPage: boolean;
@@ -31,7 +31,7 @@ export interface InfiniteHitsRenderOptions<TInfiniteHitsWidgetParams>
 }
 
 export type InfiniteHitsRenderer<TInfiniteHitsWidgetParams> = Renderer<
-  InfiniteHitsRenderOptions<
+  InfiniteHitsRendererOptions<
     InfiniteHitsConnectorParams & TInfiniteHitsWidgetParams
   >
 >;

--- a/src/connectors/query-rules/connectQueryRules.ts
+++ b/src/connectors/query-rules/connectQueryRules.ts
@@ -1,6 +1,6 @@
 import {
   Renderer,
-  RenderOptions,
+  RendererOptions,
   WidgetFactory,
   Helper,
   HelperChangeEvent,
@@ -35,13 +35,13 @@ export type QueryRulesConnectorParams = {
   transformItems?: ParamTransformItems;
 };
 
-export interface QueryRulesRenderOptions<TQueryRulesWidgetParams>
-  extends RenderOptions<TQueryRulesWidgetParams> {
+export interface QueryRulesRendererOptions<TQueryRulesWidgetParams>
+  extends RendererOptions<TQueryRulesWidgetParams> {
   items: any[];
 }
 
 export type QueryRulesRenderer<TQueryRulesWidgetParams> = Renderer<
-  QueryRulesRenderOptions<QueryRulesConnectorParams & TQueryRulesWidgetParams>
+  QueryRulesRendererOptions<QueryRulesConnectorParams & TQueryRulesWidgetParams>
 >;
 
 export type QueryRulesWidgetFactory<TQueryRulesWidgetParams> = WidgetFactory<

--- a/src/connectors/voice-search/connectVoiceSearch.ts
+++ b/src/connectors/voice-search/connectVoiceSearch.ts
@@ -3,7 +3,7 @@ import {
   createDocumentationMessageGenerator,
   noop,
 } from '../../lib/utils';
-import { Renderer, RenderOptions, WidgetFactory } from '../../types';
+import { Renderer, RendererOptions, WidgetFactory } from '../../types';
 import createVoiceSearchHelper, {
   VoiceListeningState,
   ToggleListening,
@@ -18,8 +18,8 @@ export type VoiceSearchConnectorParams = {
   searchAsYouSpeak: boolean;
 };
 
-export interface VoiceSearchRenderOptions<TVoiceSearchWidgetParams>
-  extends RenderOptions<TVoiceSearchWidgetParams> {
+export interface VoiceSearchRendererOptions<TVoiceSearchWidgetParams>
+  extends RendererOptions<TVoiceSearchWidgetParams> {
   isBrowserSupported: boolean;
   isListening: boolean;
   toggleListening: ToggleListening;
@@ -27,7 +27,7 @@ export interface VoiceSearchRenderOptions<TVoiceSearchWidgetParams>
 }
 
 export type VoiceSearchRenderer<TVoiceSearchWidgetParams> = Renderer<
-  VoiceSearchRenderOptions<
+  VoiceSearchRendererOptions<
     VoiceSearchConnectorParams & TVoiceSearchWidgetParams
   >
 >;

--- a/src/lib/insights/client.ts
+++ b/src/lib/insights/client.ts
@@ -6,7 +6,7 @@ import {
   InsightsClientPayload,
   InsightsClientWrapper,
   Renderer,
-  RenderOptions,
+  RendererOptions,
   Unmounter,
   WidgetFactory,
   Omit,
@@ -102,9 +102,9 @@ export default function withInsights(
   connector: Connector<any>
 ): Connector<unknown> {
   const wrapRenderFn = (
-    renderFn: Renderer<RenderOptions<unknown>>
-  ): Renderer<RenderOptions<unknown>> => (
-    renderOptions: RenderOptions,
+    renderFn: Renderer<RendererOptions<unknown>>
+  ): Renderer<RendererOptions<unknown>> => (
+    renderOptions: RendererOptions,
     isFirstRender: boolean
   ) => {
     const { results, hits, instantSearchInstance } = renderOptions;
@@ -124,6 +124,6 @@ export default function withInsights(
     return renderFn(renderOptions, isFirstRender);
   };
 
-  return (renderFn: Renderer<RenderOptions<unknown>>, unmountFn: Unmounter) =>
+  return (renderFn: Renderer<RendererOptions<unknown>>, unmountFn: Unmounter) =>
     connector(wrapRenderFn(renderFn), unmountFn);
 }

--- a/src/types/connector.ts
+++ b/src/types/connector.ts
@@ -1,7 +1,7 @@
 import { Hits, InstantSearch, SearchResults } from './instantsearch';
 import { InsightsClient } from './insights';
 
-export type RenderOptions<TWidgetParams = unknown> = {
+export type RendererOptions<TWidgetParams = unknown> = {
   widgetParams: TWidgetParams;
   instantSearchInstance: InstantSearch;
   results?: SearchResults;
@@ -9,7 +9,7 @@ export type RenderOptions<TWidgetParams = unknown> = {
   insights?: InsightsClient;
 };
 
-export type Renderer<TRenderOptions extends RenderOptions = any> = (
+export type Renderer<TRenderOptions extends RendererOptions = any> = (
   renderOptions: TRenderOptions,
   isFirstRender: boolean
 ) => void;


### PR DESCRIPTION
**Summary**

This PR rename the type `RenderOptions` used at the renderer level for `RendererOptions`. Widgets   have already types called `InitOptions` & `RenderOptions`. Those types are currently non-exported but it might happen to we have to export them at some point. Anyway it's better to avoid confusion with two types with the same name with almost the same domain.