### PR TITLE
fix(rangeInput): unmount component

### DIFF
--- a/src/widgets/range-input/__tests__/range-input-test.js
+++ b/src/widgets/range-input/__tests__/range-input-test.js
@@ -6,22 +6,12 @@ jest.mock('preact-compat', () => {
   const module = require.requireActual('preact-compat');
 
   module.render = jest.fn();
+  module.unmountComponentAtNode = jest.fn();
 
   return module;
 });
 
 describe('rangeInput', () => {
-  describe('Usage', () => {
-    it('throws without container', () => {
-      expect(() => rangeInput({ container: undefined }))
-        .toThrowErrorMatchingInlineSnapshot(`
-"The \`container\` option is required.
-
-See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input/js/"
-`);
-    });
-  });
-
   const attribute = 'aNumAttr';
   const createContainer = () => document.createElement('div');
   const instantSearchInstance = {};
@@ -38,6 +28,41 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
 
   afterEach(() => {
     ReactDOM.render.mockReset();
+    ReactDOM.unmountComponentAtNode.mockReset();
+  });
+
+  describe('Usage', () => {
+    it('throws without container', () => {
+      expect(() => rangeInput({ container: undefined }))
+        .toThrowErrorMatchingInlineSnapshot(`
+"The \`container\` option is required.
+
+See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input/js/"
+`);
+    });
+  });
+
+  describe('Lifecycle', () => {
+    describe('dispose', () => {
+      it('unmounts the component', () => {
+        const container = document.createElement('div');
+        const helper = createHelper();
+        const widget = rangeInput({
+          attribute: 'price',
+          container,
+        });
+
+        expect(ReactDOM.unmountComponentAtNode).toHaveBeenCalledTimes(0);
+
+        widget.dispose({
+          state: helper.state,
+          helper,
+        });
+
+        expect(ReactDOM.unmountComponentAtNode).toHaveBeenCalledTimes(1);
+        expect(ReactDOM.unmountComponentAtNode).toHaveBeenCalledWith(container);
+      });
+    });
   });
 
   it('expect to render with results', () => {

--- a/src/widgets/range-input/range-input.js
+++ b/src/widgets/range-input/range-input.js
@@ -1,4 +1,4 @@
-import React, { render } from 'preact-compat';
+import React, { render, unmountComponentAtNode } from 'preact-compat';
 import cx from 'classnames';
 import RangeInput from '../../components/RangeInput/RangeInput';
 import connectRange from '../../connectors/range/connectRange';
@@ -153,7 +153,9 @@ export default function rangeInput({
     renderState: {},
   });
 
-  const makeWidget = connectRange(specializedRenderer);
+  const makeWidget = connectRange(specializedRenderer, () =>
+    unmountComponentAtNode(containerNode)
+  );
 
   return makeWidget({
     attribute,


### PR DESCRIPTION
The `rangeInput` was not able to be removed. The unmount function was not provided. The PR fix this issue.

Note that even without the unmount function the widget should not throw. An error is raised because we don't provide a default value to the unmount function or check the value for the unmount function. This issue concern most of the connectors, that's why I didn't address it inside the PR.

**Before**

![before](https://user-images.githubusercontent.com/6513513/60426526-1dc12200-9bf5-11e9-96bc-abd9286531e1.gif)

**After**

![after](https://user-images.githubusercontent.com/6513513/60426549-2ade1100-9bf5-11e9-865f-9a4356b42b68.gif)
