### PR TITLE
chore(deps): update helper to latest canary

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "es"
   ],
   "dependencies": {
-    "algoliasearch-helper": "0.0.0-6ac260d",
+    "algoliasearch-helper": "0.0.0-94f40da",
     "classnames": "^2.2.5",
     "events": "^1.1.0",
     "hogan.js": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2166,10 +2166,10 @@ algolia-aerial@^1.5.3:
   resolved "https://registry.yarnpkg.com/algolia-aerial/-/algolia-aerial-1.5.3.tgz#c8b8ca6bc484164ffc7b36717689a424ea6bfe6c"
   integrity sha512-LZTpVlYnhqNFd+ru/Spm73omhsagiRQLmjrosa5bJ6/I9OMRp4Sb9pYZkAxcx3RSr+ZNXZqthL7rpXqMFdrnPA==
 
-algoliasearch-helper@0.0.0-6ac260d:
-  version "0.0.0-6ac260d"
-  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-0.0.0-6ac260d.tgz#9f4a0f2c8f89eafe23559375907b4070afa4cbb1"
-  integrity sha512-wG1oVPEq4bXmNUeF2voio+0UpNRtDLTG7+OPCvTxMDIQvD2Exc0s2UsWl5fh6/Dc7O++b8Ic2g+YSVo5l+nBFg==
+algoliasearch-helper@0.0.0-94f40da:
+  version "0.0.0-94f40da"
+  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-0.0.0-94f40da.tgz#302cdddc9fcbd984dcdeb3b5a521bd494077b0e0"
+  integrity sha512-7qsj8slRykVweW4ITiRxH6TlWyH291JK8upH7lYF067gRhAatI+w93cRX+1SUXIPPZSGpBhEY3nUsTKJ1fZ6Og==
   dependencies:
     events "^1.1.1"
 


### PR DESCRIPTION
1. https://github.com/algolia/instantsearch.js/pull/4000#discussion_r311457169 is fixed by https://github.com/algolia/algoliasearch-helper-js/pull/742

This requires #4000 to be updated to remove the @ts-ignore

2. https://github.com/algolia/algoliasearch-helper-js/pull/743 fixes https://github.com/algolia/instantsearch.js/pull/4024 & https://github.com/algolia/instantsearch.js/pull/4027

This change doesn't require any subsequent changes because the tests are new in those PRs
