### PR TITLE
feat(federated): keep a consistent state in the RefinementList life cycle

### DIFF
--- a/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
+++ b/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
@@ -455,7 +455,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
     ]);
   });
 
-  it('Provide a function to clear the refinements at each step', () => {
+  it('Provide a function to clear the refinements at each step (or)', () => {
     const { makeWidget, rendering } = createWidgetFactory();
     const widget = makeWidget({
       attribute: 'category',
@@ -479,9 +479,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
     const firstRenderingOptions = rendering.mock.calls[0][0];
     const { refine } = firstRenderingOptions;
     refine('value');
-    expect(helper.hasRefinements('category')).toBe(false);
+    expect(helper.state.disjunctiveFacetsRefinements.category).toHaveLength(0);
     refine('value');
-    expect(helper.hasRefinements('category')).toBe(true);
+    expect(helper.state.disjunctiveFacetsRefinements.category).toHaveLength(1);
 
     widget.render({
       results: new SearchResults(helper.state, [{}, {}]),
@@ -493,9 +493,53 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
     const secondRenderingOptions = rendering.mock.calls[1][0];
     const { refine: renderToggleRefinement } = secondRenderingOptions;
     renderToggleRefinement('value');
-    expect(helper.hasRefinements('category')).toBe(false);
+    expect(helper.state.disjunctiveFacetsRefinements.category).toHaveLength(0);
     renderToggleRefinement('value');
-    expect(helper.hasRefinements('category')).toBe(true);
+    expect(helper.state.disjunctiveFacetsRefinements.category).toHaveLength(1);
+  });
+
+  it('Provide a function to clear the refinements at each step (and)', () => {
+    const { makeWidget, rendering } = createWidgetFactory();
+    const widget = makeWidget({
+      attribute: 'category',
+      operator: 'and',
+    });
+
+    const helper = jsHelper(
+      {},
+      '',
+      widget.getConfiguration(new SearchParameters({}))
+    );
+    helper.search = jest.fn();
+
+    helper.toggleRefinement('category', 'value');
+
+    widget.init({
+      helper,
+      state: helper.state,
+      createURL: () => '#',
+    });
+
+    const firstRenderingOptions = rendering.mock.calls[0][0];
+    const { refine } = firstRenderingOptions;
+    refine('value');
+    expect(helper.state.facetsRefinements.category).toHaveLength(0);
+    refine('value');
+    expect(helper.state.facetsRefinements.category).toHaveLength(1);
+
+    widget.render({
+      results: new SearchResults(helper.state, [{}, {}]),
+      state: helper.state,
+      helper,
+      createURL: () => '#',
+    });
+
+    const secondRenderingOptions = rendering.mock.calls[1][0];
+    const { refine: renderToggleRefinement } = secondRenderingOptions;
+    renderToggleRefinement('value');
+    expect(helper.state.facetsRefinements.category).toHaveLength(0);
+    renderToggleRefinement('value');
+    expect(helper.state.facetsRefinements.category).toHaveLength(1);
   });
 
   it('If there are too few items then canToggleShowMore is false', () => {

--- a/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
+++ b/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
@@ -111,8 +111,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
         attribute: 'myFacet',
       });
 
-      expect(widget.getConfiguration()).toEqual({
+      expect(widget.getConfiguration({})).toEqual({
         disjunctiveFacets: ['myFacet'],
+        disjunctiveFacetsRefinements: { myFacet: [] },
         maxValuesPerFacet: 10,
       });
     });
@@ -124,14 +125,16 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
         limit: 20,
       });
 
-      expect(widget.getConfiguration()).toEqual({
+      expect(widget.getConfiguration({})).toEqual({
         disjunctiveFacets: ['myFacet'],
+        disjunctiveFacetsRefinements: { myFacet: [] },
         maxValuesPerFacet: 20,
       });
 
       expect(widget.getConfiguration({ maxValuesPerFacet: 100 })).toEqual(
         {
           disjunctiveFacets: ['myFacet'],
+          disjunctiveFacetsRefinements: { myFacet: [] },
           maxValuesPerFacet: 100,
         },
         'Can read the previous maxValuesPerFacet value'
@@ -188,13 +191,15 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       const secondRenderingOptions = rendering.mock.calls[1][0];
       secondRenderingOptions.toggleShowMore();
 
-      expect(widget.getConfiguration()).toEqual({
+      expect(widget.getConfiguration({})).toEqual({
         disjunctiveFacets: ['myFacet'],
+        disjunctiveFacetsRefinements: { myFacet: [] },
         maxValuesPerFacet: 30,
       });
 
       expect(widget.getConfiguration({ maxValuesPerFacet: 100 })).toEqual({
         disjunctiveFacets: ['myFacet'],
+        disjunctiveFacetsRefinements: { myFacet: [] },
         maxValuesPerFacet: 100,
       });
     });
@@ -248,8 +253,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       const secondRenderingOptions = rendering.mock.calls[1][0];
       secondRenderingOptions.toggleShowMore();
 
-      expect(widget.getConfiguration()).toEqual({
+      expect(widget.getConfiguration({})).toEqual({
         disjunctiveFacets: ['myFacet'],
+        disjunctiveFacetsRefinements: { myFacet: [] },
         maxValuesPerFacet: 20,
       });
     });
@@ -261,8 +267,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
         operator: 'and',
       });
 
-      expect(widget.getConfiguration()).toEqual({
+      expect(widget.getConfiguration({})).toEqual({
         facets: ['myFacet'],
+        facetsRefinements: { myFacet: [] },
         maxValuesPerFacet: 10,
       });
     });
@@ -280,6 +287,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
     const config = widget.getConfiguration({});
     expect(config).toEqual({
       disjunctiveFacets: ['myFacet'],
+      disjunctiveFacetsRefinements: { myFacet: [] },
       maxValuesPerFacet: 9,
     });
 

--- a/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
+++ b/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
@@ -1568,4 +1568,174 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       });
     });
   });
