### PR TITLE
fix(ratingMenu): update lifecycle state

### DIFF
--- a/src/connectors/rating-menu/__tests__/connectRatingMenu-test.js
+++ b/src/connectors/rating-menu/__tests__/connectRatingMenu-test.js
@@ -324,13 +324,27 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
       const render = jest.fn();
       const makeWidget = connectRatingMenu(render);
       const indexName = 'indexName';
-      const helper = jsHelper({}, indexName, {});
+      const attribute = 'grade';
+      const helper = jsHelper({}, indexName, {
+        disjunctiveFacets: [attribute],
+      });
       helper.search = jest.fn();
 
-      const attribute = 'grade';
       const widget = makeWidget({
         attribute,
       });
+
+      helper.addDisjunctiveFacetRefinement(attribute, [4, 5]);
+
+      expect(helper.state).toEqual(
+        new SearchParameters({
+          index: indexName,
+          disjunctiveFacets: [attribute],
+          disjunctiveFacetsRefinements: {
+            grade: ['4,5'],
+          },
+        })
+      );
 
       const nextState = widget.dispose({ state: helper.state });
 

--- a/src/connectors/rating-menu/__tests__/connectRatingMenu-test.js
+++ b/src/connectors/rating-menu/__tests__/connectRatingMenu-test.js
@@ -327,6 +327,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
       const attribute = 'grade';
       const helper = jsHelper({}, indexName, {
         disjunctiveFacets: [attribute],
+        disjunctiveFacetsRefinements: {
+          [attribute]: [4, 5],
+        },
       });
       helper.search = jest.fn();
 
@@ -334,14 +337,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
         attribute,
       });
 
-      helper.addDisjunctiveFacetRefinement(attribute, [4, 5]);
-
       expect(helper.state).toEqual(
         new SearchParameters({
           index: indexName,
           disjunctiveFacets: [attribute],
           disjunctiveFacetsRefinements: {
-            grade: ['4,5'],
+            grade: [4, 5],
           },
         })
       );

--- a/src/connectors/rating-menu/connectRatingMenu.js
+++ b/src/connectors/rating-menu/connectRatingMenu.js
@@ -185,9 +185,7 @@ export default function connectRatingMenu(renderFn, unmountFn = noop) {
       dispose({ state }) {
         unmountFn();
 
-        const nextState = state.removeDisjunctiveFacet(attribute);
-
-        return nextState;
+        return state.removeDisjunctiveFacet(attribute);
       },
 
       getWidgetState(uiState, { searchParameters }) {

--- a/src/connectors/rating-menu/connectRatingMenu.js
+++ b/src/connectors/rating-menu/connectRatingMenu.js
@@ -106,8 +106,13 @@ export default function connectRatingMenu(renderFn, unmountFn = noop) {
     return {
       $$type: 'ais.ratingMenu',
 
-      getConfiguration() {
-        return { disjunctiveFacets: [attribute] };
+      getConfiguration(state) {
+        return state.setQueryParameters({
+          disjunctiveFacets: [attribute],
+          disjunctiveFacetsRefinements: {
+            [attribute]: state.disjunctiveFacetsRefinements[attribute] || [],
+          },
+        });
       },
 
       init({ helper, createURL, instantSearchInstance }) {
@@ -134,7 +139,7 @@ export default function connectRatingMenu(renderFn, unmountFn = noop) {
         for (let v = max; v >= 0; --v) {
           allValues[v] = 0;
         }
-        results.getFacetValues(attribute).forEach(facet => {
+        (results.getFacetValues(attribute) || []).forEach(facet => {
           const val = Math.round(facet.name);
           if (!val || val > max) {
             return;
@@ -180,9 +185,7 @@ export default function connectRatingMenu(renderFn, unmountFn = noop) {
       dispose({ state }) {
         unmountFn();
 
-        const nextState = state
-          .removeDisjunctiveFacetRefinement(attribute)
-          .removeDisjunctiveFacet(attribute);
+        const nextState = state.removeDisjunctiveFacet(attribute);
 
         return nextState;
       },

--- a/src/widgets/rating-menu/__tests__/rating-menu-test.js
+++ b/src/widgets/rating-menu/__tests__/rating-menu-test.js
@@ -1,5 +1,8 @@
 import { render } from 'preact-compat';
-import jsHelper, { SearchResults } from 'algoliasearch-helper';
+import jsHelper, {
+  SearchResults,
+  SearchParameters,
+} from 'algoliasearch-helper';
 import ratingMenu from '../rating-menu';
 
 jest.mock('preact-compat', () => {
@@ -40,7 +43,11 @@ describe('ratingMenu()', () => {
       attribute,
       cssClasses: { body: ['body', 'cx'] },
     });
-    helper = jsHelper({}, '', widget.getConfiguration({}));
+    helper = jsHelper(
+      {},
+      '',
+      widget.getConfiguration(new SearchParameters({}))
+    );
     jest.spyOn(helper, 'clearRefinements');
     jest.spyOn(helper, 'addDisjunctiveFacetRefinement');
     jest.spyOn(helper, 'getRefinements');
@@ -61,9 +68,14 @@ describe('ratingMenu()', () => {
   });
 
   it('configures the underlying disjunctive facet', () => {
-    expect(widget.getConfiguration()).toEqual({
-      disjunctiveFacets: ['anAttrName'],
-    });
+    expect(widget.getConfiguration(new SearchParameters())).toEqual(
+      new SearchParameters({
+        disjunctiveFacets: ['anAttrName'],
+        disjunctiveFacetsRefinements: {
+          anAttrName: [],
+        },
+      })
+    );
   });
 
   it('calls twice render(<RefinementList props />, container)', () => {
@@ -140,7 +152,11 @@ describe('ratingMenu()', () => {
       attribute,
       cssClasses: { body: ['body', 'cx'] },
     });
-    const _helper = jsHelper({}, '', _widget.getConfiguration({}));
+    const _helper = jsHelper(
+      {},
+      '',
+      _widget.getConfiguration(new SearchParameters({}))
+    );
     _helper.search = jest.fn();
 
     _widget.init({


### PR DESCRIPTION
## Description

This fixes the lifecycle of `connectRatingMenu`.

## Changes

- `getConfiguration` returns a search parameter object
- `getConfiguration` support previously set disjunctive facets refinements
- `getFacetValues()` fallbacks to an empty array
- `dispose` doesn't call `removeDisjunctiveFacetRefinement()`