### PR TITLE
chore(helper): update to latest beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "es"
   ],
   "dependencies": {
-    "algoliasearch-helper": "0.0.0-c4a4e01",
+    "algoliasearch-helper": "0.0.0-6ac260d",
     "classnames": "^2.2.5",
     "events": "^1.1.0",
     "hogan.js": "^3.0.2",

--- a/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.js
+++ b/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.js
@@ -416,7 +416,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
     expect(renderingParameters0.items).toEqual(expectedResults0);
 
     // All the refinements are cleared by a third party
-    helper.removeNumericRefinement('numerics');
+    helper.setState(
+      helper.state.setQueryParameter('numericRefinements', {
+        numerics: {},
+      })
+    );
 
     widget.render({
       results: new SearchResults(helper.state, [{}]),

--- a/src/connectors/toggleRefinement/__tests__/__snapshots__/connectToggleRefinement-test.js.snap
+++ b/src/connectors/toggleRefinement/__tests__/__snapshots__/connectToggleRefinement-test.js.snap
@@ -5,7 +5,9 @@ SearchParameters {
   "disjunctiveFacets": Array [
     "isShippingFree",
   ],
-  "disjunctiveFacetsRefinements": Object {},
+  "disjunctiveFacetsRefinements": Object {
+    "isShippingFree": Array [],
+  },
   "facets": Array [],
   "facetsExcludes": Object {},
   "facetsRefinements": Object {},

--- a/src/connectors/toggleRefinement/__tests__/connectToggleRefinement-test.js
+++ b/src/connectors/toggleRefinement/__tests__/connectToggleRefinement-test.js
@@ -190,9 +190,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
         'true',
       ]);
       refine({ isRefined: !value.isRefined });
-      expect(helper.state.disjunctiveFacetsRefinements[attribute]).toEqual(
-        undefined
-      );
+      expect(helper.state.disjunctiveFacetsRefinements[attribute]).toEqual([]);
     }
 
     widget.render({
@@ -214,9 +212,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
 
     {
       // Second rendering
-      expect(helper.state.disjunctiveFacetsRefinements[attribute]).toEqual(
-        undefined
-      );
+      expect(helper.state.disjunctiveFacetsRefinements[attribute]).toEqual([]);
       const renderOptions =
         rendering.mock.calls[rendering.mock.calls.length - 1][0];
       const { refine, value } = renderOptions;
@@ -286,9 +282,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
         },
       });
       refine(value);
-      expect(helper.state.disjunctiveFacetsRefinements[attribute]).toEqual(
-        undefined
-      );
+      expect(helper.state.disjunctiveFacetsRefinements[attribute]).toEqual([]);
     }
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2109,10 +2109,10 @@ algolia-aerial@^1.5.3:
   resolved "https://registry.yarnpkg.com/algolia-aerial/-/algolia-aerial-1.5.3.tgz#c8b8ca6bc484164ffc7b36717689a424ea6bfe6c"
   integrity sha512-LZTpVlYnhqNFd+ru/Spm73omhsagiRQLmjrosa5bJ6/I9OMRp4Sb9pYZkAxcx3RSr+ZNXZqthL7rpXqMFdrnPA==
 
-algoliasearch-helper@0.0.0-c4a4e01:
-  version "0.0.0-c4a4e01"
-  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-0.0.0-c4a4e01.tgz#04ff0bd1289f8656f20fecaa00dc0acb2091b511"
-  integrity sha512-IhI921Q5lfKIG6nDUoeWMG1DOdK7UN4vt2LKWlgiToZPyxTSMur1M0Z9zcyIpKfCVye0FyC3FAaRq+h8OkNZdQ==
+algoliasearch-helper@0.0.0-6ac260d:
+  version "0.0.0-6ac260d"
+  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-0.0.0-6ac260d.tgz#9f4a0f2c8f89eafe23559375907b4070afa4cbb1"
+  integrity sha512-wG1oVPEq4bXmNUeF2voio+0UpNRtDLTG7+OPCvTxMDIQvD2Exc0s2UsWl5fh6/Dc7O++b8Ic2g+YSVo5l+nBFg==
   dependencies:
     events "^1.1.1"
 


### PR DESCRIPTION
Some tests needed to be changed, but only because they relied on internals of the helper, but it doesn't change any changes that are not already covered by work to do in IFW-874

The main change included in this version is https://github.com/algolia/algoliasearch-helper-js/pull/738, which is required for #3976 to work fully, as well as a change in typings required for #3984 
