### PR TITLE
chore(renovate): support examples

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,8 @@
 {
   "extends": ["config:js-lib", "algolia"],
+  "ignorePresets": [
+    ":ignoreModulesAndTests"
+  ],
   "packageRules": [
     {
       "packagePatterns": ["^@types"],


### PR DESCRIPTION
**Summary**

By default, Renovate ignores the folder `examples` which means that the dependencies inside our examples are never updated (I did the same changes inside [React InstantSearch](https://github.com/algolia/react-instantsearch/pull/2043) couple of weeks ago). It was not a huge problem until now because we used the CDN version for InstantSearch which that the update was manual anyway. We switch the e-commerce example to npm which now is easy to keep up to date.