### PR TITLE
chore(examples): fix back-to-top button

### DIFF
--- a/examples/media/index.html
+++ b/examples/media/index.html
@@ -216,13 +216,13 @@
       <a href="#" title="Back to top">
         <svg viewBow="0 0 40 40">
           <defs>
-            <linearGradient id="a" x1="100%" x2="0%" y1="100%" y2="0%">
+            <linearGradient id="d" x1="100%" x2="0%" y1="100%" y2="0%">
               <stop offset="0%" stop-color="#764ba2" />
               <stop offset="100%" stop-color="#667eea" />
             </linearGradient>
           </defs>
           <g fill="none" fill-rule="evenodd">
-            <circle cx="20" cy="20" r="20" fill="url(#a)" />
+            <circle cx="20" cy="20" r="20" fill="url('#d')" />
             <path
               stroke="#FFF"
               stroke-linecap="round"

--- a/examples/media/src/app.css
+++ b/examples/media/src/app.css
@@ -130,6 +130,10 @@ strong {
   width: 2.5rem;
 }
 
+.filtering .back-to-top {
+  display: none;
+}
+
 /* SearchBox */
 
 .header .searchbox-container {


### PR DESCRIPTION


**Summary**

- This PR fixes the problem where the backgroud of the button was not visible on desktop Chrome.
- This PR hides the button when the filter modal is open.