### PR TITLE
feat(index): resolve parent SearchParameters

### DIFF
--- a/src/lib/utils/__tests__/resolveSearchParameters-test.ts
+++ b/src/lib/utils/__tests__/resolveSearchParameters-test.ts
@@ -1,0 +1,64 @@
+import { createInitOptions } from '../../../../test/mock/createWidget';
+import index from '../../../widgets/index/index';
+import resolve from '../resolveSearchParameters';
+
+describe('mergeSearchParameters', () => {
+  describe('1 level', () => {
+    it('resolves the `SearchParameters` from the level 0', () => {
+      const level0 = index({ indexName: 'level_0_index_name' });
+
+      level0.init(createInitOptions());
+
+      const actual = resolve(level0);
+
+      expect(actual).toEqual([level0.getHelper()!.state]);
+    });
+  });
+
+  describe('2 levels', () => {
+    const level0 = index({ indexName: 'level_0_index_name' });
+    const level1 = index({ indexName: 'level_1_index_name' });
+
+    level0.addWidgets([level1]);
+    level0.init(createInitOptions());
+
+    it('resolves the `SearchParameters` from the level 0', () => {
+      expect(resolve(level0)).toEqual([level0.getHelper()!.state]);
+    });
+
+    it('resolves the `SearchParameters` from the level 1', () => {
+      expect(resolve(level1)).toEqual([
+        level0.getHelper()!.state,
+        level1.getHelper()!.state,
+      ]);
+    });
+  });
+
+  describe('3 levels', () => {
+    const level0 = index({ indexName: 'level_0_index_name' });
+    const level1 = index({ indexName: 'level_1_index_name' });
+    const level2 = index({ indexName: 'level_2_index_name' });
+
+    level0.addWidgets([level1.addWidgets([level2])]);
+    level0.init(createInitOptions());
+
+    it('resolves the `SearchParameters` from the level 0', () => {
+      expect(resolve(level0)).toEqual([level0.getHelper()!.state]);
+    });
+
+    it('resolves the `SearchParameters` from the level 1', () => {
+      expect(resolve(level1)).toEqual([
+        level0.getHelper()!.state,
+        level1.getHelper()!.state,
+      ]);
+    });
+
+    it('resolves the `SearchParameters` from the level 2', () => {
+      expect(resolve(level2)).toEqual([
+        level0.getHelper()!.state,
+        level1.getHelper()!.state,
+        level2.getHelper()!.state,
+      ]);
+    });
+  });
+});

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -21,6 +21,7 @@ export { default as isEqual } from './isEqual';
 export { default as escape } from './escape';
 export { default as find } from './find';
 export { default as mergeDeep } from './mergeDeep';
+export { default as resolveSearchParameters } from './resolveSearchParameters';
 export { warning, deprecate } from './logger';
 export {
   createDocumentationLink,

--- a/src/lib/utils/resolveSearchParameters.ts
+++ b/src/lib/utils/resolveSearchParameters.ts
@@ -1,0 +1,16 @@
+import { Index } from '../../widgets/index/index';
+import { SearchParameters } from '../../types';
+
+const resolveSearchParameters = (current: Index): SearchParameters[] => {
+  let parent = current.getParent();
+  let states = [current.getHelper()!.state];
+
+  while (parent !== null) {
+    states = [parent.getHelper()!.state].concat(states);
+    parent = parent.getParent();
+  }
+
+  return states;
+};
+
+export default resolveSearchParameters;

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -582,6 +582,108 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
       );
     });
 
