### PR TITLE
chore(examples): add word wrap to highlight & snippet

### DIFF
--- a/examples/e-commerce/src/theme.css
+++ b/examples/e-commerce/src/theme.css
@@ -63,6 +63,12 @@ a[class^='ais-'] {
   background: rgba(226, 164, 0, 0.4);
 }
 
+.ais-Highlight,
+.ais-Snippet {
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
 /* Hits */
 
 .ais-Hits-list {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

## IGNORE THIS

**Summary**

There's no word-wrapping styles in `ais-highlight` or `ais-snippet`.
This also fixes the glitches (1) and (2) mentioned [here](https://github.com/algolia/angular-instantsearch/pull/629#issuecomment-506790740).

**Result**

* [Without it](https://deploy-preview-3912--instantsearchjs.netlify.com/examples/e-commerce/?refinementList%5Bbrand%5D%5B0%5D=HP&refinementList%5Bbrand%5D%5B1%5D=Speck&refinementList%5Bbrand%5D%5B2%5D=Epson): texts are overflowing.
* [With it](https://deploy-preview-3912--instantsearchjs.netlify.com/examples/e-commerce/?refinementList%5Bbrand%5D%5B0%5D=HP&refinementList%5Bbrand%5D%5B1%5D=Speck&refinementList%5Bbrand%5D%5B2%5D=Epson): texts are wrapped.
