### PR TITLE
chore(storybook): add stories with lifecycle

### DIFF
--- a/.storybook/decorators/index.ts
+++ b/.storybook/decorators/index.ts
@@ -1,1 +1,2 @@
 export * from './withHits';
+export * from './withLifecycle';

--- a/.storybook/decorators/index.ts
+++ b/.storybook/decorators/index.ts
@@ -1,0 +1,1 @@
+export * from './withHits';

--- a/.storybook/decorators/withHits.ts
+++ b/.storybook/decorators/withHits.ts
@@ -1,7 +1,7 @@
 import { action } from '@storybook/addon-actions';
 import algoliasearch from 'algoliasearch/lite';
-import instantsearch from '../src/index';
-import defaultPlayground from './playgrounds/default';
+import instantsearch from '../../src/index';
+import defaultPlayground from '../playgrounds/default';
 
 export const withHits = (
   storyFn: ({

--- a/.storybook/decorators/withLifecycle.ts
+++ b/.storybook/decorators/withLifecycle.ts
@@ -1,3 +1,5 @@
+import { Widget } from '../../src/types';
+
 const setDisabledState = (element: HTMLButtonElement, state: boolean) => {
   element.disabled = state;
   element.classList.toggle('ais-ClearRefinements-button--disabled');
@@ -6,7 +8,7 @@ const setDisabledState = (element: HTMLButtonElement, state: boolean) => {
 export const withLifecycle = (
   search: any,
   container: HTMLElement,
-  fn: (node: HTMLElement) => void
+  fn: (node: HTMLElement) => Widget
 ) => {
   const actions = document.createElement('div');
   actions.style.marginBottom = '15px';

--- a/.storybook/decorators/withLifecycle.ts
+++ b/.storybook/decorators/withLifecycle.ts
@@ -1,0 +1,54 @@
+const setDisabledState = (element: HTMLButtonElement, state: boolean) => {
+  element.disabled = state;
+  element.classList.toggle('ais-ClearRefinements-button--disabled');
+};
+
+export const withLifecycle = (
+  search: any,
+  container: HTMLElement,
+  fn: (node: HTMLElement) => void
+) => {
+  const actions = document.createElement('div');
+  actions.style.marginBottom = '15px';
+  actions.style.paddingBottom = '15px';
+  actions.style.borderBottom = '1px solid #e4e4e4';
+
+  const description = document.createElement('p');
+  description.textContent =
+    'Click on one of the button to add/remove the widget.';
+
+  const add = document.createElement('button');
+  add.style.marginRight = '10px';
+  add.className = 'ais-ClearRefinements-button';
+  add.textContent = 'Add widget';
+
+  const remove = document.createElement('button');
+  remove.className = 'ais-ClearRefinements-button';
+  remove.textContent = 'Remove widget';
+
+  const node = document.createElement('div');
+
+  actions.appendChild(description);
+  actions.appendChild(add);
+  actions.appendChild(remove);
+
+  container.appendChild(actions);
+  container.appendChild(node);
+
+  const widget = fn(node);
+
+  search.addWidget(widget);
+  setDisabledState(add, true);
+
+  add.addEventListener('click', () => {
+    search.addWidget(widget);
+    setDisabledState(add, true);
+    setDisabledState(remove, false);
+  });
+
+  remove.addEventListener('click', () => {
+    search.removeWidget(widget);
+    setDisabledState(add, false);
+    setDisabledState(remove, true);
+  });
+};

--- a/stories/breadcrumb.stories.js
+++ b/stories/breadcrumb.stories.js
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/html';
-import { withHits } from '../.storybook/decorators';
+import { withHits, withLifecycle } from '../.storybook/decorators';
 
 storiesOf('Breadcrumb', module)
   .add(
@@ -189,4 +189,30 @@ storiesOf('Breadcrumb', module)
         },
       });
     })
+  )
+  .add(
+    'with add/remove',
+    withHits(
+      ({ search, container, instantsearch }) => {
+        withLifecycle(search, container, node =>
+          instantsearch.widgets.breadcrumb({
+            container: node,
+            attributes: [
+              'hierarchicalCategories.lvl0',
+              'hierarchicalCategories.lvl1',
+              'hierarchicalCategories.lvl2',
+            ],
+          })
+        );
+      },
+      {
+        searchParameters: {
+          hierarchicalFacetsRefinements: {
+            'hierarchicalCategories.lvl0': [
+              'Cameras & Camcorders > Digital Cameras',
+            ],
+          },
+        },
+      }
+    )
   );

--- a/stories/configure.stories.js
+++ b/stories/configure.stories.js
@@ -1,21 +1,40 @@
 import { storiesOf } from '@storybook/html';
-import { withHits } from '../.storybook/decorators';
+import { withHits, withLifecycle } from '../.storybook/decorators';
 
-storiesOf('Configure', module).add(
-  'Force 1 hit per page',
-  withHits(({ search, container, instantsearch }) => {
-    const description = document.createElement('div');
-    description.innerHTML = `
+storiesOf('Configure', module)
+  .add(
+    'Force 1 hit per page',
+    withHits(({ search, container, instantsearch }) => {
+      const description = document.createElement('div');
+      description.innerHTML = `
         <p>Search parameters provied to the Configure widget:</p>
         <pre>{ hitsPerPage: 1 }</pre>
       `;
 
-    container.appendChild(description);
+      container.appendChild(description);
 
-    search.addWidget(
-      instantsearch.widgets.configure({
-        hitsPerPage: 1,
-      })
-    );
-  })
-);
+      search.addWidget(
+        instantsearch.widgets.configure({
+          hitsPerPage: 1,
+        })
+      );
+    })
+  )
+  .add(
+    'with add/remove',
+    withHits(({ search, container, instantsearch }) => {
+      withLifecycle(search, container, () =>
+        instantsearch.widgets.configure({
+          hitsPerPage: 1,
+        })
+      );
+
+      const description = document.createElement('div');
+      description.innerHTML = `
+        <p>Search parameters provied to the Configure widget:</p>
+        <pre>{ hitsPerPage: 1 }</pre>
+      `;
+
+      container.appendChild(description);
+    })
+  );

--- a/stories/geo-search.stories.js
+++ b/stories/geo-search.stories.js
@@ -1,6 +1,6 @@
 import { storiesOf } from '@storybook/html';
 import { action } from '@storybook/addon-actions';
-import { withHits } from '../.storybook/decorators';
+import { withHits, withLifecycle } from '../.storybook/decorators';
 import createInfoBox from '../.storybook/utils/create-info-box';
 import instantsearchPlacesWidget from 'places.js/instantsearchWidget';
 import injectScript from 'scriptjs';
@@ -720,6 +720,25 @@ stories
                 ...item,
                 name: item.name.toUpperCase(),
               })),
+          })
+        );
+      })
+    )
+  )
+  .add(
+    'with add/remove',
+    wrapWithHitsAndConfiguration(({ search, container, instantsearch }) =>
+      injectGoogleMaps(() => {
+        search.addWidget(
+          instantsearch.widgets.configure({
+            aroundLatLngViaIP: true,
+          })
+        );
+
+        withLifecycle(search, container, node =>
+          instantsearch.widgets.geoSearch({
+            googleReference: window.google,
+            container: node,
           })
         );
       })

--- a/stories/hierarchical-menu.stories.js
+++ b/stories/hierarchical-menu.stories.js
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/html';
-import { withHits } from '../.storybook/decorators';
+import { withHits, withLifecycle } from '../.storybook/decorators';
 
 storiesOf('HierarchicalMenu', module)
   .add(
@@ -148,6 +148,21 @@ storiesOf('HierarchicalMenu', module)
               ...item,
               label: `${item.label} (transformed)`,
             })),
+        })
+      );
+    })
+  )
+  .add(
+    'with add/remove',
+    withHits(({ search, container, instantsearch }) => {
+      withLifecycle(search, container, node =>
+        instantsearch.widgets.hierarchicalMenu({
+          container: node,
+          attributes: [
+            'hierarchicalCategories.lvl0',
+            'hierarchicalCategories.lvl1',
+            'hierarchicalCategories.lvl2',
+          ],
         })
       );
     })

--- a/stories/hits-per-page.stories.js
+++ b/stories/hits-per-page.stories.js
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/html';
-import { withHits } from '../.storybook/decorators';
+import { withHits, withLifecycle } from '../.storybook/decorators';
 
 storiesOf('HitsPerPage', module)
   .add(
@@ -49,6 +49,21 @@ storiesOf('HitsPerPage', module)
               ...item,
               label: `${item.label} (transformed)`,
             })),
+        })
+      );
+    })
+  )
+  .add(
+    'with add/remove',
+    withHits(({ search, container, instantsearch }) => {
+      withLifecycle(search, container, node =>
+        instantsearch.widgets.hitsPerPage({
+          container: node,
+          items: [
+            { value: 3, label: '3 per page', default: true },
+            { value: 5, label: '5 per page' },
+            { value: 10, label: '10 per page' },
+          ],
         })
       );
     })

--- a/stories/menu-select.stories.js
+++ b/stories/menu-select.stories.js
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/html';
-import { withHits } from '../.storybook/decorators';
+import { withHits, withLifecycle } from '../.storybook/decorators';
 
 storiesOf('MenuSelect', module)
   .add(
@@ -39,6 +39,17 @@ storiesOf('MenuSelect', module)
           templates: {
             defaultOption: 'Default choice',
           },
+        })
+      );
+    })
+  )
+  .add(
+    'with add/remove',
+    withHits(({ search, container, instantsearch }) => {
+      withLifecycle(search, container, node =>
+        instantsearch.widgets.menuSelect({
+          container: node,
+          attribute: 'categories',
         })
       );
     })

--- a/stories/menu.stories.js
+++ b/stories/menu.stories.js
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/html';
-import { withHits } from '../.storybook/decorators';
+import { withHits, withLifecycle } from '../.storybook/decorators';
 
 storiesOf('Menu', module)
   .add(
@@ -75,6 +75,17 @@ storiesOf('Menu', module)
                   ⬇️
                 {{/isShowingMore}}`,
           },
+        })
+      );
+    })
+  )
+  .add(
+    'with add/remove',
+    withHits(({ search, container, instantsearch }) => {
+      withLifecycle(search, container, node =>
+        instantsearch.widgets.menu({
+          container: node,
+          attribute: 'categories',
         })
       );
     })

--- a/stories/sort-by.stories.js
+++ b/stories/sort-by.stories.js
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/html';
-import { withHits } from '../.storybook/decorators';
+import { withHits, withLifecycle } from '../.storybook/decorators';
 
 storiesOf('SortBy', module)
   .add(
@@ -33,6 +33,21 @@ storiesOf('SortBy', module)
               ...item,
               label: item.label.toUpperCase(),
             })),
