### PR TITLE
fix: pass noop as default value to unmountFn at connectors

### DIFF
--- a/src/connectors/autocomplete/connectAutocomplete.js
+++ b/src/connectors/autocomplete/connectAutocomplete.js
@@ -3,6 +3,7 @@ import {
   checkRendering,
   createDocumentationMessageGenerator,
   find,
+  noop,
 } from '../../lib/utils';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -41,7 +42,7 @@ const withUsage = createDocumentationMessageGenerator({
  * @param {function} unmountFn Unmount function called when the widget is disposed.
  * @return {function(CustomAutocompleteWidgetOptions)} Re-usable widget factory for a custom **Autocomplete** widget.
  */
-export default function connectAutocomplete(renderFn, unmountFn) {
+export default function connectAutocomplete(renderFn, unmountFn = noop) {
   checkRendering(renderFn, withUsage());
 
   return (widgetParams = {}) => {

--- a/src/connectors/breadcrumb/connectBreadcrumb.js
+++ b/src/connectors/breadcrumb/connectBreadcrumb.js
@@ -4,6 +4,7 @@ import {
   createDocumentationMessageGenerator,
   isEqual,
   find,
+  noop,
 } from '../../lib/utils';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -44,7 +45,7 @@ const withUsage = createDocumentationMessageGenerator({
  * @param {function} unmountFn Unmount function called when the widget is disposed.
  * @return {function(CustomBreadcrumbWidgetOptions)} Re-usable widget factory for a custom **Breadcrumb** widget.
  */
-export default function connectBreadcrumb(renderFn, unmountFn) {
+export default function connectBreadcrumb(renderFn, unmountFn = noop) {
   checkRendering(renderFn, withUsage());
   return (widgetParams = {}) => {
     const {

--- a/src/connectors/clear-refinements/connectClearRefinements.js
+++ b/src/connectors/clear-refinements/connectClearRefinements.js
@@ -3,6 +3,7 @@ import {
   clearRefinements,
   getRefinements,
   createDocumentationMessageGenerator,
+  noop,
 } from '../../lib/utils';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -67,7 +68,7 @@ const withUsage = createDocumentationMessageGenerator({
  *   })
  * );
  */
-export default function connectClearRefinements(renderFn, unmountFn) {
+export default function connectClearRefinements(renderFn, unmountFn = noop) {
   checkRendering(renderFn, withUsage());
 
   return (widgetParams = {}) => {

--- a/src/connectors/current-refinements/connectCurrentRefinements.js
+++ b/src/connectors/current-refinements/connectCurrentRefinements.js
@@ -2,6 +2,7 @@ import {
   getRefinements,
   checkRendering,
   createDocumentationMessageGenerator,
+  noop,
 } from '../../lib/utils';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -100,7 +101,7 @@ const withUsage = createDocumentationMessageGenerator({
  *   })
  * );
  */
-export default function connectCurrentRefinements(renderFn, unmountFn) {
+export default function connectCurrentRefinements(renderFn, unmountFn = noop) {
   checkRendering(renderFn, withUsage());
 
   return (widgetParams = {}) => {

--- a/src/connectors/geo-search/connectGeoSearch.js
+++ b/src/connectors/geo-search/connectGeoSearch.js
@@ -102,7 +102,7 @@ const withUsage = createDocumentationMessageGenerator({
  *   })
  * );
  */
-const connectGeoSearch = (renderFn, unmountFn) => {
+const connectGeoSearch = (renderFn, unmountFn = noop) => {
   checkRendering(renderFn, withUsage());
 
   return (widgetParams = {}) => {

--- a/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
+++ b/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
@@ -4,6 +4,7 @@ import {
   createDocumentationMessageGenerator,
   isEqual,
   find,
+  noop,
 } from '../../lib/utils';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -59,7 +60,7 @@ const withUsage = createDocumentationMessageGenerator({
  * @param {function} unmountFn Unmount function called when the widget is disposed.
  * @return {function(CustomHierarchicalMenuWidgetOptions)} Re-usable widget factory for a custom **HierarchicalMenu** widget.
  */
-export default function connectHierarchicalMenu(renderFn, unmountFn) {
+export default function connectHierarchicalMenu(renderFn, unmountFn = noop) {
   checkRendering(renderFn, withUsage());
 
   return (widgetParams = {}) => {

--- a/src/connectors/hits-per-page/connectHitsPerPage.js
+++ b/src/connectors/hits-per-page/connectHitsPerPage.js
@@ -3,6 +3,7 @@ import {
   warning,
   createDocumentationMessageGenerator,
   find,
+  noop,
 } from '../../lib/utils';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -94,7 +95,7 @@ const withUsage = createDocumentationMessageGenerator({
  *   })
  * );
  */
-export default function connectHitsPerPage(renderFn, unmountFn) {
+export default function connectHitsPerPage(renderFn, unmountFn = noop) {
   checkRendering(renderFn, withUsage());
 
   return (widgetParams = {}) => {

--- a/src/connectors/hits/connectHits.js
+++ b/src/connectors/hits/connectHits.js
@@ -4,6 +4,7 @@ import {
   createDocumentationMessageGenerator,
   addAbsolutePosition,
   addQueryID,
+  noop,
 } from '../../lib/utils';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -50,7 +51,7 @@ const withUsage = createDocumentationMessageGenerator({
  *   })
  * );
  */
-export default function connectHits(renderFn, unmountFn) {
+export default function connectHits(renderFn, unmountFn = noop) {
   checkRendering(renderFn, withUsage());
 
   return (widgetParams = {}) => {

--- a/src/connectors/menu/connectMenu.js
+++ b/src/connectors/menu/connectMenu.js
@@ -1,6 +1,7 @@
 import {
   checkRendering,
   createDocumentationMessageGenerator,
+  noop,
 } from '../../lib/utils';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -90,7 +91,7 @@ const withUsage = createDocumentationMessageGenerator({
  *   })
  * );
  */
-export default function connectMenu(renderFn, unmountFn) {
+export default function connectMenu(renderFn, unmountFn = noop) {
   checkRendering(renderFn, withUsage());
 
   return (widgetParams = {}) => {

--- a/src/connectors/numeric-menu/connectNumericMenu.js
+++ b/src/connectors/numeric-menu/connectNumericMenu.js
@@ -2,6 +2,7 @@ import {
   checkRendering,
   createDocumentationMessageGenerator,
   isFiniteNumber,
+  noop,
 } from '../../lib/utils';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -97,7 +98,7 @@ const withUsage = createDocumentationMessageGenerator({
  *   })
  * );
  */
-export default function connectNumericMenu(renderFn, unmountFn) {
+export default function connectNumericMenu(renderFn, unmountFn = noop) {
   checkRendering(renderFn, withUsage());
 
   return (widgetParams = {}) => {

--- a/src/connectors/pagination/connectPagination.js
+++ b/src/connectors/pagination/connectPagination.js
@@ -1,6 +1,7 @@
 import {
   checkRendering,
   createDocumentationMessageGenerator,
+  noop,
 } from '../../lib/utils';
 import Paginator from './Paginator';
 
@@ -84,7 +85,7 @@ const withUsage = createDocumentationMessageGenerator({
  *   })
  * );
  */
-export default function connectPagination(renderFn, unmountFn) {
+export default function connectPagination(renderFn, unmountFn = noop) {
   checkRendering(renderFn, withUsage());
 
   return (widgetParams = {}) => {

--- a/src/connectors/powered-by/connectPoweredBy.js
+++ b/src/connectors/powered-by/connectPoweredBy.js
@@ -1,6 +1,7 @@
 import {
   checkRendering,
   createDocumentationMessageGenerator,
+  noop,
 } from '../../lib/utils';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -28,7 +29,7 @@ const withUsage = createDocumentationMessageGenerator({
  * @param {function} unmountFn Unmount function called when the widget is disposed.
  * @return {function} Re-usable widget factory for a custom **PoweredBy** widget.
  */
-export default function connectPoweredBy(renderFn, unmountFn) {
+export default function connectPoweredBy(renderFn, unmountFn = noop) {
   checkRendering(renderFn, withUsage());
 
   const defaultUrl =

--- a/src/connectors/range/connectRange.js
+++ b/src/connectors/range/connectRange.js
@@ -3,6 +3,7 @@ import {
   createDocumentationMessageGenerator,
   isFiniteNumber,
   find,
+  noop,
 } from '../../lib/utils';
 
 const withUsage = createDocumentationMessageGenerator(
@@ -41,7 +42,7 @@ const withUsage = createDocumentationMessageGenerator(
  * @param {function} unmountFn Unmount function called when the widget is disposed.
  * @return {function(CustomRangeWidgetOptions)} Re-usable widget factory for a custom **Range** widget.
  */
-export default function connectRange(renderFn, unmountFn) {
+export default function connectRange(renderFn, unmountFn = noop) {
   checkRendering(renderFn, withUsage());
 
   return (widgetParams = {}) => {

--- a/src/connectors/rating-menu/connectRatingMenu.js
+++ b/src/connectors/rating-menu/connectRatingMenu.js
@@ -1,6 +1,7 @@
 import {
   checkRendering,
   createDocumentationMessageGenerator,
+  noop,
 } from '../../lib/utils';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -92,7 +93,7 @@ const withUsage = createDocumentationMessageGenerator({
  *   })
  * );
  */
-export default function connectRatingMenu(renderFn, unmountFn) {
+export default function connectRatingMenu(renderFn, unmountFn = noop) {
   checkRendering(renderFn, withUsage());
 
   return (widgetParams = {}) => {

--- a/src/connectors/refinement-list/connectRefinementList.js
+++ b/src/connectors/refinement-list/connectRefinementList.js
@@ -2,6 +2,7 @@ import {
   checkRendering,
   createDocumentationMessageGenerator,
   isEqual,
+  noop,
 } from '../../lib/utils';
 import {
   escapeFacets,
@@ -113,7 +114,7 @@ const withUsage = createDocumentationMessageGenerator({
  *   })
  * );
  */
-export default function connectRefinementList(renderFn, unmountFn) {
+export default function connectRefinementList(renderFn, unmountFn = noop) {
   checkRendering(renderFn, withUsage());
 
   return (widgetParams = {}) => {

--- a/src/connectors/search-box/connectSearchBox.js
+++ b/src/connectors/search-box/connectSearchBox.js
@@ -1,6 +1,7 @@
 import {
   checkRendering,
   createDocumentationMessageGenerator,
+  noop,
 } from '../../lib/utils';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -63,7 +64,7 @@ const withUsage = createDocumentationMessageGenerator({
  *   })
  * );
  */
-export default function connectSearchBox(renderFn, unmountFn) {
+export default function connectSearchBox(renderFn, unmountFn = noop) {
   checkRendering(renderFn, withUsage());
 
   return (widgetParams = {}) => {

--- a/src/connectors/sort-by/connectSortBy.js
+++ b/src/connectors/sort-by/connectSortBy.js
@@ -3,6 +3,7 @@ import {
   createDocumentationMessageGenerator,
   find,
   warning,
+  noop,
 } from '../../lib/utils';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -87,7 +88,7 @@ const withUsage = createDocumentationMessageGenerator({
  *   })
  * );
  */
-export default function connectSortBy(renderFn, unmountFn) {
+export default function connectSortBy(renderFn, unmountFn = noop) {
   checkRendering(renderFn, withUsage());
 
   return (widgetParams = {}) => {

--- a/src/connectors/stats/connectStats.js
+++ b/src/connectors/stats/connectStats.js
@@ -1,6 +1,7 @@
 import {
   checkRendering,
   createDocumentationMessageGenerator,
+  noop,
 } from '../../lib/utils';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -46,7 +47,7 @@ const withUsage = createDocumentationMessageGenerator({
  *   })
  * );
  */
-export default function connectStats(renderFn, unmountFn) {
+export default function connectStats(renderFn, unmountFn = noop) {
   checkRendering(renderFn, withUsage());
 
   return (widgetParams = {}) => ({

--- a/src/connectors/toggleRefinement/connectToggleRefinement.js
+++ b/src/connectors/toggleRefinement/connectToggleRefinement.js
@@ -4,6 +4,7 @@ import {
   unescapeRefinement,
   createDocumentationMessageGenerator,
   find,
+  noop,
 } from '../../lib/utils';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -86,7 +87,7 @@ const withUsage = createDocumentationMessageGenerator({
  *   })
  * );
  */
-export default function connectToggleRefinement(renderFn, unmountFn) {
+export default function connectToggleRefinement(renderFn, unmountFn = noop) {
   checkRendering(renderFn, withUsage());
 
   return (widgetParams = {}) => {


### PR DESCRIPTION
**Summary**

Many of the connectors doesn't have default value of `unmountFn`. When users create custom widget using the connectors and if they don't provide `unmountFn`, removing the widget will throw an error.
So this PR adds `noop` as the default value of `unmountFn` to all the connectors.

**Result**

All the connectors have `noop` as default value of `unmountFn`.