+    it('inherits from the parent states for the queries', () => {
+      const level0 = index({ indexName: 'level_0_index_name' });
+      const level1 = index({ indexName: 'level_1_index_name' });
+      const level2 = index({ indexName: 'level_1_index_name' });
+      const searchClient = createSearchClient();
+      const mainHelper = algoliasearchHelper(searchClient, '', {});
+      const instantSearchInstance = createInstantSearch({
+        mainHelper,
+      });
+
+      level0.addWidgets([
+        createWidget({
+          getConfiguration() {
+            return {
+              hitsPerPage: 5,
+            };
+          },
+        }),
+
+        createSearchBox({
+          getConfiguration() {
+            return {
+              query: 'Apple',
+            };
+          },
+        }),
+
+        createPagination({
+          getConfiguration() {
+            return {
+              page: 1,
+            };
+          },
+        }),
+
+        level1.addWidgets([
+          createSearchBox({
+            getConfiguration() {
+              return {
+                query: 'Apple iPhone',
+              };
+            },
+          }),
+
+          createPagination({
+            getConfiguration() {
+              return {
+                page: 2,
+              };
+            },
+          }),
+
+          level2.addWidgets([
+            createSearchBox({
+              getConfiguration() {
+                return {
+                  query: 'Apple iPhone XS',
+                };
+              },
+            }),
+          ]),
+        ]),
+      ]);
+
+      level0.init(
+        createInitOptions({
+          instantSearchInstance,
+        })
+      );
+
+      level0.getHelper()!.search();
+
+      expect(searchClient.search).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          {
+            indexName: 'level_0_index_name',
+            params: expect.objectContaining({
+              hitsPerPage: 5,
+              query: 'Apple',
+              page: 1,
+            }),
+          },
+          {
+            indexName: 'level_1_index_name',
+            params: expect.objectContaining({
+              hitsPerPage: 5,
+              query: 'Apple iPhone',
+              page: 2,
+            }),
+          },
+          {
+            indexName: 'level_1_index_name',
+            params: expect.objectContaining({
+              hitsPerPage: 5,
+              query: 'Apple iPhone XS',
+              page: 2,
+            }),
+          },
+        ])
+      );
+    });
+
     it('uses the internal state for the SFFV queries', () => {
       const instance = index({ indexName: 'index_name' });
       const searchClient = createSearchClient();

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -839,6 +839,26 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
       expect(instance.getWidgets()).toHaveLength(2);
     });
 
