### PR TITLE
feat: drop support for onHistoryChange

### DIFF
--- a/src/connectors/geo-search/__tests__/connectGeoSearch-test.js
+++ b/src/connectors/geo-search/__tests__/connectGeoSearch-test.js
@@ -25,7 +25,6 @@ describe('connectGeoSearch', () => {
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     const { refine } = render.mock.calls[0][0];

--- a/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.js
+++ b/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.js
@@ -230,7 +230,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     // test that rendering has been called during init with isFirstRendering = true
@@ -276,7 +275,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     const firstRenderingOptions = rendering.mock.calls[0][0];
@@ -317,7 +315,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     // During the first rendering there are no facet values
@@ -476,7 +473,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
         helper,
         state: helper.state,
         createURL: () => '#',
-        onHistoryChange: () => {},
       });
 
       const { refine } = rendering.mock.calls[0][0];
@@ -593,7 +589,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
         helper,
         state: helper.state,
         createURL: () => '#',
-        onHistoryChange: () => {},
       });
 
       widget.render({
@@ -705,7 +700,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
         helper,
         state: helper.state,
         createURL: () => '#',
-        onHistoryChange: () => {},
       });
 
       widget.render({

--- a/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
+++ b/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
@@ -58,7 +58,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     expect(renderFn).toHaveBeenCalledTimes(1);
@@ -192,7 +191,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     const firstRenderOptions = renderFn.mock.calls[0][0];
@@ -275,7 +273,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     const firstRenderOptions = renderFn.mock.calls[0][0];
@@ -312,7 +309,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     const firstRenderOptions = renderFn.mock.calls[0][0];
@@ -355,7 +351,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     const firstRenderOptions = renderFn.mock.calls[0][0];
@@ -398,7 +393,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     const firstRenderOptions = renderFn.mock.calls[0][0];
@@ -501,7 +495,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
         helper,
         state: helper.state,
         createURL: () => '#',
-        onHistoryChange: () => {},
       });
 
       const { refine } = renderFn.mock.calls[0][0];

--- a/src/connectors/hits/__tests__/connectHits-test.js
+++ b/src/connectors/hits/__tests__/connectHits-test.js
@@ -37,7 +37,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     expect(renderFn).toHaveBeenCalledTimes(1);
@@ -83,7 +82,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     expect(renderFn).toHaveBeenLastCalledWith(
@@ -128,7 +126,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     expect(renderFn).toHaveBeenLastCalledWith(
@@ -194,7 +191,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     expect(renderFn).toHaveBeenNthCalledWith(
@@ -235,7 +231,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     const hits = [{ name: 'name 1' }, { name: 'name 2' }];

--- a/src/connectors/menu/__tests__/connectMenu-test.js
+++ b/src/connectors/menu/__tests__/connectMenu-test.js
@@ -120,7 +120,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     // test that rendering has been called during init with isFirstRendering = true
@@ -172,7 +171,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     const firstRenderingOptions = rendering.mock.calls[0][0];
@@ -211,7 +209,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     // During the first rendering there are no facet values
@@ -386,7 +383,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
         helper,
         state: helper.state,
         createURL: () => '#',
-        onHistoryChange: () => {},
       });
 
       expect(rendering).toHaveBeenLastCalledWith(
@@ -417,7 +413,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
         helper,
         state: helper.state,
         createURL: () => '#',
-        onHistoryChange: () => {},
       });
 
       widget.render({
@@ -482,7 +477,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
         helper,
         state: helper.state,
         createURL: () => '#',
-        onHistoryChange: () => {},
       });
 
       widget.render({
@@ -530,7 +524,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
         helper,
         state: helper.state,
         createURL: () => '#',
-        onHistoryChange: () => {},
       });
 
       const { refine } = rendering2.mock.calls[0][0];

--- a/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.js
+++ b/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.js
@@ -74,7 +74,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     // test that rendering has been called during init with isFirstRendering = true
@@ -138,7 +137,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     expect(rendering).toHaveBeenLastCalledWith(
@@ -184,7 +182,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     const firstRenderingOptions = rendering.mock.calls[0][0];
@@ -263,7 +260,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     expect(rendering).toHaveBeenLastCalledWith(
@@ -326,7 +322,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     let refine =
@@ -379,7 +374,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     const refine =
@@ -443,7 +437,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     const firstRenderingOptions = rendering.mock.calls[0][0];
@@ -488,7 +481,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     expect(helper.state.page).toBe(2);
@@ -523,7 +515,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     expect(helper.state.page).toBeUndefined();
@@ -556,7 +547,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
         helper,
         state: helper.state,
         createURL: () => '#',
-        onHistoryChange: () => {},
       });
 
       const { refine } = rendering.mock.calls[0][0];