+
+  describe('dispose', () => {
+    it('removes refinements completely on dispose (and)', () => {
+      const rendering = jest.fn();
+      const makeWidget = connectRefinementList(rendering);
+
+      const widget = makeWidget({
+        attribute: 'category',
+        operator: 'and',
+      });
+
+      const indexName = 'my-index';
+      const helper = jsHelper(
+        {},
+        indexName,
+        widget.getConfiguration(new SearchParameters({}))
+      );
+      helper.search = jest.fn();
+
+      widget.init({
+        helper,
+        state: helper.state,
+        createURL: () => '#',
+      });
+
+      widget.render({
+        results: new SearchResults(helper.state, [
+          {
+            hits: [],
+            facets: {
+              category: {
+                c1: 880,
+                c2: 47,
+              },
+            },
+          },
+          {
+            facets: {
+              category: {
+                c1: 880,
+                c2: 47,
+              },
+            },
+          },
+        ]),
+        state: helper.state,
+        helper,
+      });
+
+      const { refine } = rendering.mock.calls[0][0];
+
+      expect(helper.state).toEqual(
+        new SearchParameters({
+          facets: ['category'],
+          facetsRefinements: {
+            category: [],
+          },
+          index: indexName,
+          maxValuesPerFacet: 10,
+        })
+      );
+
+      refine('zimbo');
+
+      expect(helper.state).toEqual(
+        new SearchParameters({
+          facets: ['category'],
+          facetsRefinements: {
+            category: ['zimbo'],
+          },
+          index: indexName,
+          maxValuesPerFacet: 10,
+        })
+      );
+
+      const newState = widget.dispose({
+        state: helper.state,
+      });
+
+      expect(newState).toEqual(
+        new SearchParameters({
+          index: indexName,
+        })
+      );
+    });
+
+    it('removes refinements completely on dispose (or)', () => {
+      const rendering = jest.fn();
+      const makeWidget = connectRefinementList(rendering);
+
+      const widget = makeWidget({
+        attribute: 'category',
+        operator: 'or',
+      });
+
+      const indexName = 'my-index';
+      const helper = jsHelper(
+        {},
+        indexName,
+        widget.getConfiguration(new SearchParameters({}))
+      );
+      helper.search = jest.fn();
+
+      widget.init({
+        helper,
+        state: helper.state,
+        createURL: () => '#',
+      });
+
+      widget.render({
+        results: new SearchResults(helper.state, [
+          {
+            hits: [],
+            facets: {
+              category: {
+                c1: 880,
+                c2: 47,
+              },
+            },
+          },
+          {
+            facets: {
+              category: {
+                c1: 880,
+                c2: 47,
+              },
+            },
+          },
+        ]),
+        state: helper.state,
+        helper,
+      });
+
+      const { refine } = rendering.mock.calls[0][0];
+
+      expect(helper.state).toEqual(
+        new SearchParameters({
+          disjunctiveFacets: ['category'],
+          disjunctiveFacetsRefinements: {
+            category: [],
+          },
+          index: indexName,
+          maxValuesPerFacet: 10,
+        })
+      );
+
+      refine('zimbo');
+
+      expect(helper.state).toEqual(
+        new SearchParameters({
+          disjunctiveFacets: ['category'],
+          disjunctiveFacetsRefinements: {
+            category: ['zimbo'],
+          },
+          index: indexName,
+          maxValuesPerFacet: 10,
+        })
+      );
+
+      const newState = widget.dispose({
+        state: helper.state,
+      });
+
+      expect(newState).toEqual(
+        new SearchParameters({
+          index: indexName,
+        })
+      );
+    });
+  });
 });