+    it('removes the internal parent', () => {
+      const topLevelInstance = index({ indexName: 'top_level_index_name' });
+      const subLevelInstance = index({ indexName: 'sub_level_index_name' });
+      const instantSearchInstance = createInstantSearch();
+
+      topLevelInstance.addWidgets([subLevelInstance]);
+
+      topLevelInstance.init(
+        createInitOptions({
+          instantSearchInstance,
+        })
+      );
+
+      expect(subLevelInstance.getHelper()).toBeDefined();
+
+      subLevelInstance.dispose(createDisposeOptions());
+
+      expect(subLevelInstance.getHelper()).toBe(null);
+    });
+
     it('removes the internal Helper', () => {
       const instance = index({ indexName: 'index_name' });
       const instantSearchInstance = createInstantSearch();

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -585,7 +585,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
     it('inherits from the parent states for the queries', () => {
       const level0 = index({ indexName: 'level_0_index_name' });
       const level1 = index({ indexName: 'level_1_index_name' });
-      const level2 = index({ indexName: 'level_1_index_name' });
+      const level2 = index({ indexName: 'level_2_index_name' });
       const searchClient = createSearchClient();
       const mainHelper = algoliasearchHelper(searchClient, '', {});
       const instantSearchInstance = createInstantSearch({
@@ -673,7 +673,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
             }),
           },
           {
-            indexName: 'level_1_index_name',
+            indexName: 'level_2_index_name',
             params: expect.objectContaining({
               hitsPerPage: 5,
               query: 'Apple iPhone XS',

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -12,6 +12,7 @@ import {
 } from '../../types';
 import {
   createDocumentationMessageGenerator,
+  resolveSearchParameters,
   enhanceConfiguration,
 } from '../../lib/utils';
 
@@ -206,8 +207,15 @@ const index = (props: IndexProps): Index => {
       };
 
       derivedHelper = mainHelper.derive(() => {
-        // @TODO: resolve the root and merge the SearchParameters
-        return helper!.state;
+        const parameters = resolveSearchParameters(this);
+
+        // @TODO: replace this dummy merge with the correct function
+        return parameters.reduce((previous, current) =>
+          algoliasearchHelper.SearchParameters.make({
+            ...previous,
+            ...current,
+          })
+        );
       });
 
       // We have to use `!` at the moment because `dervive` is not correctly typed.

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -25,6 +25,7 @@ type IndexProps = {
 
 export type Index = Widget & {
   getHelper(): Helper | null;
+  getParent(): Index | null;
   getWidgets(): Widget[];
   addWidgets(widgets: Widget[]): Index;
   removeWidgets(widgets: Widget[]): Index;
@@ -38,6 +39,7 @@ const index = (props: IndexProps): Index => {
 
   let localWidgets: Widget[] = [];
   let localInstantSearchInstance: InstantSearch | null = null;
+  let localParent: Index | null = null;
   let helper: Helper | null = null;
   let derivedHelper: DerivedHelper | null = null;
 
@@ -48,6 +50,10 @@ const index = (props: IndexProps): Index => {
   return {
     getHelper() {
       return helper;
+    },
+
+    getParent() {
+      return localParent;
     },
 
     getWidgets() {
@@ -156,6 +162,7 @@ const index = (props: IndexProps): Index => {
 
     init({ instantSearchInstance, parent }) {
       localInstantSearchInstance = instantSearchInstance;
+      localParent = parent;
 
       // The `mainHelper` is already defined at this point. The instance is created
       // inside InstantSearch at the `start` method, which occurs before the `init`
@@ -274,6 +281,7 @@ const index = (props: IndexProps): Index => {
       });
 
       localInstantSearchInstance = null;
+      localParent = null;
       helper = null;
 
       derivedHelper!.detach();

--- a/stories/index.stories.ts
+++ b/stories/index.stories.ts
@@ -31,8 +31,6 @@ storiesOf('Index', module)
           .index({ indexName: 'instant_search_price_asc' })
           .addWidgets([
             instantsearch.widgets.configure({
-              // @TODO: remove once we support inheritance of SearchParameters
-              attributesToSnippet: ['description'],
               hitsPerPage: 2,
             }),
             instantsearch.widgets.hits({
@@ -50,8 +48,6 @@ storiesOf('Index', module)
           .index({ indexName: 'instant_search_rating_asc' })
           .addWidgets([
             instantsearch.widgets.configure({
-              // @TODO: remove once we support inheritance of SearchParameters
-              attributesToSnippet: ['description'],
               hitsPerPage: 1,
             }),
             instantsearch.widgets.hits({
@@ -87,8 +83,6 @@ storiesOf('Index', module)
           .index({ indexName: 'instant_search_price_asc' })
           .addWidgets([
             instantsearch.widgets.configure({
-              // @TODO: remove once we support inheritance of SearchParameters
-              attributesToSnippet: ['description'],
               hitsPerPage: 2,
             }),
             instantsearch.widgets.hits({


### PR DESCRIPTION
This PR introduces a function to resolve the parent `SearchParameters` from the `index`. It allows the index to find the list of parameters that it will have to merge. Currently, the function to merge those parameters is not merged yet that's why we have a naive implementation. We'll migrate to the correct function once it's available.

At the moment the function to resolve the `SearchParameters` is fairly simple: it recursively bubbles up the hierarchy to find the root `index`. At each iteration, we collect the current state of the `index` where we are. Note that we have to expose the `parent` on the `index` instance otherwise we're not able to retrieve the parents' state.

The [examples](https://deploy-preview-3937--instantsearchjs.netlify.com/stories/?path=/story/index--default) now inherits from the `searchBox`, only the primitive values are merged (because of the naive merge function e.g. `refinementList` does not update the children indices).

**Before**

![before](https://user-images.githubusercontent.com/6513513/60977447-c545ff00-a32f-11e9-9337-b3067eb6cba3.gif)

**After**

![after](https://user-images.githubusercontent.com/6513513/60977453-c840ef80-a32f-11e9-86ac-4f7d2638735d.gif)
