### PR TITLE
feat(widgets): add `$$type` to widgets definition

### DIFF
--- a/src/connectors/autocomplete/__tests__/connectAutocomplete-test.js
+++ b/src/connectors/autocomplete/__tests__/connectAutocomplete-test.js
@@ -15,6 +15,24 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/autocomplet
 `);
   });
 
+  it('is a widget', () => {
+    const render = jest.fn();
+    const unmount = jest.fn();
+
+    const customAutocomplete = connectAutocomplete(render, unmount);
+    const widget = customAutocomplete({});
+
+    expect(widget).toEqual(
+      expect.objectContaining({
+        $$type: 'ais.autocomplete',
+        init: expect.any(Function),
+        render: expect.any(Function),
+        dispose: expect.any(Function),
+        getConfiguration: expect.any(Function),
+      })
+    );
+  });
+
   it('renders during init and render', () => {
     const renderFn = jest.fn();
     const makeWidget = connectAutocomplete(renderFn);

--- a/src/connectors/autocomplete/connectAutocomplete.js
+++ b/src/connectors/autocomplete/connectAutocomplete.js
@@ -56,6 +56,8 @@ export default function connectAutocomplete(renderFn, unmountFn = noop) {
     }
 
     return {
+      $$type: 'ais.autocomplete',
+
       getConfiguration() {
         const parameters = {
           query: '',

--- a/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.js
+++ b/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.js
@@ -38,6 +38,24 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
     });
   });
 
+  it('is a widget', () => {
+    const render = jest.fn();
+    const unmount = jest.fn();
+
+    const customBreadcrumb = connectBreadcrumb(render, unmount);
+    const widget = customBreadcrumb({ attributes: ['category'] });
+
+    expect(widget).toEqual(
+      expect.objectContaining({
+        $$type: 'ais.breadcrumb',
+        init: expect.any(Function),
+        render: expect.any(Function),
+        dispose: expect.any(Function),
+        getConfiguration: expect.any(Function),
+      })
+    );
+  });
+
   it('should compute getConfiguration() correctly', () => {
     const rendering = jest.fn();
     const makeWidget = connectBreadcrumb(rendering);

--- a/src/connectors/breadcrumb/connectBreadcrumb.js
+++ b/src/connectors/breadcrumb/connectBreadcrumb.js
@@ -64,6 +64,8 @@ export default function connectBreadcrumb(renderFn, unmountFn = noop) {
     const [hierarchicalFacetName] = attributes;
 
     return {
+      $$type: 'ais.breadcrumb',
+
       getConfiguration: currentConfiguration => {
         if (currentConfiguration.hierarchicalFacets) {
           const isFacetSet = find(

--- a/src/connectors/clear-refinements/__tests__/connectClearRefinements-test.js
+++ b/src/connectors/clear-refinements/__tests__/connectClearRefinements-test.js
@@ -27,6 +27,23 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/clear-refin
 See documentation: https://www.algolia.com/doc/api-reference/widgets/clear-refinements/js/#connector"
 `);
     });
