### PR TITLE
fix(toggleRefinement): update lifecycle state

### DIFF
--- a/src/connectors/toggleRefinement/__tests__/connectToggleRefinement-test.js
+++ b/src/connectors/toggleRefinement/__tests__/connectToggleRefinement-test.js
@@ -589,13 +589,17 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
       const render = jest.fn();
       const makeWidget = connectToggleRefinement(render);
       const indexName = 'indexName';
-      const helper = jsHelper({}, indexName, {});
+      const helper = jsHelper({}, indexName, {
+        disjunctiveFacets: ['freeShipping'],
+      });
       helper.search = jest.fn();
 
       const attribute = 'freeShipping';
       const widget = makeWidget({
         attribute,
       });
+
+      helper.addDisjunctiveFacetRefinement('freeShipping', ['true']);
 
       const nextState = widget.dispose({ state: helper.state });
 

--- a/src/connectors/toggleRefinement/__tests__/connectToggleRefinement-test.js
+++ b/src/connectors/toggleRefinement/__tests__/connectToggleRefinement-test.js
@@ -58,10 +58,15 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
       attribute,
     });
 
-    const config = widget.getConfiguration();
-    expect(config).toEqual({
-      disjunctiveFacets: [attribute],
-    });
+    const config = widget.getConfiguration(new SearchParameters({}));
+    expect(config).toEqual(
+      new SearchParameters({
+        disjunctiveFacets: [attribute],
+        disjunctiveFacetsRefinements: {
+          [attribute]: [],
+        },
+      })
+    );
 
     const helper = jsHelper({}, '', config);
     helper.search = jest.fn();
@@ -155,7 +160,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
       attribute,
     });
 
-    const helper = jsHelper({}, '', widget.getConfiguration());
+    const helper = jsHelper(
+      {},
+      '',
+      widget.getConfiguration(new SearchParameters({}))
+    );
     helper.search = jest.fn();
 
     widget.init({
@@ -166,9 +175,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
 
     {
       // first rendering
-      expect(helper.state.disjunctiveFacetsRefinements[attribute]).toEqual(
-        undefined
-      );
+      expect(helper.state.disjunctiveFacetsRefinements[attribute]).toEqual([]);
       const renderOptions =
         rendering.mock.calls[rendering.mock.calls.length - 1][0];
       const { refine, value } = renderOptions;
@@ -297,7 +304,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
       off: 'false',
     });
 
-    const helper = jsHelper({}, '', widget.getConfiguration());
+    const helper = jsHelper(
+      {},
+      '',
+      widget.getConfiguration(new SearchParameters({}))
+    );
     helper.search = jest.fn();
 
     widget.init({
@@ -451,7 +462,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
       off: false,
     });
 
-    const helper = jsHelper({}, '', widget.getConfiguration());
+    const helper = jsHelper(
+      {},
+      '',
+      widget.getConfiguration(new SearchParameters({}))
+    );
     widget.init({ helper, state: helper.state });
 
     expect(helper.state.disjunctiveFacetsRefinements).toEqual(
@@ -468,7 +483,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
       off: true,
     });
 
-    const helper = jsHelper({}, '', widget.getConfiguration());
+    const helper = jsHelper(
+      {},
+      '',
+      widget.getConfiguration(new SearchParameters({}))
+    );
     widget.init({ helper, state: helper.state });
 
     expect(helper.state.disjunctiveFacetsRefinements).toEqual(
@@ -488,12 +507,18 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
       on: false,
     });
 
-    const helper = jsHelper({ search() {} }, '', widget.getConfiguration());
+    const helper = jsHelper(
+      { search() {} },
+      '',
+      widget.getConfiguration(new SearchParameters({}))
+    );
     helper.search = jest.fn();
 
     widget.init({ helper, state: helper.state });
 
