### PR TITLE
chore(examples): e-commerce mobile design part-2

### DIFF
--- a/examples/e-commerce/index.html
+++ b/examples/e-commerce/index.html
@@ -82,8 +82,8 @@
 
       <section class="container-results">
         <header class="container-header container-options">
-          <div data-widget="sort-by"></div>
-          <div data-widget="hits-per-page"></div>
+          <div class="container-option" data-widget="sort-by"></div>
+          <div class="container-option" data-widget="hits-per-page"></div>
         </header>
 
         <div data-widget="hits"></div>

--- a/examples/e-commerce/index.html
+++ b/examples/e-commerce/index.html
@@ -22,6 +22,7 @@
     <link rel="stylesheet" href="./src/theme.css" />
     <link rel="stylesheet" href="./src/app.css" />
     <link rel="stylesheet" href="./src/app.mobile.css" />
+    <link rel="stylesheet" href="./src/widgets/PriceSlider.css" />
 
     <title>E-commerce demo | Algolia</title>
   </head>

--- a/examples/e-commerce/src/app.css
+++ b/examples/e-commerce/src/app.css
@@ -90,7 +90,7 @@ h2 {
   padding: 30px 0;
 }
 
-.container-options .container-option:not(:first-of-type) {
+.container-options .container-option:not(:first-child) {
   margin-left: 48px;
 }
 

--- a/examples/e-commerce/src/app.css
+++ b/examples/e-commerce/src/app.css
@@ -279,15 +279,6 @@ mark {
   padding: 16px 24px;
 }
 
-/* RangeSlider */
-
-.ais-RangeSlider .rheostat-tooltip::before {
-  color: #e2a400;
-  content: '$';
-  font-size: 0.6;
-  margin-right: 4px;
-}
-
 /* ToggleRefinement */
 
 .ais-ToggleRefinement-label {

--- a/examples/e-commerce/src/app.css
+++ b/examples/e-commerce/src/app.css
@@ -90,7 +90,7 @@ h2 {
   padding: 30px 0;
 }
 
-.container-options div:not(:first-of-type) {
+.container-options .container-option:not(:first-of-type) {
   margin-left: 48px;
 }
 

--- a/examples/e-commerce/src/app.mobile.css
+++ b/examples/e-commerce/src/app.mobile.css
@@ -204,14 +204,6 @@
     padding: 8px;
   }
 
-  /* RangeSlider */
-
-  .ais-RangeSlider .rheostat-handle {
-    height: 1.5rem;
-    top: -12px;
-    width: 1.5rem;
-  }
-
   /* ToggleRefinement */
 
   .ais-ToggleRefinement-checkbox {

--- a/examples/e-commerce/src/app.mobile.css
+++ b/examples/e-commerce/src/app.mobile.css
@@ -59,7 +59,7 @@
     padding: 1rem;
     position: fixed;
     width: 100%;
-    z-index: 1;
+    z-index: 5; /* avoid collision with slider UI */
   }
 
   .container-filters-footer-button-wrapper {

--- a/examples/e-commerce/src/theme.css
+++ b/examples/e-commerce/src/theme.css
@@ -227,6 +227,11 @@ a[class^='ais-'] {
   right: 0;
 }
 
+.ais-SearchBox-resetIcon {
+  width: 10px;
+  height: 10px;
+}
+
 /* SFFV search box */
 
 .ais-RefinementList .ais-SearchBox-input {

--- a/examples/e-commerce/src/widgets/PriceSlider.css
+++ b/examples/e-commerce/src/widgets/PriceSlider.css
@@ -1,0 +1,14 @@
+.ais-RangeSlider .rheostat-tooltip::before {
+  color: #e2a400;
+  content: '$';
+  font-size: 0.6;
+  margin-right: 4px;
+}
+
+@media (max-width: 899px) {
+  .ais-RangeSlider .rheostat-handle {
+    height: 1.5rem;
+    top: -12px;
+    width: 1.5rem;
+  }
+}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This adds more styles to e-commerce mobile design.
<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

This PR will

- force the size for resetIcon in SearchBox as `10x10`, because in Vue-IS and Angular-IS, the sizes are hardcoded and there is no option to override them.
- have `z-index: 5` instead of `1` at `.filtering .container-filters-footer` because there was a collision between the filters footer and the slide UIs in Vue-IS and Angular-IS.
- add class names to the children of `.container-options` because `.container-options div:...` didn't select correctly at Angular-IS.
- move slider-related styles to dedicated `PriceSlider.css` file as same as the flavors are doing.

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->