### PR TITLE
refactor(InstantSearch): avoid to store searchParameters

### DIFF
--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -91,13 +91,17 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
     this.insightsClient = insightsClient;
     this.helper = null;
     this.indexName = indexName;
-    this.searchParameters = { ...searchParameters, index: indexName };
     this.widgets = [];
     this.templatesConfig = {
       helpers: createHelpers({ numberLocale }),
       compileOptions: {},
     };
+
     this._stalledSearchDelay = stalledSearchDelay;
+    this._searchParameters = {
+      ...searchParameters,
+      index: indexName,
+    };
 
     if (searchFunction) {
       this._searchFunction = searchFunction;
@@ -163,11 +167,11 @@ See: https://www.algolia.com/doc/guides/building-search-ui/widgets/create-your-o
 
     // Init the widget directly if instantsearch has been already started
     if (this.started && Boolean(widgets.length)) {
-      this.searchParameters = this.widgets.reduce(enhanceConfiguration, {
-        ...this.helper.state,
-      });
-
-      this.helper.setState(this.searchParameters);
+      this.helper.setState(
+        this.widgets.reduce(enhanceConfiguration, {
+          ...this.helper.state,
+        })
+      );
 
       widgets.forEach(widget => {
         if (widget.init) {
@@ -235,11 +239,11 @@ See: https://www.algolia.com/doc/guides/building-search-ui/widgets/create-your-o
       // re-compute remaining widgets to the state
       // in a case two widgets were using the same configuration but we removed one
       if (nextState) {
-        this.searchParameters = this.widgets.reduce(enhanceConfiguration, {
-          ...nextState,
-        });
-
-        this.helper.setState(this.searchParameters);
+        this.helper.setState(
+          this.widgets.reduce(enhanceConfiguration, {
+            ...nextState,
+          })
+        );
       }
     });
 
@@ -298,15 +302,15 @@ See: https://www.algolia.com/doc/guides/building-search-ui/widgets/create-your-o
       this._onHistoryChange = noop;
     }
 
-    this.searchParameters = this.widgets.reduce(
+    const initialSearchParameters = this.widgets.reduce(
       enhanceConfiguration,
-      this.searchParameters
+      this._searchParameters
     );
 
     const helper = algoliasearchHelper(
       this.client,
-      this.searchParameters.index || this.indexName,
-      this.searchParameters
+      initialSearchParameters.index || this.indexName,
+      initialSearchParameters
     );
 
     if (this._searchFunction) {

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -235,7 +235,7 @@ describe('InstantSearch lifecycle', () => {
       init: () => {},
     });
     search.start();
-    expect(search.searchParameters.facetsRefinements).toEqual({
+    expect(search.helper.state.facetsRefinements).toEqual({
       fruits: ['apple'],
     });
   });
@@ -465,12 +465,12 @@ describe('InstantSearch lifecycle', () => {
       search.start();
 
       expect(search.widgets).toHaveLength(1);
-      expect(search.searchParameters.facets).toEqual(['price']);
+      expect(search.helper.state.facets).toEqual(['price']);
 
       search.removeWidget(widget1);
 
       expect(search.widgets).toHaveLength(0);
-      expect(search.searchParameters.facets).toEqual([]);
+      expect(search.helper.state.facets).toEqual([]);
     });
 
     it('should unmount a widget with hierarchicalFacets configuration', () => {
@@ -491,7 +491,7 @@ describe('InstantSearch lifecycle', () => {
       search.start();
 
       expect(search.widgets).toHaveLength(1);
-      expect(search.searchParameters.hierarchicalFacets).toEqual([
+      expect(search.helper.state.hierarchicalFacets).toEqual([
         {
           name: 'price',
           attributes: ['foo'],
@@ -504,7 +504,7 @@ describe('InstantSearch lifecycle', () => {
       search.removeWidget(widget1);
 
       expect(search.widgets).toHaveLength(0);
-      expect(search.searchParameters.hierarchicalFacets).toEqual([]);
+      expect(search.helper.state.hierarchicalFacets).toEqual([]);
     });
 
     it('should unmount a widget with disjunctiveFacets configuration', () => {
@@ -515,12 +515,12 @@ describe('InstantSearch lifecycle', () => {
       search.start();
 
       expect(search.widgets).toHaveLength(1);
-      expect(search.searchParameters.disjunctiveFacets).toEqual(['price']);
+      expect(search.helper.state.disjunctiveFacets).toEqual(['price']);
 
       search.removeWidget(widget1);
 
       expect(search.widgets).toHaveLength(0);
-      expect(search.searchParameters.disjunctiveFacets).toEqual([]);
+      expect(search.helper.state.disjunctiveFacets).toEqual([]);
     });
 
     it('should unmount a widget with numericRefinements configuration', () => {
@@ -537,7 +537,7 @@ describe('InstantSearch lifecycle', () => {
       search.start();
 
       expect(search.widgets).toHaveLength(1);
-      expect(search.searchParameters.numericRefinements).toEqual({
+      expect(search.helper.state.numericRefinements).toEqual({
         price: {
           '=': [10],
         },
@@ -546,7 +546,7 @@ describe('InstantSearch lifecycle', () => {
       search.removeWidget(widget1);
 
       expect(search.widgets).toHaveLength(0);
-      expect(search.searchParameters.numericRefinements).toEqual({});
+      expect(search.helper.state.numericRefinements).toEqual({});
     });
 
     it('should unmount a widget with maxValuesPerFacet configuration', () => {
@@ -558,14 +558,14 @@ describe('InstantSearch lifecycle', () => {
       search.start();
 
       expect(search.widgets).toHaveLength(1);
-      expect(search.searchParameters.facets).toEqual(['categories']);
-      expect(search.searchParameters.maxValuesPerFacet).toEqual(10);
+      expect(search.helper.state.facets).toEqual(['categories']);
+      expect(search.helper.state.maxValuesPerFacet).toEqual(10);
 
       search.removeWidget(widget1);
 
       expect(search.widgets).toHaveLength(0);
-      expect(search.searchParameters.facets).toEqual([]);
-      expect(search.searchParameters.maxValuesPerFacet).toBe(undefined);
+      expect(search.helper.state.facets).toEqual([]);
+      expect(search.helper.state.maxValuesPerFacet).toBe(undefined);
     });
 
     it('should unmount multiple widgets at once', () => {
@@ -588,8 +588,8 @@ describe('InstantSearch lifecycle', () => {
       search.start();
 
       expect(search.widgets).toHaveLength(2);
-      expect(search.searchParameters.disjunctiveFacets).toEqual(['price']);
-      expect(search.searchParameters.numericRefinements).toEqual({
+      expect(search.helper.state.disjunctiveFacets).toEqual(['price']);
+      expect(search.helper.state.numericRefinements).toEqual({
         price: {
           '=': [10],
         },
@@ -598,8 +598,8 @@ describe('InstantSearch lifecycle', () => {
       search.removeWidgets([widget1, widget2]);
 
       expect(search.widgets).toHaveLength(0);
-      expect(search.searchParameters.disjunctiveFacets).toEqual([]);
-      expect(search.searchParameters.numericRefinements).toEqual({});
+      expect(search.helper.state.disjunctiveFacets).toEqual([]);
+      expect(search.helper.state.numericRefinements).toEqual({});
     });
   });
 
@@ -642,8 +642,8 @@ describe('InstantSearch lifecycle', () => {
       expect(search.helper.search).toHaveBeenCalledTimes(3);
 
       expect(search.widgets).toHaveLength(2);
-      expect(search.searchParameters.facets).toEqual(['price']);
-      expect(search.searchParameters.disjunctiveFacets).toEqual(['categories']);
+      expect(search.helper.state.facets).toEqual(['price']);
+      expect(search.helper.state.disjunctiveFacets).toEqual(['categories']);
     });
 
     it('should trigger only one search using `addWidgets()`', () => {
@@ -659,8 +659,8 @@ describe('InstantSearch lifecycle', () => {
       search.addWidgets([widget1, widget2]);
 
       expect(search.helper.search).toHaveBeenCalledTimes(2);
-      expect(search.searchParameters.facets).toEqual(['price']);
-      expect(search.searchParameters.disjunctiveFacets).toEqual(['categories']);
+      expect(search.helper.state.facets).toEqual(['price']);
+      expect(search.helper.state.disjunctiveFacets).toEqual(['categories']);
     });
 
     it('should not trigger a search without widgets to add', () => {


### PR DESCRIPTION
This PR removes the `searchParameters` from the `InstantSearch` instance. We don't have to keep track of the them because we already have access to them through the `helper.state`. The PR only removes the reference on the `InstantSearch` not the usage of the `searchParameters` option.