### PR TITLE
fix(menu): prevent error on stale search

### DIFF
--- a/src/connectors/menu/__tests__/connectMenu-test.js
+++ b/src/connectors/menu/__tests__/connectMenu-test.js
@@ -2,7 +2,7 @@ import jsHelper, {
   SearchResults,
   SearchParameters,
 } from 'algoliasearch-helper';
-
+import { createSingleSearchResponse } from '../../../../test/mock/createAPIResponse';
 import connectMenu from '../connectMenu';
 
 describe('connectMenu', () => {
@@ -263,6 +263,45 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
         ],
       }),
       expect.anything()
+    );
+  });
+
+  it('returns empty items if the facet is not declared', () => {
+    const widget = makeWidget({
+      attribute: 'category',
+    });
+
+    // note that the helper is called with empty search parameters
+    // which means this can only happen in a stale search situation
+    // when this widget gets mounted
+    const helper = jsHelper({}, '', {});
+
+    widget.render({
+      results: new SearchResults(helper.state, [
+        createSingleSearchResponse({
+          hits: [],
+          facets: {
+            category: {
+              Decoration: 880,
+            },
+          },
+        }),
+        createSingleSearchResponse({
+          facets: {
+            category: {
+              Decoration: 880,
+              Outdoor: 47,
+            },
+          },
+        }),
+      ]),
+      state: helper.state,
+      helper,
+    });
+
+    expect(rendering).toHaveBeenLastCalledWith(
+      expect.objectContaining({ items: [] }),
+      false
     );
   });
 

--- a/src/connectors/menu/connectMenu.js
+++ b/src/connectors/menu/connectMenu.js
@@ -189,8 +189,10 @@ export default function connectMenu(renderFn, unmountFn) {
       },
 
       render({ results, instantSearchInstance }) {
+        const facetValues = results.getFacetValues(attribute, { sortBy });
         const facetItems =
-          results.getFacetValues(attribute, { sortBy }).data || [];
+          facetValues && facetValues.data ? facetValues.data : [];
+
         const items = transformItems(
           facetItems
             .slice(0, this.getLimit())


### PR DESCRIPTION
If a menu is added while the search is being stale, we will  recieve undefined (currently an error), so we can not fetch `.data` from it.

requires https://github.com/algolia/algoliasearch-helper-js/pull/720 to make a difference here, because otherwise an error gets thrown before the old code or the new code gets executed 

related: https://github.com/algolia/instantsearch.js/issues/3084

~~tests will fail until #3940 is merged~~