### PR TITLE
feat(index): reset page of child indexes

### DIFF
--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -809,6 +809,411 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
         });
       });
     });
+
+    it('resets pages of nested indexes when the state changes', () => {
+      const level0 = index({ indexName: 'level_0_index_name' });
+      const level1 = index({ indexName: 'level_1_index_name' });
+      const level2 = index({ indexName: 'level_2_index_name' });
+      const level3 = index({ indexName: 'level_3_index_name' });
+      const searchClient = createSearchClient();
+      const mainHelper = algoliasearchHelper(searchClient, '', {});
+      const instantSearchInstance = createInstantSearch({
+        mainHelper,
+      });
+
+      level0.addWidgets([
+        createWidget({
+          getConfiguration() {
+            return {
+              hitsPerPage: 5,
+            };
+          },
+        }),
+
+        createSearchBox({
+          getConfiguration() {
+            return {
+              query: 'Apple',
+            };
+          },
+        }),
+
+        createPagination({
+          getConfiguration() {
+            return {
+              page: 1,
+            };
+          },
+        }),
+
+        level1.addWidgets([
+          createSearchBox({
+            getConfiguration() {
+              return {
+                query: 'Apple iPhone',
+              };
+            },
+          }),
+
+          createPagination({
+            getConfiguration() {
+              return {
+                page: 2,
+              };
+            },
+          }),
+
+          level2.addWidgets([
+            createSearchBox({
+              getConfiguration() {
+                return {
+                  query: 'Apple iPhone XS',
+                };
+              },
+            }),
+
+            createPagination({
+              getConfiguration() {
+                return {
+                  page: 3,
+                };
+              },
+            }),
+
+            level3.addWidgets([
+              createSearchBox({
+                getConfiguration() {
+                  return {
+                    query: 'Apple iPhone XS Red',
+                  };
+                },
+              }),
+
+              createPagination({
+                getConfiguration() {
+                  return {
+                    page: 4,
+                  };
+                },
+              }),
+            ]),
+          ]),
+        ]),
+      ]);
+
+      level0.init(
+        createInitOptions({
+          instantSearchInstance,
+        })
+      );
+
+      // Setting a query is considered as a change
+      level1
+        .getHelper()!
+        .setQuery('Hey')
+        .search();
+
+      expect(searchClient.search).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          {
+            indexName: 'level_0_index_name',
+            params: expect.objectContaining({
+              hitsPerPage: 5,
+              query: 'Apple',
+              page: 1,
+            }),
+          },
+          {
+            indexName: 'level_1_index_name',
+            params: expect.objectContaining({
+              hitsPerPage: 5,
+              query: 'Hey',
+              page: 0,
+            }),
+          },
+          {
+            indexName: 'level_2_index_name',
+            params: expect.objectContaining({
+              hitsPerPage: 5,
+              query: 'Apple iPhone XS',
+              page: 0,
+            }),
+          },
+          {
+            indexName: 'level_3_index_name',
+            params: expect.objectContaining({
+              hitsPerPage: 5,
+              query: 'Apple iPhone XS Red',
+              page: 0,
+            }),
+          },
+        ])
+      );
+    });
+
+    it('does not reset pages of nested indexes when only the page changes', () => {
+      const level0 = index({ indexName: 'level_0_index_name' });
+      const level1 = index({ indexName: 'level_1_index_name' });
+      const level2 = index({ indexName: 'level_2_index_name' });
+      const level3 = index({ indexName: 'level_3_index_name' });
+      const searchClient = createSearchClient();
+      const mainHelper = algoliasearchHelper(searchClient, '', {});
+      const instantSearchInstance = createInstantSearch({
+        mainHelper,
+      });
+
+      level0.addWidgets([
+        createWidget({
+          getConfiguration() {
+            return {
+              hitsPerPage: 5,
+            };
+          },
+        }),
+
+        createSearchBox({
+          getConfiguration() {
+            return {
+              query: 'Apple',
+            };
+          },
+        }),
+
+        createPagination({
+          getConfiguration() {
+            return {
+              page: 1,
+            };
+          },
+        }),
+
+        level1.addWidgets([
+          createSearchBox({
+            getConfiguration() {
+              return {
+                query: 'Apple iPhone',
+              };
+            },
+          }),
+
+          createPagination({
+            getConfiguration() {
+              return {
+                page: 2,
+              };
+            },
+          }),
+
+          level2.addWidgets([
+            createSearchBox({
+              getConfiguration() {
+                return {
+                  query: 'Apple iPhone XS',
+                };
+              },
+            }),
+
+            createPagination({
+              getConfiguration() {
+                return {
+                  page: 3,
+                };
+              },
+            }),
+
+            level3.addWidgets([
+              createSearchBox({
+                getConfiguration() {
+                  return {
+                    query: 'Apple iPhone XS Red',
+                  };
+                },
+              }),
+
+              createPagination({
+                getConfiguration() {
+                  return {
+                    page: 4,
+                  };
+                },
+              }),
+            ]),
+          ]),
+        ]),
+      ]);
+
+      level0.init(
+        createInitOptions({
+          instantSearchInstance,
+        })
+      );
+
+      level1
+        .getHelper()!
+        .setPage(4)
+        .search();
+
+      expect(searchClient.search).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          {
+            indexName: 'level_0_index_name',
+            params: expect.objectContaining({
+              hitsPerPage: 5,
+              query: 'Apple',
+              page: 1,
+            }),
+          },
+          {
+            indexName: 'level_1_index_name',
+            params: expect.objectContaining({
+              hitsPerPage: 5,
+              query: 'Apple iPhone',
+              page: 4,
+            }),
+          },
+          {
+            indexName: 'level_2_index_name',
+            params: expect.objectContaining({
+              hitsPerPage: 5,
+              query: 'Apple iPhone XS',
+              page: 3,
+            }),
+          },
+          {
+            indexName: 'level_3_index_name',
+            params: expect.objectContaining({
+              hitsPerPage: 5,
+              query: 'Apple iPhone XS Red',
+              page: 4,
+            }),
+          },
+        ])
+      );
+    });
+
+    it('is a noop for unset pages of nested indexes when the state changes', () => {
+      const level0 = index({ indexName: 'level_0_index_name' });
+      const level1 = index({ indexName: 'level_1_index_name' });
+      const level2 = index({ indexName: 'level_2_index_name' });
+      const level3 = index({ indexName: 'level_3_index_name' });
+      const searchClient = createSearchClient();
+      const mainHelper = algoliasearchHelper(searchClient, '', {});
+      const instantSearchInstance = createInstantSearch({
+        mainHelper,
+      });
+
+      level0.addWidgets([
+        createWidget({
+          getConfiguration() {
+            return {
+              hitsPerPage: 5,
+            };
+          },
+        }),
+
+        createSearchBox({
+          getConfiguration() {
+            return {
+              query: 'Apple',
+            };
+          },
+        }),
+
+        createPagination({
+          getConfiguration() {
+            return {
+              page: 1,
+            };
+          },
+        }),
+
+        level1.addWidgets([
+          createSearchBox({
+            getConfiguration() {
+              return {
+                query: 'Apple iPhone',
+              };
+            },
+          }),
+
+          createPagination({
+            getConfiguration() {
+              return {
+                page: 2,
+              };
+            },
+          }),
+
+          level2.addWidgets([
+            createSearchBox({
+              getConfiguration() {
+                return {
+                  query: 'Apple iPhone XS',
+                };
+              },
+            }),
+
+            level3.addWidgets([
+              createSearchBox({
+                getConfiguration() {
+                  return {
+                    query: 'Apple iPhone XS Red',
+                  };
+                },
+              }),
+            ]),
+          ]),
+        ]),
+      ]);
+
+      level0.init(
+        createInitOptions({
+          instantSearchInstance,
+        })
+      );
+
+      level1
+        .getHelper()!
+        .setQuery('Hey')
+        .search();
+
+      expect(searchClient.search).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          {
+            indexName: 'level_0_index_name',
+            params: expect.objectContaining({
+              hitsPerPage: 5,
+              query: 'Apple',
+              page: 1,
+            }),
+          },
+          {
+            indexName: 'level_1_index_name',
+            params: expect.objectContaining({
+              hitsPerPage: 5,
+              query: 'Hey',
+              page: 0,
+            }),
+          },
+          {
+            indexName: 'level_2_index_name',
+            params: expect.objectContaining({
+              hitsPerPage: 5,
+              query: 'Apple iPhone XS',
+              page: 0,
+            }),
+          },
+          {
+            indexName: 'level_3_index_name',
+            params: expect.objectContaining({
+              hitsPerPage: 5,
+              query: 'Apple iPhone XS Red',
+              page: 0,
+            }),
+          },
+        ])
+      );
+    });
   });
 
   describe('render', () => {

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -41,7 +41,9 @@ function isIndexWidget(widget: Widget): widget is Index {
   return widget.$$type === 'ais.index';
 }
 
-function resetPageFromIndexWidgetsRecursively(indexWidgets: Index[]): void {
+function resetPageFromWidgets(widgets: Widget[]): void {
+  const indexWidgets = widgets.filter(isIndexWidget);
+
   if (indexWidgets.length === 0) {
     return;
   }
@@ -54,9 +56,7 @@ function resetPageFromIndexWidgetsRecursively(indexWidgets: Index[]): void {
       widgetHelper.state.resetPage()
     );
 
-    resetPageFromIndexWidgetsRecursively(
-      widget.getWidgets().filter(isIndexWidget)
-    );
+    resetPageFromWidgets(widget.getWidgets());
   });
 }
 
@@ -238,9 +238,7 @@ const index = (props: IndexProps): Index => {
 
       helper.on('change', ({ isPageReset }) => {
         if (isPageReset) {
-          resetPageFromIndexWidgetsRecursively(
-            localWidgets.filter(isIndexWidget)
-          );
+          resetPageFromWidgets(localWidgets);
         }
       });
 

--- a/stories/index.stories.ts
+++ b/stories/index.stories.ts
@@ -64,6 +64,76 @@ storiesOf('Index', module)
     })
   )
   .add(
+    'with nested levels',
+    withHits(({ search, container, instantsearch }) => {
+      const instantSearchPriceAscTitle = document.createElement('h3');
+      instantSearchPriceAscTitle.innerHTML =
+        '<code>instant_search_price_asc</code>';
+      const instantSearchPriceAscHits = document.createElement('div');
+      const instantSearchPriceAsc = document.createElement('div');
+      const instantSearchPriceAscPagination = document.createElement('div');
+
+      container.appendChild(instantSearchPriceAscTitle);
+      container.appendChild(instantSearchPriceAsc);
+      container.appendChild(instantSearchPriceAscHits);
+      container.appendChild(instantSearchPriceAscPagination);
+
+      const instantSearchRatingAscTitle = document.createElement('h3');
+      instantSearchRatingAscTitle.innerHTML =
+        '<code>instant_search_price_asc > instant_search_rating_asc</code>';
+      const instantSearchRatingAsc = document.createElement('div');
+      const instantSearchRatingAscHits = document.createElement('div');
+      const instantSearchRatingAscPagination = document.createElement('div');
+
+      container.appendChild(instantSearchRatingAscTitle);
+      container.appendChild(instantSearchRatingAsc);
+      container.appendChild(instantSearchRatingAscHits);
+      container.appendChild(instantSearchRatingAscPagination);
+
+      search.addWidgets([
+        instantsearch.widgets
+          .index({ indexName: 'instant_search_price_asc' })
+          .addWidgets([
+            instantsearch.widgets.configure({
+              hitsPerPage: 2,
+            }),
+            instantsearch.widgets.hits({
+              container: instantSearchPriceAscHits,
+              templates: {
+                item: hitsItemTemplate,
+              },
+              cssClasses: {
+                item: 'hits-item',
+              },
+            }),
+            instantsearch.widgets.pagination({
+              container: instantSearchPriceAscPagination,
+            }),
+
+            instantsearch.widgets
+              .index({ indexName: 'instant_search_rating_asc' })
+              .addWidgets([
+                instantsearch.widgets.configure({
+                  hitsPerPage: 1,
+                }),
+                instantsearch.widgets.hits({
+                  container: instantSearchRatingAscHits,
+                  templates: {
+                    item: hitsItemTemplate,
+                  },
+                  cssClasses: {
+                    item: 'hits-item',
+                  },
+                }),
+                instantsearch.widgets.pagination({
+                  container: instantSearchRatingAscPagination,
+                }),
+              ]),
+          ]),
+      ]);
+    })
+  )
+  .add(
     'with add/remove',
     withHits(({ search, container, instantsearch }) => {
       const lifecycle = document.createElement('div');


### PR DESCRIPTION
## Description

This adds support for resetting pagination for child indexes whenever the state changes in a parent (except when only the `page` search parameter changes). This information is given by the helper `change` event: `isPageReset`.

This is done recursively so that we reset the pagination for _all_ child index widgets. Note that this is a noop when the pagination is not set in the children (because we base the condition on `isPageReset`).

## Example

```
GIVEN

index1: page 1
  index2: page 3
    index3: page 4
  index4: page 2

WHEN

query performed on index2

THEN

index1: page 1
  index2: page 0
    index3: page 0
  index4: page 2
```

## Story

[See preview →](https://deploy-preview-3962--instantsearchjs.netlify.com/stories/?path=/story/index--with-nested-levels)