### PR TITLE
feat(types): DerivedHelper

### DIFF
--- a/src/types/instantsearch.ts
+++ b/src/types/instantsearch.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'events';
 import { Client as AlgoliaSearchClient } from 'algoliasearch';
 import { InsightsClient as AlgoliaInsightsClient } from './insights';
 import {
@@ -112,6 +113,10 @@ export type StateMapping<TRouteState = UiState> = {
 export type Client = AlgoliaSearchClient;
 
 export type Helper = AlgoliaSearchHelper;
+export type DerivedHelper = EventEmitter & {
+  lastResults: SearchResults | null;
+  detach(): void;
+};
 
 export type InstantSearch = {
   templatesConfig?: object;


### PR DESCRIPTION
This PR adds a type for the `DerivedHelper`. It only adds the API that we currently use. At some point, we have to embed the definition of the `algoliasearch-helper`. The definitions hosted on DT are not 100% correct. If we want to move fast with it it's safer to embed it inside InstantSearch.