### PR TITLE
test(utils): use runAllMicroTasks

### DIFF
--- a/src/lib/__tests__/RoutingManager-test.ts
+++ b/src/lib/__tests__/RoutingManager-test.ts
@@ -3,12 +3,11 @@
 import qs from 'qs';
 import { createSearchClient } from '../../../test/mock/createSearchClient';
 import { createWidget } from '../../../test/mock/createWidget';
+import { runAllMicroTasks } from '../../../test/utils/runAllMicroTasks';
 import { Router, Widget, StateMapping, RouteState } from '../../types';
 import historyRouter from '../routers/history';
 import RoutingManager from '../RoutingManager';
 import instantsearch from '../main';
-
-const runAllMicroTasks = (): Promise<any> => new Promise(setImmediate);
 
 const createFakeRouter = (args: Partial<Router> = {}): Router => ({
   onUpdate(..._args) {},

--- a/test/utils/runAllMicroTasks.ts
+++ b/test/utils/runAllMicroTasks.ts
@@ -1,0 +1,1 @@
+export const runAllMicroTasks = (): Promise<void> => new Promise(setImmediate);


### PR DESCRIPTION
This PR introduce a first test utils: `runAllMicroTasks`. We use it only once at the moment but we'll introduce some features that will require its usage in the next PRs. Basically it flushes the micro-tasks queue without relying on Jest's fake timers.