### PR TITLE
test(mock): use typed mock

### DIFF
--- a/src/connectors/hits/__tests__/connectHitsWithInsights-test.ts
+++ b/src/connectors/hits/__tests__/connectHitsWithInsights-test.ts
@@ -1,5 +1,10 @@
 import algoliasearchHelper, { SearchResults } from 'algoliasearch-helper';
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
+import { createInstantSearch } from '../../../../test/mock/createInstantSearch';
+import {
+  createInitOptions,
+  createRenderOptions,
+} from '../../../../test/mock/createWidget';
 import connectHitsWithInsights from '../connectHitsWithInsights';
 
 jest.mock('../../../lib/utils/hits-absolute-position', () => ({
@@ -7,28 +12,11 @@ jest.mock('../../../lib/utils/hits-absolute-position', () => ({
 }));
 
 describe('connectHitsWithInsights', () => {
-  const defaultInitOptions = {
-    instantSearchInstance: {
-      helper: null,
-      widgets: [],
-      insightsClient: () => {},
-    },
-    templatesConfig: {},
-    createURL: () => '#',
-  };
-
-  const defaultRenderOptions = {
-    instantSearchInstance: {
-      helper: null,
-      widgets: [],
-      insightsClient: () => {},
-    },
-    templatesConfig: {},
-    searchMetadata: { isSearchStalled: false },
-    createURL: () => '#',
-  };
-
   it('should expose `insights` props', () => {
+    const instantSearchInstance = createInstantSearch({
+      insightsClient() {},
+    });
+
     const rendering = jest.fn();
     const makeWidget = connectHitsWithInsights(rendering, jest.fn());
     const widget = makeWidget({});
@@ -36,23 +24,28 @@ describe('connectHitsWithInsights', () => {
     const helper = algoliasearchHelper(createSearchClient(), '', {});
     helper.search = jest.fn();
 
-    widget.init!({
-      ...defaultInitOptions,
-      helper,
-      state: helper.state,
-    });
+    widget.init!(
+      createInitOptions({
+        instantSearchInstance,
+        state: helper.state,
+        helper,
+      })
+    );
 
     const firstRenderingOptions = rendering.mock.calls[0][0];
     expect(firstRenderingOptions.insights).toBeUndefined();
 
     const hits = [{ fake: 'data' }, { sample: 'infos' }];
     const results = new SearchResults(helper.state, [{ hits }]);
-    widget.render!({
-      ...defaultRenderOptions,
-      results,
-      state: helper.state,
-      helper,
-    });
+
+    widget.render!(
+      createRenderOptions({
+        instantSearchInstance,
+        state: helper.state,
+        results,
+        helper,
+      })
+    );
 
     const secondRenderingOptions = rendering.mock.calls[1][0];
     expect(secondRenderingOptions.insights).toBeInstanceOf(Function);
@@ -66,20 +59,23 @@ describe('connectHitsWithInsights', () => {
     const helper = algoliasearchHelper(createSearchClient(), '', {});
     helper.search = jest.fn();
 
-    widget.init!({
-      ...defaultInitOptions,
-      helper,
-      state: helper.state,
-    });
+    widget.init!(
+      createInitOptions({
+        state: helper.state,
+        helper,
+      })
+    );
 
     const hits = [{ fake: 'data' }, { sample: 'infos' }];
     const results = new SearchResults(helper.state, [{ hits }]);
-    widget.render!({
-      ...defaultRenderOptions,
-      results,
-      state: helper.state,
-      helper,
-    });
+
+    widget.render!(
+      createRenderOptions({
+        state: helper.state,
+        results,
+        helper,
+      })
+    );
 
     const secondRenderingOptions = rendering.mock.calls[1][0];
     expect(secondRenderingOptions.hits).toEqual(expect.objectContaining(hits));

--- a/src/connectors/hits/__tests__/connectHitsWithInsights-test.ts
+++ b/src/connectors/hits/__tests__/connectHitsWithInsights-test.ts
@@ -1,6 +1,6 @@
-import jsHelper, { SearchResults } from 'algoliasearch-helper';
+import algoliasearchHelper, { SearchResults } from 'algoliasearch-helper';
+import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import connectHitsWithInsights from '../connectHitsWithInsights';
-import { Client } from '../../../types';
 
 jest.mock('../../../lib/utils/hits-absolute-position', () => ({
   addAbsolutePosition: hits => hits,
@@ -33,7 +33,7 @@ describe('connectHitsWithInsights', () => {
     const makeWidget = connectHitsWithInsights(rendering, jest.fn());
     const widget = makeWidget({});
 
-    const helper = jsHelper({} as Client, '', {});
+    const helper = algoliasearchHelper(createSearchClient(), '', {});
     helper.search = jest.fn();
 
     widget.init!({
@@ -63,7 +63,7 @@ describe('connectHitsWithInsights', () => {
     const makeWidget = connectHitsWithInsights(rendering, jest.fn());
     const widget = makeWidget({});
 
-    const helper = jsHelper({} as Client, '', {});
+    const helper = algoliasearchHelper(createSearchClient(), '', {});
     helper.search = jest.fn();
 
     widget.init!({

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -2,8 +2,12 @@ import algoliasearchHelper, {
   SearchResults,
   SearchParameters,
 } from 'algoliasearch-helper';
+import { createInstantSearch } from '../../../../test/mock/createInstantSearch';
+import {
+  createInitOptions,
+  createRenderOptions,
+} from '../../../../test/mock/createWidget';
 import { TAG_PLACEHOLDER } from '../../../lib/escape-highlight';
-
 import connectInfiniteHits from '../connectInfiniteHits';
 
 import { Client } from '../../../types';
@@ -13,25 +17,6 @@ jest.mock('../../../lib/utils/hits-absolute-position', () => ({
 }));
 
 describe('connectInfiniteHits', () => {
-  const defaultInitOptions = {
-    instantSearchInstance: {
-      helper: null,
-      widgets: [],
-    },
-    templatesConfig: {},
-    createURL: () => '#',
-  };
-
-  const defaultRenderOptions = {
-    instantSearchInstance: {
-      helper: null,
-      widgets: [],
-    },
-    templatesConfig: {},
-    searchMetadata: { isSearchStalled: false },
-    createURL: () => '#',
-  };
-
   it('throws without render function', () => {
     expect(() => {
       // @ts-ignore: test connectInfiniteHits with invalid parameters
@@ -45,6 +30,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
 
   it('Renders during init and render', () => {
     const renderFn = jest.fn();
+    const instantSearchInstance = createInstantSearch();
     const makeWidget = connectInfiniteHits(renderFn);
     const widget = makeWidget({
       escapeHTML: true,
@@ -55,25 +41,24 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     const helper = algoliasearchHelper({} as Client, '', {});
     helper.search = jest.fn();
 
-    widget.init!({
-      ...defaultInitOptions,
-      helper,
-      state: helper.state,
-    });
+    widget.init!(
+      createInitOptions({
+        instantSearchInstance,
+        state: helper.state,
+        helper,
+      })
+    );
 
     expect(renderFn).toHaveBeenCalledTimes(1);
     expect(renderFn).toHaveBeenLastCalledWith(
       expect.objectContaining({
+        instantSearchInstance,
         hits: [],
         showPrevious: expect.any(Function),
         showMore: expect.any(Function),
         results: undefined,
         isFirstPage: true,
         isLastPage: true,
-        instantSearchInstance: {
-          helper: null,
-          widgets: [],
-        },
         widgetParams: {
           escapeHTML: true,
         },
@@ -81,30 +66,29 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       true
     );
 
-    widget.render!({
-      ...defaultRenderOptions,
-      results: new SearchResults(helper.state, [
-        {
-          hits: [],
-        },
-      ]),
-      state: helper.state,
-      helper,
-    });
+    widget.render!(
+      createRenderOptions({
+        results: new SearchResults(helper.state, [
+          {
+            hits: [],
+          },
+        ]),
+        state: helper.state,
+        instantSearchInstance,
+        helper,
+      })
+    );
 
     expect(renderFn).toHaveBeenCalledTimes(2);
     expect(renderFn).toHaveBeenLastCalledWith(
       expect.objectContaining({
+        instantSearchInstance,
         hits: [],
         showPrevious: expect.any(Function),
         showMore: expect.any(Function),
         results: expect.any(Object),
         isFirstPage: true,
         isLastPage: false,
-        instantSearchInstance: {
-          helper: null,
-          widgets: [],
-        },
         widgetParams: {
           escapeHTML: true,
         },
@@ -121,11 +105,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     const helper = algoliasearchHelper({} as Client, '', {});
     helper.search = jest.fn();
 
-    widget.init!({
-      ...defaultInitOptions,
-      helper,
-      state: helper.state,
-    });
+    widget.init!(
+      createInitOptions({
+        state: helper.state,
+        helper,
+      })
+    );
 
     const firstRenderOptions = renderFn.mock.calls[0][0];
     expect(firstRenderOptions.hits).toEqual([]);
@@ -133,12 +118,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
 
     const hits = [{ fake: 'data' }, { sample: 'infos' }];
     const results = new SearchResults(helper.state, [{ hits }]);
-    widget.render!({
-      ...defaultRenderOptions,
-      results,
-      state: helper.state,
-      helper,
-    });
+
+    widget.render!(
+      createRenderOptions({
+        state: helper.state,
+        results,
+        helper,
+      })
+    );
 
     const secondRenderOptions = renderFn.mock.calls[1][0];
     const { showMore } = secondRenderOptions;
@@ -154,12 +141,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
         hits: otherHits,
       },
     ]);
-    widget.render!({
-      ...defaultRenderOptions,
-      results: otherResults,
-      state: helper.state,
-      helper,
-    });
+
+    widget.render!(
+      createRenderOptions({
+        results: otherResults,
+        state: helper.state,
+        helper,
+      })
+    );
 
     const thirdRenderOptions = renderFn.mock.calls[2][0];
     expect(thirdRenderOptions.hits).toEqual([...hits, ...otherHits]);
@@ -176,11 +165,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     helper.search = jest.fn();
     helper.emit = jest.fn();
 
-    widget.init!({
-      ...defaultInitOptions,
-      helper,
-      state: helper.state,
-    });
+    widget.init!(
+      createInitOptions({
+        state: helper.state,
+        helper,
+      })
+    );
 
     const firstRenderOptions = renderFn.mock.calls[0][0];
     expect(firstRenderOptions.hits).toEqual([]);
@@ -192,12 +182,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
         hits,
       },
     ]);
-    widget.render!({
-      ...defaultRenderOptions,
-      results,
-      state: helper.state,
-      helper,
-    });
+
+    widget.render!(
+      createRenderOptions({
+        state: helper.state,
+        results,
+        helper,
+      })
+    );
 
     const secondRenderOptions = renderFn.mock.calls[1][0];
     const { showPrevious } = secondRenderOptions;
@@ -215,12 +207,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
         hits: previousHits,
       },
     ]);
-    widget.render!({
-      ...defaultRenderOptions,
-      results: previousResults,
-      state: helper.state,
-      helper,
-    });
+
+    widget.render!(
+      createRenderOptions({
+        results: previousResults,
+        state: helper.state,
+        helper,
+      })
+    );
 
     const thirdRenderOptions = renderFn.mock.calls[2][0];
     expect(thirdRenderOptions.hits).toEqual([...previousHits, ...hits]);
@@ -235,11 +229,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     const helper = algoliasearchHelper({} as Client, '', {});
     helper.search = jest.fn();
 
-    widget.init!({
-      ...defaultInitOptions,
-      helper,
-      state: helper.state,
-    });
+    widget.init!(
+      createInitOptions({
+        state: helper.state,
+        helper,
+      })
+    );
 
     const firstRenderOptions = renderFn.mock.calls[0][0];
     expect(firstRenderOptions.hits).toEqual([]);
@@ -247,12 +242,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
 
     const hits = [{ fake: 'data' }, { sample: 'infos' }];
     const results = new SearchResults(helper.state, [{ hits }]);
-    widget.render!({
-      ...defaultRenderOptions,
-      results,
-      state: helper.state,
-      helper,
-    });
+
+    widget.render!(
+      createRenderOptions({
+        state: helper.state,
+        results,
+        helper,
+      })
+    );
 
     const secondRenderOptions = renderFn.mock.calls[1][0];
     expect(secondRenderOptions.hits).toEqual(hits);
@@ -263,12 +260,15 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     // If the query changes, the hits cache should be flushed
     const otherHits = [{ fake: 'data 2' }, { sample: 'infos 2' }];
     const otherResults = new SearchResults(helper.state, [{ hits: otherHits }]);
-    widget.render!({
-      ...defaultRenderOptions,
-      results: otherResults,
-      state: helper.state,
-      helper,
-    });
+
+    widget.render!(
+      createRenderOptions({
+        results: otherResults,
+        state: helper.state,
+        helper,
+      })
+    );
+
     const thirdRenderOptions = renderFn.mock.calls[2][0];
     expect(thirdRenderOptions.hits).toEqual(otherHits);
     expect(thirdRenderOptions.results).toEqual(otherResults);
@@ -282,11 +282,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     const helper = algoliasearchHelper({} as Client, '', {});
     helper.search = jest.fn();
 
-    widget.init!({
-      ...defaultInitOptions,
-      helper,
-      state: helper.state,
-    });
+    widget.init!(
+      createInitOptions({
+        state: helper.state,
+        helper,
+      })
+    );
 
     const firstRenderOptions = renderFn.mock.calls[0][0];
     expect(firstRenderOptions.hits).toEqual([]);
@@ -305,12 +306,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     ];
 
     const results = new SearchResults(helper.state, [{ hits }]);
-    widget.render!({
-      ...defaultRenderOptions,
-      results,
-      state: helper.state,
-      helper,
-    });
+
+    widget.render!(
+      createRenderOptions({
+        state: helper.state,
+        results,
+        helper,
+      })
+    );
 
     const escapedHits = [
       {
@@ -337,11 +340,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     const helper = algoliasearchHelper({} as Client, '', {});
     helper.search = jest.fn();
 
-    widget.init!({
-      ...defaultInitOptions,
-      helper,
-      state: helper.state,
-    });
+    widget.init!(
+      createInitOptions({
+        state: helper.state,
+        helper,
+      })
+    );
 
     const firstRenderOptions = renderFn.mock.calls[0][0];
     expect(firstRenderOptions.hits).toEqual([]);
@@ -357,12 +361,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     ];
 
     const results = new SearchResults(helper.state, [{ hits }]);
-    widget.render!({
-      ...defaultRenderOptions,
-      results,
-      state: helper.state,
-      helper,
-    });
+
+    widget.render!(
+      createRenderOptions({
+        state: helper.state,
+        results,
+        helper,
+      })
+    );
 
     const transformedHits = [
       {
@@ -397,11 +403,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     const helper = algoliasearchHelper({} as Client, '', {});
     helper.search = jest.fn();
 
-    widget.init!({
-      ...defaultInitOptions,
-      helper,
-      state: helper.state,
-    });
+    widget.init!(
+      createInitOptions({
+        state: helper.state,
+        helper,
+      })
+    );
 
     const hits = [
       {
@@ -427,12 +434,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     ];
 
     const results = new SearchResults(helper.state, [{ hits }]);
-    widget.render!({
-      ...defaultRenderOptions,
-      results,
-      state: helper.state,
-      helper,
-    });
+
+    widget.render!(
+      createRenderOptions({
+        state: helper.state,
+        results,
+        helper,
+      })
+    );
 
     expect(renderFn).toHaveBeenNthCalledWith(
       2,
@@ -469,11 +478,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     const helper = algoliasearchHelper({} as Client, '', {});
     helper.search = jest.fn();
 
-    widget.init!({
-      ...defaultInitOptions,
-      helper,
-      state: helper.state,
-    });
+    widget.init!(
+      createInitOptions({
+        state: helper.state,
+        helper,
+      })
+    );
 
     const hits = [
       {
@@ -487,12 +497,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     const results = new SearchResults(helper.state, [
       { hits, queryID: 'theQueryID' },
     ]);
-    widget.render!({
-      ...defaultRenderOptions,
-      results,
-      state: helper.state,
-      helper,
-    });
+
+    widget.render!(
+      createRenderOptions({
+        state: helper.state,
+        results,
+        helper,
+      })
+    );
 
     expect(renderFn).toHaveBeenNthCalledWith(
       2,
@@ -520,39 +532,42 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     const helper = algoliasearchHelper({} as Client, '', {});
     helper.search = jest.fn();
 
-    widget.init!({
-      ...defaultInitOptions,
-      helper,
-      state: helper.state,
-    });
+    widget.init!(
+      createInitOptions({
+        state: helper.state,
+        helper,
+      })
+    );
 
-    widget.render!({
-      ...defaultRenderOptions,
-      results: new SearchResults(helper.state, [
-        {
-          hits: [{ objectID: 'a' }],
-          page: 0,
-          nbPages: 4,
-        },
-      ]),
-      state: helper.state,
-      helper,
-    });
+    widget.render!(
+      createRenderOptions({
+        results: new SearchResults(helper.state, [
+          {
+            hits: [{ objectID: 'a' }],
+            page: 0,
+            nbPages: 4,
+          },
+        ]),
+        state: helper.state,
+        helper,
+      })
+    );
 
     helper.setPage(1);
 
-    widget.render!({
-      ...defaultRenderOptions,
-      results: new SearchResults(helper.state, [
-        {
-          hits: [{ objectID: 'b' }],
-          page: 1,
-          nbPages: 4,
-        },
-      ]),
-      state: helper.state,
-      helper,
-    });
+    widget.render!(
+      createRenderOptions({
+        results: new SearchResults(helper.state, [
+          {
+            hits: [{ objectID: 'b' }],
+            page: 1,
+            nbPages: 4,
+          },
+        ]),
+        state: helper.state,
+        helper,
+      })
+    );
 
     expect(renderFn).toHaveBeenCalledTimes(3);
     expect(renderFn).toHaveBeenLastCalledWith(
@@ -562,18 +577,19 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       false
     );
 
-    widget.render!({
-      ...defaultRenderOptions,
-      results: new SearchResults(helper.state, [
-        {
-          hits: [{ objectID: 'b' }],
-          page: 1,
-          nbPages: 4,
-        },
-      ]),
-      state: helper.state,
-      helper,
-    });
+    widget.render!(
+      createRenderOptions({
+        results: new SearchResults(helper.state, [
+          {
+            hits: [{ objectID: 'b' }],
+            page: 1,
+            nbPages: 4,
+          },
+        ]),
+        state: helper.state,
+        helper,
+      })
+    );
 
     expect(renderFn).toHaveBeenCalledTimes(4);
     expect(renderFn).toHaveBeenLastCalledWith(
@@ -733,11 +749,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
         const helper = algoliasearchHelper({} as Client, '', {});
         helper.search = jest.fn();
 
-        widget.init!({
-          ...defaultInitOptions,
-          helper,
-          state: helper.state,
-        });
+        widget.init!(
+          createInitOptions({
+            state: helper.state,
+            helper,
+          })
+        );
 
         const uiStateBefore = { page: 1 };
         const uiStateAfter = widget.getWidgetState!(uiStateBefore, {
@@ -756,11 +773,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
         const helper = algoliasearchHelper({} as Client, '', {});
         helper.search = jest.fn();
 
-        widget.init!({
-          ...defaultInitOptions,
-          helper,
-          state: helper.state,
-        });
+        widget.init!(
+          createInitOptions({
+            state: helper.state,
+            helper,
+          })
+        );
 
         const { showMore } = renderFn.mock.calls[0][0];
 
@@ -783,11 +801,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
         const helper = algoliasearchHelper({} as Client, '', {});
         helper.search = jest.fn();
 
-        widget.init!({
-          ...defaultInitOptions,
-          helper,
-          state: helper.state,
-        });
+        widget.init!(
+          createInitOptions({
+            state: helper.state,
+            helper,
+          })
+        );
 
         const { showMore } = renderFn.mock.calls[0][0];
 
@@ -812,11 +831,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
         const helper = algoliasearchHelper({} as Client, '', {});
         helper.search = jest.fn();
 
-        widget.init!({
-          ...defaultInitOptions,
-          helper,
-          state: helper.state,
-        });
+        widget.init!(
+          createInitOptions({
+            state: helper.state,
+            helper,
+          })
+        );
 
         // The user presses back (browser), and the URL contains no parameters
         const uiState = {};
@@ -839,11 +859,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
         const helper = algoliasearchHelper({} as Client, '', {});
         helper.search = jest.fn();
 
-        widget.init!({
-          ...defaultInitOptions,
-          helper,
-          state: helper.state,
-        });
+        widget.init!(
+          createInitOptions({
+            state: helper.state,
+            helper,
+          })
+        );
 
         const { showMore } = renderFn.mock.calls[0][0];
 
@@ -872,11 +893,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
         const helper = algoliasearchHelper({} as Client, '', {});
         helper.search = jest.fn();
 
-        widget.init!({
-          ...defaultInitOptions,
-          helper,
-          state: helper.state,
-        });
+        widget.init!(
+          createInitOptions({
+            state: helper.state,
+            helper,
+          })
+        );
 
         const { showMore } = renderFn.mock.calls[0][0];
 
@@ -908,11 +930,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       const helper = algoliasearchHelper({} as Client, '', {});
       helper.search = jest.fn();
 
-      widget.init!({
-        ...defaultInitOptions,
-        helper,
-        state: helper.state,
-      });
+      widget.init!(
+        createInitOptions({
+          state: helper.state,
+          helper,
+        })
+      );
 
       const { showMore } = renderFn.mock.calls[0][0];
 

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHitsWithInsights-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHitsWithInsights-test.ts
@@ -1,6 +1,6 @@
-import jsHelper, { SearchResults } from 'algoliasearch-helper';
+import algoliasearchHelper, { SearchResults } from 'algoliasearch-helper';
+import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import connectInfiniteHitsWithInsights from '../connectInfiniteHitsWithInsights';
-import { Client } from '../../../types';
 
 jest.mock('../../../lib/utils/hits-absolute-position', () => ({
   addAbsolutePosition: hits => hits,
@@ -33,7 +33,7 @@ describe('connectInfiniteHitsWithInsights', () => {
     const makeWidget = connectInfiniteHitsWithInsights(rendering, jest.fn());
     const widget = makeWidget({});
 
-    const helper = jsHelper({} as Client, '', {});
+    const helper = algoliasearchHelper(createSearchClient(), '', {});
     helper.search = jest.fn();
 
     widget.init!({
@@ -63,7 +63,7 @@ describe('connectInfiniteHitsWithInsights', () => {
     const makeWidget = connectInfiniteHitsWithInsights(rendering, jest.fn());
     const widget = makeWidget({});
 
-    const helper = jsHelper({} as Client, '', {});
+    const helper = algoliasearchHelper(createSearchClient(), '', {});
     helper.search = jest.fn();
 
     widget.init!({

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHitsWithInsights-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHitsWithInsights-test.ts
@@ -1,5 +1,11 @@
 import algoliasearchHelper, { SearchResults } from 'algoliasearch-helper';
+import {
+  createInitOptions,
+  createRenderOptions,
+} from '../../../../test/mock/createWidget';
+import { createInstantSearch } from '../../../../test/mock/createInstantSearch';
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
+import { InstantSearch, InitOptions, RenderOptions } from '../../../types';
 import connectInfiniteHitsWithInsights from '../connectInfiniteHitsWithInsights';
 
 jest.mock('../../../lib/utils/hits-absolute-position', () => ({
@@ -7,26 +13,26 @@ jest.mock('../../../lib/utils/hits-absolute-position', () => ({
 }));
 
 describe('connectInfiniteHitsWithInsights', () => {
-  const defaultInitOptions = {
-    instantSearchInstance: {
-      helper: null,
-      widgets: [],
-      insightsClient: () => {},
-    },
-    templatesConfig: {},
-    createURL: () => '#',
-  };
+  const createInstantSearchWithInsights = (): InstantSearch =>
+    createInstantSearch({
+      insightsClient() {},
+    });
 
-  const defaultRenderOptions = {
-    instantSearchInstance: {
-      helper: null,
-      widgets: [],
-      insightsClient: () => {},
-    },
-    templatesConfig: {},
-    searchMetadata: { isSearchStalled: false },
-    createURL: () => '#',
-  };
+  const createInitOptionsWithInsights = (
+    args: Partial<InitOptions>
+  ): InitOptions =>
+    createInitOptions({
+      instantSearchInstance: createInstantSearchWithInsights(),
+      ...args,
+    });
+
+  const createRenderOptionsWithInsights = (
+    args: Partial<RenderOptions>
+  ): RenderOptions =>
+    createRenderOptions({
+      instantSearchInstance: createInstantSearchWithInsights(),
+      ...args,
+    });
 
   it('should expose `insights` props', () => {
     const rendering = jest.fn();
@@ -36,23 +42,26 @@ describe('connectInfiniteHitsWithInsights', () => {
     const helper = algoliasearchHelper(createSearchClient(), '', {});
     helper.search = jest.fn();
 
-    widget.init!({
-      ...defaultInitOptions,
-      helper,
-      state: helper.state,
-    });
+    widget.init!(
+      createInitOptionsWithInsights({
+        state: helper.state,
+        helper,
+      })
+    );
 
     const firstRenderingOptions = rendering.mock.calls[0][0];
     expect(firstRenderingOptions.insights).toBeUndefined();
 
     const hits = [{ fake: 'data' }, { sample: 'infos' }];
     const results = new SearchResults(helper.state, [{ hits }]);
-    widget.render!({
-      ...defaultRenderOptions,
-      results,
-      state: helper.state,
-      helper,
-    });
+
+    widget.render!(
+      createRenderOptionsWithInsights({
+        state: helper.state,
+        results,
+        helper,
+      })
+    );
 
     const secondRenderingOptions = rendering.mock.calls[1][0];
     expect(secondRenderingOptions.insights).toBeInstanceOf(Function);
@@ -66,20 +75,23 @@ describe('connectInfiniteHitsWithInsights', () => {
     const helper = algoliasearchHelper(createSearchClient(), '', {});
     helper.search = jest.fn();
 
-    widget.init!({
-      ...defaultInitOptions,
-      helper,
-      state: helper.state,
-    });
+    widget.init!(
+      createInitOptionsWithInsights({
+        state: helper.state,
+        helper,
+      })
+    );
 
     const hits = [{ fake: 'data' }, { sample: 'infos' }];
     const results = new SearchResults(helper.state, [{ hits }]);
-    widget.render!({
-      ...defaultRenderOptions,
-      results,
-      state: helper.state,
-      helper,
-    });
+
+    widget.render!(
+      createRenderOptionsWithInsights({
+        state: helper.state,
+        results,
+        helper,
+      })
+    );
 
     const secondRenderingOptions = rendering.mock.calls[1][0];
     expect(secondRenderingOptions.hits).toEqual(expect.objectContaining(hits));

--- a/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
+++ b/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
@@ -1,5 +1,10 @@
 import algoliasearchHelper, { SearchResults } from 'algoliasearch-helper';
+import { createInstantSearch } from '../../../../test/mock/createInstantSearch';
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
+import {
+  createInitOptions,
+  createRenderOptions,
+} from '../../../../test/mock/createWidget';
 import { Helper, SearchParameters } from '../../../types';
 import connectQueryRules, {
   QueryRulesWidgetFactory,
@@ -9,25 +14,6 @@ describe('connectQueryRules', () => {
   let renderFn = jest.fn();
   let unmountFn = jest.fn();
   let makeWidget: QueryRulesWidgetFactory<{}>;
-
-  const defaultInitOptions = {
-    instantSearchInstance: {
-      helper: null,
-      widgets: [],
-    },
-    templatesConfig: {},
-    createURL: () => '#',
-  };
-
-  const defaultRenderOptions = {
-    instantSearchInstance: {
-      helper: null,
-      widgets: [],
-    },
-    templatesConfig: {},
-    searchMetadata: { isSearchStalled: false },
-    createURL: () => '#',
-  };
 
   const createFakeHelper = (state = {}): Helper => {
     const client = createSearchClient();
@@ -83,45 +69,50 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
     test('calls the render function on init', () => {
       const helper = createFakeHelper();
       const widget = makeWidget({});
-
-      widget.init!({
-        ...defaultInitOptions,
-        helper,
+      const instantSearchInstance = createInstantSearch();
+      const initOptions = createInitOptions({
+        instantSearchInstance,
         state: helper.state,
+        helper,
       });
+
+      widget.init!(initOptions);
 
       const [renderingParameters, isFirstRender] = renderFn.mock.calls[0];
 
       expect(isFirstRender).toBe(true);
 
       const {
+        instantSearchInstance: localInstantSearchInstance,
         items,
-        instantSearchInstance,
         widgetParams,
       } = renderingParameters;
 
       expect(items).toEqual([]);
-      expect(instantSearchInstance).toEqual(
-        defaultInitOptions.instantSearchInstance
-      );
+      expect(localInstantSearchInstance).toEqual(instantSearchInstance);
       expect(widgetParams).toEqual({});
     });
 
     test('calls the render function on render', () => {
       const helper = createFakeHelper();
       const widget = makeWidget({});
+      const instantSearchInstance = createInstantSearch();
+      const initOptions = createInitOptions({
+        helper,
+        instantSearchInstance,
+        state: helper.state,
+      });
 
-      widget.init!({
-        ...defaultInitOptions,
-        helper,
-        state: helper.state,
-      });
-      widget.render!({
-        ...defaultRenderOptions,
-        helper,
-        state: helper.state,
-        results: new SearchResults(helper.state, [{ hits: [] }]),
-      });
+      widget.init!(initOptions);
+
+      widget.render!(
+        createRenderOptions({
+          helper,
+          instantSearchInstance,
+          state: helper.state,
+          results: new SearchResults(helper.state, [{ hits: [] }]),
+        })
+      );
 
       {
         const [renderingParameters, isFirstRender] = renderFn.mock.calls[1];
@@ -129,26 +120,26 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
         expect(isFirstRender).toBe(false);
 
         const {
+          instantSearchInstance: localInstantSearchInstance,
           items,
-          instantSearchInstance,
           widgetParams,
         } = renderingParameters;
 
         expect(items).toEqual([]);
-        expect(instantSearchInstance).toEqual(
-          defaultInitOptions.instantSearchInstance
-        );
+        expect(localInstantSearchInstance).toEqual(instantSearchInstance);
         expect(widgetParams).toEqual({});
       }
 
-      widget.render!({
-        ...defaultRenderOptions,
-        helper,
-        state: helper.state,
-        results: new SearchResults(helper.state, [
-          { hits: [], userData: [{ banner: 'image.png' }] },
-        ]),
-      });
+      widget.render!(
+        createRenderOptions({
+          helper,
+          instantSearchInstance,
+          state: helper.state,
+          results: new SearchResults(helper.state, [
+            { hits: [], userData: [{ banner: 'image.png' }] },
+          ]),
+        })
+      );
 
       {
         const [renderingParameters, isFirstRender] = renderFn.mock.calls[2];
@@ -156,15 +147,13 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
         expect(isFirstRender).toBe(false);
 
         const {
+          instantSearchInstance: localInstantSearchInstance,
           items,
-          instantSearchInstance,
           widgetParams,
         } = renderingParameters;
 
         expect(items).toEqual([{ banner: 'image.png' }]);
-        expect(instantSearchInstance).toEqual(
-          defaultInitOptions.instantSearchInstance
-        );
+        expect(localInstantSearchInstance).toEqual(instantSearchInstance);
         expect(widgetParams).toEqual({});
       }
     });
@@ -173,11 +162,13 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
       const helper = createFakeHelper();
       const widget = makeWidget({});
 
-      widget.init!({
-        ...defaultInitOptions,
-        helper,
-        state: helper.state,
-      });
+      widget.init!(
+        createInitOptions({
+          helper,
+          state: helper.state,
+        })
+      );
+
       widget.dispose!({ helper, state: helper.state });
 
       expect(unmountFn).toHaveBeenCalledTimes(1);
@@ -192,22 +183,25 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
           transformItems: customItems => customItems[0],
         });
 
-        widget.init!({
-          ...defaultInitOptions,
-          helper,
-          state: helper.state,
-        });
-        widget.render!({
-          ...defaultRenderOptions,
-          helper,
-          state: helper.state,
-          results: new SearchResults(helper.state, [
-            {
-              hits: [],
-              userData: [{ banner: 'image1.png' }, { banner: 'image2.png' }],
-            },
-          ]),
-        });
+        widget.init!(
+          createInitOptions({
+            helper,
+            state: helper.state,
+          })
+        );
+
+        widget.render!(
+          createRenderOptions({
+            helper,
+            state: helper.state,
+            results: new SearchResults(helper.state, [
+              {
+                hits: [],
+                userData: [{ banner: 'image1.png' }, { banner: 'image2.png' }],
+              },
+            ]),
+          })
+        );
 
         const [renderingParameters] = renderFn.mock.calls[1];
 
@@ -240,11 +234,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
           },
         });
 
-        widget.init!({
-          ...defaultInitOptions,
-          helper,
-          state: helper.state,
-        });
+        widget.init!(
+          createInitOptions({
+            helper,
+            state: helper.state,
+          })
+        );
 
         // Query parameters are initially set in the helper.
         // Therefore, `ruleContexts` should be set.
@@ -273,11 +268,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
           transformRuleContexts: () => ['overriden-rule'],
         });
 
-        widget.init!({
-          ...defaultInitOptions,
-          helper,
-          state: helper.state,
-        });
+        widget.init!(
+          createInitOptions({
+            helper,
+            state: helper.state,
+          })
+        );
 
         expect((helper.state as SearchParameters).ruleContexts).toEqual([
           'overriden-rule',
@@ -299,11 +295,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
           },
         });
 
-        widget.init!({
-          ...defaultInitOptions,
-          helper,
-          state: helper.state,
-        });
+        widget.init!(
+          createInitOptions({
+            helper,
+            state: helper.state,
+          })
+        );
 
         // There's no results yet, so no `ruleContexts` should be set.
         expect((helper.state as SearchParameters).ruleContexts).toEqual(
@@ -312,22 +309,23 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
         expect(brandFilterSpy).toHaveBeenCalledTimes(0);
         expect(priceFilterSpy).toHaveBeenCalledTimes(0);
 
-        widget.render!({
-          ...defaultRenderOptions,
-          helper,
-          state: helper.state,
-          results: new SearchResults(helper.state, [
-            {},
-            {
-              facets: {
-                brand: {
-                  Samsung: 100,
-                  Apple: 100,
+        widget.render!(
+          createRenderOptions({
+            helper,
+            state: helper.state,
+            results: new SearchResults(helper.state, [
+              {},
+              {
+                facets: {
+                  brand: {
+                    Samsung: 100,
+                    Apple: 100,
+                  },
                 },
               },
-            },
-          ]),
-        });
+            ]),
+          })
+        );
 
         // There are some results with the facets that we track in the
         // widget but the query parameters are not set in the helper.
@@ -352,22 +350,23 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
           },
         });
 
-        widget.render!({
-          ...defaultRenderOptions,
-          helper,
-          state: helper.state,
-          results: new SearchResults(helper.state, [
-            {},
-            {
-              facets: {
-                brand: {
-                  Samsung: 100,
-                  Apple: 100,
+        widget.render!(
+          createRenderOptions({
+            helper,
+            state: helper.state,
+            results: new SearchResults(helper.state, [
+              {},
+              {
+                facets: {
+                  brand: {
+                    Samsung: 100,
+                    Apple: 100,
+                  },
                 },
               },
-            },
-          ]),
-        });
+            ]),
+          })
+        );
 
         // The search state contains the facets that we track,
         // therefore the `ruleContexts` should finally be set.
@@ -395,33 +394,35 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
           },
         });
 
-        widget.init!({
-          ...defaultInitOptions,
-          helper,
-          state: helper.state,
-        });
+        widget.init!(
+          createInitOptions({
+            helper,
+            state: helper.state,
+          })
+        );
 
         expect((helper.state as SearchParameters).ruleContexts).toEqual(
           undefined
         );
         expect(brandFilterSpy).toHaveBeenCalledTimes(0);
 
-        widget.render!({
-          ...defaultRenderOptions,
-          helper,
-          state: helper.state,
-          results: new SearchResults(helper.state, [
-            {},
-            {
-              facets: {
-                brand: {
-                  Samsung: 100,
-                  Apple: 100,
+        widget.render!(
+          createRenderOptions({
+            helper,
+            state: helper.state,
+            results: new SearchResults(helper.state, [
+              {},
+              {
+                facets: {
+                  brand: {
+                    Samsung: 100,
+                    Apple: 100,
+                  },
                 },
               },
-            },
-          ]),
-        });
+            ]),
+          })
+        );
 
         expect((helper.state as SearchParameters).ruleContexts).toEqual(
           undefined
@@ -434,22 +435,23 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
           },
         });
 
-        widget.render!({
-          ...defaultRenderOptions,
-          helper,
-          state: helper.state,
-          results: new SearchResults(helper.state, [
-            {},
-            {
-              facets: {
-                brand: {
-                  Samsung: 100,
-                  Apple: 100,
+        widget.render!(
+          createRenderOptions({
+            helper,
+            state: helper.state,
+            results: new SearchResults(helper.state, [
+              {},
+              {
+                facets: {
+                  brand: {
+                    Samsung: 100,
+                    Apple: 100,
+                  },
                 },
               },
-            },
-          ]),
-        });
+            ]),
+          })
+        );
 
         expect((helper.state as SearchParameters).ruleContexts).toEqual([
           'ais-brand-Samsung',
@@ -467,23 +469,25 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
           },
         });
 
-        widget.init!({
-          ...defaultInitOptions,
-          helper,
-          state: helper.state,
-        });
+        widget.init!(
+          createInitOptions({
+            helper,
+            state: helper.state,
+          })
+        );
 
         expect((helper.state as SearchParameters).ruleContexts).toEqual(
           undefined
         );
         expect(priceFilterSpy).toHaveBeenCalledTimes(0);
 
-        widget.render!({
-          ...defaultRenderOptions,
-          helper,
-          state: helper.state,
-          results: new SearchResults(helper.state, [{}, {}]),
-        });
+        widget.render!(
+          createRenderOptions({
+            helper,
+            state: helper.state,
+            results: new SearchResults(helper.state, [{}, {}]),
+          })
+        );
 
         expect((helper.state as SearchParameters).ruleContexts).toEqual(
           undefined
@@ -499,12 +503,13 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
           },
         });
 
-        widget.render!({
-          ...defaultRenderOptions,
-          helper,
-          state: helper.state,
-          results: new SearchResults(helper.state, [{}, {}]),
-        });
+        widget.render!(
+          createRenderOptions({
+            helper,
+            state: helper.state,
+            results: new SearchResults(helper.state, [{}, {}]),
+          })
+        );
 
         expect((helper.state as SearchParameters).ruleContexts).toEqual([
           'ais-price-500',
@@ -523,11 +528,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
           },
         });
 
-        widget.init!({
-          ...defaultInitOptions,
-          helper,
-          state: helper.state,
-        });
+        widget.init!(
+          createInitOptions({
+            helper,
+            state: helper.state,
+          })
+        );
 
         helper.setState({
           disjunctiveFacetsRefinements: {
@@ -535,22 +541,23 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
           },
         });
 
-        widget.render!({
-          ...defaultRenderOptions,
-          helper,
-          state: helper.state,
-          results: new SearchResults(helper.state, [
-            {},
-            {
-              facets: {
-                brand: {
-                  'Insignia™': 100,
-                  '© Apple': 100,
+        widget.render!(
+          createRenderOptions({
+            helper,
+            state: helper.state,
+            results: new SearchResults(helper.state, [
+              {},
+              {
+                facets: {
+                  brand: {
+                    'Insignia™': 100,
+                    '© Apple': 100,
+                  },
                 },
               },
-            },
-          ]),
-        });
+            ]),
+          })
+        );
 
         expect((helper.state as SearchParameters).ruleContexts).toEqual([
           'ais-brand-Insignia_',
@@ -584,11 +591,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
           },
         });
 
-        widget.init!({
-          ...defaultInitOptions,
-          helper,
-          state: helper.state,
-        });
+        widget.init!(
+          createInitOptions({
+            helper,
+            state: helper.state,
+          })
+        );
 
         expect(() => {
           helper.setState({
@@ -600,31 +608,32 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
           .toWarnDev(`[InstantSearch.js]: The maximum number of \`ruleContexts\` is 10. They have been sliced to that limit.
 Consider using \`transformRuleContexts\` to minimize the number of rules sent to Algolia.`);
 
-        widget.render!({
-          ...defaultRenderOptions,
-          helper,
-          state: helper.state,
-          results: new SearchResults(helper.state, [
-            {},
-            {
-              facets: {
-                brand: {
-                  Insignia: 100,
-                  Canon: 100,
-                  Dynex: 100,
-                  LG: 100,
-                  Metra: 100,
-                  Sony: 100,
-                  HP: 100,
-                  Apple: 100,
-                  Samsung: 100,
-                  Speck: 100,
-                  PNY: 100,
+        widget.render!(
+          createRenderOptions({
+            helper,
+            state: helper.state,
+            results: new SearchResults(helper.state, [
+              {},
+              {
+                facets: {
+                  brand: {
+                    Insignia: 100,
+                    Canon: 100,
+                    Dynex: 100,
+                    LG: 100,
+                    Metra: 100,
+                    Sony: 100,
+                    HP: 100,
+                    Apple: 100,
+                    Samsung: 100,
+                    Speck: 100,
+                    PNY: 100,
+                  },
                 },
               },
-            },
-          ]),
-        });
+            ]),
+          })
+        );
 
         expect((helper.state as SearchParameters).ruleContexts).toHaveLength(
           10
@@ -654,11 +663,12 @@ Consider using \`transformRuleContexts\` to minimize the number of rules sent to
           },
         });
 
-        widget.init!({
-          ...defaultInitOptions,
-          helper,
-          state: helper.state,
-        });
+        widget.init!(
+          createInitOptions({
+            helper,
+            state: helper.state,
+          })
+        );
 
         helper.setState({
           disjunctiveFacetsRefinements: {
@@ -666,22 +676,23 @@ Consider using \`transformRuleContexts\` to minimize the number of rules sent to
           },
         });
 
-        widget.render!({
-          ...defaultRenderOptions,
-          helper,
-          state: helper.state,
-          results: new SearchResults(helper.state, [
-            {},
-            {
-              facets: {
-                brand: {
-                  Samsung: 100,
-                  Apple: 100,
+        widget.render!(
+          createRenderOptions({
+            helper,
+            state: helper.state,
+            results: new SearchResults(helper.state, [
+              {},
+              {
+                facets: {
+                  brand: {
+                    Samsung: 100,
+                    Apple: 100,
+                  },
                 },
               },
-            },
-          ]),
-        });
+            ]),
+          })
+        );
 
         expect((helper.state as SearchParameters).ruleContexts).toEqual([
           'initial-rule',
@@ -714,11 +725,12 @@ Consider using \`transformRuleContexts\` to minimize the number of rules sent to
           undefined
         );
 
-        widget.init!({
-          ...defaultInitOptions,
-          helper,
-          state: helper.state,
-        });
+        widget.init!(
+          createInitOptions({
+            helper,
+            state: helper.state,
+          })
+        );
 
         expect((helper.state as SearchParameters).ruleContexts).toEqual([
           'ais-brand-Samsung',
@@ -760,28 +772,30 @@ Consider using \`transformRuleContexts\` to minimize the number of rules sent to
           transformRuleContexts: transformRuleContextsSpy,
         });
 
-        widget.init!({
-          ...defaultInitOptions,
-          helper,
-          state: helper.state,
-        });
+        widget.init!(
+          createInitOptions({
+            helper,
+            state: helper.state,
+          })
+        );
 
-        widget.render!({
-          ...defaultRenderOptions,
-          helper,
-          state: helper.state,
-          results: new SearchResults(helper.state, [
-            {},
-            {
-              facets: {
-                brand: {
-                  Samsung: 100,
-                  Apple: 100,
+        widget.render!(
+          createRenderOptions({
+            helper,
+            state: helper.state,
+            results: new SearchResults(helper.state, [
+              {},
+              {
+                facets: {
+                  brand: {
+                    Samsung: 100,
+                    Apple: 100,
+                  },
                 },
               },
-            },
-          ]),
-        });
+            ]),
+          })
+        );
 
         expect(transformRuleContextsSpy).toHaveBeenCalledTimes(1);
         expect(transformRuleContextsSpy).toHaveBeenCalledWith([

--- a/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
+++ b/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
@@ -1,5 +1,6 @@
 import algoliasearchHelper, { SearchResults } from 'algoliasearch-helper';
-import { Client, Helper, SearchParameters } from '../../../types';
+import { createSearchClient } from '../../../../test/mock/createSearchClient';
+import { Helper, SearchParameters } from '../../../types';
 import connectQueryRules, {
   QueryRulesWidgetFactory,
 } from '../connectQueryRules';
@@ -28,12 +29,8 @@ describe('connectQueryRules', () => {
     createURL: () => '#',
   };
 
-  const createFakeClient = (options = {}): Client => {
-    return options as Client;
-  };
-
   const createFakeHelper = (state = {}): Helper => {
-    const client = createFakeClient();
+    const client = createSearchClient();
     const indexName = '';
     const helper = algoliasearchHelper(client, indexName, state);
 

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -1,4 +1,5 @@
-import algoliaSearchHelper from 'algoliasearch-helper';
+import algoliasearchHelper from 'algoliasearch-helper';
+import { createSearchClient } from '../../../test/mock/createSearchClient';
 import InstantSearch from '../InstantSearch';
 import version from '../version';
 
@@ -54,7 +55,7 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
       // eslint-disable-next-line no-new
       new InstantSearch({
         indexName: 'indexName',
-        searchClient: { search: () => {} },
+        searchClient: createSearchClient(),
         insightsClient: 'insights',
       });
     }).toThrowErrorMatchingInlineSnapshot(
@@ -76,7 +77,7 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
     expect(() => {
       const search = new InstantSearch({
         indexName: 'indexName',
-        searchClient: { search: () => {} },
+        searchClient: createSearchClient(),
       });
       search.addWidgets({});
     }).toThrowErrorMatchingInlineSnapshot(`
@@ -92,7 +93,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
     expect(() => {
       const search = new InstantSearch({
         indexName: 'indexName',
-        searchClient: { search: () => {} },
+        searchClient: createSearchClient(),
       });
       search.addWidgets(widgets);
     }).toThrowErrorMatchingInlineSnapshot(`
@@ -108,7 +109,7 @@ See: https://www.algolia.com/doc/guides/building-search-ui/widgets/create-your-o
     expect(() => {
       const search = new InstantSearch({
         indexName: 'indexName',
-        searchClient: { search: () => {} },
+        searchClient: createSearchClient(),
       });
       search.addWidgets(widgets);
     }).not.toThrow();
@@ -120,7 +121,7 @@ See: https://www.algolia.com/doc/guides/building-search-ui/widgets/create-your-o
     expect(() => {
       const search = new InstantSearch({
         indexName: 'indexName',
-        searchClient: { search: () => {} },
+        searchClient: createSearchClient(),
       });
       search.addWidgets(widgets);
     }).not.toThrow();
@@ -130,7 +131,7 @@ See: https://www.algolia.com/doc/guides/building-search-ui/widgets/create-your-o
     expect(() => {
       const search = new InstantSearch({
         indexName: 'indexName',
-        searchClient: { search: () => {} },
+        searchClient: createSearchClient(),
       });
       search.removeWidgets({});
     }).toThrowErrorMatchingInlineSnapshot(`
@@ -146,7 +147,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
     expect(() => {
       const search = new InstantSearch({
         indexName: 'indexName',
-        searchClient: { search: () => {} },
+        searchClient: createSearchClient(),
       });
       search.removeWidgets(widgets);
     }).toThrowErrorMatchingInlineSnapshot(`
@@ -198,7 +199,7 @@ describe('InstantSearch lifecycle', () => {
 
   afterEach(() => {
     client.addAlgoliaAgent.mockClear();
-    algoliaSearchHelper.mockClear();
+    algoliasearchHelper.mockClear();
   });
 
   it('calls algoliasearch(appId, apiKey)', () => {
@@ -214,7 +215,7 @@ describe('InstantSearch lifecycle', () => {
   });
 
   it('does not call algoliasearchHelper', () => {
-    expect(algoliaSearchHelper).not.toHaveBeenCalled();
+    expect(algoliasearchHelper).not.toHaveBeenCalled();
   });
 
   it('does not fail when passing same references inside multiple searchParameters props', () => {
@@ -271,8 +272,8 @@ describe('InstantSearch lifecycle', () => {
       });
 
       it('calls algoliasearchHelper(client, indexName, searchParameters)', () => {
-        expect(algoliaSearchHelper).toHaveBeenCalledTimes(1);
-        expect(algoliaSearchHelper).toHaveBeenCalledWith(client, indexName, {
+        expect(algoliasearchHelper).toHaveBeenCalledTimes(1);
+        expect(algoliasearchHelper).toHaveBeenCalledWith(client, indexName, {
           some: 'modified',
           values: [-2, -1],
           index: indexName,
@@ -346,7 +347,7 @@ describe('InstantSearch lifecycle', () => {
     });
 
     it('recursively merges searchParameters.values array', () => {
-      expect(algoliaSearchHelper.mock.calls[0][2].values).toEqual([
+      expect(algoliasearchHelper.mock.calls[0][2].values).toEqual([
         -2,
         -1,
         0,

--- a/src/lib/__tests__/RoutingManager-test.ts
+++ b/src/lib/__tests__/RoutingManager-test.ts
@@ -2,6 +2,7 @@
 
 import qs from 'qs';
 import { createSearchClient } from '../../../test/mock/createSearchClient';
+import { createWidget } from '../../../test/mock/createWidget';
 import { Router, Widget, StateMapping, RouteState } from '../../types';
 import historyRouter from '../routers/history';
 import RoutingManager from '../RoutingManager';
@@ -72,38 +73,39 @@ const createFakeHistory = (
   };
 };
 
-const createFakeSearchBox = (): Widget => ({
-  render({ helper }) {
-    (this as any).refine = (value: string) => {
-      helper.setQuery(value).search();
-    };
-  },
-  dispose({ state }) {
-    return state.setQuery('');
-  },
-  getWidgetSearchParameters(searchParameters, { uiState }) {
-    return searchParameters.setQuery(uiState.query || '');
-  },
-  getWidgetState(uiState, { searchParameters }) {
-    return {
-      ...uiState,
-      query: searchParameters.query,
-    };
-  },
-});
+const createFakeSearchBox = (): Widget =>
+  createWidget({
+    render({ helper }) {
+      (this as any).refine = (value: string) => {
+        helper.setQuery(value).search();
+      };
+    },
+    dispose({ state }) {
+      return state.setQuery('');
+    },
+    getWidgetSearchParameters(searchParameters, { uiState }) {
+      return searchParameters.setQuery(uiState.query || '');
+    },
+    getWidgetState(uiState, { searchParameters }) {
+      return {
+        ...uiState,
+        query: searchParameters.query,
+      };
+    },
+  });
 
-const createFakeHitsPerPage = (): Widget => ({
-  render() {},
-  dispose({ state }) {
-    return state;
-  },
-  getWidgetSearchParameters(parameters) {
-    return parameters;
-  },
-  getWidgetState(uiState) {
-    return uiState;
-  },
-});
+const createFakeHitsPerPage = (): Widget =>
+  createWidget({
+    dispose({ state }) {
+      return state;
+    },
+    getWidgetSearchParameters(parameters) {
+      return parameters;
+    },
+    getWidgetState(uiState) {
+      return uiState;
+    },
+  });
 
 describe('RoutingManager', () => {
   const defaultRouter: Router = {
@@ -400,17 +402,17 @@ describe('RoutingManager', () => {
         },
       });
 
-      const widget: Widget = {
-        render: jest.fn(),
-        getWidgetSearchParameters: jest.fn(),
-        getWidgetState(uiState, { searchParameters }) {
-          return {
-            ...uiState,
-            query: searchParameters.query,
-          };
-        },
-      };
-      search.addWidget(widget);
+      search.addWidget(
+        createWidget({
+          getWidgetSearchParameters: jest.fn(),
+          getWidgetState(uiState, { searchParameters }) {
+            return {
+              ...uiState,
+              query: searchParameters.query,
+            };
+          },
+        })
+      );
 
       search.start();
 

--- a/src/lib/__tests__/RoutingManager-test.ts
+++ b/src/lib/__tests__/RoutingManager-test.ts
@@ -1,19 +1,13 @@
 /* globals jsdom */
+
 import qs from 'qs';
-import instantsearch from '../main';
-import RoutingManager from '../RoutingManager';
-import historyRouter from '../routers/history';
+import { createSearchClient } from '../../../test/mock/createSearchClient';
 import { Router, Widget, StateMapping, RouteState } from '../../types';
+import historyRouter from '../routers/history';
+import RoutingManager from '../RoutingManager';
+import instantsearch from '../main';
 
 const runAllMicroTasks = (): Promise<any> => new Promise(setImmediate);
-
-type FakeSearchClient = {
-  search: (query: string) => Promise<{ results: object[] }>;
-};
-
-const createFakeSearchClient = (): FakeSearchClient => ({
-  search: () => Promise.resolve({ results: [{}] }),
-});
 
 const createFakeRouter = (args: Partial<Router> = {}): Router => ({
   onUpdate(..._args) {},
@@ -122,7 +116,7 @@ describe('RoutingManager', () => {
 
   describe('getAllUiStates', () => {
     test('reads the state of widgets with a getWidgetState implementation', () => {
-      const searchClient = createFakeSearchClient();
+      const searchClient = createSearchClient();
       const search = instantsearch({
         indexName: '',
         searchClient,
@@ -171,7 +165,7 @@ describe('RoutingManager', () => {
     });
 
     test('Does not read UI state from widgets without an implementation of getWidgetState', () => {
-      const searchClient = createFakeSearchClient();
+      const searchClient = createSearchClient();
       const search = instantsearch({
         indexName: '',
         searchClient,
@@ -208,7 +202,7 @@ describe('RoutingManager', () => {
 
   describe('getAllSearchParameters', () => {
     test('should get searchParameters from widget that implements getWidgetSearchParameters', () => {
-      const searchClient = createFakeSearchClient();
+      const searchClient = createSearchClient();
       const search = instantsearch({
         indexName: '',
         searchClient,
@@ -254,7 +248,7 @@ describe('RoutingManager', () => {
     });
 
     test('should not change the searchParameters if no widget has a getWidgetSearchParameters', () => {
-      const searchClient = createFakeSearchClient();
+      const searchClient = createSearchClient();
       const search = instantsearch({
         indexName: '',
         searchClient,
@@ -289,7 +283,7 @@ describe('RoutingManager', () => {
 
   describe('within instantsearch', () => {
     test('should write in the router on searchParameters change', done => {
-      const searchClient = createFakeSearchClient();
+      const searchClient = createSearchClient();
       const router = createFakeRouter({
         write: jest.fn(),
       });
@@ -333,7 +327,7 @@ describe('RoutingManager', () => {
     });
 
     test('should update the searchParameters on router state update', done => {
-      const searchClient = createFakeSearchClient();
+      const searchClient = createSearchClient();
 
       let onRouterUpdateCallback: (args: object) => void;
       const router = createFakeRouter({
@@ -380,7 +374,7 @@ describe('RoutingManager', () => {
     });
 
     test('should apply state mapping on differences after searchfunction', done => {
-      const searchClient = createFakeSearchClient();
+      const searchClient = createSearchClient();
 
       const router = createFakeRouter({
         write: jest.fn(),
@@ -434,7 +428,7 @@ describe('RoutingManager', () => {
     });
 
     test('should keep the UI state up to date on state changes', async () => {
-      const searchClient = createFakeSearchClient();
+      const searchClient = createSearchClient();
       const stateMapping = createFakeStateMapping({});
       const router = createFakeRouter({
         write: jest.fn(),
@@ -481,7 +475,7 @@ describe('RoutingManager', () => {
     });
 
     test('should keep the UI state up to date on first render', async () => {
-      const searchClient = createFakeSearchClient();
+      const searchClient = createSearchClient();
       const stateMapping = createFakeStateMapping({});
       const router = createFakeRouter({
         write: jest.fn(),
@@ -528,7 +522,7 @@ describe('RoutingManager', () => {
     });
 
     test('should keep the UI state up to date on router.update', async () => {
-      const searchClient = createFakeSearchClient();
+      const searchClient = createSearchClient();
       const stateMapping = createFakeStateMapping({});
       const history = createFakeHistory();
       const router = createFakeRouter({
@@ -603,7 +597,7 @@ describe('RoutingManager', () => {
       });
 
       const setWindowTitle = jest.spyOn(window.document, 'title', 'set');
-      const searchClient = createFakeSearchClient();
+      const searchClient = createSearchClient();
       const stateMapping = createFakeStateMapping({});
       const router = historyRouter({
         windowTitle(routeState: RouteState) {

--- a/src/types/instantsearch.ts
+++ b/src/types/instantsearch.ts
@@ -115,7 +115,7 @@ export type Helper = AlgoliaSearchHelper;
 
 export type InstantSearch = {
   templatesConfig: object;
-  insightsClient?: AlgoliaInsightsClient;
+  insightsClient: AlgoliaInsightsClient | null;
   helper: Helper | null;
   widgets: Widget[];
 };

--- a/src/types/instantsearch.ts
+++ b/src/types/instantsearch.ts
@@ -114,7 +114,7 @@ export type Client = AlgoliaSearchClient;
 export type Helper = AlgoliaSearchHelper;
 
 export type InstantSearch = {
-  templatesConfig?: object;
+  templatesConfig: object;
   insightsClient?: AlgoliaInsightsClient;
   helper: Helper | null;
   widgets: Widget[];

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -5,7 +5,7 @@ import {
   SearchParameters,
 } from './instantsearch';
 
-interface InitOptions {
+export interface InitOptions {
   instantSearchInstance: InstantSearch;
   state: SearchParameters;
   helper: Helper;
@@ -13,7 +13,7 @@ interface InitOptions {
   createURL(state: SearchParameters): string;
 }
 
-interface RenderOptions {
+export interface RenderOptions {
   instantSearchInstance: InstantSearch;
   templatesConfig: object;
   results: SearchResults;
@@ -25,7 +25,7 @@ interface RenderOptions {
   createURL(state: SearchParameters): string;
 }
 
-interface DisposeOptions {
+export interface DisposeOptions {
   helper: Helper;
   state: SearchParameters;
 }

--- a/src/widgets/query-rule-custom-data/__tests__/query-rule-custom-data-test.ts
+++ b/src/widgets/query-rule-custom-data/__tests__/query-rule-custom-data-test.ts
@@ -1,6 +1,7 @@
 import { render, unmountComponentAtNode } from 'preact-compat';
 import algoliasearchHelper from 'algoliasearch-helper';
-import { Client, Helper } from '../../../types';
+import { createSearchClient } from '../../../../test/mock/createSearchClient';
+import { Helper } from '../../../types';
 import queryRuleCustomData from '../query-rule-custom-data';
 
 jest.mock('preact-compat', () => {
@@ -22,12 +23,8 @@ describe('queryRuleCustomData', () => {
     createURL: () => '#',
   };
 
-  const createFakeClient = (options = {}): Client => {
-    return options as Client;
-  };
-
   const createFakeHelper = (state = {}): Helper => {
-    const client = createFakeClient();
+    const client = createSearchClient();
     const indexName = '';
     const helper = algoliasearchHelper(client, indexName, state);
 

--- a/src/widgets/query-rule-custom-data/__tests__/query-rule-custom-data-test.ts
+++ b/src/widgets/query-rule-custom-data/__tests__/query-rule-custom-data-test.ts
@@ -1,6 +1,7 @@
 import { render, unmountComponentAtNode } from 'preact-compat';
 import algoliasearchHelper from 'algoliasearch-helper';
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
+import { createInitOptions } from '../../../../test/mock/createWidget';
 import { Helper } from '../../../types';
 import queryRuleCustomData from '../query-rule-custom-data';
 
@@ -14,15 +15,6 @@ jest.mock('preact-compat', () => {
 });
 
 describe('queryRuleCustomData', () => {
-  const defaultInitOptions = {
-    instantSearchInstance: {
-      helper: null,
-      widgets: [],
-    },
-    templatesConfig: {},
-    createURL: () => '#',
-  };
-
   const createFakeHelper = (state = {}): Helper => {
     const client = createSearchClient();
     const indexName = '';
@@ -70,11 +62,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rule-
           container: document.createElement('div'),
         });
 
-        widget.init!({
-          ...defaultInitOptions,
-          helper,
-          state: helper.state,
-        });
+        widget.init!(
+          createInitOptions({
+            helper,
+            state: helper.state,
+          })
+        );
 
         const { cssClasses } = render.mock.calls[0][0].props;
 
@@ -92,11 +85,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rule-
           },
         });
 
-        widget.init!({
-          ...defaultInitOptions,
-          helper,
-          state: helper.state,
-        });
+        widget.init!(
+          createInitOptions({
+            helper,
+            state: helper.state,
+          })
+        );
 
         const { cssClasses } = render.mock.calls[0][0].props;
 
@@ -113,11 +107,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rule-
           container: document.createElement('div'),
         });
 
-        widget.init!({
-          ...defaultInitOptions,
-          helper,
-          state: helper.state,
-        });
+        widget.init!(
+          createInitOptions({
+            helper,
+            state: helper.state,
+          })
+        );
 
         const { templates } = render.mock.calls[0][0].props;
 
@@ -149,11 +144,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rule-
           },
         });
 
-        widget.init!({
-          ...defaultInitOptions,
-          helper,
-          state: helper.state,
-        });
+        widget.init!(
+          createInitOptions({
+            helper,
+            state: helper.state,
+          })
+        );
 
         const { templates } = render.mock.calls[0][0].props;
 
@@ -173,11 +169,13 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rule-
           container,
         });
 
-        widget.init!({
-          ...defaultInitOptions,
-          helper,
-          state: helper.state,
-        });
+        widget.init!(
+          createInitOptions({
+            helper,
+            state: helper.state,
+          })
+        );
+
         widget.dispose!({
           helper,
           state: helper.state,

--- a/src/widgets/voice-search/__tests__/voice-search-test.ts
+++ b/src/widgets/voice-search/__tests__/voice-search-test.ts
@@ -1,11 +1,15 @@
 import { render } from 'preact-compat';
+import algoliasearch from 'algoliasearch';
 import algoliasearchHelper, {
   SearchResults,
   SearchParameters,
 } from 'algoliasearch-helper';
-import voiceSearch from '../voice-search';
-import algoliasearch from 'algoliasearch';
+import {
+  createInitOptions,
+  createRenderOptions,
+} from '../../../../test/mock/createWidget';
 import { Helper, Widget } from '../../../types';
+import voiceSearch from '../voice-search';
 
 jest.mock('preact-compat', () => {
   const module = require.requireActual('preact-compat');
@@ -23,39 +27,32 @@ interface DefaultSetupWrapper {
 function defaultSetup(opts = {}): DefaultSetupWrapper {
   const container = document.createElement('div');
   const widget = voiceSearch({ container, ...opts });
+
   const widgetInit = (helper: Helper): void => {
     if (!widget.init) {
       throw new Error('VoiceSearch widget has no init method.');
     }
-    widget.init({
-      helper,
-      instantSearchInstance: {
-        helper: null,
-        widgets: [],
-      },
-      state: helper.state,
-      templatesConfig: {},
-      createURL: () => '',
-    });
+
+    widget.init(
+      createInitOptions({
+        helper,
+        state: helper.state,
+      })
+    );
   };
+
   const widgetRender = (helper: Helper): void => {
     if (!widget.render) {
       throw new Error('VoiceSearch widget has no render method.');
     }
-    widget.render({
-      helper,
-      instantSearchInstance: {
-        helper: null,
-        widgets: [],
-      },
-      templatesConfig: {},
-      results: new SearchResults(helper.state, [{}]),
-      state: helper.state,
-      searchMetadata: {
-        isSearchStalled: false,
-      },
-      createURL: () => '',
-    });
+
+    widget.render(
+      createRenderOptions({
+        helper,
+        state: helper.state,
+        results: new SearchResults(helper.state, [{}]),
+      })
+    );
   };
 
   return { container, widget, widgetInit, widgetRender };

--- a/test/mock/createAPIResponse.ts
+++ b/test/mock/createAPIResponse.ts
@@ -1,0 +1,39 @@
+import { SearchForFacetValues, Response, MultiResponse } from 'algoliasearch';
+
+export const createSingleSearchResponse = (
+  args: Partial<Response> = {}
+): Response => ({
+  hits: [],
+  nbHits: 0,
+  page: 0,
+  nbPages: 0,
+  hitsPerPage: 4,
+  processingTimeMS: 1,
+  query: '',
+  params: '',
+  index: 'index_name',
+  ...args,
+});
+
+export const createMutliSearchResponse = (
+  ...args: Array<Partial<Response>>
+): MultiResponse => {
+  if (!args.length) {
+    return {
+      results: [createSingleSearchResponse()],
+    };
+  }
+
+  return {
+    results: args.map(createSingleSearchResponse),
+  };
+};
+
+export const createSFFVResponse = (
+  args: Partial<SearchForFacetValues.Response> = {}
+): SearchForFacetValues.Response => ({
+  facetHits: [],
+  exhaustiveFacetsCount: true,
+  processingTimeMS: 1,
+  ...args,
+});

--- a/test/mock/createInstantSearch.ts
+++ b/test/mock/createInstantSearch.ts
@@ -1,0 +1,16 @@
+import algoliasearchHelper from 'algoliasearch-helper';
+import { InstantSearch } from '../../src/types';
+
+export const createInstantSearch = (
+  args: Partial<InstantSearch> = {}
+): InstantSearch => {
+  const helper = algoliasearchHelper({} as any, '', {});
+
+  return {
+    helper,
+    widgets: [],
+    templatesConfig: {},
+    insightsClient: null,
+    ...args,
+  };
+};

--- a/test/mock/createSearchClient.ts
+++ b/test/mock/createSearchClient.ts
@@ -1,0 +1,21 @@
+import { Client } from '../../src/types';
+import {
+  createSingleSearchResponse,
+  createMutliSearchResponse,
+  createSFFVResponse,
+} from './createAPIResponse';
+
+export const createSearchClient = (args: Partial<Client> = {}): Client =>
+  ({
+    search: jest.fn(requests =>
+      Promise.resolve(
+        createMutliSearchResponse(
+          ...requests.map(() => createSingleSearchResponse())
+        )
+      )
+    ),
+    searchForFacetValues: jest.fn(() =>
+      Promise.resolve([createSFFVResponse()])
+    ),
+    ...args,
+  } as Client);

--- a/test/mock/createWidget.ts
+++ b/test/mock/createWidget.ts
@@ -1,0 +1,50 @@
+import algolisearchHelper from 'algoliasearch-helper';
+import { InitOptions, RenderOptions, Widget } from '../../src/types';
+import { createMutliSearchResponse } from './createAPIResponse';
+import { createInstantSearch } from './createInstantSearch';
+
+export const createInitOptions = (
+  args: Partial<InitOptions> = {}
+): InitOptions => {
+  const instantSearchInstance = createInstantSearch();
+
+  return {
+    instantSearchInstance,
+    templatesConfig: instantSearchInstance.templatesConfig,
+    helper: instantSearchInstance.helper!,
+    state: instantSearchInstance.helper!.state,
+    createURL: jest.fn(() => '#'),
+    ...args,
+  };
+};
+
+export const createRenderOptions = (
+  args: Partial<RenderOptions> = {}
+): RenderOptions => {
+  const instantSearchInstance = createInstantSearch();
+  const response = createMutliSearchResponse();
+
+  return {
+    instantSearchInstance,
+    templatesConfig: instantSearchInstance.templatesConfig,
+    helper: instantSearchInstance.helper!,
+    state: instantSearchInstance.helper!.state,
+    results: new algolisearchHelper.SearchResults(
+      instantSearchInstance.helper!.state,
+      response.results
+    ),
+    searchMetadata: {
+      isSearchStalled: false,
+    },
+    createURL: jest.fn(() => '#'),
+    ...args,
+  };
+};
+
+export const createWidget = (args: Partial<Widget> = {}): Widget => ({
+  getConfiguration: jest.fn(),
+  init: jest.fn(),
+  render: jest.fn(),
+  dispose: jest.fn(),
+  ...args,
+});


### PR DESCRIPTION
This PR introduces mock helpers for the common types that we currently have inside our tests. Those helper functions allow us to easily change the type of one of the interface. Without them, one change inside the type has an impact on every test files that require this type. It's still the case but since the type is encapsulated inside a function we have to change it once (for most cases). Here which mock have been introduced:

- `createSearchClient`: create a `searchClient` with pre-defined response 
- `createInstantSearch`: create an InstantSearch instance
- `createWidget`: create a widget with `jest.fn()`
- `createInitOptions`: create the widget `init` options
- `createRenderOptions`: create the widget `render` options

Each one of them accepts an argument which is a `Partial` of the return type. It allows to easily override every attribute on the returned object. I haven't updated all the tests that rely on private mock only the ones that are written in TypeScript (because they break the CI otherwise).

I did it in one PR rather than multiple ones because otherwise, I don't have a CI that pass for each step. The review should be straightforward it mostly search/replace.