### PR TITLE
fix(hitsPerPage): update lifecycle state

### DIFF
--- a/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
+++ b/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
@@ -64,7 +64,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       ],
     });
 
-    expect(typeof widget.getConfiguration).toEqual('function');
     expect(widget.getConfiguration(new SearchParameters({}))).toEqual(
       new SearchParameters({})
     );
@@ -176,8 +175,27 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
     });
 
     expect(widget.getConfiguration(new SearchParameters({}))).toEqual(
-      expect.objectContaining({
+      new SearchParameters({
         hitsPerPage: 10,
+      })
+    );
+  });
+
+  it('Configures the search with the previous hitsPerPage', () => {
+    const renderFn = jest.fn();
+    const makeWidget = connectHitsPerPage(renderFn);
+    const widget = makeWidget({
+      items: [
+        { value: 3, label: '3 items per page' },
+        { value: 10, label: '10 items per page', default: true },
+      ],
+    });
+
+    expect(
+      widget.getConfiguration(new SearchParameters({ hitsPerPage: 20 }))
+    ).toEqual(
+      new SearchParameters({
+        hitsPerPage: 20,
       })
     );
   });

--- a/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
+++ b/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
@@ -65,7 +65,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
     });
 
     expect(typeof widget.getConfiguration).toEqual('function');
-    expect(widget.getConfiguration()).toEqual({});
+    expect(widget.getConfiguration(new SearchParameters({}))).toEqual(
+      new SearchParameters({})
+    );
 
     expect(renderFn).toHaveBeenCalledTimes(0);
 
@@ -173,9 +175,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       ],
     });
 
-    expect(widget.getConfiguration()).toEqual({
-      hitsPerPage: 10,
-    });
+    expect(widget.getConfiguration(new SearchParameters({}))).toEqual(
+      expect.objectContaining({
+        hitsPerPage: 10,
+      })
+    );
   });
 
   it('Does not configures the search when there is no default value', () => {
@@ -188,7 +192,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       ],
     });
 
-    expect(widget.getConfiguration()).toEqual({});
+    expect(widget.getConfiguration(new SearchParameters({}))).toEqual(
+      new SearchParameters({})
+    );
   });
 
   it('Provide a function to change the current hits per page, and provide the current value', () => {
@@ -508,7 +514,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
         ],
       });
 
-      const helper = algoliasearchHelper({}, '', widget.getConfiguration({}));
+      const helper = algoliasearchHelper(
+        {},
+        '',
+        widget.getConfiguration(new SearchParameters({}))
+      );
       helper.search = jest.fn();
 
       widget.init({

--- a/src/connectors/hits-per-page/connectHitsPerPage.js
+++ b/src/connectors/hits-per-page/connectHitsPerPage.js
@@ -126,7 +126,7 @@ export default function connectHitsPerPage(renderFn, unmountFn = noop) {
         }
 
         return state.setQueryParameters({
-          hitsPerPage: defaultValue.value,
+          hitsPerPage: state.hitsPerPage || defaultValue.value,
         });
       },
 

--- a/src/connectors/hits-per-page/connectHitsPerPage.js
+++ b/src/connectors/hits-per-page/connectHitsPerPage.js
@@ -120,10 +120,14 @@ export default function connectHitsPerPage(renderFn, unmountFn = noop) {
     return {
       $$type: 'ais.hitsPerPage',
 
-      getConfiguration() {
-        return defaultValues.length > 0
-          ? { hitsPerPage: defaultValues[0].value }
-          : {};
+      getConfiguration(state) {
+        if (!defaultValue) {
+          return state;
+        }
+
+        return state.setQueryParameters({
+          hitsPerPage: defaultValue.value,
+        });
       },
 
       init({ helper, createURL, state, instantSearchInstance }) {

--- a/src/widgets/hits-per-page/__tests__/hits-per-page-test.js
+++ b/src/widgets/hits-per-page/__tests__/hits-per-page-test.js
@@ -1,4 +1,5 @@
 import { render } from 'preact-compat';
+import { SearchParameters } from 'algoliasearch-helper';
 import hitsPerPage from '../hits-per-page';
 
 jest.mock('preact-compat', () => {
@@ -62,7 +63,9 @@ describe('hitsPerPage()', () => {
 
   it('does not configure the default hits per page if not specified', () => {
     expect(typeof widget.getConfiguration).toEqual('function');
-    expect(widget.getConfiguration()).toEqual({});
+    expect(widget.getConfiguration(new SearchParameters({}))).toEqual(
+      new SearchParameters({})
+    );
   });
 
   it('does configures the default hits per page if specified', () => {
@@ -74,9 +77,13 @@ describe('hitsPerPage()', () => {
       ],
     });
 
-    expect(widgetWithDefaults.getConfiguration()).toEqual({
-      hitsPerPage: 20,
-    });
+    expect(
+      widgetWithDefaults.getConfiguration(new SearchParameters({}))
+    ).toEqual(
+      expect.objectContaining({
+        hitsPerPage: 20,
+      })
+    );
   });
 
   it('calls twice render(<Selector props />, container)', () => {

--- a/src/widgets/hits-per-page/__tests__/hits-per-page-test.js
+++ b/src/widgets/hits-per-page/__tests__/hits-per-page-test.js
@@ -80,7 +80,7 @@ describe('hitsPerPage()', () => {
     expect(
       widgetWithDefaults.getConfiguration(new SearchParameters({}))
     ).toEqual(
-      expect.objectContaining({
+      new SearchParameters({
         hitsPerPage: 20,
       })
     );


### PR DESCRIPTION
## Description

This fixes the lifecycle of `connectHitsPerPage`.

## Changes

- `getConfiguration` returns a state computed with `SearchParameters`