--- a/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
+++ b/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
@@ -363,6 +363,31 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
     });
   });
 
+  it('can render before getConfiguration', () => {
+    const { makeWidget, rendering } = createWidgetFactory();
+
+    const widget = makeWidget({
+      attribute: 'myFacet',
+      limit: 9,
+    });
+
+    const helper = jsHelper({}, '');
+
+    widget.render({
+      results: new SearchResults(helper.state, [{}]),
+      state: helper.state,
+      helper,
+      createURL: () => '#',
+    });
+
+    expect(rendering).toHaveBeenCalledWith(
+      expect.objectContaining({
+        items: [],
+      }),
+      false
+    );
+  });
+
   it('transforms items if requested', () => {
     const { makeWidget, rendering } = createWidgetFactory();
     const widget = makeWidget({

--- a/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
+++ b/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
@@ -111,11 +111,13 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
         attribute: 'myFacet',
       });
 
-      expect(widget.getConfiguration({})).toEqual({
-        disjunctiveFacets: ['myFacet'],
-        disjunctiveFacetsRefinements: { myFacet: [] },
-        maxValuesPerFacet: 10,
-      });
+      expect(widget.getConfiguration(new SearchParameters({}))).toEqual(
+        new SearchParameters({
+          disjunctiveFacets: ['myFacet'],
+          disjunctiveFacetsRefinements: { myFacet: [] },
+          maxValuesPerFacet: 10,
+        })
+      );
     });
 
     it('`limit`', () => {
@@ -125,19 +127,24 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
         limit: 20,
       });
 
-      expect(widget.getConfiguration({})).toEqual({
-        disjunctiveFacets: ['myFacet'],
-        disjunctiveFacetsRefinements: { myFacet: [] },
-        maxValuesPerFacet: 20,
-      });
+      expect(widget.getConfiguration(new SearchParameters())).toEqual(
+        new SearchParameters({
+          disjunctiveFacets: ['myFacet'],
+          disjunctiveFacetsRefinements: { myFacet: [] },
+          maxValuesPerFacet: 20,
+        })
+      );
 
-      expect(widget.getConfiguration({ maxValuesPerFacet: 100 })).toEqual(
-        {
+      expect(
+        widget.getConfiguration(
+          new SearchParameters({ maxValuesPerFacet: 100 })
+        )
+      ).toEqual(
+        new SearchParameters({
           disjunctiveFacets: ['myFacet'],
           disjunctiveFacetsRefinements: { myFacet: [] },
           maxValuesPerFacet: 100,
-        },
-        'Can read the previous maxValuesPerFacet value'
+        })
       );
     });
 
@@ -150,7 +157,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
         showMoreLimit: 30,
       });
 
