### PR TITLE
refactor: extract enhanceConfiguration into utils

### DIFF
--- a/src/connectors/configure/connectConfigure.js
+++ b/src/connectors/configure/connectConfigure.js
@@ -1,9 +1,9 @@
 import {
   createDocumentationMessageGenerator,
-  noop,
+  enhanceConfiguration,
   isPlainObject,
+  noop,
 } from '../../lib/utils';
-import { enhanceConfiguration } from '../../lib/InstantSearch';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'configure',

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -7,9 +7,9 @@ import version from './version';
 import createHelpers from './createHelpers';
 import {
   createDocumentationMessageGenerator,
-  noop,
+  enhanceConfiguration,
   isPlainObject,
-  mergeDeep,
+  noop,
 } from './utils';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -437,17 +437,6 @@ See: https://www.algolia.com/doc/guides/building-search-ui/widgets/create-your-o
       }
     });
   }
-}
-
-export function enhanceConfiguration(configuration, widgetDefinition) {
-  if (!widgetDefinition.getConfiguration) {
-    return configuration;
-  }
-
-  // Get the relevant partial configuration asked by the widget
-  const partialConfiguration = widgetDefinition.getConfiguration(configuration);
-
-  return mergeDeep(configuration, partialConfiguration);
 }
 
 export default InstantSearch;

--- a/src/lib/utils/__tests__/enhanceConfiguration-test.js
+++ b/src/lib/utils/__tests__/enhanceConfiguration-test.js
@@ -1,4 +1,4 @@
-import { enhanceConfiguration } from '../InstantSearch';
+import enhanceConfiguration from '../enhanceConfiguration';
 
 const createWidget = (configuration = {}) => ({
   getConfiguration: () => configuration,

--- a/src/lib/utils/enhanceConfiguration.ts
+++ b/src/lib/utils/enhanceConfiguration.ts
@@ -1,0 +1,18 @@
+import { SearchParameters, Widget } from '../../types';
+import mergeDeep from './mergeDeep';
+
+function enhanceConfiguration(
+  configuration: Partial<SearchParameters>,
+  widget: Widget
+): Partial<SearchParameters> {
+  if (!widget.getConfiguration) {
+    return configuration;
+  }
+
+  // Get the relevant partial configuration asked by the widget
+  const partialConfiguration = widget.getConfiguration(configuration);
+
+  return mergeDeep(configuration, partialConfiguration);
+}
+
+export default enhanceConfiguration;

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -7,6 +7,7 @@ export { default as renderTemplate } from './renderTemplate';
 export { default as getRefinements } from './getRefinements';
 export { default as clearRefinements } from './clearRefinements';
 export { default as escapeRefinement } from './escapeRefinement';
+export { default as enhanceConfiguration } from './enhanceConfiguration';
 export { default as unescapeRefinement } from './unescapeRefinement';
 export { default as checkRendering } from './checkRendering';
 export { default as getPropertyByPath } from './getPropertyByPath';


### PR DESCRIPTION
This PR extracts `enhanceConfiguration` from `InstantSearch` to `utils`. We won't use this function inside InstantSearch anymore, it doesn't make sense to keep it there. The tests didn't change place because they were already inside `utils`.