### PR TITLE
chore(enhanceConfiguration): prevent helper to be superfluously created

### DIFF
--- a/src/connectors/configure/connectConfigure.js
+++ b/src/connectors/configure/connectConfigure.js
@@ -61,12 +61,9 @@ export default function connectConfigure(renderFn = noop, unmountFn = noop) {
         return searchParameters => {
           // merge new `searchParameters` with the ones set from other widgets
           const actualState = this.removeSearchParameters(helper.state);
-          const nextSearchParameters = enhanceConfiguration(
-            { ...actualState },
-            {
-              getConfiguration: () => searchParameters,
-            }
-          );
+          const nextSearchParameters = enhanceConfiguration(actualState, {
+            getConfiguration: () => searchParameters,
+          });
 
           // trigger a search with the new merged searchParameters
           helper.setState(nextSearchParameters).search();

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -663,7 +663,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       const makeWidget = connectInfiniteHits(renderFn);
       const widget = makeWidget({});
 
-      const nextConfiguration = widget.getConfiguration!();
+      const nextConfiguration = widget.getConfiguration!(
+        new SearchParameters()
+      );
 
       expect(nextConfiguration.page).toBe(0);
     });
@@ -673,7 +675,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       const makeWidget = connectInfiniteHits(renderFn);
       const widget = makeWidget({});
 
-      const nextConfiguration = widget.getConfiguration!();
+      const nextConfiguration = widget.getConfiguration!(
+        new SearchParameters()
+      );
 
       expect(nextConfiguration.highlightPreTag).toBe(
         TAG_PLACEHOLDER.highlightPreTag
@@ -691,7 +695,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
         escapeHTML: false,
       });
 
-      const nextConfiguration = widget.getConfiguration!();
+      const nextConfiguration = widget.getConfiguration!(
+        new SearchParameters()
+      );
 
       expect(nextConfiguration.highlightPreTag).toBeUndefined();
       expect(nextConfiguration.highlightPostTag).toBeUndefined();

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -1,5 +1,5 @@
 import escapeHits, { TAG_PLACEHOLDER } from '../../lib/escape-highlight';
