### PR TITLE
feat(currentRefinements): support multiple indices

### DIFF
--- a/src/components/CurrentRefinements/CurrentRefinements.tsx
+++ b/src/components/CurrentRefinements/CurrentRefinements.tsx
@@ -37,7 +37,10 @@ const CurrentRefinements = ({ items, cssClasses }: CurrentRefinementsProps) => (
   <div className={cssClasses.root}>
     <ul className={cssClasses.list}>
       {items.map((item, index) => (
-        <li key={`${item.attribute}-${index}`} className={cssClasses.item}>
+        <li
+          key={`${item.indexName}-${item.attribute}-${index}`}
+          className={cssClasses.item}
+        >
           <span className={cssClasses.label}>{capitalize(item.label)}:</span>
 
           {item.refinements.map(refinement => (

--- a/src/components/CurrentRefinements/__tests__/CurrentRefinements-test.tsx
+++ b/src/components/CurrentRefinements/__tests__/CurrentRefinements-test.tsx
@@ -19,6 +19,7 @@ describe('CurrentRefinements', () => {
       cssClasses,
       items: [
         {
+          indexName: 'indexName',
           attribute: 'facet',
           label: 'facet',
           refine: () => {},
@@ -38,6 +39,7 @@ describe('CurrentRefinements', () => {
           ],
         },
         {
+          indexName: 'indexName',
           attribute: 'facetExclude',
           label: 'facetExclude',
           refine: () => {},
@@ -52,6 +54,7 @@ describe('CurrentRefinements', () => {
           ],
         },
         {
+          indexName: 'indexName',
           attribute: 'disjunctive',
           label: 'disjunctive',
           refine: () => {},
@@ -65,6 +68,7 @@ describe('CurrentRefinements', () => {
           ],
         },
         {
+          indexName: 'indexName',
           attribute: 'hierarchical',
           label: 'hierarchical',
           refine: () => {},
@@ -78,6 +82,7 @@ describe('CurrentRefinements', () => {
           ],
         },
         {
+          indexName: 'indexName',
           attribute: 'numeric',
           label: 'numeric',
           refine: () => {},
@@ -92,6 +97,7 @@ describe('CurrentRefinements', () => {
           ],
         },
         {
+          indexName: 'indexName',
           attribute: 'tag',
           label: 'tag',
           refine: () => {},
@@ -118,6 +124,7 @@ describe('CurrentRefinements', () => {
         cssClasses,
         items: [
           {
+            indexName: 'indexName',
             attribute: 'customFacet',
             label: 'customFacet',
             refine: () => {},
@@ -143,6 +150,7 @@ describe('CurrentRefinements', () => {
         cssClasses,
         items: [
           {
+            indexName: 'indexName',
             attribute: 'customExcludeFacet',
             label: 'customExcludeFacet',
             refine: () => {},
@@ -169,6 +177,7 @@ describe('CurrentRefinements', () => {
         cssClasses,
         items: [
           {
+            indexName: 'indexName',
             attribute: 'customDisjunctiveFacet',
             label: 'customDisjunctiveFacet',
             refine: () => {},
@@ -194,6 +203,7 @@ describe('CurrentRefinements', () => {
         cssClasses,
         items: [
           {
+            indexName: 'indexName',
             attribute: 'customHierarchicalFacet',
             label: 'customHierarchicalFacet',
             refine: () => {},
@@ -219,6 +229,7 @@ describe('CurrentRefinements', () => {
         cssClasses,
         items: [
           {
+            indexName: 'indexName',
             attribute: 'customNumericFilter',
             label: 'customNumericFilter',
             refine: () => {},
@@ -233,6 +244,7 @@ describe('CurrentRefinements', () => {
             ],
           },
           {
+            indexName: 'indexName',
             attribute: 'customNumericFilter',
             label: 'customNumericFilter',
             refine: () => {},
@@ -247,6 +259,7 @@ describe('CurrentRefinements', () => {
             ],
           },
           {
+            indexName: 'indexName',
             attribute: 'customNumericFilter',
             label: 'customNumericFilter',
             refine: () => {},
@@ -273,6 +286,7 @@ describe('CurrentRefinements', () => {
         cssClasses,
         items: [
           {
+            indexName: 'indexName',
             attribute: '_tags',
             label: '_tags',
             refine: () => {},
@@ -298,6 +312,7 @@ describe('CurrentRefinements', () => {
         cssClasses,
         items: [
           {
+            indexName: 'indexName',
             attribute: 'query',
             label: 'query',
             refine: () => {},

--- a/src/components/CurrentRefinements/__tests__/__snapshots__/CurrentRefinements-test.tsx.snap
+++ b/src/components/CurrentRefinements/__tests__/__snapshots__/CurrentRefinements-test.tsx.snap
@@ -9,7 +9,7 @@ exports[`CurrentRefinements options.refinements can be used with a disjunctive f
   >
     <li
       className="item"
-      key="customDisjunctiveFacet-0"
+      key="indexName-customDisjunctiveFacet-0"
     >
       <span
         className="label"
@@ -47,7 +47,7 @@ exports[`CurrentRefinements options.refinements can be used with a facet 1`] = `
   >
     <li
       className="item"
-      key="customFacet-0"
+      key="indexName-customFacet-0"
     >
       <span
         className="label"
@@ -85,7 +85,7 @@ exports[`CurrentRefinements options.refinements can be used with a hierarchical 
   >
     <li
       className="item"
-      key="customHierarchicalFacet-0"
+      key="indexName-customHierarchicalFacet-0"
     >
       <span
         className="label"
@@ -123,7 +123,7 @@ exports[`CurrentRefinements options.refinements can be used with a query 1`] = `
   >
     <li
       className="item"
-      key="query-0"
+      key="indexName-query-0"
     >
       <span
         className="label"
@@ -163,7 +163,7 @@ exports[`CurrentRefinements options.refinements can be used with a tag 1`] = `
   >
     <li
       className="item"
-      key="_tags-0"
+      key="indexName-_tags-0"
     >
       <span
         className="label"
@@ -201,7 +201,7 @@ exports[`CurrentRefinements options.refinements can be used with an exclude 1`] 
   >
     <li
       className="item"
-      key="customExcludeFacet-0"
+      key="indexName-customExcludeFacet-0"
     >
       <span
         className="label"
@@ -239,7 +239,7 @@ exports[`CurrentRefinements options.refinements can be used with numeric filters
   >
     <li
       className="item"
-      key="customNumericFilter-0"
+      key="indexName-customNumericFilter-0"
     >
       <span
         className="label"
@@ -266,7 +266,7 @@ exports[`CurrentRefinements options.refinements can be used with numeric filters
     </li>
     <li
       className="item"
-      key="customNumericFilter-1"
+      key="indexName-customNumericFilter-1"
     >
       <span
         className="label"
@@ -293,7 +293,7 @@ exports[`CurrentRefinements options.refinements can be used with numeric filters
     </li>
     <li
       className="item"
-      key="customNumericFilter-2"
+      key="indexName-customNumericFilter-2"
     >
       <span
         className="label"
@@ -331,7 +331,7 @@ exports[`CurrentRefinements renders 1`] = `
   >
     <li
       className="item"
-      key="facet-0"
+      key="indexName-facet-0"
     >
       <span
         className="label"
@@ -374,7 +374,7 @@ exports[`CurrentRefinements renders 1`] = `
     </li>
     <li
       className="item"
-      key="facetExclude-1"
+      key="indexName-facetExclude-1"
     >
       <span
         className="label"
@@ -401,7 +401,7 @@ exports[`CurrentRefinements renders 1`] = `
     </li>
     <li
       className="item"
-      key="disjunctive-2"
+      key="indexName-disjunctive-2"
     >
       <span
         className="label"
@@ -428,7 +428,7 @@ exports[`CurrentRefinements renders 1`] = `
     </li>
     <li
       className="item"
-      key="hierarchical-3"
+      key="indexName-hierarchical-3"
     >
       <span
         className="label"
@@ -455,7 +455,7 @@ exports[`CurrentRefinements renders 1`] = `
     </li>
     <li
       className="item"
-      key="numeric-4"
+      key="indexName-numeric-4"
     >
       <span
         className="label"
@@ -482,7 +482,7 @@ exports[`CurrentRefinements renders 1`] = `
     </li>
     <li
       className="item"
-      key="tag-5"
+      key="indexName-tag-5"
     >
       <span
         className="label"

--- a/src/connectors/autocomplete/__tests__/connectAutocomplete-test.ts
+++ b/src/connectors/autocomplete/__tests__/connectAutocomplete-test.ts
@@ -166,6 +166,7 @@ search.addWidgets([
             hits: firstIndexHits,
           }),
         ]),
+        helper,
       },
       {
         indexId: 'index1',
@@ -175,6 +176,7 @@ search.addWidgets([
             hits: secondIndexHits,
           }),
         ]),
+        helper,
       },
     ];
 
@@ -255,6 +257,7 @@ search.addWidgets([
             results: new SearchResults(helper.state, [
               createSingleSearchResponse({ hits }),
             ]),
+            helper,
           },
         ],
         state: helper.state,
@@ -297,6 +300,7 @@ search.addWidgets([
             results: new SearchResults(helper.state, [
               createSingleSearchResponse({ hits }),
             ]),
+            helper,
           },
         ],
         state: helper.state,

--- a/src/connectors/current-refinements/__tests__/connectCurrentRefinements-test.ts
+++ b/src/connectors/current-refinements/__tests__/connectCurrentRefinements-test.ts
@@ -490,9 +490,17 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
 
       widget.render!(
         createRenderOptions({
-          results: new SearchResults(helper.state, [
-            createSingleSearchResponse(),
-          ]),
+          scopedResults: [
+            {
+              indexId: 'firstIndex',
+              helper,
+              results: new SearchResults(helper.state, [
+                createSingleSearchResponse({
+                  index: 'firstIndex',
+                }),
+              ]),
+            },
+          ],
           state: helper.state,
           helper,
         })
@@ -500,6 +508,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
 
       const secondRenderingOptions = rendering.mock.calls[1][0];
       const items: Item[] = secondRenderingOptions.items;
+
+      expect(items).toHaveLength(2);
       expect(items).toEqual([
         {
           attribute: 'facet1',
@@ -551,6 +561,110 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
           facetsRefinements: { facet1: [], facet2: ['facetValue'] },
         })
       );
+    });
+
+    it('provides the items from multiple scoped results', () => {
+      const rendering = jest.fn();
+      const customCurrentRefinements = connectCurrentRefinements(rendering);
+      const widget = customCurrentRefinements({});
+
+      helper.addFacetRefinement('facet1', 'facetValue');
+
+      widget.init!(
+        createInitOptions({
+          helper,
+          state: helper.state,
+        })
+      );
+
+      helper
+        .addFacetRefinement('facet1', 'facetValue')
+        .addFacetRefinement('facet2', 'facetValue');
+
+      widget.render!(
+        createRenderOptions({
+          scopedResults: [
+            {
+              indexId: 'firstIndex',
+              helper,
+              results: new SearchResults(helper.state, [
+                createSingleSearchResponse({
+                  index: 'firstIndex',
+                }),
+              ]),
+            },
+            {
+              indexId: 'secondIndex',
+              helper,
+              results: new SearchResults(helper.state, [
+                createSingleSearchResponse({
+                  index: 'secondIndex',
+                }),
+              ]),
+            },
+          ],
+          state: helper.state,
+          helper,
+        })
+      );
+
+      const secondRenderingOptions = rendering.mock.calls[1][0];
+      const items: Item[] = secondRenderingOptions.items;
+      expect(items).toHaveLength(4);
+      expect(items).toEqual([
+        {
+          attribute: 'facet1',
+          label: 'facet1',
+          refinements: [
+            {
+              attribute: 'facet1',
+              label: 'facetValue',
+              type: 'facet',
+              value: 'facetValue',
+            },
+          ],
+          refine: expect.any(Function),
+        },
+        {
+          attribute: 'facet2',
+          label: 'facet2',
+          refinements: [
+            {
+              attribute: 'facet2',
+              label: 'facetValue',
+              type: 'facet',
+              value: 'facetValue',
+            },
+          ],
+          refine: expect.any(Function),
+        },
+        {
+          attribute: 'facet1',
+          label: 'facet1',
+          refinements: [
+            {
+              attribute: 'facet1',
+              label: 'facetValue',
+              type: 'facet',
+              value: 'facetValue',
+            },
+          ],
+          refine: expect.any(Function),
+        },
+        {
+          attribute: 'facet2',
+          label: 'facet2',
+          refinements: [
+            {
+              attribute: 'facet2',
+              label: 'facetValue',
+              type: 'facet',
+              value: 'facetValue',
+            },
+          ],
+          refine: expect.any(Function),
+        },
+      ]);
     });
   });
 });

--- a/src/connectors/current-refinements/__tests__/connectCurrentRefinements-test.ts
+++ b/src/connectors/current-refinements/__tests__/connectCurrentRefinements-test.ts
@@ -51,7 +51,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
 
   describe('Lifecycle', () => {
     it('renders during init and render', () => {
-      const helper = algoliasearchHelper(createSearchClient(), '', {});
+      const helper = algoliasearchHelper(createSearchClient(), 'indexName', {});
       helper.search = jest.fn();
       // test that the dummyRendering is called with the isFirstRendering
       // flag set accordingly
@@ -111,7 +111,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
     });
 
     it('does not throw without the unmount function', () => {
-      const helper = algoliasearchHelper(createSearchClient(), '', {});
+      const helper = algoliasearchHelper(createSearchClient(), 'indexName', {});
       const rendering = () => {};
       const customCurrentRefinements = connectCurrentRefinements(rendering);
       const widget = customCurrentRefinements({});
@@ -126,7 +126,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
     let helper: AlgoliaSearchHelper;
 
     beforeEach(() => {
-      helper = algoliasearchHelper(createSearchClient(), '', {
+      helper = algoliasearchHelper(createSearchClient(), 'indexName', {
         facets: ['facet1', 'facet2', 'facet3'],
       });
       helper.search = jest.fn();
@@ -447,7 +447,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
     let helper: AlgoliaSearchHelper;
 
     beforeEach(() => {
-      helper = algoliasearchHelper(createSearchClient(), '', {
+      helper = algoliasearchHelper(createSearchClient(), 'indexName', {
         facets: ['facet1', 'facet2', 'facet3'],
       });
       helper.search = jest.fn();
@@ -470,6 +470,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
       const firstRenderingOptions = rendering.mock.calls[0][0];
       expect(firstRenderingOptions.items).toEqual([
         {
+          indexName: 'indexName',
           attribute: 'facet1',
           label: 'facet1',
           refinements: [
@@ -512,6 +513,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
       expect(items).toHaveLength(2);
       expect(items).toEqual([
         {
+          indexName: 'indexName',
           attribute: 'facet1',
           label: 'facet1',
           refinements: [
@@ -525,6 +527,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
           refine: expect.any(Function),
         },
         {
+          indexName: 'indexName',
           attribute: 'facet2',
           label: 'facet2',
           refinements: [
@@ -541,7 +544,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
 
       expect(helper.state).toEqual(
         new SearchParameters({
-          index: '',
+          index: 'indexName',
           facets: ['facet1', 'facet2', 'facet3'],
           facetsRefinements: { facet1: ['facetValue'], facet2: ['facetValue'] },
         })
@@ -556,7 +559,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
 
       expect(helper.state).toEqual(
         new SearchParameters({
-          index: '',
+          index: 'indexName',
           facets: ['facet1', 'facet2', 'facet3'],
           facetsRefinements: { facet1: [], facet2: ['facetValue'] },
         })
@@ -613,6 +616,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
       expect(items).toHaveLength(4);
       expect(items).toEqual([
         {
+          indexName: 'indexName',
           attribute: 'facet1',
           label: 'facet1',
           refinements: [
@@ -626,6 +630,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
           refine: expect.any(Function),
         },
         {
+          indexName: 'indexName',
           attribute: 'facet2',
           label: 'facet2',
           refinements: [
@@ -639,6 +644,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
           refine: expect.any(Function),
         },
         {
+          indexName: 'indexName',
           attribute: 'facet1',
           label: 'facet1',
           refinements: [
@@ -652,6 +658,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
           refine: expect.any(Function),
         },
         {
+          indexName: 'indexName',
           attribute: 'facet2',
           label: 'facet2',
           refinements: [

--- a/src/connectors/current-refinements/connectCurrentRefinements.ts
+++ b/src/connectors/current-refinements/connectCurrentRefinements.ts
@@ -146,7 +146,6 @@ const connectCurrentRefinements: CurrentRefinementsConnector = (
         const items = transformItems(
           getItems({
             results: {} as SearchResults,
-            state: helper.state,
             helper,
             includedAttributes,
             excludedAttributes,
@@ -166,16 +165,19 @@ const connectCurrentRefinements: CurrentRefinementsConnector = (
         );
       },
 
-      render({ results, helper, state, createURL, instantSearchInstance }) {
-        const items = transformItems(
-          getItems({
-            results,
-            state,
-            helper,
-            includedAttributes,
-            excludedAttributes,
-          })
-        );
+      render({ scopedResults, helper, createURL, instantSearchInstance }) {
+        const items = scopedResults.reduce<Item[]>((results, scopedResult) => {
+          return results.concat(
+            transformItems(
+              getItems({
+                results: scopedResult.results,
+                helper: scopedResult.helper,
+                includedAttributes,
+                excludedAttributes,
+              })
+            )
+          );
+        }, []);
 
         renderFn(
           {
@@ -199,13 +201,11 @@ const connectCurrentRefinements: CurrentRefinementsConnector = (
 
 function getItems({
   results,
-  state,
   helper,
   includedAttributes,
   excludedAttributes,
 }: {
   results: SearchResults;
-  state: SearchParameters;
   helper: AlgoliaSearchHelper;
   includedAttributes: CurrentRefinementsConnectorParams['includedAttributes'];
   excludedAttributes: CurrentRefinementsConnectorParams['excludedAttributes'];
@@ -220,7 +220,7 @@ function getItems({
     : (item: ConnectorRefinement) =>
         excludedAttributes!.indexOf(item.attribute) === -1;
 
-  const items = getRefinements(results, state, clearsQuery)
+  const items = getRefinements(results, helper.state, clearsQuery)
     .map(normalizeRefinement)
     .filter(filterFunction);
 

--- a/src/connectors/current-refinements/connectCurrentRefinements.ts
+++ b/src/connectors/current-refinements/connectCurrentRefinements.ts
@@ -37,6 +37,7 @@ interface ConnectorNumericRefinement extends ConnectorRefinement {
 }
 
 export type Item = {
+  indexName: string;
   attribute: string;
   label: string;
   refinements: ItemRefinement[];
@@ -230,6 +231,7 @@ function getItems({
         (item: Item) => item.attribute !== currentItem.attribute
       ),
       {
+        indexName: helper.state.index,
         attribute: currentItem.attribute,
         label: currentItem.attribute,
         refinements: items

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -18,6 +18,7 @@ export interface InitOptions {
 export interface ScopedResult {
   indexId: string;
   results: SearchResults;
+  helper: Helper;
 }
 
 export interface RenderOptions {

--- a/src/widgets/current-refinements/__tests__/__snapshots__/current-refinements-test.ts.snap
+++ b/src/widgets/current-refinements/__tests__/__snapshots__/current-refinements-test.ts.snap
@@ -17,6 +17,7 @@ exports[`currentRefinements() render() DOM output renders correctly 1`] = `
     Array [
       Object {
         "attribute": "facet",
+        "indexName": "indexName",
         "label": "facet",
         "refine": [Function],
         "refinements": Array [
@@ -30,6 +31,7 @@ exports[`currentRefinements() render() DOM output renders correctly 1`] = `
       },
       Object {
         "attribute": "facetExclude",
+        "indexName": "indexName",
         "label": "facetExclude",
         "refine": [Function],
         "refinements": Array [
@@ -43,6 +45,7 @@ exports[`currentRefinements() render() DOM output renders correctly 1`] = `
       },
       Object {
         "attribute": "rating",
+        "indexName": "indexName",
         "label": "rating",
         "refine": [Function],
         "refinements": Array [
@@ -62,6 +65,7 @@ exports[`currentRefinements() render() DOM output renders correctly 1`] = `
       },
       Object {
         "attribute": "brand",
+        "indexName": "indexName",
         "label": "brand",
         "refine": [Function],
         "refinements": Array [
@@ -81,6 +85,7 @@ exports[`currentRefinements() render() DOM output renders correctly 1`] = `
       },
       Object {
         "attribute": "hierarchicalCategories.lvl0",
+        "indexName": "indexName",
         "label": "hierarchicalCategories.lvl0",
         "refine": [Function],
         "refinements": Array [
@@ -96,6 +101,7 @@ exports[`currentRefinements() render() DOM output renders correctly 1`] = `
       },
       Object {
         "attribute": "price",
+        "indexName": "indexName",
         "label": "price",
         "refine": [Function],
         "refinements": Array [
@@ -117,6 +123,7 @@ exports[`currentRefinements() render() DOM output renders correctly 1`] = `
       },
       Object {
         "attribute": "_tags",
+        "indexName": "indexName",
         "label": "_tags",
         "refine": [Function],
         "refinements": Array [
@@ -173,6 +180,7 @@ exports[`currentRefinements() render() should render twice <CurrentRefinements .
     Array [
       Object {
         "attribute": "facet",
+        "indexName": "index_name",
         "label": "facet",
         "refine": [Function],
         "refinements": Array [
@@ -208,6 +216,7 @@ exports[`currentRefinements() render() should render twice <CurrentRefinements .
     Array [
       Object {
         "attribute": "facet",
+        "indexName": "index_name",
         "label": "facet",
         "refine": [Function],
         "refinements": Array [

--- a/src/widgets/current-refinements/__tests__/current-refinements-test.ts
+++ b/src/widgets/current-refinements/__tests__/current-refinements-test.ts
@@ -122,15 +122,21 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
       );
 
       const renderParameters = {
-        results: new SearchResults(helper.state, [
-          createSingleSearchResponse({
-            facets: {
-              facet: {
-                'facet-val1': 1,
-              },
-            },
-          }),
-        ]),
+        scopedResults: [
+          {
+            indexId: 'index_name',
+            helper,
+            results: new SearchResults(helper.state, [
+              createSingleSearchResponse({
+                facets: {
+                  facet: {
+                    'facet-val1': 1,
+                  },
+                },
+              }),
+            ]),
+          },
+        ],
         helper,
         state: helper.state,
       };
@@ -199,24 +205,30 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
         );
         widget.render!(
           createRenderOptions({
-            results: new SearchResults(helper.state, [
-              createSingleSearchResponse({
-                facets: {
-                  facet: {
-                    'facet-val1': 1,
-                    'facet-val2': 2,
-                  },
-                  extraFacet: {
-                    'extraFacet-val1': 42,
-                    'extraFacet-val2': 42,
-                  },
-                  disjunctiveFacet: {
-                    'disjunctiveFacet-val1': 3,
-                    'disjunctiveFacet-val2': 4,
-                  },
-                },
-              }),
-            ]),
+            scopedResults: [
+              {
+                indexId: 'index_name',
+                helper,
+                results: new SearchResults(helper.state, [
+                  createSingleSearchResponse({
+                    facets: {
+                      facet: {
+                        'facet-val1': 1,
+                        'facet-val2': 2,
+                      },
+                      extraFacet: {
+                        'extraFacet-val1': 42,
+                        'extraFacet-val2': 42,
+                      },
+                      disjunctiveFacet: {
+                        'disjunctiveFacet-val1': 3,
+                        'disjunctiveFacet-val2': 4,
+                      },
+                    },
+                  }),
+                ]),
+              },
+            ],
             helper,
             state: helper.state,
           })
@@ -257,20 +269,26 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
         );
         widget.render!(
           createRenderOptions({
-            results: new SearchResults(helper.state, [
-              createSingleSearchResponse({
-                facets: {
-                  extraFacet: {
-                    'extraFacet-val1': 42,
-                    'extraFacet-val2': 42,
-                  },
-                  disjunctiveFacet: {
-                    'disjunctiveFacet-val1': 3,
-                    'disjunctiveFacet-val2': 4,
-                  },
-                },
-              }),
-            ]),
+            scopedResults: [
+              {
+                indexId: 'index_name',
+                helper,
+                results: new SearchResults(helper.state, [
+                  createSingleSearchResponse({
+                    facets: {
+                      extraFacet: {
+                        'extraFacet-val1': 42,
+                        'extraFacet-val2': 42,
+                      },
+                      disjunctiveFacet: {
+                        'disjunctiveFacet-val1': 3,
+                        'disjunctiveFacet-val2': 4,
+                      },
+                    },
+                  }),
+                ]),
+              },
+            ],
             helper,
             state: helper.state,
           })
@@ -318,24 +336,30 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
         );
         widget.render!(
           createRenderOptions({
-            results: new SearchResults(helper.state, [
-              createSingleSearchResponse({
-                facets: {
-                  facet: {
-                    'facet-val1': 1,
-                    'facet-val2': 2,
-                  },
-                  extraFacet: {
-                    'extraFacet-val1': 42,
-                    'extraFacet-val2': 42,
-                  },
-                  disjunctiveFacet: {
-                    'disjunctiveFacet-val1': 3,
-                    'disjunctiveFacet-val2': 4,
-                  },
-                },
-              }),
-            ]),
+            scopedResults: [
+              {
+                indexId: 'index_name',
+                helper,
+                results: new SearchResults(helper.state, [
+                  createSingleSearchResponse({
+                    facets: {
+                      facet: {
+                        'facet-val1': 1,
+                        'facet-val2': 2,
+                      },
+                      extraFacet: {
+                        'extraFacet-val1': 42,
+                        'extraFacet-val2': 42,
+                      },
+                      disjunctiveFacet: {
+                        'disjunctiveFacet-val1': 3,
+                        'disjunctiveFacet-val2': 4,
+                      },
+                    },
+                  }),
+                ]),
+              },
+            ],
             helper,
             state: helper.state,
           })
@@ -463,41 +487,47 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
 
         widget.render!(
           createRenderOptions({
-            results: new SearchResults(helper.state, [
-              createSingleSearchResponse({
-                facets: {
-                  'hierarchicalCategories.lvl0': {
-                    'Cell Phones': 3291,
-                  },
-                  'hierarchicalCategories.lvl1': {
-                    'Cell Phones > All Cell Phones with Plans': 126,
-                    'Cell Phones > Cell Phone Accessories': 2836,
-                    'Cell Phones > Mobile Broadband': 1,
-                    'Cell Phones > Prepaid Phones': 55,
-                    'Cell Phones > Refurbished Phones': 27,
-                    'Cell Phones > Samsung Galaxy': 8,
-                    'Cell Phones > Unlocked Cell Phones': 198,
-                    'Cell Phones > iPhone': 35,
-                  },
-                },
-              }),
-              createSingleSearchResponse({
-                facets: {
-                  'hierarchicalCategories.lvl0': {
-                    Appliances: 4306,
-                    Audio: 1570,
-                    'Cameras & Camcorders': 1369,
-                    'Car Electronics & GPS': 1208,
-                    'Cell Phones': 3291,
-                    'Computers & Tablets': 3563,
-                    'Health, Fitness & Beauty': 923,
-                    'Office & School Supplies': 617,
-                    'TV & Home Theater': 1201,
-                    'Video Games': 505,
-                  },
-                },
-              }),
-            ]),
+            scopedResults: [
+              {
+                indexId: 'index_name',
+                helper,
+                results: new SearchResults(helper.state, [
+                  createSingleSearchResponse({
+                    facets: {
+                      'hierarchicalCategories.lvl0': {
+                        'Cell Phones': 3291,
+                      },
+                      'hierarchicalCategories.lvl1': {
+                        'Cell Phones > All Cell Phones with Plans': 126,
+                        'Cell Phones > Cell Phone Accessories': 2836,
+                        'Cell Phones > Mobile Broadband': 1,
+                        'Cell Phones > Prepaid Phones': 55,
+                        'Cell Phones > Refurbished Phones': 27,
+                        'Cell Phones > Samsung Galaxy': 8,
+                        'Cell Phones > Unlocked Cell Phones': 198,
+                        'Cell Phones > iPhone': 35,
+                      },
+                    },
+                  }),
+                  createSingleSearchResponse({
+                    facets: {
+                      'hierarchicalCategories.lvl0': {
+                        Appliances: 4306,
+                        Audio: 1570,
+                        'Cameras & Camcorders': 1369,
+                        'Car Electronics & GPS': 1208,
+                        'Cell Phones': 3291,
+                        'Computers & Tablets': 3563,
+                        'Health, Fitness & Beauty': 923,
+                        'Office & School Supplies': 617,
+                        'TV & Home Theater': 1201,
+                        'Video Games': 505,
+                      },
+                    },
+                  }),
+                ]),
+              },
+            ],
             helper,
             state: helper.state,
           })

--- a/src/widgets/current-refinements/__tests__/current-refinements-test.ts
+++ b/src/widgets/current-refinements/__tests__/current-refinements-test.ts
@@ -131,6 +131,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
                 facets: {
                   facet: {
                     'facet-val1': 1,
+                    'facet-val2': 2,
+                  },
+                  extraFacet: {
+                    'extraFacet-val1': 42,
+                    'extraFacet-val2': 42,
                   },
                 },
               }),

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -1514,6 +1514,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
             {
               indexId: 'indexName',
               results: (widget.render as jest.Mock).mock.calls[0][0].results,
+              helper: instance.getHelper(),
             },
           ],
           state: expect.any(algoliasearchHelper.SearchParameters),
@@ -1599,27 +1600,33 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
               indexId: 'level1IndexName',
               results: (searchBoxLevel1.render as jest.Mock).mock.calls[0][0]
                 .results,
+              helper: level1.getHelper(),
             },
             // Siblings and children
             {
               indexId: 'level2IndexName',
               results: expect.any(algoliasearchHelper.SearchResults),
+              helper: level2.getHelper(),
             },
             {
               indexId: 'level21IndeName',
               results: expect.any(algoliasearchHelper.SearchResults),
+              helper: level21.getHelper(),
             },
             {
               indexId: 'level22IndexName',
               results: expect.any(algoliasearchHelper.SearchResults),
+              helper: level22.getHelper(),
             },
             {
               indexId: 'level221IndexName',
               results: expect.any(algoliasearchHelper.SearchResults),
+              helper: level221.getHelper(),
             },
             {
               indexId: 'level3IndexName',
               results: expect.any(algoliasearchHelper.SearchResults),
+              helper: level3.getHelper(),
             },
           ],
         })
@@ -1635,15 +1642,18 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
               indexId: 'level21IndeName',
               results: (seachBoxLevel21.render as jest.Mock).mock.calls[0][0]
                 .results,
+              helper: level21.getHelper(),
             },
             // Siblings and children
             {
               indexId: 'level22IndexName',
               results: expect.any(algoliasearchHelper.SearchResults),
+              helper: level22.getHelper(),
             },
             {
               indexId: 'level221IndexName',
               results: expect.any(algoliasearchHelper.SearchResults),
+              helper: level221.getHelper(),
             },
           ],
         })
@@ -1659,32 +1669,39 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
               indexId: 'level0IndexName',
               results: (searchBoxLevel0.render as jest.Mock).mock.calls[0][0]
                 .results,
+              helper: level0.getHelper(),
             },
             // Siblings and children
             {
               indexId: 'level1IndexName',
               results: (searchBoxLevel1.render as jest.Mock).mock.calls[0][0]
                 .results,
+              helper: level1.getHelper(),
             },
             {
               indexId: 'level2IndexName',
               results: expect.any(algoliasearchHelper.SearchResults),
+              helper: level2.getHelper(),
             },
             {
               indexId: 'level21IndeName',
               results: expect.any(algoliasearchHelper.SearchResults),
+              helper: level21.getHelper(),
             },
             {
               indexId: 'level22IndexName',
               results: expect.any(algoliasearchHelper.SearchResults),
+              helper: level22.getHelper(),
             },
             {
               indexId: 'level221IndexName',
               results: expect.any(algoliasearchHelper.SearchResults),
+              helper: level221.getHelper(),
             },
             {
               indexId: 'level3IndexName',
               results: expect.any(algoliasearchHelper.SearchResults),
+              helper: level3.getHelper(),
             },
           ],
         })

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -90,6 +90,7 @@ function resolveScopedResultsFromWidgets(widgets: Widget[]): ScopedResult[] {
       {
         indexId: current.getIndexId(),
         results: current.getResults()!,
+        helper: current.getHelper()!,
       },
       ...resolveScopedResultsFromWidgets(current.getWidgets())
     );

--- a/stories/current-refinements.stories.js
+++ b/stories/current-refinements.stories.js
@@ -287,7 +287,8 @@ storiesOf('CurrentRefinements', module)
       instantSearchPriceAscTitle.innerHTML =
         '<code>instant_search_price_asc</code>';
       const instantSearchMediaTitle = document.createElement('h3');
-      instantSearchMediaTitle.innerHTML = '<code>instant_search_media</code>';
+      instantSearchMediaTitle.innerHTML =
+        '<code>instant_search_rating_asc</code>';
       const refinementListContainer1 = document.createElement('div');
       const refinementListContainer2 = document.createElement('div');
 
@@ -316,12 +317,12 @@ storiesOf('CurrentRefinements', module)
 
         instantsearch.widgets
           .index({
-            indexName: 'instant_search_media',
+            indexName: 'instant_search_rating_asc',
           })
           .addWidgets([
             instantsearch.widgets.refinementList({
               container: refinementListContainer2,
-              attribute: 'locations',
+              attribute: 'categories',
               limit: 3,
             }),
           ]),

--- a/stories/current-refinements.stories.js
+++ b/stories/current-refinements.stories.js
@@ -278,4 +278,53 @@ storiesOf('CurrentRefinements', module)
         })
       );
     })
+  )
+  .add(
+    'with multi indices',
+    withHits(({ search, container, instantsearch }) => {
+      const currentRefinementsContainer1 = document.createElement('div');
+      const instantSearchPriceAscTitle = document.createElement('h3');
+      instantSearchPriceAscTitle.innerHTML =
+        '<code>instant_search_price_asc</code>';
+      const instantSearchMediaTitle = document.createElement('h3');
+      instantSearchMediaTitle.innerHTML = '<code>instant_search_media</code>';
+      const refinementListContainer1 = document.createElement('div');
+      const refinementListContainer2 = document.createElement('div');
+
+      container.appendChild(currentRefinementsContainer1);
+      container.appendChild(instantSearchPriceAscTitle);
+      container.appendChild(refinementListContainer1);
+      container.appendChild(instantSearchMediaTitle);
+      container.appendChild(refinementListContainer2);
+
+      search.addWidgets([
+        instantsearch.widgets.currentRefinements({
+          container: currentRefinementsContainer1,
+        }),
+
+        instantsearch.widgets
+          .index({
+            indexName: 'instant_search_price_asc',
+          })
+          .addWidgets([
+            instantsearch.widgets.refinementList({
+              container: refinementListContainer1,
+              attribute: 'brand',
+              limit: 3,
+            }),
+          ]),
+
+        instantsearch.widgets
+          .index({
+            indexName: 'instant_search_media',
+          })
+          .addWidgets([
+            instantsearch.widgets.refinementList({
+              container: refinementListContainer2,
+              attribute: 'locations',
+              limit: 3,
+            }),
+          ]),
+      ]);
+    })
   );

--- a/test/mock/createWidget.ts
+++ b/test/mock/createWidget.ts
@@ -44,6 +44,7 @@ export const createRenderOptions = (
       {
         indexId: instantSearchInstance.helper!.state.index,
         results,
+        helper: instantSearchInstance.helper!,
       },
     ],
     searchMetadata: {


### PR DESCRIPTION
## Description

This implements multi-index context in `CurrentRefinements` leveraging `scopedResults` (#3964).

A `CurrentRefinements` widget now displays the refinements coming from its siblings and its children.

## Internal changes

The `index` now calls the `render` hook with an enhanced `scopedResults` containing the helper for this index. This is needed to call `refine` on each item coming from the `CurrentRefinements`. Otherwise, calling `setState` on the helper doesn't change the correct helper state (and thus breaks).

The new structure is:

```ts
interface ScopedResult {
  indexId: string;
  results: SearchResults;
  helper: Helper;
}
```

A new property `indexName` is added to the CurrentRefinements items. This property is given to the renderer. This `indexName` can be used to display the index where the attribute is coming from, or compute a node key for component-based flavors (e.g. React). The new structure is:

```diff
 type Item = {
+  indexName: string;
   attribute: string;
   label: string;
   refinements: ItemRefinement[];
   refine(refinement: ItemRefinement): void;
 };
```

## Example

```js
search.addWidgets([
  // Displays both the refinements for `index1` and `index2`
  instantsearch.widgets.currentRefinements({
    container,
  }),

  instantsearch.widgets
    .index({
      indexName: 'index1',
    })
    .addWidgets([
      instantsearch.widgets.refinementList({
        container,
        attribute: 'brand',
      }),
    ]),

  instantsearch.widgets
    .index({
      indexName: 'index2',
    })
    .addWidgets([
      instantsearch.widgets.refinementList({
        container,
        attribute: 'locations',
      }),
    ]),
]);
```

## Preview

[See story →](http://deploy-preview-4012--instantsearchjs.netlify.com/stories/?path=/story/currentrefinements--with-multi-indices)