### PR TITLE
feat(autocomplete): participate in routing

### DIFF
--- a/src/connectors/autocomplete/__tests__/connectAutocomplete-test.ts
+++ b/src/connectors/autocomplete/__tests__/connectAutocomplete-test.ts
@@ -537,6 +537,7 @@ search.addWidgets([
         new SearchParameters({
           index: '',
           query: 'Apple',
+          ...TAG_PLACEHOLDER,
         })
       );
     });
@@ -558,6 +559,7 @@ search.addWidgets([
         new SearchParameters({
           index: '',
           query: '',
+          ...TAG_PLACEHOLDER,
         })
       );
     });

--- a/src/connectors/autocomplete/__tests__/connectAutocomplete-test.ts
+++ b/src/connectors/autocomplete/__tests__/connectAutocomplete-test.ts
@@ -11,8 +11,34 @@ import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import { createSingleSearchResponse } from '../../../../test/mock/createAPIResponse';
 import connectAutocomplete from '../connectAutocomplete';
 import { TAG_PLACEHOLDER } from '../../../lib/escape-highlight';
+import { Client } from 'algoliasearch/lite';
 
 describe('connectAutocomplete', () => {
+  const getInitializedWidget = (config = {}) => {
+    const renderFn = jest.fn();
+    const makeWidget = connectAutocomplete(renderFn);
+    const widget = makeWidget({
+      ...config,
+    });
+
+    const initialConfig = {};
+    const helper = algoliasearchHelper({} as Client, '', initialConfig);
+    helper.search = jest.fn();
+
+    widget.init!({
+      helper,
+      state: helper.state,
+      createURL: () => '#',
+      instantSearchInstance: undefined as any,
+      parent: undefined as any,
+      templatesConfig: undefined as any,
+    });
+
+    const { refine } = renderFn.mock.calls[0][0];
+
+    return [widget, helper, refine];
+  };
+
   it('throws without render function', () => {
     expect(() => {
       // @ts-ignore
@@ -446,6 +472,94 @@ search.addWidgets([
 
       expect(nextState.highlightPreTag).toBe('<mark>');
       expect(nextState.highlightPostTag).toBe('</mark>');
+    });
+  });
+
+  describe('getWidgetState', () => {
+    test('should give back the object unmodified if the default value is selected', () => {
+      const [widget, helper] = getInitializedWidget();
+      const uiStateBefore = {};
+      const uiStateAfter = widget.getWidgetState(uiStateBefore, {
+        searchParameters: helper.state,
+        helper,
+      });
+      expect(uiStateAfter).toBe(uiStateBefore);
+    });
+
+    test('should add an entry equal to the refinement', () => {
+      const [widget, helper, refine] = getInitializedWidget();
+      refine('some query');
+      const uiStateBefore = {};
+      const uiStateAfter = widget.getWidgetState(uiStateBefore, {
+        searchParameters: helper.state,
+        helper,
+      });
+      expect(uiStateAfter).toEqual({
+        query: 'some query',
+      });
+    });
+
+    test('should give back the same instance if the value is alreay in the uiState', () => {
+      const [widget, helper, refine] = getInitializedWidget();
+      refine('query');
+      const uiStateBefore = widget.getWidgetState(
+        {},
+        {
+          searchParameters: helper.state,
+          helper,
+        }
+      );
+      const uiStateAfter = widget.getWidgetState(uiStateBefore, {
+        searchParameters: helper.state,
+        helper,
+      });
+      expect(uiStateAfter).toBe(uiStateBefore);
+    });
+  });
+
+  describe('getWidgetSearchParameters', () => {
+    test('returns the `SearchParameters` with the value from `uiState`', () => {
+      const [widget, helper] = getInitializedWidget();
+
+      expect(helper.state).toEqual(
+        new SearchParameters({
+          index: '',
+        })
+      );
+
+      const actual = widget.getWidgetSearchParameters(helper.state, {
+        uiState: {
+          query: 'Apple',
+        },
+      });
+
+      expect(actual).toEqual(
+        new SearchParameters({
+          index: '',
+          query: 'Apple',
+        })
+      );
+    });
+
+    test('returns the `SearchParameters` with the default value', () => {
+      const [widget, helper] = getInitializedWidget();
+
+      expect(helper.state).toEqual(
+        new SearchParameters({
+          index: '',
+        })
+      );
+
+      const actual = widget.getWidgetSearchParameters(helper.state, {
+        uiState: {},
+      });
+
+      expect(actual).toEqual(
+        new SearchParameters({
+          index: '',
+          query: '',
+        })
+      );
     });
   });
 });

--- a/src/connectors/autocomplete/connectAutocomplete.ts
+++ b/src/connectors/autocomplete/connectAutocomplete.ts
@@ -93,7 +93,6 @@ search.addWidgets([
     );
 
     type ConnectorState = {
-      instantSearchInstance?: InstantSearch;
       refine?: (query: string) => void;
     };
 
@@ -118,7 +117,6 @@ search.addWidgets([
       },
 
       init({ instantSearchInstance, helper }) {
-        connectorState.instantSearchInstance = instantSearchInstance;
         connectorState.refine = (query: string) => {
           helper.setQuery(query).search();
         };
@@ -129,13 +127,13 @@ search.addWidgets([
             currentRefinement: helper.state.query || '',
             indices: [],
             refine: connectorState.refine,
-            instantSearchInstance: connectorState.instantSearchInstance,
+            instantSearchInstance,
           },
           true
         );
       },
 
-      render({ helper, scopedResults }) {
+      render({ helper, scopedResults, instantSearchInstance }) {
         const indices = scopedResults.map(scopedResult => {
           // We need to escape the hits because highlighting
           // exposes HTML tags to the end-user.
@@ -156,10 +154,27 @@ search.addWidgets([
             currentRefinement: helper.state.query || '',
             indices,
             refine: connectorState.refine!,
-            instantSearchInstance: connectorState.instantSearchInstance!,
+            instantSearchInstance,
           },
           false
         );
+      },
+
+      getWidgetState(uiState, { searchParameters }) {
+        const query = searchParameters.query || '';
+
+        if (query === '' || (uiState && uiState.query === query)) {
+          return uiState;
+        }
+
+        return {
+          ...uiState,
+          query,
+        };
+      },
+
+      getWidgetSearchParameters(searchParameters, { uiState }) {
+        return searchParameters.setQueryParameter('query', uiState.query || '');
       },
 
       dispose({ state }) {

--- a/src/connectors/autocomplete/connectAutocomplete.ts
+++ b/src/connectors/autocomplete/connectAutocomplete.ts
@@ -174,7 +174,18 @@ search.addWidgets([
       },
 
       getWidgetSearchParameters(searchParameters, { uiState }) {
-        return searchParameters.setQueryParameter('query', uiState.query || '');
+        const parameters = {
+          query: uiState.query || '',
+        };
+
+        if (!escapeHTML) {
+          return searchParameters.setQueryParameters(parameters);
+        }
+
+        return searchParameters.setQueryParameters({
+          ...parameters,
+          ...TAG_PLACEHOLDER,
+        });
       },
 
       dispose({ state }) {


### PR DESCRIPTION
autocomplete is acting just like search box, but also sets the parameters for highlighting from hits. This is a copy-paste from the tests & code of searchbox (#4002), but with the tags added.

This has an impact on routing (it used to not be synchronised if you type in an autocomplete, but now it will be).