### PR TITLE
fix(hierarchicalFacets): prevent different rootPath on same attribute

### DIFF
--- a/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.js
+++ b/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.js
@@ -1,4 +1,5 @@
 import jsHelper, { SearchResults } from 'algoliasearch-helper';
+import { warning } from '../../../lib/utils';
 import connectBreadcrumb from '../connectBreadcrumb';
 
 describe('connectBreadcrumb', () => {
@@ -38,73 +39,193 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
     });
   });
 
-  it('should compute getConfiguration() correctly', () => {
-    const rendering = jest.fn();
-    const makeWidget = connectBreadcrumb(rendering);
-
-    const widget = makeWidget({ attributes: ['category', 'sub_category'] });
-
-    // when there is no hierarchicalFacets into current configuration
-    {
-      const config = widget.getConfiguration({});
-      expect(config).toEqual({
-        hierarchicalFacets: [
-          {
-            attributes: ['category', 'sub_category'],
-            name: 'category',
-            rootPath: null,
-            separator: ' > ',
-          },
-        ],
-      });
-    }
-
-    // when there is an identical hierarchicalFacets into current configuration
-    expect(() => {
-      const config = widget.getConfiguration({
-        hierarchicalFacets: [{ name: 'category' }],
-      });
-
-      expect(config).toEqual({});
-    }).toWarnDev();
-
-    // when there is already a different hierarchicalFacets into current configuration
-    {
-      const config = widget.getConfiguration({
-        hierarchicalFacets: [{ name: 'foo' }],
-      });
-      expect(config).toEqual({
-        hierarchicalFacets: [
-          {
-            attributes: ['category', 'sub_category'],
-            name: 'category',
-            rootPath: null,
-            separator: ' > ',
-          },
-        ],
-      });
-    }
-  });
-
-  it('should compute getConfiguration() correctly with a custom separator', () => {
-    const rendering = jest.fn();
-    const makeWidget = connectBreadcrumb(rendering);
-
-    const widget = makeWidget({
-      attributes: ['category', 'sub_category'],
-      separator: ' / ',
+  describe('getConfiguration', () => {
+    beforeEach(() => {
+      warning.cache = {};
     });
-    const widgetConfiguration = widget.getConfiguration({});
 
-    expect(widgetConfiguration).toEqual({
-      hierarchicalFacets: [
-        {
-          attributes: ['category', 'sub_category'],
-          name: 'category',
-          rootPath: null,
-          separator: ' / ',
-        },
-      ],
+    it('returns the default configuration', () => {
+      const render = () => {};
+      const makeWidget = connectBreadcrumb(render);
+      const widget = makeWidget({
+        attributes: ['category', 'sub_category'],
+      });
+
+      const previous = {};
+
+      const actual = widget.getConfiguration(previous);
+
+      expect(actual).toEqual({
+        hierarchicalFacets: [
+          {
+            name: 'category',
+            attributes: ['category', 'sub_category'],
+            rootPath: null,
+            separator: ' > ',
+          },
+        ],
+      });
+    });
+
+    it('returns the configuration with custom `separator`', () => {
+      const render = () => {};
+      const makeWidget = connectBreadcrumb(render);
+      const widget = makeWidget({
+        attributes: ['category', 'sub_category'],
+        separator: ' / ',
+      });
+
+      const previous = {};
+
+      const actual = widget.getConfiguration(previous);
+
+      expect(actual).toEqual({
+        hierarchicalFacets: [
+          {
+            name: 'category',
+            attributes: ['category', 'sub_category'],
+            rootPath: null,
+            separator: ' / ',
+          },
+        ],
+      });
+    });
+
+    it('returns the configuration with custom `rootPath`', () => {
+      const render = () => {};
+      const makeWidget = connectBreadcrumb(render);
+      const widget = makeWidget({
+        attributes: ['category', 'sub_category'],
+        rootPath: 'TopLevel > SubLevel',
+      });
+
+      const previous = {};
+
+      const actual = widget.getConfiguration(previous);
+
+      expect(actual).toEqual({
+        hierarchicalFacets: [
+          {
+            name: 'category',
+            attributes: ['category', 'sub_category'],
+            rootPath: 'TopLevel > SubLevel',
+            separator: ' > ',
+          },
+        ],
+      });
+    });
+
+    it('returns the configuration with another `hierarchicalFacets` already defined', () => {
+      const render = () => {};
+      const makeWidget = connectBreadcrumb(render);
+      const widget = makeWidget({
+        attributes: ['category', 'sub_category'],
+      });
+
+      const previous = {
+        hierarchicalFacets: [
+          {
+            name: 'country',
+            attributes: ['country', 'sub_country'],
+            separator: ' > ',
+            rootPath: null,
+          },
+        ],
+      };
+
+      const actual = widget.getConfiguration(previous);
+
+      expect(actual).toEqual({
+        hierarchicalFacets: [
+          {
+            name: 'category',
+            attributes: ['category', 'sub_category'],
+            separator: ' > ',
+            rootPath: null,
+          },
+        ],
+      });
+    });
+
+    it('returns an empty configuration with the same `hierarchicalFacets` already defined', () => {
+      const render = () => {};
+      const makeWidget = connectBreadcrumb(render);
+      const widget = makeWidget({ attributes: ['category', 'sub_category'] });
+
+      const previous = {
+        hierarchicalFacets: [
+          {
+            name: 'category',
+            attributes: ['category', 'sub_category'],
+            separator: ' > ',
+            rootPath: null,
+          },
+        ],
+      };
+
+      const actual = widget.getConfiguration(previous);
+
+      expect(actual).toEqual({});
+    });
+
+    it('warns with the same `hierarchicalFacets` already defined with different `attributes`', () => {
+      const render = () => {};
+      const makeWidget = connectBreadcrumb(render);
+      const widget = makeWidget({ attributes: ['category', 'sub_category'] });
+
+      const previous = {
+        hierarchicalFacets: [
+          {
+            name: 'category',
+            attributes: ['category', 'sub_category', 'sub_sub_category'],
+          },
+        ],
+      };
+
+      expect(() => widget.getConfiguration(previous)).toWarnDev();
+    });
+
+    it('warns with the same `hierarchicalFacets` already defined with different `separator`', () => {
+      const render = () => {};
+      const makeWidget = connectBreadcrumb(render);
+      const widget = makeWidget({
+        attributes: ['category', 'sub_category'],
+        separator: ' / ',
+      });
+
+      const previous = {
+        hierarchicalFacets: [
+          {
+            name: 'category',
+            attributes: ['category', 'sub_category'],
+            separator: ' > ',
+          },
+        ],
+      };
+
+      expect(() => widget.getConfiguration(previous)).toWarnDev();
+    });
+
+    it('warns with the same `hierarchicalFacets` already defined with different `rootPath`', () => {
+      const render = () => {};
+      const makeWidget = connectBreadcrumb(render);
+      const widget = makeWidget({
+        attributes: ['category', 'sub_category'],
+        rootPath: 'TopLevel',
+      });
+
+      const previous = {
+        hierarchicalFacets: [
+          {
+            name: 'category',
+            attributes: ['category', 'sub_category'],
+            separator: ' > ',
+            rootPath: 'TopLevel > SubLevel',
+          },
+        ],
+      };
+
+      expect(() => widget.getConfiguration(previous)).toWarnDev();
     });
   });
 
@@ -193,7 +314,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
           name: 'category',
           rootPath: null,
           separator: ' > ',
-          showParentLevel: true,
         },
       ],
     });

--- a/src/connectors/breadcrumb/connectBreadcrumb.js
+++ b/src/connectors/breadcrumb/connectBreadcrumb.js
@@ -70,12 +70,15 @@ export default function connectBreadcrumb(renderFn, unmountFn = noop) {
             currentConfiguration.hierarchicalFacets,
             ({ name }) => name === hierarchicalFacetName
           );
+
           if (isFacetSet) {
             warning(
               isEqual(isFacetSet.attributes, attributes) &&
-                isFacetSet.separator === separator,
+                isFacetSet.separator === separator &&
+                isFacetSet.rootPath === rootPath,
               'Using Breadcrumb and HierarchicalMenu on the same facet with different options overrides the configuration of the HierarchicalMenu.'
             );
+
             return {};
           }
         }

--- a/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
+++ b/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
@@ -120,18 +120,23 @@ export default function connectHierarchicalMenu(renderFn, unmountFn = noop) {
             currentConfiguration.hierarchicalFacets,
             ({ name }) => name === hierarchicalFacetName
           );
-          if (
-            isFacetSet &&
-            !(
-              isEqual(isFacetSet.attributes, attributes) &&
-              isFacetSet.separator === separator
-            )
-          ) {
+
+          const isAttributesEqual =
+            isFacetSet && isEqual(isFacetSet.attributes, attributes);
+          const isSeparatorEqual =
+            isFacetSet && isFacetSet.separator === separator;
+          const isRootPathEqual =
+            isFacetSet && isFacetSet.rootPath === rootPath;
+
+          const isHierarchicalOptionsEqual =
+            isAttributesEqual && isSeparatorEqual && isRootPathEqual;
+
+          if (isFacetSet && !isHierarchicalOptionsEqual) {
             warning(
-              isEqual(isFacetSet.attributes, attributes) &&
-                isFacetSet.separator === separator,
+              false,
               'Using Breadcrumb and HierarchicalMenu on the same facet with different options overrides the configuration of the HierarchicalMenu.'
             );
+
             return {};
           }
         }

--- a/stories/breadcrumb.stories.js
+++ b/stories/breadcrumb.stories.js
@@ -156,14 +156,12 @@ storiesOf('Breadcrumb', module)
 
       search.addWidget(
         instantsearch.widgets.hierarchicalMenu({
-          showParentLevel: false,
           container: hierarchicalMenu,
           attributes: [
             'hierarchicalCategories.lvl0',
             'hierarchicalCategories.lvl1',
             'hierarchicalCategories.lvl2',
           ],
-          rootPath: 'Cameras & Camcorders',
         })
       );
     })