--- a/src/connectors/pagination/__tests__/connectPagination-test.js
+++ b/src/connectors/pagination/__tests__/connectPagination-test.js
@@ -32,7 +32,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/pagination/
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     {
@@ -91,7 +90,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/pagination/
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     {
@@ -136,7 +134,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/pagination/
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     // page 0
@@ -202,7 +199,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/pagination/
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     widget.render({
@@ -322,7 +318,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/pagination/
         helper,
         state: helper.state,
         createURL: () => '#',
-        onHistoryChange: () => {},
       });
 
       const { refine } = renderFn.mock.calls[0][0];

--- a/src/connectors/range/__tests__/connectRange-test.js
+++ b/src/connectors/range/__tests__/connectRange-test.js
@@ -50,7 +50,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     {
@@ -164,7 +163,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     {
@@ -233,7 +231,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     {
@@ -273,7 +270,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     {
@@ -310,7 +306,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     {
@@ -925,7 +920,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
         helper,
         state: helper.state,
         createURL: () => '#',
-        onHistoryChange: () => {},
       });
 
       const { refine } = rendering.mock.calls[0][0];

--- a/src/connectors/rating-menu/__tests__/connectRatingMenu-test.js
+++ b/src/connectors/rating-menu/__tests__/connectRatingMenu-test.js
@@ -50,7 +50,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     {
@@ -144,7 +143,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     {
@@ -249,7 +247,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
         helper,
         state: helper.state,
         createURL: () => '#',
-        onHistoryChange: () => {},
       });
 
       const { refine } = rendering.mock.calls[0][0];

--- a/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
+++ b/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
@@ -134,7 +134,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
         helper,
         state: helper.state,
         createURL: () => '#',
-        onHistoryChange: () => {},
       });
 
       widget.render({
@@ -195,7 +194,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
         helper,
         state: helper.state,
         createURL: () => '#',
-        onHistoryChange: () => {},
       });
 
       widget.render({
@@ -275,7 +273,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     // test that rendering has been called during init with isFirstRendering = true
@@ -387,7 +384,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     const firstRenderingOptions = rendering.mock.calls[0][0];
@@ -428,7 +424,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     widget.render({
@@ -474,7 +469,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     widget.render({
@@ -526,7 +520,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     widget.render({
@@ -578,7 +571,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     widget.render({
@@ -633,7 +625,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     widget.render({
@@ -725,7 +716,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     expect(rendering.mock.calls[0][0].hasExhaustiveItems).toEqual(true);
@@ -805,7 +795,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     expect(rendering.mock.calls[0][0].hasExhaustiveItems).toEqual(true);
@@ -903,7 +892,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
     expect(rendering).toHaveBeenCalledTimes(1);
 
@@ -1010,7 +998,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
     expect(rendering).toHaveBeenCalledTimes(1);
 
@@ -1112,7 +1099,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
     expect(rendering).toHaveBeenCalledTimes(1);
 
@@ -1220,7 +1206,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
     expect(rendering).toHaveBeenCalledTimes(1);
 
@@ -1301,7 +1286,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
         helper,
         state: helper.state,
         createURL: () => '#',
-        onHistoryChange: () => {},
       });
 
       const { refine } = rendering.mock.calls[0][0];

--- a/src/connectors/search-box/__tests__/connectSearchBox-test.js
+++ b/src/connectors/search-box/__tests__/connectSearchBox-test.js
@@ -31,7 +31,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     expect(renderFn).toHaveBeenCalledTimes(1);
@@ -73,7 +72,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     {
@@ -117,7 +115,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     {
@@ -165,7 +162,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     {
@@ -222,7 +218,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     widget.render({
@@ -264,7 +259,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     const { clear } = renderFn.mock.calls[0][0];
@@ -347,7 +341,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
         helper,
         state: helper.state,
         createURL: () => '#',
-        onHistoryChange: () => {},
       });
 
       const { refine } = renderFn.mock.calls[0][0];

--- a/src/connectors/sort-by/__tests__/connectSortBy-test.js
+++ b/src/connectors/sort-by/__tests__/connectSortBy-test.js
@@ -64,7 +64,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
       instantSearchInstance,
     });
 
@@ -182,7 +181,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
       instantSearchInstance,
     });
 
@@ -245,7 +243,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
         helper,
         state: helper.state,
         createURL: () => '#',
-        onHistoryChange: () => {},
         instantSearchInstance,
       });
 

--- a/src/connectors/stats/__tests__/connectStats-test.js
+++ b/src/connectors/stats/__tests__/connectStats-test.js
@@ -35,7 +35,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/stats/js/#c
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     {

--- a/src/connectors/toggleRefinement/__tests__/connectToggleRefinement-test.js
+++ b/src/connectors/toggleRefinement/__tests__/connectToggleRefinement-test.js
@@ -40,7 +40,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     {
@@ -133,7 +132,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     {
@@ -282,7 +280,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
       helper,
       state: helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
     });
 
     {
@@ -519,7 +516,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
         helper,
         state: helper.state,
         createURL: () => '#',
-        onHistoryChange: () => {},
       });
 
       const { refine } = rendering.mock.calls[

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -231,9 +231,6 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
         ...this.routing,
         instantSearchInstance: this,
       });
-      this._onHistoryChange = routingManager.onHistoryChange.bind(
-        routingManager
-      );
       this._createURL = routingManager.createURL.bind(routingManager);
       this._createAbsoluteURL = this._createURL;
       // We don't use `addWidgets` because we have to ensure that `RoutingManager`
@@ -243,7 +240,6 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
     } else {
       this._createURL = defaultCreateURL;
       this._createAbsoluteURL = defaultCreateURL;
-      this._onHistoryChange = noop;
     }
 
     // This Helper is used for the queries, we don't care about its state. The

--- a/src/lib/RoutingManager.ts
+++ b/src/lib/RoutingManager.ts
@@ -187,33 +187,6 @@ class RoutingManager implements Widget {
 
     return this.router.createURL(route);
   }
-
-  public onHistoryChange(
-    callback: (state: Partial<SearchParameters>) => void
-  ): void {
-    const helper = this.instantSearchInstance.mainIndex.getHelper()!;
-
-    this.router.onUpdate(route => {
-      const nextUiState = this.stateMapping.routeToState(route);
-
-      const widgetsUiState = this.getAllUiStates({
-        searchParameters: helper.state,
-      });
-
-      if (isEqual(nextUiState, widgetsUiState)) {
-        return;
-      }
-
-      this.currentUiState = nextUiState;
-
-      const searchParameters = this.getAllSearchParameters({
-        currentSearchParameters: helper.state,
-        uiState: this.currentUiState,
-      });
-
-      callback({ ...searchParameters });
-    });
-  }
 }
 
 export default RoutingManager;

--- a/src/types/instantsearch.ts
+++ b/src/types/instantsearch.ts
@@ -129,7 +129,6 @@ export type InstantSearch = {
   _isSearchStalled: boolean;
   _searchParameters: Partial<SearchParameters>;
   _createAbsoluteURL(state: Partial<SearchParameters>): string;
-  _onHistoryChange(callback: (state: Partial<SearchParameters>) => void): void;
   scheduleSearch(): void;
   scheduleRender(): void;
   scheduleStalledRender(): void;

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -13,7 +13,6 @@ export interface InitOptions {
   helper: Helper;
   templatesConfig: object;
   createURL(state: SearchParameters): string;
-  onHistoryChange(callback: (state: Partial<SearchParameters>) => void): void;
 }
 
 export interface RenderOptions {

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -175,7 +175,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
             state: instance.getHelper()!.state,
             templatesConfig: instantSearchInstance.templatesConfig,
             createURL: instantSearchInstance._createAbsoluteURL,
-            onHistoryChange: instantSearchInstance._onHistoryChange,
           });
         });
       });
@@ -790,7 +789,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
           state: instance.getHelper()!.state,
           templatesConfig: instantSearchInstance.templatesConfig,
           createURL: instantSearchInstance._createAbsoluteURL,
-          onHistoryChange: instantSearchInstance._onHistoryChange,
         });
       });
     });

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -111,7 +111,6 @@ const index = (props: IndexProps): Index => {
               state: helper!.state,
               templatesConfig: localInstantSearchInstance.templatesConfig,
               createURL: localInstantSearchInstance._createAbsoluteURL,
-              onHistoryChange: localInstantSearchInstance._onHistoryChange,
             });
           }
         });
