### PR TITLE
feat(connectSearchBox): update getWidgetSearchParameters

### DIFF
--- a/src/connectors/search-box/__tests__/__snapshots__/connectSearchBox-test.js.snap
+++ b/src/connectors/search-box/__tests__/__snapshots__/connectSearchBox-test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`connectSearchBox routing getWidgetSearchParameters should add the refinements according to the UI state provided 1`] = `
+exports[`connectSearchBox getWidgetSearchParameters should add the refinements according to the UI state provided 1`] = `
 SearchParameters {
   "disjunctiveFacets": Array [],
   "disjunctiveFacetsRefinements": Object {},
@@ -16,7 +16,7 @@ SearchParameters {
 }
 `;
 
-exports[`connectSearchBox routing getWidgetSearchParameters should enforce the default value if no value is the ui state 1`] = `
+exports[`connectSearchBox getWidgetSearchParameters should enforce the default value if no value is the ui state 1`] = `
 SearchParameters {
   "disjunctiveFacets": Array [],
   "disjunctiveFacetsRefinements": Object {},
@@ -31,7 +31,7 @@ SearchParameters {
 }
 `;
 
-exports[`connectSearchBox routing getWidgetState should add an entry equal to the refinement 1`] = `
+exports[`connectSearchBox getWidgetState should add an entry equal to the refinement 1`] = `
 Object {
   "query": "some query",
 }

--- a/src/connectors/search-box/__tests__/__snapshots__/connectSearchBox-test.js.snap
+++ b/src/connectors/search-box/__tests__/__snapshots__/connectSearchBox-test.js.snap
@@ -1,36 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`connectSearchBox getWidgetSearchParameters should add the refinements according to the UI state provided 1`] = `
-SearchParameters {
-  "disjunctiveFacets": Array [],
-  "disjunctiveFacetsRefinements": Object {},
-  "facets": Array [],
-  "facetsExcludes": Object {},
-  "facetsRefinements": Object {},
-  "hierarchicalFacets": Array [],
-  "hierarchicalFacetsRefinements": Object {},
-  "index": "",
-  "numericRefinements": Object {},
-  "query": "some search",
-  "tagRefinements": Array [],
-}
-`;
-
-exports[`connectSearchBox getWidgetSearchParameters should enforce the default value if no value is the ui state 1`] = `
-SearchParameters {
-  "disjunctiveFacets": Array [],
-  "disjunctiveFacetsRefinements": Object {},
-  "facets": Array [],
-  "facetsExcludes": Object {},
-  "facetsRefinements": Object {},
-  "hierarchicalFacets": Array [],
-  "hierarchicalFacetsRefinements": Object {},
-  "index": "",
-  "numericRefinements": Object {},
-  "tagRefinements": Array [],
-}
-`;
-
 exports[`connectSearchBox getWidgetState should add an entry equal to the refinement 1`] = `
 Object {
   "query": "some query",

--- a/src/connectors/search-box/__tests__/connectSearchBox-test.js
+++ b/src/connectors/search-box/__tests__/connectSearchBox-test.js
@@ -440,40 +440,48 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
   });
 
   describe('getWidgetSearchParameters', () => {
-    test('should return the same SP if no value is in the UI state', () => {
+    test('returns the `SearchParameters` with the value from `uiState`', () => {
       const [widget, helper] = getInitializedWidget();
-      const uiState = {};
-      const searchParametersBefore = SearchParameters.make(helper.state);
-      const searchParametersAfter = widget.getWidgetSearchParameters(
-        searchParametersBefore,
-        { uiState }
+
+      expect(helper.state).toEqual(
+        new SearchParameters({
+          index: '',
+        })
       );
-      expect(searchParametersAfter).toBe(searchParametersBefore);
+
+      const actual = widget.getWidgetSearchParameters(helper.state, {
+        uiState: {
+          query: 'Apple',
+        },
+      });
+
+      expect(actual).toEqual(
+        new SearchParameters({
+          index: '',
+          query: 'Apple',
+        })
+      );
     });
 
-    test('should add the refinements according to the UI state provided', () => {
+    test('returns the `SearchParameters` with the default value', () => {
       const [widget, helper] = getInitializedWidget();
-      const uiState = {
-        query: 'some search',
-      };
-      const searchParametersBefore = SearchParameters.make(helper.state);
-      const searchParametersAfter = widget.getWidgetSearchParameters(
-        searchParametersBefore,
-        { uiState }
-      );
-      expect(searchParametersAfter).toMatchSnapshot();
-    });
 
-    test('should enforce the default value if no value is the ui state', () => {
-      const [widget, helper, refine] = getInitializedWidget();
-      refine('previous search');
-      const uiState = {};
-      const searchParametersBefore = SearchParameters.make(helper.state);
-      const searchParametersAfter = widget.getWidgetSearchParameters(
-        searchParametersBefore,
-        { uiState }
+      expect(helper.state).toEqual(
+        new SearchParameters({
+          index: '',
+        })
       );
-      expect(searchParametersAfter).toMatchSnapshot();
+
+      const actual = widget.getWidgetSearchParameters(helper.state, {
+        uiState: {},
+      });
+
+      expect(actual).toEqual(
+        new SearchParameters({
+          index: '',
+          query: '',
+        })
+      );
     });
   });
 });

--- a/src/connectors/search-box/connectSearchBox.js
+++ b/src/connectors/search-box/connectSearchBox.js
@@ -159,7 +159,7 @@ export default function connectSearchBox(renderFn, unmountFn = noop) {
       },
 
       getWidgetSearchParameters(searchParameters, { uiState }) {
-        return searchParameters.setQueryParameter('query', uiState.query);
+        return searchParameters.setQueryParameter('query', uiState.query || '');
       },
     };
   };


### PR DESCRIPTION
This PR updates the lifecycle `getWidgetSearchParameters` to `connectSearchBox` to take the add the default value without `uiState`. We don't apply the previous value on purpose, the `uiState` drives completely the `SearchParameters`.

I've not removed the `getConfiguration` lifecycle (yet) to avoid breaking everything. Once we've made the switch to `getWidgetSearchParameters` we'll remove them.