### PR TITLE
chore(jest): ignore path patterns in watch mode

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,12 +3,21 @@
 module.exports = {
   rootDir: process.cwd(),
   testEnvironment: 'jest-environment-jsdom-global',
+  setupFilesAfterEnv: ['./scripts/jest/setupTests.js'],
   testPathIgnorePatterns: [
     '<rootDir>/node_modules/',
     '<rootDir>/dist*',
     '<rootDir>/functional-tests',
   ],
-  setupFilesAfterEnv: ['./scripts/jest/setupTests.js'],
+  watchPathIgnorePatterns: [
+    '<rootDir>/cjs',
+    '<rootDir>/dist',
+    '<rootDir>/es',
+    '<rootDir>/examples',
+    '<rootDir>/scripts',
+    '<rootDir>/stories',
+    '<rootDir>/website',
+  ],
   watchPlugins: [
     'jest-watch-typeahead/filename',
     'jest-watch-typeahead/testname',


### PR DESCRIPTION
When running Jest in watch mode and editing the stories, the tests unnecessarily rerun although the source files didn't change. The same happens when building the library. This results in slowing down the feedback loop when actually editing the source.

The PR adds folders to ignore while running Jest in watch mode with the [`watchPathIgnorePatterns `](https://jestjs.io/docs/en/configuration#watchpathignorepatterns-array-string) option.