--- a/stories/breadcrumb.stories.js
+++ b/stories/breadcrumb.stories.js
@@ -4,91 +4,96 @@ import { withHits } from '../.storybook/decorators';
 storiesOf('Breadcrumb', module)
   .add(
     'default',
-    withHits(({ search, container, instantsearch }) => {
-      const breadcrumb = document.createElement('div');
-      container.appendChild(breadcrumb);
+    withHits(
+      ({ search, container, instantsearch }) => {
+        const breadcrumb = document.createElement('div');
+        container.appendChild(breadcrumb);
 
-      search.addWidget(
-        instantsearch.widgets.breadcrumb({
-          container: breadcrumb,
-          attributes: [
-            'hierarchicalCategories.lvl0',
-            'hierarchicalCategories.lvl1',
-            'hierarchicalCategories.lvl2',
-          ],
-        })
-      );
-
-      // Custom Widget to toggle refinement
-      search.addWidget({
-        init({ helper }) {
-          helper.toggleRefinement(
-            'hierarchicalCategories.lvl0',
-            'Cameras & Camcorders > Digital Cameras'
-          );
+        search.addWidget(
+          instantsearch.widgets.breadcrumb({
+            container: breadcrumb,
+            attributes: [
+              'hierarchicalCategories.lvl0',
+              'hierarchicalCategories.lvl1',
+              'hierarchicalCategories.lvl2',
+            ],
+          })
+        );
+      },
+      {
+        searchParameters: {
+          hierarchicalFacetsRefinements: {
+            'hierarchicalCategories.lvl0': [
+              'Cameras & Camcorders > Digital Cameras',
+            ],
+          },
         },
-      });
-    })
+      }
+    )
   )
   .add(
     'with custom separators',
-    withHits(({ search, container, instantsearch }) => {
-      const breadcrumb = document.createElement('div');
-      container.appendChild(breadcrumb);
+    withHits(
+      ({ search, container, instantsearch }) => {
+        const breadcrumb = document.createElement('div');
+        container.appendChild(breadcrumb);
 
-      search.addWidget(
-        instantsearch.widgets.breadcrumb({
-          container: breadcrumb,
-          templates: {
-            separator: ' + ',
+        search.addWidget(
+          instantsearch.widgets.breadcrumb({
+            container: breadcrumb,
+            templates: {
+              separator: ' + ',
+            },
+            attributes: [
+              'hierarchicalCategories.lvl0',
+              'hierarchicalCategories.lvl1',
+              'hierarchicalCategories.lvl2',
+            ],
+          })
+        );
+      },
+      {
+        searchParameters: {
+          hierarchicalFacetsRefinements: {
+            'hierarchicalCategories.lvl0': [
+              'Cameras & Camcorders > Digital Cameras',
+            ],
           },
-          attributes: [
-            'hierarchicalCategories.lvl0',
-            'hierarchicalCategories.lvl1',
-            'hierarchicalCategories.lvl2',
-          ],
-        })
-      );
-
-      // Custom Widget to toggle refinement
-      search.addWidget({
-        init({ helper }) {
-          helper.toggleRefinement(
-            'hierarchicalCategories.lvl0',
-            'Cameras & Camcorders > Digital Cameras'
-          );
         },
-      });
-    })
+      }
+    )
   )
   .add(
     'with custom home label',
-    withHits(({ search, container, instantsearch }) => {
-      const breadcrumb = document.createElement('div');
-      container.appendChild(breadcrumb);
+    withHits(
+      ({ search, container, instantsearch }) => {
+        const breadcrumb = document.createElement('div');
+        container.appendChild(breadcrumb);
 
-      search.addWidget(
-        instantsearch.widgets.breadcrumb({
-          container: breadcrumb,
-          attributes: [
-            'hierarchicalCategories.lvl0',
-            'hierarchicalCategories.lvl1',
-            'hierarchicalCategories.lvl2',
-          ],
-          templates: { home: 'Home Page' },
-        })
-      );
-
-      // Custom Widget to toggle refinement
-      search.addWidget({
-        init({ helper }) {
-          helper.toggleRefinement(
-            'hierarchicalCategories.lvl0',
-            'Cameras & Camcorders > Digital Cameras'
-          );
+        search.addWidget(
+          instantsearch.widgets.breadcrumb({
+            container: breadcrumb,
+            attributes: [
+              'hierarchicalCategories.lvl0',
+              'hierarchicalCategories.lvl1',
+              'hierarchicalCategories.lvl2',
+            ],
+            templates: {
+              home: 'Home Page',
+            },
+          })
+        );
+      },
+      {
+        searchParameters: {
+          hierarchicalFacetsRefinements: {
+            'hierarchicalCategories.lvl0': [
+              'Cameras & Camcorders > Digital Cameras',
+            ],
+          },
         },
-      });
-    })
+      }
+    )
   )
   .add(
     'with root path',
@@ -137,65 +142,77 @@ storiesOf('Breadcrumb', module)
   )
   .add(
     'with hierarchical menu',
-    withHits(({ search, container, instantsearch }) => {
-      const breadcrumb = document.createElement('div');
-      container.appendChild(breadcrumb);
-      const hierarchicalMenu = document.createElement('div');
-      container.appendChild(hierarchicalMenu);
+    withHits(
+      ({ search, container, instantsearch }) => {
+        const breadcrumb = document.createElement('div');
+        container.appendChild(breadcrumb);
+        const hierarchicalMenu = document.createElement('div');
+        container.appendChild(hierarchicalMenu);
 
-      search.addWidget(
-        instantsearch.widgets.breadcrumb({
-          container: breadcrumb,
-          attributes: [
-            'hierarchicalCategories.lvl0',
-            'hierarchicalCategories.lvl1',
-            'hierarchicalCategories.lvl2',
-          ],
-        })
-      );
+        search.addWidget(
+          instantsearch.widgets.breadcrumb({
+            container: breadcrumb,
+            attributes: [
+              'hierarchicalCategories.lvl0',
+              'hierarchicalCategories.lvl1',
+              'hierarchicalCategories.lvl2',
+            ],
+          })
+        );
 
-      search.addWidget(
-        instantsearch.widgets.hierarchicalMenu({
-          container: hierarchicalMenu,
-          attributes: [
-            'hierarchicalCategories.lvl0',
-            'hierarchicalCategories.lvl1',
-            'hierarchicalCategories.lvl2',
-          ],
-        })
-      );
-    })
+        search.addWidget(
+          instantsearch.widgets.hierarchicalMenu({
+            container: hierarchicalMenu,
+            attributes: [
+              'hierarchicalCategories.lvl0',
+              'hierarchicalCategories.lvl1',
+              'hierarchicalCategories.lvl2',
+            ],
+          })
+        );
+      },
+      {
+        searchParameters: {
+          hierarchicalFacetsRefinements: {
+            'hierarchicalCategories.lvl0': [
+              'Cameras & Camcorders > Digital Cameras',
+            ],
+          },
+        },
+      }
+    )
   )
   .add(
     'with transformed items',
-    withHits(({ search, container, instantsearch }) => {
-      const breadcrumb = document.createElement('div');
-      container.appendChild(breadcrumb);
+    withHits(
+      ({ search, container, instantsearch }) => {
+        const breadcrumb = document.createElement('div');
+        container.appendChild(breadcrumb);
 
-      search.addWidget(
-        instantsearch.widgets.breadcrumb({
-          container: breadcrumb,
-          attributes: [
-            'hierarchicalCategories.lvl0',
-            'hierarchicalCategories.lvl1',
-            'hierarchicalCategories.lvl2',
-          ],
-          transformItems: items =>
-            items.map(item => ({
-              ...item,
-              label: `${item.label} (transformed)`,
-            })),
-        })
-      );
-
-      // Custom Widget to toggle refinement
-      search.addWidget({
-        init({ helper }) {
-          helper.toggleRefinement(
-            'hierarchicalCategories.lvl0',
-            'Cameras & Camcorders > Digital Cameras'
-          );
+        search.addWidget(
+          instantsearch.widgets.breadcrumb({
+            container: breadcrumb,
+            attributes: [
+              'hierarchicalCategories.lvl0',
+              'hierarchicalCategories.lvl1',
+              'hierarchicalCategories.lvl2',
+            ],
+            transformItems: items =>
+              items.map(item => ({
+                ...item,
+                label: `${item.label} (transformed)`,
+              })),
+          })
+        );
+      },
+      {
+        searchParameters: {
+          hierarchicalFacetsRefinements: {
+            'hierarchicalCategories.lvl0': [
+              'Cameras & Camcorders > Digital Cameras',
+            ],
+          },
         },
-      });
-    })
+      }
+    )
   );

--- a/stories/breadcrumb.stories.js
+++ b/stories/breadcrumb.stories.js
@@ -91,38 +91,49 @@ storiesOf('Breadcrumb', module)
     })
   )
   .add(
-    'with default selected item',
-    withHits(({ search, container, instantsearch }) => {
-      const breadcrumb = document.createElement('div');
-      container.appendChild(breadcrumb);
-      const hierarchicalMenu = document.createElement('div');
-      container.appendChild(hierarchicalMenu);
+    'with root path',
+    withHits(
+      ({ search, container, instantsearch }) => {
+        const breadcrumb = document.createElement('div');
+        container.appendChild(breadcrumb);
+        const hierarchicalMenu = document.createElement('div');
+        container.appendChild(hierarchicalMenu);
 
-      search.addWidget(
-        instantsearch.widgets.breadcrumb({
-          container: breadcrumb,
-          attributes: [
-            'hierarchicalCategories.lvl0',
-            'hierarchicalCategories.lvl1',
-            'hierarchicalCategories.lvl2',
-          ],
-          rootPath: 'Cameras & Camcorders > Digital Cameras',
-        })
-      );
+        search.addWidget(
+          instantsearch.widgets.breadcrumb({
+            container: breadcrumb,
+            attributes: [
+              'hierarchicalCategories.lvl0',
+              'hierarchicalCategories.lvl1',
+              'hierarchicalCategories.lvl2',
+            ],
+            rootPath: 'Cameras & Camcorders',
+          })
+        );
 
-      search.addWidget(
-        instantsearch.widgets.hierarchicalMenu({
-          showParentLevel: false,
-          container: hierarchicalMenu,
-          attributes: [
-            'hierarchicalCategories.lvl0',
-            'hierarchicalCategories.lvl1',
-            'hierarchicalCategories.lvl2',
-          ],
-          rootPath: 'Cameras & Camcorders',
-        })
-      );
-    })
+        search.addWidget(
+          instantsearch.widgets.hierarchicalMenu({
+            showParentLevel: false,
+            container: hierarchicalMenu,
+            attributes: [
+              'hierarchicalCategories.lvl0',
+              'hierarchicalCategories.lvl1',
+              'hierarchicalCategories.lvl2',
+            ],
+            rootPath: 'Cameras & Camcorders',
+          })
+        );
+      },
+      {
+        searchParameters: {
+          hierarchicalFacetsRefinements: {
+            'hierarchicalCategories.lvl0': [
+              'Cameras & Camcorders > Digital Cameras',
+            ],
+          },
+        },
+      }
+    )
   )
   .add(
     'with hierarchical menu',

--- a/stories/hierarchical-menu.stories.js
+++ b/stories/hierarchical-menu.stories.js
@@ -60,7 +60,7 @@ storiesOf('HierarchicalMenu', module)
     )
   )
   .add(
-    'with header',
+    'with root path',
     withHits(({ search, container, instantsearch }) => {
       search.addWidget(
         instantsearch.widgets.hierarchicalMenu({

--- a/stories/hierarchical-menu.stories.js
+++ b/stories/hierarchical-menu.stories.js
@@ -45,7 +45,6 @@ storiesOf('HierarchicalMenu', module)
               'hierarchicalCategories.lvl1',
               'hierarchicalCategories.lvl2',
             ],
-            rootPath: 'Cameras & Camcorders',
           })
         );
       },


### PR DESCRIPTION
This PR fixes the `getConfiguration` lifecycle for `hierarchicalMenu` & `breadcrumb`. The previous implementation ignores the different `rootPath`, which leads to issues when both widgets are mounted with different values. One of the two value is picked but what should happen is a warning + ignore the current configuration like the other options.

**Before with `rootPath` only on the `hierarchicalMenu`:**  

- the value should not be refined
- a warning should be displayed
- only the level of the `rootPath` should be displayed

![Screenshot 2019-07-19 at 15 32 00](https://user-images.githubusercontent.com/6513513/61538873-94a24b80-aa3a-11e9-8c8b-e64acdea5a5f.png)

**After: with `rootPath` only on the `hierarchicalMenu`**

- the value is not refined
- a warning is displayed
- only the level of the `rootPath` is displayed

![Screenshot 2019-07-19 at 15 32 57](https://user-images.githubusercontent.com/6513513/61538917-a1bf3a80-aa3a-11e9-910d-f2cc1268c352.png)