-    expect(helper.state.disjunctiveFacetsRefinements).toEqual({});
+    expect(helper.state.disjunctiveFacetsRefinements).toEqual({
+      whatever: [],
+    });
 
     widget.render({
       results: new SearchResults(helper.state, [
@@ -521,6 +546,67 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
     );
   });
 
+  describe('getConfiguration', () => {
+    test('returns initial search parameters', () => {
+      const rendering = jest.fn();
+      const makeWidget = connectToggleRefinement(rendering);
+
+      const attribute = 'freeShipping';
+      const widget = makeWidget({
+        attribute,
+      });
+
+      expect(widget.getConfiguration(new SearchParameters({}))).toEqual(
+        new SearchParameters({
+          disjunctiveFacets: [attribute],
+          disjunctiveFacetsRefinements: {
+            freeShipping: [],
+          },
+        })
+      );
+    });
+  });
+
+  describe('dispose', () => {
+    test('calls the unmount function', () => {
+      const render = jest.fn();
+      const unmount = jest.fn();
+      const makeWidget = connectToggleRefinement(render, unmount);
+      const helper = jsHelper({}, '', {});
+      helper.search = jest.fn();
+
+      const attribute = 'freeShipping';
+      const widget = makeWidget({
+        attribute,
+      });
+
+      widget.dispose({ state: helper.state });
+
+      expect(unmount).toHaveBeenCalledTimes(1);
+    });
+
+    test('resets the state', () => {
+      const render = jest.fn();
+      const makeWidget = connectToggleRefinement(render);
+      const indexName = 'indexName';
+      const helper = jsHelper({}, indexName, {});
+      helper.search = jest.fn();
+
+      const attribute = 'freeShipping';
+      const widget = makeWidget({
+        attribute,
+      });
+
+      const nextState = widget.dispose({ state: helper.state });
+
+      expect(nextState).toEqual(
+        new SearchParameters({
+          index: indexName,
+        })
+      );
+    });
+  });
+
   describe('routing', () => {
     const getInitializedWidget = (config = {}) => {
       const rendering = jest.fn();
@@ -532,7 +618,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
         ...config,
       });
 
-      const initialConfig = widget.getConfiguration({});
+      const initialConfig = widget.getConfiguration(new SearchParameters({}));
       const helper = jsHelper({}, '', initialConfig);
       helper.search = jest.fn();
 

--- a/src/connectors/toggleRefinement/__tests__/connectToggleRefinement-test.js
+++ b/src/connectors/toggleRefinement/__tests__/connectToggleRefinement-test.js
@@ -601,6 +601,16 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
 
       helper.addDisjunctiveFacetRefinement('freeShipping', ['true']);
 
+      expect(helper.state).toEqual(
+        new SearchParameters({
+          index: indexName,
+          disjunctiveFacets: ['freeShipping'],
+          disjunctiveFacetsRefinements: {
+            freeShipping: ['true'],
+          },
+        })
+      );
+
       const nextState = widget.dispose({ state: helper.state });
 
       expect(nextState).toEqual(

--- a/src/connectors/toggleRefinement/__tests__/connectToggleRefinement-test.js
+++ b/src/connectors/toggleRefinement/__tests__/connectToggleRefinement-test.js
@@ -591,6 +591,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
       const indexName = 'indexName';
       const helper = jsHelper({}, indexName, {
         disjunctiveFacets: ['freeShipping'],
+        disjunctiveFacetsRefinements: {
+          freeShipping: ['true'],
+        },
       });
       helper.search = jest.fn();
 
@@ -598,8 +601,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
       const widget = makeWidget({
         attribute,
       });
-
-      helper.addDisjunctiveFacetRefinement('freeShipping', ['true']);
 
       expect(helper.state).toEqual(
         new SearchParameters({

--- a/src/connectors/toggleRefinement/connectToggleRefinement.js
+++ b/src/connectors/toggleRefinement/connectToggleRefinement.js
@@ -105,10 +105,13 @@ export default function connectToggleRefinement(renderFn, unmountFn = noop) {
     return {
       $$type: 'ais.toggleRefinement',
 
-      getConfiguration() {
-        return {
+      getConfiguration(state) {
+        return state.setQueryParameters({
           disjunctiveFacets: [attribute],
-        };
+          disjunctiveFacetsRefinements: {
+            [attribute]: [],
+          },
+        });
       },
 
       _toggleRefinement(helper, { isRefined } = {}) {
@@ -193,7 +196,7 @@ export default function connectToggleRefinement(renderFn, unmountFn = noop) {
       render({ helper, results, state, instantSearchInstance }) {
         const isRefined = helper.state.isDisjunctiveFacetRefined(attribute, on);
         const offValue = off === undefined ? false : off;
-        const allFacetValues = results.getFacetValues(attribute);
+        const allFacetValues = results.getFacetValues(attribute) || [];
 
         const onData = find(
           allFacetValues,
@@ -248,11 +251,7 @@ export default function connectToggleRefinement(renderFn, unmountFn = noop) {
       dispose({ state }) {
         unmountFn();
 
-        const nextState = state
-          .removeDisjunctiveFacetRefinement(attribute)
-          .removeDisjunctiveFacet(attribute);
-
-        return nextState;
+        return state.removeDisjunctiveFacet(attribute);
       },
 
       getWidgetState(uiState, { searchParameters }) {

--- a/src/widgets/toggleRefinement/__tests__/toggleRefinement-test.js
+++ b/src/widgets/toggleRefinement/__tests__/toggleRefinement-test.js
@@ -1,5 +1,5 @@
 import { render } from 'preact-compat';
-import jsHelper from 'algoliasearch-helper';
+import jsHelper, { SearchParameters } from 'algoliasearch-helper';
 import toggleRefinement from '../toggleRefinement';
 import RefinementList from '../../../components/RefinementList/RefinementList';
 
@@ -43,9 +43,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
     });
 
     it('configures disjunctiveFacets', () => {
-      expect(widget.getConfiguration()).toEqual({
-        disjunctiveFacets: ['world!'],
-      });
+      expect(widget.getConfiguration(new SearchParameters({}))).toEqual(
+        new SearchParameters({
+          disjunctiveFacets: ['world!'],
+          disjunctiveFacetsRefinements: {
+            'world!': [],
+          },
+        })
+      );
     });
 
     describe('render', () => {
@@ -88,7 +93,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
           attribute,
           /* on: true, off: undefined */
         });
-        widget.getConfiguration();
+        widget.getConfiguration(new SearchParameters({}));
         widget.init({ helper, state, createURL, instantSearchInstance });
         widget.render({ results, helper, state });
         widget.render({ results, helper, state });
@@ -120,7 +125,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
           /* on: true, off: undefined */
           RefinementList,
         });
-        widget.getConfiguration();
+        widget.getConfiguration(new SearchParameters({}));
         widget.init({ state, helper, createURL, instantSearchInstance });
         widget.render({ results, helper, state });
         expect(render.mock.calls[0][0]).toMatchSnapshot();
@@ -143,7 +148,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
           /* on: true, off: undefined */
           RefinementList,
         });
-        widget.getConfiguration();
+        widget.getConfiguration(new SearchParameters({}));
         widget.init({ state, helper, createURL, instantSearchInstance });
         widget.render({ results, helper, state });
         widget.render({ results, helper, state });
@@ -171,7 +176,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
           on: 5,
         });
 
-        const config = widget.getConfiguration();
+        const config = widget.getConfiguration(new SearchParameters({}));
         const altHelper = jsHelper({}, '', config);
         altHelper.search = () => {};
 
@@ -210,7 +215,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
           /* on: true, off: undefined */
           RefinementList,
         });
-        widget.getConfiguration();
+        widget.getConfiguration(new SearchParameters({}));
         widget.init({ state, helper, createURL, instantSearchInstance });
         widget.render({ results, helper, state });
         widget.render({ results, helper, state });
@@ -241,7 +246,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
           /* on: true, off: undefined */
           RefinementList,
         });
-        widget.getConfiguration();
+        widget.getConfiguration(new SearchParameters({}));
         widget.init({ state, helper, createURL, instantSearchInstance });
         widget.render({ results, helper, state });
         widget.render({ results, helper, state });
@@ -267,7 +272,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
           /* on: true, off: undefined */
           RefinementList,
         });
-        widget.getConfiguration();
+        widget.getConfiguration(new SearchParameters({}));
         widget.init({ state, helper, createURL, instantSearchInstance });
         widget.render({ results, helper, state });
         const { refine } = render.mock.calls[0][0].props;
@@ -308,7 +313,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
             attribute,
             /* on: true, off: undefined */
           });
