### PR TITLE
fix(panel): return value from dispose

### DIFF
--- a/src/widgets/panel/__tests__/panel-test.js
+++ b/src/widgets/panel/__tests__/panel-test.js
@@ -182,4 +182,19 @@ describe('Lifecycle', () => {
     expect(widget.render).toHaveBeenCalledTimes(1);
     expect(widget.dispose).toHaveBeenCalledTimes(1);
   });
+
+  test('returns the `state` from the widget dispose function', () => {
+    const widget = {
+      dispose: jest.fn(() => 'nextState'),
+    };
+    const widgetFactory = () => widget;
+
+    const widgetWithPanel = panel()(widgetFactory)({
+      container: document.createElement('div'),
+    });
+
+    const nextState = widgetWithPanel.dispose({});
+
+    expect(nextState).toBe('nextState');
+  });
 });

--- a/src/widgets/panel/panel.js
+++ b/src/widgets/panel/panel.js
@@ -179,8 +179,10 @@ export default function panel({
         unmountComponentAtNode(getContainerNode(container));
 
         if (typeof widget.dispose === 'function') {
-          widget.dispose.call(this, ...args);
+          return widget.dispose.call(this, ...args);
         }
+
+        return undefined;
       },
       render(...args) {
         const [options] = args;


### PR DESCRIPTION
The return value of  `dispose`  is swallowed by the `panel`. It leads to issue when a widget refined wrapped by a `panel` is removed from the search. The refined values should be removed but since the return value is ignored the refinement persist. This PR aims to fix this issue.

**Before**

![before](https://user-images.githubusercontent.com/6513513/60248441-f3085e00-98c2-11e9-8fad-3d1c689b5d09.gif)

**After**

![after](https://user-images.githubusercontent.com/6513513/60248453-f996d580-98c2-11e9-8451-d91f9f40a6d8.gif)