-import algoliasearchHelper, {
+import {
   AlgoliaSearchHelper as Helper,
   SearchParameters,
 } from 'algoliasearch-helper';
@@ -143,16 +143,16 @@ const connectInfiniteHits: InfiniteHitsConnector = (
     return {
       $$type: 'ais.infiniteHits',
 
-      getConfiguration() {
+      getConfiguration(config) {
         const parameters = {
           page: 0,
         };
 
         if (!escapeHTML) {
-          return new algoliasearchHelper.SearchParameters(parameters);
+          return config.setQueryParameters(parameters);
         }
 
-        return new algoliasearchHelper.SearchParameters({
+        return config.setQueryParameters({
           ...parameters,
           ...TAG_PLACEHOLDER,
         });

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -1,5 +1,5 @@
 import escapeHits, { TAG_PLACEHOLDER } from '../../lib/escape-highlight';
-import {
+import algoliasearchHelper, {
   AlgoliaSearchHelper as Helper,
   SearchParameters,
 } from 'algoliasearch-helper';
@@ -149,13 +149,13 @@ const connectInfiniteHits: InfiniteHitsConnector = (
         };
 
         if (!escapeHTML) {
-          return parameters;
+          return new algoliasearchHelper.SearchParameters(parameters);
         }
 
-        return {
+        return new algoliasearchHelper.SearchParameters({
           ...parameters,
           ...TAG_PLACEHOLDER,
-        };
+        });
       },
 
       init({ instantSearchInstance, helper }) {

--- a/src/connectors/voice-search/__tests__/connectVoiceSearch-test.js
+++ b/src/connectors/voice-search/__tests__/connectVoiceSearch-test.js
@@ -139,7 +139,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/voice-searc
       const makeWidget = connectVoiceSearch(renderFn);
       const widget = makeWidget({});
 
-      const nextConfiguration = widget.getConfiguration();
+      const nextConfiguration = widget.getConfiguration(new SearchParameters());
 
       expect(nextConfiguration.query).toBe('');
     });

--- a/src/connectors/voice-search/connectVoiceSearch.ts
+++ b/src/connectors/voice-search/connectVoiceSearch.ts
@@ -77,7 +77,7 @@ const connectVoiceSearch: VoiceSearchConnector = (
       $$type: 'ais.voiceSearch',
 
       getConfiguration(config) {
-        return config.setQuery(config.query || '');
+        return config.setQuery('');
       },
 
       init({ helper, instantSearchInstance }) {

--- a/src/connectors/voice-search/connectVoiceSearch.ts
+++ b/src/connectors/voice-search/connectVoiceSearch.ts
@@ -76,10 +76,8 @@ const connectVoiceSearch: VoiceSearchConnector = (
     return {
       $$type: 'ais.voiceSearch',
 
-      getConfiguration() {
-        return {
-          query: '',
-        };
+      getConfiguration(config) {
+        return config.setQuery(config.query || '');
       },
 
       init({ helper, instantSearchInstance }) {

--- a/src/lib/RoutingManager.ts
+++ b/src/lib/RoutingManager.ts
@@ -137,7 +137,7 @@ class RoutingManager implements Widget {
   }
 
   public getConfiguration(
-    currentConfiguration: PlainSearchParameters
+    currentConfiguration: SearchParameters
   ): PlainSearchParameters {
     // We have to create a `SearchParameters` because `getAllSearchParameters`
     // expects an instance of `SearchParameters` and not a plain object.

--- a/src/lib/RoutingManager.ts
+++ b/src/lib/RoutingManager.ts
@@ -1,4 +1,4 @@
-import algoliasearchHelper, { SearchParameters } from 'algoliasearch-helper';
+import { SearchParameters } from 'algoliasearch-helper';
 import { isEqual } from './utils';
 import {
   InstantSearch,

--- a/src/lib/RoutingManager.ts
+++ b/src/lib/RoutingManager.ts
@@ -136,15 +136,9 @@ class RoutingManager implements Widget {
   public getConfiguration(
     currentConfiguration: SearchParameters
   ): SearchParameters {
-    // We have to create a `SearchParameters` because `getAllSearchParameters`
-    // expects an instance of `SearchParameters` and not a plain object.
-    const currentSearchParameters = algoliasearchHelper.SearchParameters.make(
-      currentConfiguration
-    );
-
     return this.getAllSearchParameters({
       uiState: this.currentUiState,
-      currentSearchParameters,
+      currentSearchParameters: currentConfiguration,
     });
   }
 

--- a/src/lib/RoutingManager.ts
+++ b/src/lib/RoutingManager.ts
@@ -1,7 +1,4 @@
-import algoliasearchHelper, {
-  SearchParameters,
-  PlainSearchParameters,
-} from 'algoliasearch-helper';
+import algoliasearchHelper, { SearchParameters } from 'algoliasearch-helper';
 import { isEqual } from './utils';
 import {
   InstantSearch,
@@ -138,19 +135,17 @@ class RoutingManager implements Widget {
 
   public getConfiguration(
     currentConfiguration: SearchParameters
-  ): PlainSearchParameters {
+  ): SearchParameters {
     // We have to create a `SearchParameters` because `getAllSearchParameters`
     // expects an instance of `SearchParameters` and not a plain object.
     const currentSearchParameters = algoliasearchHelper.SearchParameters.make(
       currentConfiguration
     );
 
-    return {
-      ...this.getAllSearchParameters({
-        uiState: this.currentUiState,
-        currentSearchParameters,
-      }),
-    };
+    return this.getAllSearchParameters({
+      uiState: this.currentUiState,
+      currentSearchParameters,
+    });
   }
 
   public init({ state }: { state: SearchParameters }): void {

--- a/src/lib/utils/__tests__/enhanceConfiguration-test.js
+++ b/src/lib/utils/__tests__/enhanceConfiguration-test.js
@@ -1,3 +1,4 @@
+import { SearchParameters } from 'algoliasearch-helper';
 import enhanceConfiguration from '../enhanceConfiguration';
 
 const createWidget = (configuration = {}) => ({
@@ -6,7 +7,7 @@ const createWidget = (configuration = {}) => ({
 
 describe('enhanceConfiguration', () => {
   it('should return the same object if widget does not provide a configuration', () => {
-    const configuration = { analytics: true, page: 2 };
+    const configuration = new SearchParameters({ analytics: true, page: 2 });
     const widget = {};
 
     const output = enhanceConfiguration(configuration, widget);
@@ -14,7 +15,7 @@ describe('enhanceConfiguration', () => {
   });
 
   it('should return a new object if widget does provide a configuration', () => {
-    const configuration = { analytics: true, page: 2 };
+    const configuration = new SearchParameters({ analytics: true, page: 2 });
     const widget = createWidget(configuration);
 
     const output = enhanceConfiguration(configuration, widget);
@@ -22,7 +23,7 @@ describe('enhanceConfiguration', () => {
   });
 
   it('should add widget configuration to an empty state', () => {
-    const configuration = { analytics: true, page: 2 };
+    const configuration = new SearchParameters({ analytics: true, page: 2 });
     const widget = createWidget(configuration);
 
     const output = enhanceConfiguration(configuration, widget);
@@ -32,7 +33,7 @@ describe('enhanceConfiguration', () => {
   it('should call `getConfiguration` from widget correctly', () => {
     const widget = { getConfiguration: jest.fn() };
 
-    const configuration = {};
+    const configuration = new SearchParameters({});
 
     enhanceConfiguration(configuration, widget);
 
@@ -41,7 +42,7 @@ describe('enhanceConfiguration', () => {
   });
 
   it('should replace boolean values', () => {
-    const actualConfiguration = { analytics: false };
+    const actualConfiguration = new SearchParameters({ analytics: false });
     const widget = createWidget({ analytics: true });
 
     const output = enhanceConfiguration(actualConfiguration, widget);
@@ -50,7 +51,7 @@ describe('enhanceConfiguration', () => {
 
   it('should union facets', () => {
     {
-      const actualConfiguration = { facets: ['foo'] };
+      const actualConfiguration = new SearchParameters({ facets: ['foo'] });
       const widget = createWidget({ facets: ['foo', 'bar'] });
 
       const output = enhanceConfiguration(actualConfiguration, widget);
@@ -58,7 +59,7 @@ describe('enhanceConfiguration', () => {
     }
 
     {
-      const actualConfiguration = { facets: ['foo'] };
+      const actualConfiguration = new SearchParameters({ facets: ['foo'] });
       const widget = createWidget({ facets: ['bar'] });
 
       const output = enhanceConfiguration(actualConfiguration, widget);
@@ -66,7 +67,9 @@ describe('enhanceConfiguration', () => {
     }
 
     {
-      const actualConfiguration = { facets: ['foo', 'bar'] };
+      const actualConfiguration = new SearchParameters({
+        facets: ['foo', 'bar'],
+      });
       const widget = createWidget({ facets: [] });
 
       const output = enhanceConfiguration(actualConfiguration, widget);
@@ -75,13 +78,31 @@ describe('enhanceConfiguration', () => {
   });
 
   it('should replace unknown deep values', () => {
-    const actualConfiguration = { refinements: { lvl1: ['foo'], lvl2: false } };
+    const actualConfiguration = new SearchParameters({
+      refinements: { lvl1: ['foo'], lvl2: false },
+    });
     const widget = createWidget({ refinements: { lvl1: ['bar'], lvl2: true } });
 
     const output = enhanceConfiguration(actualConfiguration, widget);
     expect(output).toEqual(
       expect.objectContaining({
         refinements: { lvl1: ['bar'], lvl2: true },
+      })
+    );
+  });
+
+  it('does not duplicate hierarchicalFacets (object in array)', () => {
+    const actualConfiguration = new SearchParameters({
+      hierarchicalFacets: [{ attribute: 'duplicate' }],
+    });
+    const widget = createWidget({
+      hierarchicalFacets: [{ attribute: 'duplicate' }],
+    });
+    const output = enhanceConfiguration(actualConfiguration, widget);
+
+    expect(output).toEqual(
+      expect.objectContaining({
+        hierarchicalFacets: [{ attribute: 'duplicate' }],
       })
     );
   });

--- a/src/lib/utils/enhanceConfiguration.ts
+++ b/src/lib/utils/enhanceConfiguration.ts
@@ -15,6 +15,7 @@ function enhanceConfiguration(
 
   return mergeSearchParameters(
     configuration,
+    // @TODO: remove this after IFW-874 is completed (all widgets return SP)
     new algoliasearchHelper.SearchParameters(partialConfiguration)
   );
 }

--- a/src/lib/utils/enhanceConfiguration.ts
+++ b/src/lib/utils/enhanceConfiguration.ts
@@ -1,13 +1,11 @@
-import algoliasearchHelper, {
-  PlainSearchParameters,
-} from 'algoliasearch-helper';
+import algoliasearchHelper, { SearchParameters } from 'algoliasearch-helper';
 import { Widget } from '../../types';
 import mergeSearchParameters from './mergeSearchParameters';
 
 function enhanceConfiguration(
-  configuration: PlainSearchParameters,
+  configuration: SearchParameters,
   widget: Widget
-): PlainSearchParameters {
+): SearchParameters {
   if (!widget.getConfiguration) {
     return configuration;
   }
@@ -16,7 +14,7 @@ function enhanceConfiguration(
   const partialConfiguration = widget.getConfiguration(configuration);
 
   return mergeSearchParameters(
-    new algoliasearchHelper.SearchParameters(configuration),
+    configuration,
     new algoliasearchHelper.SearchParameters(partialConfiguration)
   );
 }

--- a/src/types/instantsearch.ts
+++ b/src/types/instantsearch.ts
@@ -1,5 +1,9 @@
 import { Client as AlgoliaSearchClient } from 'algoliasearch';
-import { AlgoliaSearchHelper, SearchParameters } from 'algoliasearch-helper';
+import {
+  AlgoliaSearchHelper,
+  SearchParameters,
+  PlainSearchParameters,
+} from 'algoliasearch-helper';
 import { Index } from '../widgets/index/index';
 import { InsightsClient as AlgoliaInsightsClient } from './insights';
 import { Widget, UiState } from './widget';
@@ -107,8 +111,8 @@ export type InstantSearch = {
   insightsClient: AlgoliaInsightsClient | null;
   templatesConfig: object;
   _isSearchStalled: boolean;
-  _searchParameters: Partial<SearchParameters>;
-  _createAbsoluteURL(state: Partial<SearchParameters>): string;
+  _searchParameters: PlainSearchParameters;
+  _createAbsoluteURL(state: PlainSearchParameters): string;
   scheduleSearch(): void;
   scheduleRender(): void;
   scheduleStalledRender(): void;

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -3,7 +3,6 @@ import {
   AlgoliaSearchHelper as Helper,
   SearchParameters,
   SearchResults,
-  PlainSearchParameters,
 } from 'algoliasearch-helper';
 import { InstantSearch } from './instantsearch';
 
@@ -93,9 +92,7 @@ export interface Widget {
   init?(options: InitOptions): void;
   render?(options: RenderOptions): void;
   dispose?(options: DisposeOptions): SearchParameters | void;
-  getConfiguration?(
-    previousConfiguration?: SearchParameters
-  ): PlainSearchParameters;
+  getConfiguration?(previousConfiguration: SearchParameters): SearchParameters;
   getWidgetState?(
     uiState: UiState,
     widgetStateOptions: {

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -94,7 +94,7 @@ export interface Widget {
   render?(options: RenderOptions): void;
   dispose?(options: DisposeOptions): SearchParameters | void;
   getConfiguration?(
-    previousConfiguration?: PlainSearchParameters
+    previousConfiguration?: SearchParameters
   ): PlainSearchParameters;
   getWidgetState?(
     uiState: UiState,

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -1,4 +1,4 @@
-import algoliasearchHelper from 'algoliasearch-helper';
+import algoliasearchHelper, { SearchParameters } from 'algoliasearch-helper';
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import { createInstantSearch } from '../../../../test/mock/createInstantSearch';
 import {
@@ -15,9 +15,9 @@ describe('index', () => {
   const createSearchBox = (args: Partial<Widget> = {}): Widget =>
     createWidget({
       getConfiguration: jest.fn(() => {
-        return {
+        return new SearchParameters({
           query: 'Apple',
-        };
+        });
       }),
       dispose: jest.fn(({ state }) => {
         return state.setQueryParameter('query', undefined);
@@ -28,9 +28,9 @@ describe('index', () => {
   const createPagination = (args: Partial<Widget> = {}): Widget =>
     createWidget({
       getConfiguration: jest.fn(() => {
-        return {
+        return new SearchParameters({
           page: 5,
-        };
+        });
       }),
       dispose: jest.fn(({ state }) => {
         return state.setQueryParameter('page', undefined);
@@ -609,51 +609,51 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
       level0.addWidgets([
         createWidget({
           getConfiguration() {
-            return {
+            return new SearchParameters({
               hitsPerPage: 5,
-            };
+            });
           },
         }),
 
         createSearchBox({
           getConfiguration() {
-            return {
+            return new SearchParameters({
               query: 'Apple',
-            };
+            });
           },
         }),
 
         createPagination({
           getConfiguration() {
-            return {
+            return new SearchParameters({
               page: 1,
-            };
+            });
           },
         }),
 
         level1.addWidgets([
           createSearchBox({
             getConfiguration() {
-              return {
+              return new SearchParameters({
                 query: 'Apple iPhone',
-              };
+              });
             },
           }),
 
           createPagination({
             getConfiguration() {
-              return {
+              return new SearchParameters({
                 page: 2,
-              };
+              });
             },
           }),
 
           level2.addWidgets([
             createSearchBox({
               getConfiguration() {
-                return {
+                return new SearchParameters({
                   query: 'Apple iPhone XS',
-                };
+                });
               },
             }),
           ]),

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -101,9 +101,7 @@ const index = (props: IndexProps): Index => {
 
       if (localInstantSearchInstance && Boolean(widgets.length)) {
         helper!.setState(
-          localWidgets.reduce(enhanceConfiguration, {
-            ...helper!.state,
-          })
+          localWidgets.reduce(enhanceConfiguration, helper!.state)
         );
 
         widgets.forEach(widget => {
@@ -150,11 +148,7 @@ const index = (props: IndexProps): Index => {
           return next || state;
         }, helper!.state);
 
-        helper!.setState(
-          localWidgets.reduce(enhanceConfiguration, {
-            ...nextState,
-          })
-        );
+        helper!.setState(localWidgets.reduce(enhanceConfiguration, nextState));
 
         if (localWidgets.length) {
           localInstantSearchInstance.scheduleSearch();
@@ -176,7 +170,11 @@ const index = (props: IndexProps): Index => {
       const initialSearchParameters =
         // Uses the `searchParameters` for the top level index only, it allows
         // us to have the exact same behaviour than before for the mono-index.
-        parent === null ? instantSearchInstance._searchParameters : {};
+        parent === null
+          ? new algoliasearchHelper.SearchParameters(
+              instantSearchInstance._searchParameters
+            )
+          : new algoliasearchHelper.SearchParameters();
 
       // This Helper is only used for state management we do not care about the
       // `searchClient`. Only the "main" Helper created at the `InstantSearch`

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -167,14 +167,11 @@ const index = (props: IndexProps): Index => {
       // step.
       const mainHelper = instantSearchInstance.mainHelper!;
 
-      const initialSearchParameters =
+      const initialSearchParameters = new algoliasearchHelper.SearchParameters(
         // Uses the `searchParameters` for the top level index only, it allows
         // us to have the exact same behaviour than before for the mono-index.
-        parent === null
-          ? new algoliasearchHelper.SearchParameters(
-              instantSearchInstance._searchParameters
-            )
-          : new algoliasearchHelper.SearchParameters();
+        parent === null ? instantSearchInstance._searchParameters : {}
+      );
 
       // This Helper is only used for state management we do not care about the
       // `searchClient`. Only the "main" Helper created at the `InstantSearch`


### PR DESCRIPTION
follow-up on #3945, enhanceConfiguration now accepts a SearchParameters, and all usages have been changed to instantiate this helper themselves.

I wonder if we could force the result of getConfiguration be a SearchParameters too so we can avoid that instantiation? 🤔 