### PR TITLE
chore(examples): convert `cssClasses` to raw CSS specs

### DIFF
--- a/examples/e-commerce/src/app.css
+++ b/examples/e-commerce/src/app.css
@@ -133,18 +133,18 @@ mark {
 
 /* Panel */
 
-.panel-header {
+.ais-Panel-header {
   font-family: Hind, sans-serif;
 }
 
 /* Search box */
 
-.searchbox {
+.header .ais-SearchBox {
   height: 64px;
   width: 740px;
 }
 
-.searchbox .searchbox-input {
+.header .ais-SearchBox .ais-SearchBox-input {
   background-color: #fff;
   border-radius: 8px;
   box-shadow: 0 4px 48px 0 rgba(0, 0, 0, 0.2);
@@ -157,25 +157,25 @@ mark {
   padding: 4px 48px 0 58px;
 }
 
-.searchbox .searchbox-input::placeholder {
+.header .ais-SearchBox .ais-SearchBox-input::placeholder {
   color: rgba(33, 36, 61, 0.24);
   opacity: 1; /* Firefox */
 }
 
-.searchbox-input:-ms-input-placeholder {
+.ais-SearchBox-input:-ms-input-placeholder {
   color: rgba(33, 36, 61, 0.24);
 }
 
-.searchbox-input::-ms-input-placeholder {
+.ais-SearchBox-input::-ms-input-placeholder {
   color: rgba(33, 36, 61, 0.24);
 }
 
-.searchbox-submit {
+.ais-SearchBox-submit {
   color: #e2a400;
   height: 16px;
 }
 
-.refinement-list-searchbox-input {
+.ais-RefinementList .ais-SearchBox-input {
   font-family: Hind, sans-serif;
   /*
     The "Hind" font family is vertically off-balance.
@@ -240,7 +240,7 @@ mark {
 
 /* RangeSlider */
 
-.rheostat-tooltip::before {
+.ais-RangeSlider .rheostat-tooltip::before {
   color: #e2a400;
   content: '$';
   font-size: 0.6;
@@ -249,23 +249,23 @@ mark {
 
 /* ToggleRefinement */
 
-.toggle-refinement-label {
+.ais-ToggleRefinement-label {
   display: flex;
   flex-direction: row-reverse;
   justify-content: space-between;
 }
 
-.toggle-refinement-checkbox {
+.ais-ToggleRefinement-checkbox {
   font: inherit;
   margin-left: 1rem;
   margin-right: 0;
 }
 
-.toggle-refinement-checkbox:checked::before {
+.ais-ToggleRefinement-checkbox:checked::before {
   color: #e2a400;
 }
 
-.toggle-refinement-checkbox::before {
+.ais-ToggleRefinement-checkbox::before {
   align-items: center;
   color: rgba(33, 36, 61, 0.32);
   content: 'No';
@@ -276,16 +276,16 @@ mark {
   right: 38px;
 }
 
-.toggle-refinement-checkbox:checked::before {
+.ais-ToggleRefinement-checkbox:checked::before {
   content: 'Yes';
 }
 
 /* RatingMenu */
 
-.rating-menu-item:not(.rating-menu-item--selected) {
+.ais-RatingMenu-item:not(.ais-RatingMenu-item--selected) {
   opacity: 0.5;
 }
 
-.rating-menu-starIcon {
+.ais-RatingMenu-starIcon {
   margin-right: 0.5rem;
 }

--- a/examples/e-commerce/src/app.mobile.css
+++ b/examples/e-commerce/src/app.mobile.css
@@ -73,7 +73,7 @@
     width: calc(50% - 0.5rem);
   }
 
-  .clear-refinements-button,
+  .ais-ClearRefinements-button,
   .container-filters-footer .button {
     background-color: rgba(65, 66, 71, 0.08);
     border: none;
@@ -147,7 +147,9 @@
     transition: transform 200ms ease-out;
   }
 
-  .searchbox {
+  /* SearchBox */
+
+  .header .ais-SearchBox {
     bottom: 0;
     left: 0;
     position: absolute;
@@ -155,27 +157,29 @@
     width: 100vw;
   }
 
-  .searchbox .searchbox-form {
+  .header .ais-SearchBox .ais-SearchBox-form {
     margin: auto;
     max-width: 90%;
   }
 
-  .refinement-list-list {
+  /* RefinementList */
+
+  .ais-RefinementList-list {
     display: grid;
     grid-auto-flow: column;
     grid-template-rows: repeat(5, 1fr);
   }
 
-  .refinement-list-item {
+  .ais-RefinementList-item {
     flex: 50%;
   }
 
-  .refinement-list-checkbox {
+  .ais-RefinementList-checkbox {
     height: 1.5rem;
     width: 1.5rem;
   }
 
-  .refinement-list-selectedItem .refinement-list-checkbox::after {
+  .ais-RefinementList-item--selected .ais-RefinementList-checkbox::after {
     align-items: center;
     background: none;
     content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='12' height='9'%3E%3Cdefs%3E%3Cpath id='a' d='M0 0h24v24H0z'/%3E%3C/defs%3E%3Cg fill='none' fill-rule='evenodd' transform='translate(-6 -8)'%3E%3Cmask id='b' fill='%23fff'%3E%3Cuse xlink:href='%23a'/%3E%3C/mask%3E%3Cpath fill='%23fff' fill-rule='nonzero' d='M16.5 8.5L18 10l-6.99 7-4.51-4.5L8 11l3.01 3z' mask='url(%23b)'/%3E%3C/g%3E%3C/svg%3E");
@@ -189,44 +193,54 @@
     width: initial;
   }
 
-  .hierarchical-menu-link::before {
+  /* HierarchicalMenu */
+
+  .ais-HierarchicalMenu-link::before {
     background-color: rgba(65, 66, 71, 0.08);
     border-radius: 50%;
     padding: 8px;
   }
 
-  .range-slider .rheostat-handle {
+  /* RangeSlider */
+
+  .ais-RangeSlider .rheostat-handle {
     height: 1.5rem;
     top: -12px;
     width: 1.5rem;
   }
 
-  .toggle-refinement-checkbox {
+  /* ToggleRefinement */
+
+  .ais-ToggleRefinement-checkbox {
     min-width: 47px;
     position: relative;
   }
 
-  .toggle-refinement-checkbox {
+  .ais-ToggleRefinement-checkbox {
     margin-left: 2rem;
   }
 
-  .toggle-refinement-checkbox::after {
+  .ais-ToggleRefinement-checkbox::after {
     height: 1.5rem;
     top: -4px;
     width: 1.5rem;
   }
 
-  .toggle-refinement-checkbox::before {
+  .ais-ToggleRefinement-checkbox::before {
     right: 54px;
   }
 
-  .rating-menu-starIcon {
+  /* RatingMenu */
+
+  .ais-RatingMenu-starIcon {
     height: 1.5rem;
     margin-right: 1rem;
     width: 1.5rem;
   }
 
-  .hits-list {
+  /* Hits */
+
+  .ais-Hits-list {
     grid-gap: 1rem;
   }
 

--- a/examples/e-commerce/src/widgets/Brands.js
+++ b/examples/e-commerce/src/widgets/Brands.js
@@ -7,9 +7,6 @@ const brandRefinementList = panel({
     collapseButtonText,
   },
   collapsed: () => false,
-  cssClasses: {
-    header: 'panel-header',
-  },
 })(refinementList);
 
 const brands = brandRefinementList({
@@ -27,13 +24,6 @@ const brands = brandRefinementList({
   </g>
 </svg>
     `,
-  },
-  cssClasses: {
-    list: 'refinement-list-list',
-    item: 'refinement-list-item',
-    selectedItem: 'refinement-list-selectedItem',
-    checkbox: 'refinement-list-checkbox',
-    searchableInput: 'refinement-list-searchbox-input',
   },
 });
 

--- a/examples/e-commerce/src/widgets/Categories.js
+++ b/examples/e-commerce/src/widgets/Categories.js
@@ -7,17 +7,11 @@ const categoryHierarchicalMenu = panel({
     collapseButtonText,
   },
   collapsed: () => false,
-  cssClasses: {
-    header: 'panel-header',
-  },
 })(hierarchicalMenu);
 
 const categories = categoryHierarchicalMenu({
   container: '[data-widget="categories"]',
   attributes: ['hierarchicalCategories.lvl0', 'hierarchicalCategories.lvl1'],
-  cssClasses: {
-    link: 'hierarchical-menu-link',
-  },
 });
 
 export default categories;

--- a/examples/e-commerce/src/widgets/FreeShipping.js
+++ b/examples/e-commerce/src/widgets/FreeShipping.js
@@ -7,9 +7,6 @@ const freeShippingToggleRefinement = panel({
     collapseButtonText,
   },
   collapsed: () => false,
-  cssClasses: {
-    header: 'panel-header',
-  },
 })(toggleRefinement);
 
 const freeShipping = freeShippingToggleRefinement({
@@ -17,10 +14,6 @@ const freeShipping = freeShippingToggleRefinement({
   attribute: 'free_shipping',
   templates: {
     labelText: 'Display only items with free shipping',
-  },
-  cssClasses: {
-    label: 'toggle-refinement-label',
-    checkbox: 'toggle-refinement-checkbox',
   },
 });
 

--- a/examples/e-commerce/src/widgets/PriceSlider.js
+++ b/examples/e-commerce/src/widgets/PriceSlider.js
@@ -7,9 +7,6 @@ const priceRangeSlider = panel({
     collapseButtonText,
   },
   collapsed: () => false,
-  cssClasses: {
-    header: 'panel-header',
-  },
 })(rangeSlider);
 
 const priceSlider = priceRangeSlider({
@@ -20,9 +17,6 @@ const priceSlider = priceRangeSlider({
     format(value) {
       return `${Math.round(value).toLocaleString()}`;
     },
-  },
-  cssClasses: {
-    root: 'range-slider',
   },
 });
 

--- a/examples/e-commerce/src/widgets/Products.js
+++ b/examples/e-commerce/src/widgets/Products.js
@@ -2,9 +2,6 @@ import { hits } from 'instantsearch.js/es/widgets';
 
 const products = hits({
   container: '[data-widget="hits"]',
-  cssClasses: {
-    list: 'hits-list',
-  },
   templates: {
     item: `
 <article class="hit">

--- a/examples/e-commerce/src/widgets/Ratings.js
+++ b/examples/e-commerce/src/widgets/Ratings.js
@@ -7,9 +7,6 @@ const ratingsMenu = panel({
     collapseButtonText,
   },
   collapsed: () => false,
-  cssClasses: {
-    header: 'panel-header',
-  },
 })(ratingMenu);
 
 const ratings = ratingsMenu({
@@ -42,11 +39,6 @@ const ratings = ratingsMenu({
   </div>
 {{/count}}
   `,
-  },
-  cssClasses: {
-    item: 'rating-menu-item',
-    selectedItem: 'rating-menu-item--selected',
-    starIcon: 'rating-menu-starIcon',
   },
 });
 

--- a/examples/e-commerce/src/widgets/SearchBox.js
+++ b/examples/e-commerce/src/widgets/SearchBox.js
@@ -3,12 +3,6 @@ import { searchBox as searchBoxWidget } from 'instantsearch.js/es/widgets';
 const searchBox = searchBoxWidget({
   container: '[data-widget="searchbox"]',
   placeholder: 'Search for a product, brand, color, …',
-  cssClasses: {
-    root: 'searchbox',
-    form: 'searchbox-form',
-    input: 'searchbox-input',
-    submit: 'searchbox-submit',
-  },
   templates: {
     submit: `
 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 18 18">


### PR DESCRIPTION
Using our raw CSS classes specs is easier to then port the theme to other flavors without having to deal with the class mapping.

[See preview →](https://deploy-preview-3868--instantsearchjs.netlify.com/examples/e-commerce/)