### PR TITLE
fix(index): prevent render without results

### DIFF
--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -108,7 +108,7 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
 
     this._stalledSearchDelay = stalledSearchDelay;
     this._searchStalledTimer = null;
-    this._isSearchStalled = true;
+    this._isSearchStalled = false;
     this._searchParameters = {
       ...searchParameters,
       index: indexName,
@@ -351,7 +351,7 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
   });
 
   scheduleStalledRender() {
-    if (!this._isSearchStalled && !this._searchStalledTimer) {
+    if (!this._searchStalledTimer) {
       this._searchStalledTimer = setTimeout(() => {
         this._isSearchStalled = true;
         this.scheduleRender();

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -961,25 +961,6 @@ describe('scheduleStalledRender', () => {
       })
     );
   });
-
-  // https://github.com/algolia/instantsearch.js/pull/2623
-  it('does not trigger a re-`render` without results', () => {
-    const { searchClient } = createControlledSearchClient();
-    const search = new InstantSearch({
-      indexName: 'index_name',
-      searchClient,
-    });
-
-    search.start();
-
-    search.addWidget({
-      render: () => {},
-    });
-
-    jest.runOnlyPendingTimers();
-
-    return runAllMicroTasks();
-  });
 });
 
 describe('createURL', () => {

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -745,6 +745,40 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
         });
       });
     });
+
+    // https://github.com/algolia/instantsearch.js/pull/2623
+    it('does not call `render` without `lastResults`', () => {
+      const instance = index({ indexName: 'index_name' });
+      const instantSearchInstance = createInstantSearch();
+
+      const widgets = [createSearchBox(), createPagination()];
+
+      instance.addWidgets(widgets);
+
+      widgets.forEach(widget => {
+        expect(widget.render).toHaveBeenCalledTimes(0);
+      });
+
+      instance.init(
+        createInitOptions({
+          instantSearchInstance,
+        })
+      );
+
+      widgets.forEach(widget => {
+        expect(widget.render).toHaveBeenCalledTimes(0);
+      });
+
+      instance.render(
+        createRenderOptions({
+          instantSearchInstance,
+        })
+      );
+
+      widgets.forEach(widget => {
+        expect(widget.render).toHaveBeenCalledTimes(0);
+      });
+    });
   });
 
   describe('dispose', () => {

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -238,16 +238,18 @@ const index = (props: IndexProps): Index => {
     render({ instantSearchInstance }) {
       localWidgets.forEach(widget => {
         // At this point, all the variables used below are set. Both `helper`
-        //  and `derivedHelper` has been created at the `init` step. The attribute
-        // `lastResults` is set before the event `result` is emitted. At this stage,
-        // the event has emitted hence the value is already set.
+        // and `derivedHelper` has been created at the `init` step. The attribute
+        // `lastResults` might be `null` though. It's possible that a stalled render
+        // happen before the result e.g with a dynamically added index the request might
+        // be delayed. The render is triggered for the complete tree but some parts do
+        // not have results yet.
 
-        if (widget.render) {
+        if (widget.render && derivedHelper!.lastResults) {
           widget.render({
             helper: helper!,
             instantSearchInstance,
-            results: derivedHelper!.lastResults!,
-            state: derivedHelper!.lastResults!._state,
+            results: derivedHelper!.lastResults,
+            state: derivedHelper!.lastResults._state,
             templatesConfig: instantSearchInstance.templatesConfig,
             createURL: instantSearchInstance._createAbsoluteURL,
             searchMetadata: {

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -238,9 +238,9 @@ const index = (props: IndexProps): Index => {
     render({ instantSearchInstance }) {
       localWidgets.forEach(widget => {
         // At this point, all the variables used below are set. Both `helper`
-        // and `derivedHelper` has been created at the `init` step. The attribute
+        // and `derivedHelper` have been created at the `init` step. The attribute
         // `lastResults` might be `null` though. It's possible that a stalled render
-        // happen before the result e.g with a dynamically added index the request might
+        // happens before the result e.g with a dynamically added index the request might
         // be delayed. The render is triggered for the complete tree but some parts do
         // not have results yet.
 


### PR DESCRIPTION
The `index` assumes that the `lastResults` prop is set which is not always the case. The issue arises only when the stalled render kicks in. The previous implementation (without `index`) fixed this issue by turning the default value of `_isSearchStalled` to `true` to avoid extra `render` until we have results (https://github.com/algolia/instantsearch.js/pull/2623). This fix does not work anymore since we don't have a single Helper. 

This PR revert the change to a default value of `false` which makes more sense (it's not stalled by default). Only the `index` is aware that we have results or not, then the condition belongs to its render function.

**Before**

![before](https://user-images.githubusercontent.com/6513513/60871507-35228f80-a233-11e9-898e-7be612912d5e.gif)

**After**

![after](https://user-images.githubusercontent.com/6513513/60871517-38b61680-a233-11e9-92d1-e9ec23805cd7.gif)