### PR TITLE
fix(voiceSearch): update lifecycle state

### DIFF
--- a/src/connectors/voice-search/__tests__/connectVoiceSearch-test.js
+++ b/src/connectors/voice-search/__tests__/connectVoiceSearch-test.js
@@ -141,7 +141,29 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/voice-searc
 
       const nextConfiguration = widget.getConfiguration(new SearchParameters());
 
-      expect(nextConfiguration.query).toBe('');
+      expect(nextConfiguration).toEqual(
+        new SearchParameters({
+          query: '',
+        })
+      );
+    });
+
+    it('support previous `query` from the `SearchParameters`', () => {
+      const renderFn = () => {};
+      const makeWidget = connectVoiceSearch(renderFn);
+      const widget = makeWidget({});
+
+      const nextConfiguration = widget.getConfiguration(
+        new SearchParameters({
+          query: 'Previous query',
+        })
+      );
+
+      expect(nextConfiguration).toEqual(
+        new SearchParameters({
+          query: 'Previous query',
+        })
+      );
     });
   });
 

--- a/src/connectors/voice-search/connectVoiceSearch.ts
+++ b/src/connectors/voice-search/connectVoiceSearch.ts
@@ -77,7 +77,7 @@ const connectVoiceSearch: VoiceSearchConnector = (
       $$type: 'ais.voiceSearch',
 
       getConfiguration(config) {
-        return config.setQuery('');
+        return config.setQuery(config.query || '');
       },
 
       init({ helper, instantSearchInstance }) {


### PR DESCRIPTION
## Description

This fixes the lifecycle of `connectVoiceSearch`.

## Changes

- `getConfiguration` supports previous queries
- `getConfiguration` tests check the `SearchParameters` type returned