### PR TITLE
fix(infiniteHits): update lifecycle state

### DIFF
--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -658,16 +658,36 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
   });
 
   describe('getConfiguration', () => {
+    it('returns `SearchParameters`', () => {
+      const renderFn = (): void => {};
+      const makeWidget = connectInfiniteHits(renderFn);
+      const widget = makeWidget({});
+
+      expect(widget.getConfiguration!(new SearchParameters())).toBeInstanceOf(
+        SearchParameters
+      );
+    });
+
     it('adds a `page` to the `SearchParameters`', () => {
       const renderFn = (): void => {};
       const makeWidget = connectInfiniteHits(renderFn);
       const widget = makeWidget({});
 
-      const nextConfiguration = widget.getConfiguration!(
-        new SearchParameters()
-      );
+      expect(widget.getConfiguration!(new SearchParameters()).page).toEqual(0);
+    });
 
-      expect(nextConfiguration.page).toBe(0);
+    it('supports previous `page` from the `SearchParameters`', () => {
+      const renderFn = (): void => {};
+      const makeWidget = connectInfiniteHits(renderFn);
+      const widget = makeWidget({});
+
+      expect(
+        widget.getConfiguration!(new SearchParameters({ page: 0 })).page
+      ).toEqual(0);
+
+      expect(
+        widget.getConfiguration!(new SearchParameters({ page: 6 })).page
+      ).toEqual(6);
     });
 
     it('adds the TAG_PLACEHOLDER to the `SearchParameters`', () => {

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -145,7 +145,7 @@ const connectInfiniteHits: InfiniteHitsConnector = (
 
       getConfiguration(config) {
         const parameters = {
-          page: 0,
+          page: config.page || 0,
         };
 
         if (!escapeHTML) {


### PR DESCRIPTION
## Description

This fixes the lifecycle of `connectInfiniteHits`.

## Changes

- `getConfiguration` support previously set `page` parameter
- `getConfiguration` tests check that the returned type is `SearchParameters`