### PR TITLE
chore(routing): correct types

### DIFF
--- a/src/lib/RoutingManager.ts
+++ b/src/lib/RoutingManager.ts
@@ -42,7 +42,10 @@ class RoutingManager implements Widget {
   private getAllSearchParameters({
     currentSearchParameters,
     uiState,
-  }): PlainSearchParameters {
+  }: {
+    currentSearchParameters: SearchParameters;
+    uiState: UiState;
+  }): SearchParameters {
     const widgets = this.instantSearchInstance.mainIndex.getWidgets();
 
     return widgets.reduce((parameters, widget) => {

--- a/test/mock/createAPIResponse.ts
+++ b/test/mock/createAPIResponse.ts
@@ -1,30 +1,27 @@
 import { SearchForFacetValues, Response, MultiResponse } from 'algoliasearch';
 
-export function createSingleSearchResponse<THit = any>(
+export const createSingleSearchResponse = <THit = any>(
   subset: Partial<Response<THit>> = {}
-): Response<THit> {
+): Response<THit> => {
   const {
+    query = '',
     page = 0,
     hitsPerPage = 20,
-    nbHits,
-    nbPages,
-    processingTimeMS = 0,
     hits = [],
-    query = '',
+    nbHits = hits.length,
+    nbPages = Math.ceil(nbHits / hitsPerPage),
     params = '',
     exhaustiveNbHits = true,
     exhaustiveFacetsCount = true,
+    processingTimeMS = 0,
     ...rest
   } = subset;
-  const fallbackNbHits = nbHits !== undefined ? nbHits : hits.length;
-  const fallbackNbPages =
-    nbPages !== undefined ? nbPages : Math.ceil(fallbackNbHits / hitsPerPage);
 
   return {
     page,
     hitsPerPage,
-    nbHits: fallbackNbHits,
-    nbPages: fallbackNbPages,
+    nbHits,
+    nbPages,
     processingTimeMS,
     hits,
     query,
@@ -33,7 +30,7 @@ export function createSingleSearchResponse<THit = any>(
     exhaustiveFacetsCount,
     ...rest,
   };
-}
+};
 
 export const createMultiSearchResponse = (
   ...args: Array<Partial<Response>>


### PR DESCRIPTION
This is a follow-up on #3940 requested by @samouss

- correct the type for `getAllSearchParameters`
- move defaults  in response mock to not have intermediary variables
- consistent function style in mock

sorry for the 3-in-1 PR, but wasn't really worth splitting IMO