+        })
+      );
+    })
+  )
+  .add(
+    'with add/remove',
+    withHits(({ search, container, instantsearch }) => {
+      withLifecycle(search, container, node =>
+        instantsearch.widgets.sortBy({
+          container: node,
+          items: [
+            { value: 'instant_search', label: 'Most relevant' },
+            { value: 'instant_search_price_asc', label: 'Lowest price' },
+            { value: 'instant_search_price_desc', label: 'Highest price' },
+          ],
         })
       );
     })

--- a/stories/toggleRefinement.stories.js
+++ b/stories/toggleRefinement.stories.js
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/html';
-import { withHits } from '../.storybook/decorators';
+import { withHits, withLifecycle } from '../.storybook/decorators';
 
 storiesOf('ToggleRefinement', module)
   .add(
@@ -38,6 +38,20 @@ storiesOf('ToggleRefinement', module)
           off: 'Canon',
           templates: {
             labelText: 'Canon (not checked) or sony (checked)',
+          },
+        })
+      );
+    })
+  )
+  .add(
+    'with add/remove',
+    withHits(({ search, container, instantsearch }) => {
+      withLifecycle(search, container, node =>
+        instantsearch.widgets.toggleRefinement({
+          container: node,
+          attribute: 'free_shipping',
+          templates: {
+            labelText: 'Free Shipping (toggle single value)',
           },
         })
       );


### PR DESCRIPTION
It's always painful to test the behavior of a widget when it's added or removed. This PR aims to fix this issue with a decorator that creates a preview to dynamically add/remove the widget. You have to call the decorator inside the `withHits` decorator. I didn't implement a way to chain them because they don't have the same signature (we'll have to implement an adapter for the last one). This approach keeps the flexibility.

I added the `withLifecycle` to the stories when it's relevant: 
- when the `dispose` function actually does something (remove the refinements)
- when the previewed widget does not conflict with the one of the playground

**Usage**

```js
storiesOf("searchBox", module).add(
  "with add/remove",
  withHits(({ search, container, instantsearch }) => {
    withLifecycle(search, container, node =>
      instantsearch.widgets.searchBox({
        container: node
      })
    );
  })
);
```

You can test it live on the [preview](https://deploy-preview-3896--instantsearchjs.netlify.com/stories/?path=/story/menu--with-add-remove).