-      const helper = jsHelper({}, '', widget.getConfiguration({}));
+      const helper = jsHelper(
+        {},
+        '',
+        widget.getConfiguration(new SearchParameters({}))
+      );
       helper.search = jest.fn();
 
       widget.init({
@@ -191,17 +202,25 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       const secondRenderingOptions = rendering.mock.calls[1][0];
       secondRenderingOptions.toggleShowMore();
 
-      expect(widget.getConfiguration({})).toEqual({
-        disjunctiveFacets: ['myFacet'],
-        disjunctiveFacetsRefinements: { myFacet: [] },
-        maxValuesPerFacet: 30,
-      });
+      expect(widget.getConfiguration(new SearchParameters({}))).toEqual(
+        new SearchParameters({
+          disjunctiveFacets: ['myFacet'],
+          disjunctiveFacetsRefinements: { myFacet: [] },
+          maxValuesPerFacet: 30,
+        })
+      );
 
-      expect(widget.getConfiguration({ maxValuesPerFacet: 100 })).toEqual({
-        disjunctiveFacets: ['myFacet'],
-        disjunctiveFacetsRefinements: { myFacet: [] },
-        maxValuesPerFacet: 100,
-      });
+      expect(
+        widget.getConfiguration(
+          new SearchParameters({ maxValuesPerFacet: 100 })
+        )
+      ).toEqual(
+        new SearchParameters({
+          disjunctiveFacets: ['myFacet'],
+          disjunctiveFacetsRefinements: { myFacet: [] },
+          maxValuesPerFacet: 100,
+        })
+      );
     });
 
     it('`showMoreLimit` without `showMore` does not set anything', () => {
@@ -212,7 +231,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
         showMoreLimit: 30,
       });
 
-      const helper = jsHelper({}, '', widget.getConfiguration({}));
+      const helper = jsHelper(
+        {},
+        '',
+        widget.getConfiguration(new SearchParameters({}))
+      );
       helper.search = jest.fn();
 
       widget.init({
@@ -253,11 +276,13 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       const secondRenderingOptions = rendering.mock.calls[1][0];
       secondRenderingOptions.toggleShowMore();
 
-      expect(widget.getConfiguration({})).toEqual({
-        disjunctiveFacets: ['myFacet'],
-        disjunctiveFacetsRefinements: { myFacet: [] },
-        maxValuesPerFacet: 20,
-      });
+      expect(widget.getConfiguration(new SearchParameters({}))).toEqual(
+        new SearchParameters({
+          disjunctiveFacets: ['myFacet'],
+          disjunctiveFacetsRefinements: { myFacet: [] },
+          maxValuesPerFacet: 20,
+        })
+      );
     });
 
     it('`operator="and"`', () => {
@@ -267,11 +292,13 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
         operator: 'and',
       });
 
-      expect(widget.getConfiguration({})).toEqual({
-        facets: ['myFacet'],
-        facetsRefinements: { myFacet: [] },
-        maxValuesPerFacet: 10,
-      });
+      expect(widget.getConfiguration(new SearchParameters({}))).toEqual(
+        new SearchParameters({
+          facets: ['myFacet'],
+          facetsRefinements: { myFacet: [] },
+          maxValuesPerFacet: 10,
+        })
+      );
     });
   });
 
@@ -284,12 +311,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       limit: 9,
     });
 
-    const config = widget.getConfiguration({});
-    expect(config).toEqual({
-      disjunctiveFacets: ['myFacet'],
-      disjunctiveFacetsRefinements: { myFacet: [] },
-      maxValuesPerFacet: 9,
-    });
+    const config = widget.getConfiguration(new SearchParameters({}));
+    expect(config).toEqual(
+      new SearchParameters({
+        disjunctiveFacets: ['myFacet'],
+        disjunctiveFacetsRefinements: { myFacet: [] },
+        maxValuesPerFacet: 9,
+      })
+    );
 
     // test if widget is not rendered yet at this point
     expect(rendering).not.toHaveBeenCalled();
@@ -347,7 +376,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
         })),
     });
 
-    const helper = jsHelper({}, '', widget.getConfiguration({}));
+    const helper = jsHelper(
+      {},
+      '',
+      widget.getConfiguration(new SearchParameters({}))
+    );
     helper.search = jest.fn();
 
     widget.init({
@@ -403,7 +436,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       attribute: 'category',
     });
 
-    const helper = jsHelper({}, '', widget.getConfiguration({}));
+    const helper = jsHelper(
+      {},
+      '',
+      widget.getConfiguration(new SearchParameters({}))
+    );
     helper.search = jest.fn();
 
     helper.toggleRefinement('category', 'value');