@@ -244,7 +243,6 @@ const index = (props: IndexProps): Index => {
             state: helper!.state,
             templatesConfig: instantSearchInstance.templatesConfig,
             createURL: instantSearchInstance._createAbsoluteURL,
-            onHistoryChange: instantSearchInstance._onHistoryChange,
           });
         }
       });

--- a/src/widgets/rating-menu/__tests__/rating-menu-test.js
+++ b/src/widgets/rating-menu/__tests__/rating-menu-test.js
@@ -147,7 +147,6 @@ describe('ratingMenu()', () => {
       helper: _helper,
       state: _helper.state,
       createURL: () => '#',
-      onHistoryChange: () => {},
       instantSearchInstance: {
         templatesConfig: {},
       },

--- a/test/mock/createInstantSearch.ts
+++ b/test/mock/createInstantSearch.ts
@@ -23,7 +23,6 @@ export const createInstantSearch = (
     _isSearchStalled: true,
     _searchParameters: {},
     _createAbsoluteURL: jest.fn(() => '#'),
-    _onHistoryChange: jest.fn(),
     ...args,
   };
 };

--- a/test/mock/createWidget.ts
+++ b/test/mock/createWidget.ts
@@ -20,7 +20,6 @@ export const createInitOptions = (
     helper: instantSearchInstance.helper!,
     state: instantSearchInstance.helper!.state,
     createURL: jest.fn(() => '#'),
-    onHistoryChange: jest.fn(),
     ...args,
   };
 };


### PR DESCRIPTION
This PR drops the support for `onHistoryChange`. This API have been introduced to fix [an issue with the `searchBox`](https://github.com/algolia/instantsearch.js/issues/729). The codebase has evolve since then and we don't use the option anymore. The options is not documented on [algolia.com/doc](https://www.algolia.com/doc/), IMO it's safe enough to remove it on the next major.