### PR TITLE
fix(menuSelect): unmount component

### DIFF
--- a/src/widgets/menu-select/__tests__/__snapshots__/menu-select-test.js.snap
+++ b/src/widgets/menu-select/__tests__/__snapshots__/menu-select-test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`menuSelect render renders correctly 1`] = `
+exports[`menuSelect Lifecycle render renders correctly 1`] = `
 <MenuSelect
   canRefine={true}
   cssClasses={
@@ -40,7 +40,7 @@ exports[`menuSelect render renders correctly 1`] = `
 />
 `;
 
-exports[`menuSelect render renders transformed items correctly 1`] = `
+exports[`menuSelect Lifecycle render renders transformed items correctly 1`] = `
 <MenuSelect
   canRefine={true}
   cssClasses={

--- a/src/widgets/menu-select/menu-select.js
+++ b/src/widgets/menu-select/menu-select.js
@@ -1,4 +1,4 @@
-import React, { render } from 'preact-compat';
+import React, { render, unmountComponentAtNode } from 'preact-compat';
 import cx from 'classnames';
 import connectMenu from '../../connectors/menu/connectMenu';
 import MenuSelect from '../../components/MenuSelect/MenuSelect';
@@ -112,7 +112,9 @@ export default function menuSelect({
     templates,
   });
 
-  const makeWidget = connectMenu(specializedRenderer);
+  const makeWidget = connectMenu(specializedRenderer, () =>
+    unmountComponentAtNode(containerNode)
+  );
 
   return makeWidget({ attribute, limit, sortBy, transformItems });
 }


### PR DESCRIPTION
The `menuSelect` was not able to be removed. The unmount function was not provided. The PR fix this issue.

Note that even without the unmount function the widget should not throw. An error is raised because we don't provide a default value to the unmount function or check the value for the unmount function. This issue concern most of the connectors, that's why I didn't address it inside the PR.

**Before**

![before](https://user-images.githubusercontent.com/6513513/60439089-6a672600-9c12-11e9-90d0-2ce04cb095d8.gif)

**After**

![after](https://user-images.githubusercontent.com/6513513/60439098-6d621680-9c12-11e9-9a49-e14bc05f37ed.gif)