@@ -445,7 +482,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       showMoreLimit: 10,
     });
 
-    const helper = jsHelper({}, '', widget.getConfiguration({}));
+    const helper = jsHelper(
+      {},
+      '',
+      widget.getConfiguration(new SearchParameters({}))
+    );
     helper.search = jest.fn();
 
     widget.init({
@@ -490,7 +531,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       limit: 1,
     });
 
-    const helper = jsHelper({}, '', widget.getConfiguration({}));
+    const helper = jsHelper(
+      {},
+      '',
+      widget.getConfiguration(new SearchParameters({}))
+    );
     helper.search = jest.fn();
 
     widget.init({
@@ -541,7 +586,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       showMoreLimit: 10,
     });
 
-    const helper = jsHelper({}, '', widget.getConfiguration({}));
+    const helper = jsHelper(
+      {},
+      '',
+      widget.getConfiguration(new SearchParameters({}))
+    );
     helper.search = jest.fn();
 
     widget.init({
@@ -592,7 +641,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       showMoreLimit: 10,
     });
 
-    const helper = jsHelper({}, '', widget.getConfiguration({}));
+    const helper = jsHelper(
+      {},
+      '',
+      widget.getConfiguration(new SearchParameters({}))
+    );
     helper.search = jest.fn();
 
     widget.init({
@@ -646,7 +699,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       showMoreLimit: 3,
     });
 
-    const helper = jsHelper({}, '', widget.getConfiguration({}));
+    const helper = jsHelper(
+      {},
+      '',
+      widget.getConfiguration(new SearchParameters({}))
+    );
     helper.search = jest.fn();
 
     widget.init({
@@ -737,7 +794,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       limit: 2,
     });
 
-    const helper = jsHelper({}, '', widget.getConfiguration({}));
+    const helper = jsHelper(
+      {},
+      '',
+      widget.getConfiguration(new SearchParameters({}))
+    );
     helper.search = jest.fn();
 
     widget.init({
@@ -814,7 +875,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
     });
 
     const helper = jsHelper({}, '', {
-      ...widget.getConfiguration({}),
+      ...widget.getConfiguration(new SearchParameters({})),
       maxValuesPerFacet: 3,
     });
     helper.search = jest.fn();
@@ -894,7 +955,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       escapeFacetValues: false,
     });
 
-    const helper = jsHelper({}, '', widget.getConfiguration({}));
+    const helper = jsHelper(
+      {},
+      '',
+      widget.getConfiguration(new SearchParameters({}))
+    );
     helper.search = jest.fn();
     helper.searchForFacetValues = jest.fn().mockReturnValue(
       Promise.resolve({
@@ -1000,7 +1065,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
         })),
     });
 
-    const helper = jsHelper({}, '', widget.getConfiguration({}));
+    const helper = jsHelper(
+      {},
+      '',
+      widget.getConfiguration(new SearchParameters({}))
+    );
     helper.search = jest.fn();
     helper.searchForFacetValues = jest.fn().mockReturnValue(
       Promise.resolve({
@@ -1098,7 +1167,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
     });
 
     const helper = jsHelper({}, '', {
-      ...widget.getConfiguration({}),
+      ...widget.getConfiguration(new SearchParameters({})),
       // Here we simulate that another widget has set some highlight tags
       ...TAG_PLACEHOLDER,
     });
@@ -1201,7 +1270,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
     });
 
     const helper = jsHelper({}, '', {
-      ...widget.getConfiguration({}),
+      ...widget.getConfiguration(new SearchParameters({})),
       // Here we simulate that another widget has set some highlight tags
       ...TAG_PLACEHOLDER,
     });
@@ -1306,7 +1375,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
         ...config,
       });
 
-      const initialConfig = widget.getConfiguration({}, {});
+      const initialConfig = widget.getConfiguration(new SearchParameters({}));
       const helper = jsHelper({}, '', initialConfig);
       helper.search = jest.fn();
 

--- a/src/connectors/refinement-list/connectRefinementList.js
+++ b/src/connectors/refinement-list/connectRefinementList.js
@@ -349,7 +349,7 @@ export default function connectRefinementList(renderFn, unmountFn = noop) {
           instantSearchInstance,
         } = renderOptions;
 
