### PR TITLE
docs(examples): make sure e-commerce example can be ran on codeSandBox

### DIFF
--- a/examples/e-commerce/tsconfig.json
+++ b/examples/e-commerce/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "lib": [
+      "es6",
+      "dom",
+      "dom.iterable"
+    ],
+    "downlevelIteration": true
+  }
+}

--- a/examples/e-commerce/tsconfig.json
+++ b/examples/e-commerce/tsconfig.json
@@ -5,6 +5,7 @@
       "dom",
       "dom.iterable"
     ],
-    "downlevelIteration": true
+    "downlevelIteration": true,
+    "esModuleInterop": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     // @TODO: It's mandatory to disable this strict check at the moment,
     // otherwise we have to type every import we use. The migration is an
     // incremental process so we import JavaScript modules from TypeScript ones.
-    // The compiler always translates those imports as impliciy `any`.
+    // The compiler always translates those imports as implicit `any`.
     "noImplicitAny": false,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
This wasn't possible before because the array generated from spreading a form element got transformed into .slice which it didn't have. If downlevelIteration is true & dom.iterable is true the code will work however!

see https://github.com/codesandbox/codesandbox-client/issues/2166#issuecomment-513210419


you can verify this fix by comparing:

https://codesandbox.io/s/github/algolia/instantsearch.js/tree/develop/examples/e-commerce

to the fixed version:

https://codesandbox.io/s/github/algolia/instantsearch.js/tree/docs/fix-codesandbox/examples/e-commerce

