### PR TITLE
feat(utils): implement defer

### DIFF
--- a/src/lib/utils/__tests__/defer.ts
+++ b/src/lib/utils/__tests__/defer.ts
@@ -1,0 +1,54 @@
+import defer from '../defer';
+
+describe('defer', () => {
+  it('defers the call to the function', async () => {
+    const fn = jest.fn();
+    const deferred = defer(fn);
+
+    deferred();
+
+    expect(fn).toHaveBeenCalledTimes(0);
+
+    await Promise.resolve();
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('deduplicates the calls to the function', async () => {
+    const fn = jest.fn();
+    const deferred = defer(fn);
+
+    deferred();
+    deferred();
+    deferred();
+
+    expect(fn).toHaveBeenCalledTimes(0);
+
+    await Promise.resolve();
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('deduplicates the calls only until the next microtask', async () => {
+    const fn = jest.fn();
+    const deferred = defer(fn);
+
+    deferred();
+    deferred();
+    deferred();
+
+    expect(fn).toHaveBeenCalledTimes(0);
+
+    await Promise.resolve();
+
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    deferred();
+    deferred();
+    deferred();
+
+    await Promise.resolve();
+
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/utils/defer.ts
+++ b/src/lib/utils/defer.ts
@@ -1,0 +1,19 @@
+const nextMicroTask = Promise.resolve();
+
+type Callback = (...args: any[]) => void;
+
+const defer = (callback: Callback): Callback => {
+  let progress: Promise<void> | null = null;
+  return (...args) => {
+    if (progress !== null) {
+      return;
+    }
+
+    progress = nextMicroTask.then(() => {
+      callback(...args);
+      progress = null;
+    });
+  };
+};
+
+export default defer;

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,4 +1,5 @@
 export { default as capitalize } from './capitalize';
+export { default as defer } from './defer';
 export { default as isDomElement } from './isDomElement';
 export { default as getContainerNode } from './getContainerNode';
 export { default as isSpecialClick } from './isSpecialClick';


### PR DESCRIPTION
**Summary**

This PR introduce the utility function `defer`. It allows a provided function to be delayed until the next micro task i.e. `Promise.resolve()`. It also ensure that only one call to this function can occur inside the same micro task. We'll use this function to "batch" the calls to `search` and `render` in the coming PRs.  Here is an example of its usage:

```js
const fn1 = defer(() => {
  console.log('Hello');
});

const fn2 = defer(() => {
  console.log('Bye');
});

fn1();
fn2();
fn1();
fn2();
fn1();
fn2();

console.log('Start');
Promise.resolve().then(() => {
  console.log('Done');
});

// Output:
// Start
// Hello
// Bye
// Done
```