### PR TITLE
fix(InstantSearch): cancel scheduled operations

### DIFF
--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -312,6 +312,7 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
    * @return {undefined} This method does not return anything
    */
   dispose() {
+    this.scheduleSearch.cancel();
     this.scheduleRender.cancel();
 
     this.removeWidgets(this.mainIndex.getWidgets());

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -314,6 +314,7 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
   dispose() {
     this.scheduleSearch.cancel();
     this.scheduleRender.cancel();
+    clearTimeout(this._searchStalledTimer);
 
     this.removeWidgets(this.mainIndex.getWidgets());
     this.mainIndex.dispose();

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -312,6 +312,8 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
    * @return {undefined} This method does not return anything
    */
   dispose() {
+    this.scheduleRender.cancel();
+
     this.removeWidgets(this.mainIndex.getWidgets());
     this.mainIndex.dispose();
 

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -506,6 +506,28 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
 });
 
 describe('dispose', () => {
+  it('cancels the scheduled render', async () => {
+    const search = new InstantSearch({
+      indexName: 'index_name',
+      searchClient: createSearchClient(),
+    });
+
+    search.addWidgets([createWidget(), createWidget()]);
+
+    search.start();
+
+    // We only wait for the search to schedule the render. We have now a render
+    // that is scheduled, it will be processed in the next microtask if not canceled.
+    await Promise.resolve();
+
+    search.dispose();
+
+    // Without the cancel operation, the function call throws an error which
+    // prevents the test to complete. We can't assert that the function throws
+    // because we don't have access to the promise that throws in the first place.
+    await runAllMicroTasks();
+  });
+
   it('removes the widgets from the main index', () => {
     const search = new InstantSearch({
       indexName: 'index_name',

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -1,7 +1,9 @@
 import algoliasearchHelper from 'algoliasearch-helper';
-import { createSearchClient } from '../../../test/mock/createSearchClient';
+import {
+  createSearchClient,
+  createControlledSearchClient,
+} from '../../../test/mock/createSearchClient';
 import { createWidget } from '../../../test/mock/createWidget';
-import { createMutliSearchResponse } from '../../../test/mock/createAPIResponse';
 import { runAllMicroTasks } from '../../../test/utils/runAllMicroTasks';
 import InstantSearch from '../InstantSearch';
 import version from '../version';
@@ -552,30 +554,6 @@ describe('dispose', () => {
   });
 
   it('cancels the scheduled stalled render', async () => {
-    const createControlledSearchClient = () => {
-      const searches = [];
-      const searchClient = {
-        search: jest.fn(() => {
-          let resolver;
-          const promise = new Promise(resolve => {
-            resolver = () => resolve(createMutliSearchResponse());
-          });
-
-          searches.push({
-            promise,
-            resolver,
-          });
-
-          return promise;
-        }),
-      };
-
-      return {
-        searchClient,
-        searches,
-      };
-    };
-
     const { searches, searchClient } = createControlledSearchClient();
     const search = new InstantSearch({
       indexName: 'index_name',
@@ -588,9 +566,6 @@ describe('dispose', () => {
 
     // Resolve the `search`
     searches[0].resolver();
-
-    // Wait for the `search`
-    await searches[0].promise;
 
     // Wait for the `render`
     await runAllMicroTasks();
@@ -848,30 +823,6 @@ describe('scheduleRender', () => {
 });
 
 describe('scheduleStalledRender', () => {
-  const createControlledSearchClient = () => {
-    const searches = [];
-    const searchClient = {
-      search: jest.fn(() => {
-        let resolver;
-        const promise = new Promise(resolve => {
-          resolver = () => resolve(createMutliSearchResponse());
-        });
-
-        searches.push({
-          promise,
-          resolver,
-        });
-
-        return promise;
-      }),
-    };
-
-    return {
-      searchClient,
-      searches,
-    };
-  };
-
   it('calls the `render` method on the main index', async () => {
     const { searches, searchClient } = createControlledSearchClient();
     const search = new InstantSearch({
@@ -887,9 +838,6 @@ describe('scheduleStalledRender', () => {
 
     // Resolve the `search`
     searches[0].resolver();
-
-    // Wait for the `search`
-    await searches[0].promise;
 
     // Wait for the `render`
     await runAllMicroTasks();
@@ -923,9 +871,6 @@ describe('scheduleStalledRender', () => {
 
     // Resolve the `search`
     searches[0].resolver();
-
-    // Wait for the `search`
-    await searches[0].promise;
 
     // Wait for the `render`
     await runAllMicroTasks();
@@ -967,9 +912,6 @@ describe('scheduleStalledRender', () => {
     // Resolve the `search`
     searches[0].resolver();
 
-    // Wait for the `search`
-    await searches[0].promise;
-
     // Wait for the `render`
     await runAllMicroTasks();
 
@@ -1005,9 +947,6 @@ describe('scheduleStalledRender', () => {
 
     // Resolve the `search`
     searches[1].resolver();
-
-    // Wait for the `search`
-    await searches[1].promise;
 
     // Wait for the `render`
     await runAllMicroTasks();

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -506,6 +506,29 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
 });
 
 describe('dispose', () => {
+  it('cancels the scheduled search', async () => {
+    const search = new InstantSearch({
+      indexName: 'index_name',
+      searchClient: createSearchClient(),
+    });
+
+    search.addWidgets([createWidget(), createWidget()]);
+
+    search.start();
+
+    await runAllMicroTasks();
+
+    // The call to `addWidgets` schedules a new search
+    search.addWidgets([createWidget()]);
+
+    search.dispose();
+
+    // Without the cancel operation, the function call throws an error which
+    // prevents the test to complete. We can't assert that the function throws
+    // because we don't have access to the promise that throws in the first place.
+    await runAllMicroTasks();
+  });
+
   it('cancels the scheduled render', async () => {
     const search = new InstantSearch({
       indexName: 'index_name',

--- a/test/mock/createSearchClient.ts
+++ b/test/mock/createSearchClient.ts
@@ -1,3 +1,4 @@
+import { MultiResponse } from 'algoliasearch';
 import { Client } from '../../src/types';
 import {
   createSingleSearchResponse,
@@ -19,3 +20,39 @@ export const createSearchClient = (args: Partial<Client> = {}): Client =>
     ),
     ...args,
   } as Client);
+
+type ControlledClient = {
+  searchClient: Client;
+  searches: Array<{
+    promise: Promise<MultiResponse>;
+    resolver: () => void;
+  }>;
+};
+
+export const createControlledSearchClient = (
+  args: Partial<Client> = {}
+): ControlledClient => {
+  const searches: ControlledClient['searches'] = [];
+  const searchClient = createSearchClient({
+    search: jest.fn(() => {
+      let resolver: () => void;
+      const promise: Promise<MultiResponse> = new Promise(resolve => {
+        resolver = () => resolve(createMutliSearchResponse());
+      });
+
+      searches.push({
+        promise,
+        // @ts-ignore
+        resolver,
+      });
+
+      return promise;
+    }),
+    ...args,
+  });
+
+  return {
+    searchClient,
+    searches,
+  };
+};


### PR DESCRIPTION
Some operations are now asynchronous, which means that we have to clean up those operations when the `InstantSearch` instance is disposed. Otherwise, the functions are called and might refer to props that have been pruned. This PR "cancel" the pending operations on `dispose`.