### PR TITLE
 test(searchbox): remove needless snapshot

### DIFF
--- a/src/connectors/search-box/__tests__/__snapshots__/connectSearchBox-test.js.snap
+++ b/src/connectors/search-box/__tests__/__snapshots__/connectSearchBox-test.js.snap
@@ -1,7 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`connectSearchBox getWidgetState should add an entry equal to the refinement 1`] = `
-Object {
-  "query": "some query",
-}
-`;

--- a/src/connectors/search-box/__tests__/connectSearchBox-test.js
+++ b/src/connectors/search-box/__tests__/connectSearchBox-test.js
@@ -418,7 +418,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
         searchParameters: helper.state,
         helper,
       });
-      expect(uiStateAfter).toMatchSnapshot();
+      expect(uiStateAfter).toEqual({
+        query: 'some query',
+      });
     });
 
     test('should give back the same instance if the value is alreay in the uiState', () => {


### PR DESCRIPTION
This removes a snapshot with an inline assertion, since it's very small, and avoids the indirection. In the future if we don't want to write an assertion, I'd suggest the following flow:

1. add toMatchInlineSnapshot
2. change snapshot to real assertion
3. profit