-        const facetValues = results.getFacetValues(attribute, { sortBy });
+        const facetValues = results.getFacetValues(attribute, { sortBy }) || [];
         const items = transformItems(
           facetValues.slice(0, this.getLimit()).map(formatItems)
         );

--- a/src/connectors/refinement-list/connectRefinementList.js
+++ b/src/connectors/refinement-list/connectRefinementList.js
@@ -391,9 +391,8 @@ export default function connectRefinementList(renderFn, unmountFn = noop) {
 
         if (operator === 'and') {
           return state.removeFacet(attribute);
-        } else {
-          return state.removeDisjunctiveFacet(attribute);
         }
+        return state.removeDisjunctiveFacet(attribute);
       },
 
       getWidgetState(uiState, { searchParameters }) {

--- a/src/connectors/refinement-list/connectRefinementList.js
+++ b/src/connectors/refinement-list/connectRefinementList.js
@@ -388,15 +388,14 @@ export default function connectRefinementList(renderFn, unmountFn = noop) {
       dispose({ state }) {
         unmountFn();
 
-        const newState = state.setQueryParameter(
+        const withoutMaxValuesPerFacet = state.setQueryParameter(
           'maxValuesPerFacet',
           undefined
         );
         if (operator === 'and') {
-          return newState.removeFacet(attribute);
-        } else {
-          return newState.removeDisjunctiveFacet(attribute);
+          return withoutMaxValuesPerFacet.removeFacet(attribute);
         }
+        return withoutMaxValuesPerFacet.removeDisjunctiveFacet(attribute);
       },
 
       getWidgetState(uiState, { searchParameters }) {

--- a/src/connectors/refinement-list/connectRefinementList.js
+++ b/src/connectors/refinement-list/connectRefinementList.js
@@ -315,7 +315,7 @@ export default function connectRefinementList(renderFn, unmountFn = noop) {
           showMore ? showMoreLimit : limit
         );
 
-        return new algoliasearchHelper.SearchParameters(widgetConfiguration);
+        return configuration.setQueryParameters(widgetConfiguration);
       },
 
       init({ helper, createURL, instantSearchInstance }) {

--- a/src/connectors/refinement-list/connectRefinementList.js
+++ b/src/connectors/refinement-list/connectRefinementList.js
@@ -388,14 +388,15 @@ export default function connectRefinementList(renderFn, unmountFn = noop) {
       dispose({ state }) {
         unmountFn();
 
-        let newState;
+        const newState = state.setQueryParameter(
+          'maxValuesPerFacet',
+          undefined
+        );
         if (operator === 'and') {
-          newState = state.removeFacet(attribute);
+          return newState.removeFacet(attribute);
         } else {
-          newState = state.removeDisjunctiveFacet(attribute);
+          return newState.removeDisjunctiveFacet(attribute);
         }
-
-        return newState.setQueryParameter('maxValuesPerFacet', undefined);
       },
 
       getWidgetState(uiState, { searchParameters }) {

--- a/src/connectors/refinement-list/connectRefinementList.js
+++ b/src/connectors/refinement-list/connectRefinementList.js
@@ -9,7 +9,6 @@ import {
   TAG_PLACEHOLDER,
   TAG_REPLACEMENT,
 } from '../../lib/escape-highlight';
-import algoliasearchHelper from 'algoliasearch-helper';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'refinement-list',
@@ -389,10 +388,14 @@ export default function connectRefinementList(renderFn, unmountFn = noop) {
       dispose({ state }) {
         unmountFn();
 
+        let newState;
         if (operator === 'and') {
-          return state.removeFacet(attribute);
+          newState = state.removeFacet(attribute);
+        } else {
+          newState = state.removeDisjunctiveFacet(attribute);
         }
-        return state.removeDisjunctiveFacet(attribute);
+
+        return newState.setQueryParameter('maxValuesPerFacet', undefined);
       },
 
       getWidgetState(uiState, { searchParameters }) {

--- a/src/connectors/refinement-list/connectRefinementList.js
+++ b/src/connectors/refinement-list/connectRefinementList.js
@@ -9,6 +9,7 @@ import {
   TAG_PLACEHOLDER,
   TAG_REPLACEMENT,
 } from '../../lib/escape-highlight';
+import algoliasearchHelper from 'algoliasearch-helper';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'refinement-list',
@@ -294,12 +295,16 @@ export default function connectRefinementList(renderFn, unmountFn = noop) {
         if (operator === 'and') {
           widgetConfiguration = {
             facets: [attribute],
-            facetsRefinements: { [attribute]: [] },
+            facetsRefinements: {
+              [attribute]: configuration.facetsRefinements[attribute] || [],
+            },
           };
         } else {
           widgetConfiguration = {
             disjunctiveFacets: [attribute],
-            disjunctiveFacetsRefinements: { [attribute]: [] },
+            disjunctiveFacetsRefinements: {
+              [attribute]: configuration.facetsRefinements[attribute] || [],
+            },
           };
         }
 
@@ -310,7 +315,7 @@ export default function connectRefinementList(renderFn, unmountFn = noop) {
           showMore ? showMoreLimit : limit
         );
 
-        return widgetConfiguration;
+        return new algoliasearchHelper.SearchParameters(widgetConfiguration);
       },
 
       init({ helper, createURL, instantSearchInstance }) {

--- a/src/connectors/refinement-list/connectRefinementList.js
+++ b/src/connectors/refinement-list/connectRefinementList.js
@@ -289,10 +289,19 @@ export default function connectRefinementList(renderFn, unmountFn = noop) {
         return this.isShowingMore ? showMoreLimit : limit;
       },
 
-      getConfiguration: (configuration = {}) => {
-        const widgetConfiguration = {
-          [operator === 'and' ? 'facets' : 'disjunctiveFacets']: [attribute],
-        };
+      getConfiguration(configuration) {
+        let widgetConfiguration;
+        if (operator === 'and') {
+          widgetConfiguration = {
+            facets: [attribute],
+            facetsRefinements: { [attribute]: [] },
+          };
+        } else {
+          widgetConfiguration = {
+            disjunctiveFacets: [attribute],
+            disjunctiveFacetsRefinements: { [attribute]: [] },
+          };
+        }
 
         const currentMaxValuesPerFacet = configuration.maxValuesPerFacet || 0;
 
@@ -376,11 +385,9 @@ export default function connectRefinementList(renderFn, unmountFn = noop) {
         unmountFn();
 
         if (operator === 'and') {
-          return state.removeFacetRefinement(attribute).removeFacet(attribute);
+          return state.removeFacet(attribute);
         } else {
-          return state
-            .removeDisjunctiveFacetRefinement(attribute)
-            .removeDisjunctiveFacet(attribute);
+          return state.removeDisjunctiveFacet(attribute);
         }
       },
 

--- a/src/widgets/refinement-list/__tests__/refinement-list-test.js
+++ b/src/widgets/refinement-list/__tests__/refinement-list-test.js
@@ -185,7 +185,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
         limit: 1,
       };
       const wdgt = refinementList(opts);
-      const partialConfig = wdgt.getConfiguration({});
+      const partialConfig = wdgt.getConfiguration(new SearchParameters({}));
       expect(partialConfig.maxValuesPerFacet).toBe(1);
     });
 
@@ -198,7 +198,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
         showMoreLimit: 99,
       };
       const wdgt = refinementList(opts);
-      const partialConfig = wdgt.getConfiguration({});
+      const partialConfig = wdgt.getConfiguration(new SearchParameters({}));
       expect(partialConfig.maxValuesPerFacet).toBe(opts.showMoreLimit);
     });
 


### PR DESCRIPTION
IFW-875

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

RefinementList no longer sets any type of refinements to an empty object, always keeping this attribute as an empty array in refinements.

- getConfiguration sets empty array to XRefinement
- getConfiguration reads from existing state to set value from other identical widgets in index
- getConfiguration returns a SearchParameters
- getFacetValues should have a fallback
- Refine (via toggleXRefinement in https://github.com/algolia/algoliasearch-helper-js/pull/738) doesn’t remove refinement if empty (helper)
- Dispose removes XRefinement, using only helper.removeXFacet

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->


~~tests will fail until https://github.com/algolia/algoliasearch-helper-js/pull/738 is used here~~

Dispose & get Configuration work as expected 