+
+    it('is a widget', () => {
+      const render = jest.fn();
+      const unmount = jest.fn();
+
+      const customClearRefinements = connectClearRefinements(render, unmount);
+      const widget = customClearRefinements({});
+
+      expect(widget).toEqual(
+        expect.objectContaining({
+          $$type: 'ais.clearRefinements',
+          init: expect.any(Function),
+          render: expect.any(Function),
+          dispose: expect.any(Function),
+        })
+      );
+    });
   });
 
   describe('Lifecycle', () => {

--- a/src/connectors/clear-refinements/connectClearRefinements.js
+++ b/src/connectors/clear-refinements/connectClearRefinements.js
@@ -87,6 +87,8 @@ export default function connectClearRefinements(renderFn, unmountFn = noop) {
     } = widgetParams;
 
     return {
+      $$type: 'ais.clearRefinements',
+
       init({ helper, instantSearchInstance, createURL }) {
         const attributesToClear = getAttributesToClear({
           helper,

--- a/src/connectors/configure/__tests__/connectConfigure-test.js
+++ b/src/connectors/configure/__tests__/connectConfigure-test.js
@@ -53,6 +53,24 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
     });
   });
 
+  it('is a widget', () => {
+    const render = jest.fn();
+    const unmount = jest.fn();
+
+    const customConfigure = connectConfigure(render, unmount);
+    const widget = customConfigure({ searchParameters: {} });
+
+    expect(widget).toEqual(
+      expect.objectContaining({
+        $$type: 'ais.configure',
+        init: expect.any(Function),
+        render: expect.any(Function),
+        dispose: expect.any(Function),
+        getConfiguration: expect.any(Function),
+      })
+    );
+  });
+
   it('should apply searchParameters', () => {
     const makeWidget = connectConfigure();
     const widget = makeWidget({ searchParameters: { analytics: true } });

--- a/src/connectors/configure/connectConfigure.js
+++ b/src/connectors/configure/connectConfigure.js
@@ -39,6 +39,8 @@ export default function connectConfigure(renderFn = noop, unmountFn = noop) {
     }
 
     return {
+      $$type: 'ais.configure',
+
       getConfiguration() {
         return widgetParams.searchParameters;
       },

--- a/src/connectors/current-refinements/__tests__/connectCurrentRefinements-test.js
+++ b/src/connectors/current-refinements/__tests__/connectCurrentRefinements-test.js
@@ -17,6 +17,26 @@ describe('connectCurrentRefinements', () => {
 See documentation: https://www.algolia.com/doc/api-reference/widgets/current-refinements/js/#connector"
 `);
     });
+
+    it('is a widget', () => {
+      const render = jest.fn();
+      const unmount = jest.fn();
+
+      const customCurrentRefinements = connectCurrentRefinements(
+        render,
+        unmount
+      );
+      const widget = customCurrentRefinements({});
+
+      expect(widget).toEqual(
+        expect.objectContaining({
+          $$type: 'ais.currentRefinements',
+          init: expect.any(Function),
+          render: expect.any(Function),
+          dispose: expect.any(Function),
+        })
+      );
+    });
   });
 
   describe('Lifecycle', () => {

--- a/src/connectors/current-refinements/connectCurrentRefinements.js
+++ b/src/connectors/current-refinements/connectCurrentRefinements.js
@@ -120,6 +120,8 @@ export default function connectCurrentRefinements(renderFn, unmountFn = noop) {
     } = widgetParams;
 
     return {
+      $$type: 'ais.currentRefinements',
+
       init({ helper, createURL, instantSearchInstance }) {
         const items = transformItems(
           getFilteredRefinements({

--- a/src/connectors/geo-search/__tests__/connectGeoSearch-test.js
+++ b/src/connectors/geo-search/__tests__/connectGeoSearch-test.js
@@ -52,9 +52,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
     const unmount = jest.fn();
 
     const customGeoSearch = connectGeoSearch(render, unmount);
-    const widget = customGeoSearch();
+    const widget = customGeoSearch({});
 
     expect(widget).toEqual({
+      $$type: 'ais.geoSearch',
       init: expect.any(Function),
       render: expect.any(Function),
       dispose: expect.any(Function),

--- a/src/connectors/geo-search/connectGeoSearch.js
+++ b/src/connectors/geo-search/connectGeoSearch.js
@@ -332,7 +332,10 @@ http://community.algolia.com/instantsearch.js/migration-guide
     };
 
     return {
+      $$type: 'ais.geoSearch',
+
       init,
+
       render,
 
       dispose({ state }) {

--- a/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.js
+++ b/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.js
@@ -45,6 +45,26 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
 See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchical-menu/js/#connector"
 `);
     });
+
+    it('is a widget', () => {
+      const render = jest.fn();
+      const unmount = jest.fn();
+
+      const customHierarchicalMenu = connectHierarchicalMenu(render, unmount);
+      const widget = customHierarchicalMenu({ attributes: ['category'] });
+
+      expect(widget).toEqual(
+        expect.objectContaining({
+          $$type: 'ais.hierarchicalMenu',
+          init: expect.any(Function),
+          render: expect.any(Function),
+          dispose: expect.any(Function),
+          getConfiguration: expect.any(Function),
+          getWidgetState: expect.any(Function),
+          getWidgetSearchParameters: expect.any(Function),
+        })
+      );
+    });
   });
 
   describe('getConfiguration', () => {

--- a/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
+++ b/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
@@ -94,6 +94,8 @@ export default function connectHierarchicalMenu(renderFn, unmountFn = noop) {
     const [hierarchicalFacetName] = attributes;
 
     return {
+      $$type: 'ais.hierarchicalMenu',
+
       isShowingMore: false,
 
       // Provide the same function to the `renderFn` so that way the user

--- a/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
+++ b/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
@@ -32,6 +32,26 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
 See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-page/js/#connector"
 `);
     });
+
+    it('is a widget', () => {
+      const render = jest.fn();
+      const unmount = jest.fn();
+
+      const customHitsPerPage = connectHitsPerPage(render, unmount);
+      const widget = customHitsPerPage({ items: [] });
+
+      expect(widget).toEqual(
+        expect.objectContaining({
+          $$type: 'ais.hitsPerPage',
+          init: expect.any(Function),
+          render: expect.any(Function),
+          dispose: expect.any(Function),
+          getConfiguration: expect.any(Function),
+          getWidgetState: expect.any(Function),
+          getWidgetSearchParameters: expect.any(Function),
+        })
+      );
+    });
   });
 
   it('Renders during init and render', () => {

--- a/src/connectors/hits-per-page/connectHitsPerPage.js
+++ b/src/connectors/hits-per-page/connectHitsPerPage.js
@@ -118,6 +118,8 @@ export default function connectHitsPerPage(renderFn, unmountFn = noop) {
     const defaultValue = find(userItems, item => item.default === true);
 
     return {
+      $$type: 'ais.hitsPerPage',
+
       getConfiguration() {
         return defaultValues.length > 0
           ? { hitsPerPage: defaultValues[0].value }

--- a/src/connectors/hits/__tests__/connectHits-test.js
+++ b/src/connectors/hits/__tests__/connectHits-test.js
@@ -20,6 +20,24 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
 `);
   });
 
+  it('is a widget', () => {
+    const render = jest.fn();
+    const unmount = jest.fn();
+
+    const customHits = connectHits(render, unmount);
+    const widget = customHits({});
+
+    expect(widget).toEqual(
+      expect.objectContaining({
+        $$type: 'ais.hits',
+        init: expect.any(Function),
+        render: expect.any(Function),
+        dispose: expect.any(Function),
+        getConfiguration: expect.any(Function),
+      })
+    );
+  });
+
   it('Renders during init and render', () => {
     const rendering = jest.fn();
     const makeWidget = connectHits(rendering);

--- a/src/connectors/hits/connectHits.js
+++ b/src/connectors/hits/connectHits.js
@@ -58,6 +58,8 @@ export default function connectHits(renderFn, unmountFn = noop) {
     const { escapeHTML = true, transformItems = items => items } = widgetParams;
 
     return {
+      $$type: 'ais.hits',
+
       getConfiguration() {
         return escapeHTML ? TAG_PLACEHOLDER : undefined;
       },

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -32,6 +32,26 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
 `);
   });
 
+  it('is a widget', () => {
+    const render = jest.fn();
+    const unmount = jest.fn();
+
+    const customInfiniteHits = connectInfiniteHits(render, unmount);
+    const widget = customInfiniteHits({});
+
+    expect(widget).toEqual(
+      expect.objectContaining({
+        $$type: 'ais.infiniteHits',
+        init: expect.any(Function),
+        render: expect.any(Function),
+        dispose: expect.any(Function),
+        getConfiguration: expect.any(Function),
+        getWidgetState: expect.any(Function),
+        getWidgetSearchParameters: expect.any(Function),
+      })
+    );
+  });
+
   it('Renders during init and render', () => {
     const renderFn = jest.fn();
     const instantSearchInstance = createInstantSearch();

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -141,6 +141,8 @@ const connectInfiniteHits: InfiniteHitsConnector = (
     };
 
     return {
+      $$type: 'ais.infiniteHits',
+
       getConfiguration() {
         const parameters = {
           page: 0,

--- a/src/connectors/menu/__tests__/connectMenu-test.js
+++ b/src/connectors/menu/__tests__/connectMenu-test.js
@@ -15,7 +15,7 @@ describe('connectMenu', () => {
   });
 
   describe('Usage', () => {
-    it('throws with render function', () => {
+    it('throws without render function', () => {
       expect(() => {
         connectMenu()({});
       }).toThrowErrorMatchingInlineSnapshot(`
@@ -54,6 +54,26 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
 See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#connector"
 `);
     });
+  });
+
+  it('is a widget', () => {
+    const render = jest.fn();
+    const unmount = jest.fn();
+
+    const customMenu = connectMenu(render, unmount);
+    const widget = customMenu({ attribute: 'facet' });
+
+    expect(widget).toEqual(
+      expect.objectContaining({
+        $$type: 'ais.menu',
+        init: expect.any(Function),
+        render: expect.any(Function),
+        dispose: expect.any(Function),
+        getConfiguration: expect.any(Function),
+        getWidgetState: expect.any(Function),
+        getWidgetSearchParameters: expect.any(Function),
+      })
+    );
   });
 
   describe('options configuring the helper', () => {

--- a/src/connectors/menu/connectMenu.js
+++ b/src/connectors/menu/connectMenu.js
@@ -115,6 +115,8 @@ export default function connectMenu(renderFn, unmountFn = noop) {
     }
 
     return {
+      $$type: 'ais.menu',
+
       isShowingMore: false,
 
       // Provide the same function to the `renderFn` so that way the user

--- a/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.js
+++ b/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.js
@@ -46,6 +46,25 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
 See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-menu/js/#connector"
 `);
     });
+
+    it('is a widget', () => {
+      const render = jest.fn();
+      const unmount = jest.fn();
+
+      const customNumericMenu = connectNumericMenu(render, unmount);
+      const widget = customNumericMenu({ attribute: 'facet', items: [] });
+
+      expect(widget).toEqual(
+        expect.objectContaining({
+          $$type: 'ais.numericMenu',
+          init: expect.any(Function),
+          render: expect.any(Function),
+          dispose: expect.any(Function),
+          getWidgetState: expect.any(Function),
+          getWidgetSearchParameters: expect.any(Function),
+        })
+      );
+    });
   });
 
   it('Renders during init and render', () => {

--- a/src/connectors/numeric-menu/connectNumericMenu.js
+++ b/src/connectors/numeric-menu/connectNumericMenu.js
@@ -115,6 +115,8 @@ export default function connectNumericMenu(renderFn, unmountFn = noop) {
     }
 
     return {
+      $$type: 'ais.numericMenu',
+
       init({ helper, createURL, instantSearchInstance }) {
         this._refine = facetValue => {
           const refinedState = refine(

--- a/src/connectors/pagination/__tests__/connectPagination-test.js
+++ b/src/connectors/pagination/__tests__/connectPagination-test.js
@@ -16,6 +16,26 @@ describe('connectPagination', () => {
 See documentation: https://www.algolia.com/doc/api-reference/widgets/pagination/js/#connector"
 `);
     });
+
+    it('is a widget', () => {
+      const render = jest.fn();
+      const unmount = jest.fn();
+
+      const customPagination = connectPagination(render, unmount);
+      const widget = customPagination({});
+
+      expect(widget).toEqual(
+        expect.objectContaining({
+          $$type: 'ais.pagination',
+          init: expect.any(Function),
+          render: expect.any(Function),
+          dispose: expect.any(Function),
+          getConfiguration: expect.any(Function),
+          getWidgetState: expect.any(Function),
+          getWidgetSearchParameters: expect.any(Function),
+        })
+      );
+    });
   });
 
   it('connectPagination - Renders during init and render', () => {

--- a/src/connectors/pagination/connectPagination.js
+++ b/src/connectors/pagination/connectPagination.js
@@ -98,6 +98,8 @@ export default function connectPagination(renderFn, unmountFn = noop) {
     });
 
     return {
+      $$type: 'ais.pagination',
+
       getConfiguration() {
         return {
           page: 0,

--- a/src/connectors/powered-by/__tests__/connectPoweredBy-test.js
+++ b/src/connectors/powered-by/__tests__/connectPoweredBy-test.js
@@ -11,6 +11,23 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/powered-by/
 `);
   });
 
+  it('is a widget', () => {
+    const render = jest.fn();
+    const unmount = jest.fn();
+
+    const customPoweredBy = connectPoweredBy(render, unmount);
+    const widget = customPoweredBy({});
+
+    expect(widget).toEqual(
+      expect.objectContaining({
+        $$type: 'ais.poweredBy',
+        init: expect.any(Function),
+        render: expect.any(Function),
+        dispose: expect.any(Function),
+      })
+    );
+  });
+
   it('renders during init and render', () => {
     const rendering = jest.fn();
     const makeWidget = connectPoweredBy(rendering);

--- a/src/connectors/powered-by/connectPoweredBy.js
+++ b/src/connectors/powered-by/connectPoweredBy.js
@@ -47,6 +47,8 @@ export default function connectPoweredBy(renderFn, unmountFn = noop) {
     const { url = defaultUrl } = widgetParams;
 
     return {
+      $$type: 'ais.poweredBy',
+
       init() {
         renderFn(
           {

--- a/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
+++ b/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
@@ -67,6 +67,23 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
 See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules/js/#connector"
 `);
     });
+
+    it('is a widget', () => {
+      const render = jest.fn();
+      const unmount = jest.fn();
+
+      const customQueryRules = connectQueryRules(render, unmount);
+      const widget = customQueryRules({});
+
+      expect(widget).toEqual(
+        expect.objectContaining({
+          $$type: 'ais.queryRules',
+          init: expect.any(Function),
+          render: expect.any(Function),
+          dispose: expect.any(Function),
+        })
+      );
+    });
   });
 
   describe('lifecycle', () => {

--- a/src/connectors/query-rules/connectQueryRules.ts
+++ b/src/connectors/query-rules/connectQueryRules.ts
@@ -196,6 +196,8 @@ const connectQueryRules: QueryRulesConnector = (render, unmount = noop) => {
     let onHelperChange: (event: HelperChangeEvent) => void;
 
     return {
+      $$type: 'ais.queryRules',
+
       init({ helper, state, instantSearchInstance }) {
         initialRuleContexts = state.ruleContexts || [];
         onHelperChange = applyRuleContexts.bind({

--- a/src/connectors/range/__tests__/connectRange-test.js
+++ b/src/connectors/range/__tests__/connectRange-test.js
@@ -25,6 +25,26 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
 See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input/js/#connector, https://www.algolia.com/doc/api-reference/widgets/range-slider/js/#connector"
 `);
     });
+
+    it('is a widget', () => {
+      const render = jest.fn();
+      const unmount = jest.fn();
+
+      const customRange = connectRange(render, unmount);
+      const widget = customRange({ attribute: 'facet' });
+
+      expect(widget).toEqual(
+        expect.objectContaining({
+          $$type: 'ais.range',
+          init: expect.any(Function),
+          render: expect.any(Function),
+          dispose: expect.any(Function),
+          getConfiguration: expect.any(Function),
+          getWidgetState: expect.any(Function),
+          getWidgetSearchParameters: expect.any(Function),
+        })
+      );
+    });
   });
 
   it('Renders during init and render', () => {

--- a/src/connectors/range/connectRange.js
+++ b/src/connectors/range/connectRange.js
@@ -68,6 +68,8 @@ export default function connectRange(renderFn, unmountFn = noop) {
     };
 
     return {
+      $$type: 'ais.range',
+
       _getCurrentRange(stats) {
         const pow = Math.pow(10, precision);
 

--- a/src/connectors/rating-menu/__tests__/connectRatingMenu-test.js
+++ b/src/connectors/rating-menu/__tests__/connectRatingMenu-test.js
@@ -25,6 +25,26 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
 See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu/js/#connector"
 `);
     });
+
+    it('is a widget', () => {
+      const render = jest.fn();
+      const unmount = jest.fn();
+
+      const customRatingMenu = connectRatingMenu(render, unmount);
+      const widget = customRatingMenu({ attribute: 'facet' });
+
+      expect(widget).toEqual(
+        expect.objectContaining({
+          $$type: 'ais.ratingMenu',
+          init: expect.any(Function),
+          render: expect.any(Function),
+          dispose: expect.any(Function),
+          getConfiguration: expect.any(Function),
+          getWidgetState: expect.any(Function),
+          getWidgetSearchParameters: expect.any(Function),
+        })
+      );
+    });
   });
 
   it('Renders during init and render', () => {

--- a/src/connectors/rating-menu/connectRatingMenu.js
+++ b/src/connectors/rating-menu/connectRatingMenu.js
@@ -104,6 +104,8 @@ export default function connectRatingMenu(renderFn, unmountFn = noop) {
     }
 
     return {
+      $$type: 'ais.ratingMenu',
+
       getConfiguration() {
         return { disjunctiveFacets: [attribute] };
       },

--- a/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
+++ b/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
@@ -84,6 +84,26 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
 `);
   });
 
+  it('is a widget', () => {
+    const render = jest.fn();
+    const unmount = jest.fn();
+
+    const customRefinementList = connectRefinementList(render, unmount);
+    const widget = customRefinementList({ attribute: 'facet' });
+
+    expect(widget).toEqual(
+      expect.objectContaining({
+        $$type: 'ais.refinementList',
+        init: expect.any(Function),
+        render: expect.any(Function),
+        dispose: expect.any(Function),
+        getConfiguration: expect.any(Function),
+        getWidgetState: expect.any(Function),
+        getWidgetSearchParameters: expect.any(Function),
+      })
+    );
+  });
+
   describe('options configuring the helper', () => {
     it('`attribute`', () => {
       const { makeWidget } = createWidgetFactory();

--- a/src/connectors/refinement-list/connectRefinementList.js
+++ b/src/connectors/refinement-list/connectRefinementList.js
@@ -267,6 +267,8 @@ export default function connectRefinementList(renderFn, unmountFn = noop) {
     };
 
     return {
+      $$type: 'ais.refinementList',
+
       isShowingMore: false,
 
       // Provide the same function to the `renderFn` so that way the user

--- a/src/connectors/search-box/__tests__/connectSearchBox-test.js
+++ b/src/connectors/search-box/__tests__/connectSearchBox-test.js
@@ -15,6 +15,26 @@ describe('connectSearchBox', () => {
 See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/js/#connector"
 `);
     });
+
+    it('is a widget', () => {
+      const render = jest.fn();
+      const unmount = jest.fn();
+
+      const customSearchBox = connectSearchBox(render, unmount);
+      const widget = customSearchBox({});
+
+      expect(widget).toEqual(
+        expect.objectContaining({
+          $$type: 'ais.searchBox',
+          init: expect.any(Function),
+          render: expect.any(Function),
+          dispose: expect.any(Function),
+          getConfiguration: expect.any(Function),
+          getWidgetState: expect.any(Function),
+          getWidgetSearchParameters: expect.any(Function),
+        })
+      );
+    });
   });
 
   it('Renders during init and render', () => {

--- a/src/connectors/search-box/connectSearchBox.js
+++ b/src/connectors/search-box/connectSearchBox.js
@@ -78,7 +78,10 @@ export default function connectSearchBox(renderFn, unmountFn = noop) {
     }
 
     return {
+      $$type: 'ais.searchBox',
+
       _clear() {},
+
       _cachedClear() {
         this._clear();
       },

--- a/src/connectors/sort-by/__tests__/connectSortBy-test.js
+++ b/src/connectors/sort-by/__tests__/connectSortBy-test.js
@@ -37,6 +37,25 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
 See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/#connector"
 `);
     });
+
+    it('is a widget', () => {
+      const render = jest.fn();
+      const unmount = jest.fn();
+
+      const customSortBy = connectSortBy(render, unmount);
+      const widget = customSortBy({ items: [] });
+
+      expect(widget).toEqual(
+        expect.objectContaining({
+          $$type: 'ais.sortBy',
+          init: expect.any(Function),
+          render: expect.any(Function),
+          dispose: expect.any(Function),
+          getWidgetState: expect.any(Function),
+          getWidgetSearchParameters: expect.any(Function),
+        })
+      );
+    });
   });
 
   it('Renders during init and render', () => {

--- a/src/connectors/sort-by/connectSortBy.js
+++ b/src/connectors/sort-by/connectSortBy.js
@@ -101,6 +101,8 @@ export default function connectSortBy(renderFn, unmountFn = noop) {
     }
 
     return {
+      $$type: 'ais.sortBy',
+
       init({ helper, instantSearchInstance }) {
         const initialIndex = helper.state.index;
         const isInitialIndexInItems = find(

--- a/src/connectors/stats/__tests__/connectStats-test.js
+++ b/src/connectors/stats/__tests__/connectStats-test.js
@@ -14,6 +14,23 @@ describe('connectStats', () => {
 See documentation: https://www.algolia.com/doc/api-reference/widgets/stats/js/#connector"
 `);
     });
+
+    it('is a widget', () => {
+      const render = jest.fn();
+      const unmount = jest.fn();
+
+      const customStats = connectStats(render, unmount);
+      const widget = customStats({});
+
+      expect(widget).toEqual(
+        expect.objectContaining({
+          $$type: 'ais.stats',
+          init: expect.any(Function),
+          render: expect.any(Function),
+          dispose: expect.any(Function),
+        })
+      );
+    });
   });
 
   it('Renders during init and render', () => {

--- a/src/connectors/stats/connectStats.js
+++ b/src/connectors/stats/connectStats.js
@@ -51,6 +51,8 @@ export default function connectStats(renderFn, unmountFn = noop) {
   checkRendering(renderFn, withUsage());
 
   return (widgetParams = {}) => ({
+    $$type: 'ais.stats',
+
     init({ helper, instantSearchInstance }) {
       renderFn(
         {

--- a/src/connectors/toggleRefinement/__tests__/connectToggleRefinement-test.js
+++ b/src/connectors/toggleRefinement/__tests__/connectToggleRefinement-test.js
@@ -15,6 +15,36 @@ describe('connectToggleRefinement', () => {
 See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refinement/js/#connector"
 `);
     });
+
+    it('throws without attribute option', () => {
+      expect(() => {
+        connectToggleRefinement(() => {})({});
+      }).toThrowErrorMatchingInlineSnapshot(`
+"The \`attribute\` option is required.
+
+See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refinement/js/#connector"
+`);
+    });
+
+    it('is a widget', () => {
+      const render = jest.fn();
+      const unmount = jest.fn();
+
+      const customToggleRefinement = connectToggleRefinement(render, unmount);
+      const widget = customToggleRefinement({ attribute: 'facet' });
+
+      expect(widget).toEqual(
+        expect.objectContaining({
+          $$type: 'ais.toggleRefinement',
+          init: expect.any(Function),
+          render: expect.any(Function),
+          dispose: expect.any(Function),
+          getConfiguration: expect.any(Function),
+          getWidgetState: expect.any(Function),
+          getWidgetSearchParameters: expect.any(Function),
+        })
+      );
+    });
   });
 
   it('Renders during init and render', () => {

--- a/src/connectors/toggleRefinement/connectToggleRefinement.js
+++ b/src/connectors/toggleRefinement/connectToggleRefinement.js
@@ -103,6 +103,8 @@ export default function connectToggleRefinement(renderFn, unmountFn = noop) {
     const off = hasAnOffValue ? escapeRefinement(userOff) : undefined;
 
     return {
+      $$type: 'ais.toggleRefinement',
+
       getConfiguration() {
         return {
           disjunctiveFacets: [attribute],

--- a/src/connectors/voice-search/__tests__/connectVoiceSearch-test.js
+++ b/src/connectors/voice-search/__tests__/connectVoiceSearch-test.js
@@ -45,6 +45,26 @@ describe('connectVoiceSearch', () => {
 See documentation: https://www.algolia.com/doc/api-reference/widgets/voice-search/js/#connector"
 `);
     });
+
+    it('is a widget', () => {
+      const render = jest.fn();
+      const unmount = jest.fn();
+
+      const customVoiceSearch = connectVoiceSearch(render, unmount);
+      const widget = customVoiceSearch({});
+
+      expect(widget).toEqual(
+        expect.objectContaining({
+          $$type: 'ais.voiceSearch',
+          init: expect.any(Function),
+          render: expect.any(Function),
+          dispose: expect.any(Function),
+          getConfiguration: expect.any(Function),
+          getWidgetState: expect.any(Function),
+          getWidgetSearchParameters: expect.any(Function),
+        })
+      );
+    });
   });
 
   it('calls renderFn during init and render', () => {

--- a/src/connectors/voice-search/connectVoiceSearch.ts
+++ b/src/connectors/voice-search/connectVoiceSearch.ts
@@ -74,6 +74,8 @@ const connectVoiceSearch: VoiceSearchConnector = (
     const { searchAsYouSpeak = false } = widgetParams;
 
     return {
+      $$type: 'ais.voiceSearch',
+
       getConfiguration() {
         return {
           query: '',

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -89,6 +89,7 @@ export type UiState = {
 };
 
 export interface Widget {
+  $$type?: string;
   init?(options: InitOptions): void;
   render?(options: RenderOptions): void;
   dispose?(options: DisposeOptions): SearchParameters | void;

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -59,6 +59,19 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
 `);
   });
 
+  it('is a widget', () => {
+    const widget = index({ indexName: 'indexName' });
+
+    expect(widget).toEqual(
+      expect.objectContaining({
+        $$type: 'ais.index',
+        init: expect.any(Function),
+        render: expect.any(Function),
+        dispose: expect.any(Function),
+      })
+    );
+  });
+
   describe('addWidgets', () => {
     it('adds given widgets to the instance', () => {
       const instance = index({ indexName: 'index_name' });

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -51,6 +51,8 @@ const index = (props: IndexProps): Index => {
   }
 
   return {
+    $$type: 'ais.index',
+
     getHelper() {
       return helper;
     },


### PR DESCRIPTION
Adding a type to the `index` widget is necessary to filter it out from the list of the widgets. This is needed to implement the "reset page" behavior to get all the `index`-type children and reset their own page.

I took this opportunity to add a type to all widgets for debugging purpose. The widgets sharing the same connector have the same type. This is fine for now. We can provide an option to override it from the widget parameters later if needed.

The `$$type` property is not required in TypeScript because once we expose the widget interface, users might not need to mark them.
