### PR TITLE
feat(index): provide scoped results to render hook

### DIFF
--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -15,10 +15,16 @@ export interface InitOptions {
   createURL(state: SearchParameters): string;
 }
 
+export interface ScopedResult {
+  indexId: string;
+  results: SearchResults;
+}
+
 export interface RenderOptions {
   instantSearchInstance: InstantSearch;
   templatesConfig: object;
   results: SearchResults;
+  scopedResults: ScopedResult[];
   state: SearchParameters;
   helper: Helper;
   searchMetadata: {

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -824,76 +824,76 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
       level0.addWidgets([
         createWidget({
           getConfiguration() {
-            return {
+            return new SearchParameters({
               hitsPerPage: 5,
-            };
+            });
           },
         }),
 
         createSearchBox({
           getConfiguration() {
-            return {
+            return new SearchParameters({
               query: 'Apple',
-            };
+            });
           },
         }),
 
         createPagination({
           getConfiguration() {
-            return {
+            return new SearchParameters({
               page: 1,
-            };
+            });
           },
         }),
 
         level1.addWidgets([
           createSearchBox({
             getConfiguration() {
-              return {
+              return new SearchParameters({
                 query: 'Apple iPhone',
-              };
+              });
             },
           }),
 
           createPagination({
             getConfiguration() {
-              return {
+              return new SearchParameters({
                 page: 2,
-              };
+              });
             },
           }),
 
           level2.addWidgets([
             createSearchBox({
               getConfiguration() {
-                return {
+                return new SearchParameters({
                   query: 'Apple iPhone XS',
-                };
+                });
               },
             }),
 
             createPagination({
               getConfiguration() {
-                return {
+                return new SearchParameters({
                   page: 3,
-                };
+                });
               },
             }),
 
             level3.addWidgets([
               createSearchBox({
                 getConfiguration() {
-                  return {
+                  return new SearchParameters({
                     query: 'Apple iPhone XS Red',
-                  };
+                  });
                 },
               }),
 
               createPagination({
                 getConfiguration() {
-                  return {
+                  return new SearchParameters({
                     page: 4,
-                  };
+                  });
                 },
               }),
             ]),
@@ -965,76 +965,76 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
       level0.addWidgets([
         createWidget({
           getConfiguration() {
-            return {
+            return new SearchParameters({
               hitsPerPage: 5,
-            };
+            });
           },
         }),
 
         createSearchBox({
           getConfiguration() {
-            return {
+            return new SearchParameters({
               query: 'Apple',
-            };
+            });
           },
         }),
 
         createPagination({
           getConfiguration() {
-            return {
+            return new SearchParameters({
               page: 1,
-            };
+            });
           },
         }),
 
         level1.addWidgets([
           createSearchBox({
             getConfiguration() {
-              return {
+              return new SearchParameters({
                 query: 'Apple iPhone',
-              };
+              });
             },
           }),
 
           createPagination({
             getConfiguration() {
-              return {
+              return new SearchParameters({
                 page: 2,
-              };
+              });
             },
           }),
 
           level2.addWidgets([
             createSearchBox({
               getConfiguration() {
-                return {
+                return new SearchParameters({
                   query: 'Apple iPhone XS',
-                };
+                });
               },
             }),
 
             createPagination({
               getConfiguration() {
-                return {
+                return new SearchParameters({
                   page: 3,
-                };
+                });
               },
             }),
 
             level3.addWidgets([
               createSearchBox({
                 getConfiguration() {
-                  return {
+                  return new SearchParameters({
                     query: 'Apple iPhone XS Red',
-                  };
+                  });
                 },
               }),
 
               createPagination({
                 getConfiguration() {
-                  return {
+                  return new SearchParameters({
                     page: 4,
-                  };
+                  });
                 },
               }),
             ]),
@@ -1105,60 +1105,60 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
       level0.addWidgets([
         createWidget({
           getConfiguration() {
-            return {
+            return new SearchParameters({
               hitsPerPage: 5,
-            };
+            });
           },
         }),
 
         createSearchBox({
           getConfiguration() {
-            return {
+            return new SearchParameters({
               query: 'Apple',
-            };
+            });
           },
         }),
 
         createPagination({
           getConfiguration() {
-            return {
+            return new SearchParameters({
               page: 1,
-            };
+            });
           },
         }),
 
         level1.addWidgets([
           createSearchBox({
             getConfiguration() {
-              return {
+              return new SearchParameters({
                 query: 'Apple iPhone',
-              };
+              });
             },
           }),
 
           createPagination({
             getConfiguration() {
-              return {
+              return new SearchParameters({
                 page: 2,
-              };
+              });
             },
           }),
 
           level2.addWidgets([
             createSearchBox({
               getConfiguration() {
-                return {
+                return new SearchParameters({
                   query: 'Apple iPhone XS',
-                };
+                });
               },
             }),
 
             level3.addWidgets([
               createSearchBox({
                 getConfiguration() {
-                  return {
+                  return new SearchParameters({
                     query: 'Apple iPhone XS Red',
-                  };
+                  });
                 },
               }),
             ]),

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -1318,15 +1318,16 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
       const level2_2_1 = index({ indexName: 'level2_2_1_index_name' });
       const level3 = index({ indexName: 'level3_index_name' });
       const instantSearchInstance = createInstantSearch();
-      const level0SearchBox = createSearchBox();
-      const level1SearchBox = createSearchBox();
+      const searchBoxLevel0 = createSearchBox();
+      const searchBoxLevel1 = createSearchBox();
+      const seachBoxLevel2_1 = createSearchBox();
 
       level0.addWidgets([
-        level0SearchBox,
-        level1.addWidgets([level1SearchBox]),
+        searchBoxLevel0,
+        level1.addWidgets([searchBoxLevel1]),
         level2.addWidgets([
           createSearchBox(),
-          level2_1.addWidgets([createSearchBox()]),
+          level2_1.addWidgets([seachBoxLevel2_1]),
           level2_2.addWidgets([
             createSearchBox(),
             level2_2_1.addWidgets([createSearchBox()]),
@@ -1354,15 +1355,15 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
         })
       );
 
-      // First-level index
-      expect(level1SearchBox.render).toHaveBeenCalledTimes(1);
-      expect(level1SearchBox.render).toHaveBeenCalledWith(
+      // First-level child index
+      expect(searchBoxLevel1.render).toHaveBeenCalledTimes(1);
+      expect(searchBoxLevel1.render).toHaveBeenCalledWith(
         expect.objectContaining({
           scopedResults: [
-            // Current index
+            // Root index
             {
               indexId: 'level1_index_name',
-              results: (level1SearchBox.render as jest.Mock).mock.calls[0][0]
+              results: (searchBoxLevel1.render as jest.Mock).mock.calls[0][0]
                 .results,
             },
             // Siblings and children
@@ -1390,21 +1391,45 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
         })
       );
 
-      // Top-level index
-      expect(level0SearchBox.render).toHaveBeenCalledTimes(1);
-      expect(level0SearchBox.render).toHaveBeenCalledWith(
+      // Sibling index
+      expect(seachBoxLevel2_1.render).toHaveBeenCalledTimes(1);
+      expect(seachBoxLevel2_1.render).toHaveBeenCalledWith(
         expect.objectContaining({
           scopedResults: [
-            // Current index
+            // Root index
+            {
+              indexId: 'level2_1_index_name',
+              results: (seachBoxLevel2_1.render as jest.Mock).mock.calls[0][0]
+                .results,
+            },
+            // Siblings and children
+            {
+              indexId: 'level2_2_index_name',
+              results: expect.any(algoliasearchHelper.SearchResults),
+            },
+            {
+              indexId: 'level2_2_1_index_name',
+              results: expect.any(algoliasearchHelper.SearchResults),
+            },
+          ],
+        })
+      );
+
+      // Top-level index
+      expect(searchBoxLevel0.render).toHaveBeenCalledTimes(1);
+      expect(searchBoxLevel0.render).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scopedResults: [
+            // Root index
             {
               indexId: 'level0_index_name',
-              results: (level0SearchBox.render as jest.Mock).mock.calls[0][0]
+              results: (searchBoxLevel0.render as jest.Mock).mock.calls[0][0]
                 .results,
             },
             // Siblings and children
             {
               indexId: 'level1_index_name',
-              results: (level1SearchBox.render as jest.Mock).mock.calls[0][0]
+              results: (searchBoxLevel1.render as jest.Mock).mock.calls[0][0]
                 .results,
             },
             {

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -67,17 +67,13 @@ function resolveScopedResultsFromWidgets(widgets: Widget[]): ScopedResult[] {
   const indexWidgets = widgets.filter(isIndexWidget);
 
   return indexWidgets.reduce<ScopedResult[]>((scopedResults, current) => {
-    const currentDerivedHelper = current.getDerivedHelper()!;
-
-    scopedResults.push(
+    return scopedResults.concat(
       {
         indexId: current.getIndexId(),
-        results: currentDerivedHelper.lastResults!,
+        results: current.getDerivedHelper()!.lastResults!,
       },
       ...resolveScopedResultsFromWidgets(current.getWidgets())
     );
-
-    return scopedResults;
   }, []);
 }
 

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -2,6 +2,7 @@ import algoliasearchHelper, {
   AlgoliaSearchHelper as Helper,
   DerivedHelper,
   PlainSearchParameters,
+  SearchResults,
 } from 'algoliasearch-helper';
 import {
   InstantSearch,
@@ -30,7 +31,7 @@ type IndexProps = {
 export type Index = Widget & {
   getIndexId(): string;
   getHelper(): Helper | null;
-  getDerivedHelper(): DerivedHelper | null;
+  getResults(): SearchResults | null;
   getParent(): Index | null;
   getWidgets(): Widget[];
   addWidgets(widgets: Widget[]): Index;
@@ -70,7 +71,7 @@ function resolveScopedResultsFromWidgets(widgets: Widget[]): ScopedResult[] {
     return scopedResults.concat(
       {
         indexId: current.getIndexId(),
-        results: current.getDerivedHelper()!.lastResults!,
+        results: current.getResults()!,
       },
       ...resolveScopedResultsFromWidgets(current.getWidgets())
     );
@@ -109,8 +110,8 @@ const index = (props: IndexProps): Index => {
       return helper;
     },
 
-    getDerivedHelper() {
-      return derivedHelper;
+    getResults() {
+      return derivedHelper && derivedHelper.lastResults;
     },
 
     getParent() {

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -66,10 +66,6 @@ function resetPageFromWidgets(widgets: Widget[]): void {
 function resolveScopedResultsFromWidgets(widgets: Widget[]): ScopedResult[] {
   const indexWidgets = widgets.filter(isIndexWidget);
 
-  if (indexWidgets.length === 0) {
-    return [];
-  }
-
   return indexWidgets.reduce<ScopedResult[]>((scopedResults, current) => {
     const currentDerivedHelper = current.getDerivedHelper()!;
 

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -73,15 +73,15 @@ function resolveScopedResultsFromWidgets(widgets: Widget[]): ScopedResult[] {
   return indexWidgets.reduce<ScopedResult[]>((scopedResults, current) => {
     const currentDerivedHelper = current.getDerivedHelper()!;
 
-    scopedResults.push({
-      indexId: current.getIndexId(),
-      results: currentDerivedHelper.lastResults!,
-    });
+    scopedResults.push(
+      {
+        indexId: current.getIndexId(),
+        results: currentDerivedHelper.lastResults!,
+      },
+      ...resolveScopedResultsFromWidgets(current.getWidgets())
+    );
 
-    return [
-      ...scopedResults,
-      ...resolveScopedResultsFromWidgets(current.getWidgets()),
-    ];
+    return scopedResults;
   }, []);
 }
 

--- a/test/mock/createWidget.ts
+++ b/test/mock/createWidget.ts
@@ -39,6 +39,15 @@ export const createRenderOptions = (
       instantSearchInstance.helper!.state,
       response.results
     ),
+    scopedResults: [
+      {
+        indexId: instantSearchInstance.helper!.state.index,
+        results: new algolisearchHelper.SearchResults(
+          instantSearchInstance.helper!.state,
+          response.results
+        ),
+      },
+    ],
     searchMetadata: {
       isSearchStalled: false,
     },

--- a/test/mock/createWidget.ts
+++ b/test/mock/createWidget.ts
@@ -29,23 +29,21 @@ export const createRenderOptions = (
 ): RenderOptions => {
   const instantSearchInstance = createInstantSearch();
   const response = createMultiSearchResponse();
+  const results = new algolisearchHelper.SearchResults(
+    instantSearchInstance.helper!.state,
+    response.results
+  );
 
   return {
     instantSearchInstance,
     templatesConfig: instantSearchInstance.templatesConfig,
     helper: instantSearchInstance.helper!,
     state: instantSearchInstance.helper!.state,
-    results: new algolisearchHelper.SearchResults(
-      instantSearchInstance.helper!.state,
-      response.results
-    ),
+    results,
     scopedResults: [
       {
         indexId: instantSearchInstance.helper!.state.index,
-        results: new algolisearchHelper.SearchResults(
-          instantSearchInstance.helper!.state,
-          response.results
-        ),
+        results,
       },
     ],
     searchMetadata: {


### PR DESCRIPTION
## Description

This introduces the concept of _scoped results_ during the `render` hook.

## Why

Since InstantSearch.js now handles multi-index search, we will need to revisit the behavior of some widgets:

- `autocomplete` may need to access the scope of its current index, as well as all the siblings and children
- `currentRefinements` may need to show the refinements coming from the current index and all its siblings/children
- `clearRefinement` may need to reset the refinements coming from the current index and all its siblings/children

## Explanation

### Behavior

An index now has access to all its children and siblings (+ siblings children) results. As illustrated in the image below, the lower in the tree, the fewer results the index has access to.

![instantsearch-scoped-results](https://user-images.githubusercontent.com/6137112/61467735-6f4f0800-a97c-11e9-9bb5-ebd795f828ec.png)

The more transparent a level is, the less view it has on the global results.

### Render options interface

This information is given in the `scopedResults` key of the render options. The new interface is:

```ts
interface ScopedResult {
  indexId: string;
  results: SearchResults;
}

interface RenderOptions {
  instantSearchInstance: InstantSearch;
  templatesConfig: object;
  results: SearchResults;
  scopedResults: ScopedResult[]; // ← this is new
  state: SearchParameters;
  helper: Helper;
  searchMetadata: {
    isSearchStalled: boolean;
  };
  createURL(state: SearchParameters): string;
}
```

A scoped result contains an `indexId` and a `results` key. It always has a least one entry in `scopedResults`, being the current index and its own result. Once you start nesting indexes, more results appear in `scopedResults`.

- `indexId`: unique identifier of the results. This is not true for now because the  `indexId` is the `indexName` and you can use the same index several times. We might later need to introduce an `indexId` option in the `index` widget.
- `results`: the results of the given index