-          widget.getConfiguration();
+          widget.getConfiguration(new SearchParameters({}));
           const state = {
             isDisjunctiveFacetRefined: jest.fn().mockReturnValue(false),
           };
@@ -334,7 +339,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
             attribute,
             /* on: true, off: undefined */
           });
-          widget.getConfiguration();
+          widget.getConfiguration(new SearchParameters({}));
           const state = {
             isDisjunctiveFacetRefined: jest.fn().mockReturnValue(true),
           };
@@ -362,7 +367,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
             ...userValues,
           });
 
-          const config = widget.getConfiguration();
+          const config = widget.getConfiguration(new SearchParameters({}));
           const altHelper = jsHelper({}, '', config);
           altHelper.search = () => {};
 
@@ -395,7 +400,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
             attribute,
             ...userValues,
           });
-          widget.getConfiguration();
+          widget.getConfiguration(new SearchParameters({}));
           const state = {
             isDisjunctiveFacetRefined: jest.fn().mockReturnValue(true),
           };
@@ -428,7 +433,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
           attribute,
           ...userValues,
         });
-        const config = widget.getConfiguration();
+        const config = widget.getConfiguration(new SearchParameters({}));
         const helper = jsHelper({}, '', config);
 
         // When
@@ -453,7 +458,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
           attribute,
           ...userValues,
         });
-        widget.getConfiguration();
+        widget.getConfiguration(new SearchParameters({}));
         const state = {
           isDisjunctiveFacetRefined: jest.fn().mockReturnValue(true),
         };
@@ -476,7 +481,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
           attribute,
           ...userValues,
         });
-        widget.getConfiguration();
+        widget.getConfiguration(new SearchParameters({}));
         const state = {
           isDisjunctiveFacetRefined: () => false,
         };


### PR DESCRIPTION
## Description

This fixes the lifecycle of `connectToggleRefinement`.

## Changes

- `getConfiguration` returns a state computed with `SearchParameters`
- `getConfiguration` sets default `disjunctiveFacetsRefinements`
- `getFacetValues` falls back to an empty array