### PR TITLE
feat(connectRange): default `precision` to 0

### DIFF
--- a/src/connectors/range/__tests__/connectRange-test.js
+++ b/src/connectors/range/__tests__/connectRange-test.js
@@ -67,7 +67,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       expect(start).toEqual([-Infinity, Infinity]);
       expect(widgetParams).toEqual({
         attribute,
-        precision: 2,
+        precision: 0,
       });
     }
 
@@ -110,7 +110,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       expect(start).toEqual([-Infinity, Infinity]);
       expect(widgetParams).toEqual({
         attribute,
-        precision: 2,
+        precision: 0,
       });
     }
   });
@@ -652,8 +652,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
 
       widget._refine(helper, range)(values);
 
-      expect(helper.getNumericRefinement(attribute, '>=')).toEqual([10.5]);
-      expect(helper.getNumericRefinement(attribute, '<=')).toEqual([490.5]);
+      expect(helper.getNumericRefinement(attribute, '>=')).toEqual([11]);
+      expect(helper.getNumericRefinement(attribute, '<=')).toEqual([491]);
       expect(helper.clearRefinements).toHaveBeenCalled();
       expect(helper.search).toHaveBeenCalled();
     });

--- a/src/connectors/range/connectRange.js
+++ b/src/connectors/range/connectRange.js
@@ -49,7 +49,7 @@ export default function connectRange(renderFn, unmountFn) {
       attribute,
       min: minBound,
       max: maxBound,
-      precision = 2, // @MAJOR: the `precision` default value should be 0
+      precision = 0,
     } = widgetParams;
 
     if (!attribute) {


### PR DESCRIPTION
> This PR is targeting the `next` branch.

In the next major, `connectRange`'s default `precision` should be `0` to be consistent with other flavors.

We'll need to update the documentation when we release InstantSearch.js 4 (noted on my side).