### PR TITLE
fix(defer): recover from error

### DIFF
--- a/src/lib/utils/__tests__/defer.ts
+++ b/src/lib/utils/__tests__/defer.ts
@@ -128,4 +128,36 @@ describe('defer', () => {
       `"The deferred function should be called before calling \`wait()\`"`
     );
   });
+
+  it('recovers a deferred function that throws an error', async () => {
+    const fn = jest.fn();
+    const deferred = defer(fn);
+
+    fn.mockImplementation(() => {
+      throw new Error('FAIL');
+    });
+
+    deferred();
+
+    expect(fn).toHaveBeenCalledTimes(0);
+
+    try {
+      await deferred.wait();
+    } catch {
+      // The test verifies that the function is able to recover. We don't want
+      // to terminate the test on this expected error.
+    }
+
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    fn.mockImplementation();
+
+    deferred();
+
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    await deferred.wait();
+
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/lib/utils/__tests__/defer.ts
+++ b/src/lib/utils/__tests__/defer.ts
@@ -9,7 +9,7 @@ describe('defer', () => {
 
     expect(fn).toHaveBeenCalledTimes(0);
 
-    await Promise.resolve();
+    await deferred.wait();
 
     expect(fn).toHaveBeenCalledTimes(1);
   });
@@ -24,7 +24,7 @@ describe('defer', () => {
 
     expect(fn).toHaveBeenCalledTimes(0);
 
-    await Promise.resolve();
+    await deferred.wait();
 
     expect(fn).toHaveBeenCalledTimes(1);
   });
@@ -39,7 +39,7 @@ describe('defer', () => {
 
     expect(fn).toHaveBeenCalledTimes(0);
 
-    await Promise.resolve();
+    await deferred.wait();
 
     expect(fn).toHaveBeenCalledTimes(1);
 
@@ -47,7 +47,7 @@ describe('defer', () => {
     deferred();
     deferred();
 
-    await Promise.resolve();
+    await deferred.wait();
 
     expect(fn).toHaveBeenCalledTimes(2);
   });
@@ -64,7 +64,7 @@ describe('defer', () => {
 
     expect(fn).toHaveBeenCalledTimes(0);
 
-    await Promise.resolve();
+    await deferred.wait();
 
     expect(fn).toHaveBeenCalledTimes(0);
   });
@@ -81,13 +81,13 @@ describe('defer', () => {
 
     expect(fn).toHaveBeenCalledTimes(0);
 
-    await Promise.resolve();
+    await deferred.wait();
 
     expect(fn).toHaveBeenCalledTimes(0);
 
     deferred();
 
-    await Promise.resolve();
+    await deferred.wait();
 
     expect(fn).toHaveBeenCalledTimes(1);
   });
@@ -104,8 +104,28 @@ describe('defer', () => {
 
     expect(fn).toHaveBeenCalledTimes(0);
 
-    await Promise.resolve();
+    await deferred.wait();
 
     expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits for the deferred function', async () => {
+    const fn = jest.fn();
+    const deferred = defer(fn);
+
+    deferred();
+
+    await deferred.wait();
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws an error when `wait` is called before the deferred function', () => {
+    const fn = jest.fn();
+    const deferred = defer(fn);
+
+    expect(() => deferred.wait()).toThrowErrorMatchingInlineSnapshot(
+      `"The deferred function should be called before calling \`wait()\`"`
+    );
   });
 });

--- a/src/lib/utils/__tests__/defer.ts
+++ b/src/lib/utils/__tests__/defer.ts
@@ -109,17 +109,6 @@ describe('defer', () => {
     expect(fn).toHaveBeenCalledTimes(1);
   });
 
-  it('waits for the deferred function', async () => {
-    const fn = jest.fn();
-    const deferred = defer(fn);
-
-    deferred();
-
-    await deferred.wait();
-
-    expect(fn).toHaveBeenCalledTimes(1);
-  });
-
   it('throws an error when `wait` is called before the deferred function', () => {
     const fn = jest.fn();
     const deferred = defer(fn);

--- a/src/lib/utils/defer.ts
+++ b/src/lib/utils/defer.ts
@@ -1,15 +1,16 @@
 const nextMicroTask = Promise.resolve();
 
 type Callback = (...args: any[]) => void;
-type Cancellable = Callback & {
+type Defer = Callback & {
+  wait(): Promise<void>;
   cancel(): void;
 };
 
-const defer = (callback: Callback): Cancellable => {
+const defer = (callback: Callback): Defer => {
   let progress: Promise<void> | null = null;
   let cancelled = false;
 
-  const fn: Cancellable = (...args) => {
+  const fn: Defer = (...args) => {
     if (progress !== null) {
       return;
     }
@@ -26,10 +27,22 @@ const defer = (callback: Callback): Cancellable => {
     });
   };
 
-  fn.cancel = () => {
-    if (progress !== null) {
-      cancelled = true;
+  fn.wait = () => {
+    if (progress === null) {
+      throw new Error(
+        'The deferred function should be called before calling `wait()`'
+      );
     }
+
+    return progress;
+  };
+
+  fn.cancel = () => {
+    if (progress === null) {
+      return;
+    }
+
+    cancelled = true;
   };
 
   return fn;

--- a/src/lib/utils/defer.ts
+++ b/src/lib/utils/defer.ts
@@ -16,14 +16,14 @@ const defer = (callback: Callback): Defer => {
     }
 
     progress = nextMicroTask.then(() => {
+      progress = null;
+
       if (cancelled) {
-        progress = null;
         cancelled = false;
         return;
       }
 
       callback(...args);
-      progress = null;
     });
   };
 


### PR DESCRIPTION
This PR fixes an issue when the deferred function throws an error. The next calls to the function shouldn't be impacted by the error that happens inside a previous call. Previously it was the case because the value of `progress` was reset only if the call to the callback succeeds. It's not the case anymore the value is always reset whether or not the call succeeds.