### PR TITLE
feat(hitsPerPage): support new routing system

### DIFF
--- a/src/connectors/hits-per-page/__tests__/__snapshots__/connectHitsPerPage-test.js.snap
+++ b/src/connectors/hits-per-page/__tests__/__snapshots__/connectHitsPerPage-test.js.snap
@@ -39,25 +39,3 @@ Array [
   },
 ]
 `;
-
-exports[`connectHitsPerPage routing getWidgetSearchParameters should add the refinements according to the UI state provided 1`] = `
-SearchParameters {
-  "disjunctiveFacets": Array [],
-  "disjunctiveFacetsRefinements": Object {},
-  "facets": Array [],
-  "facetsExcludes": Object {},
-  "facetsRefinements": Object {},
-  "hierarchicalFacets": Array [],
-  "hierarchicalFacetsRefinements": Object {},
-  "hitsPerPage": 10,
-  "index": "",
-  "numericRefinements": Object {},
-  "tagRefinements": Array [],
-}
-`;
-
-exports[`connectHitsPerPage routing getWidgetState should add an entry equal to the refinement 1`] = `
-Object {
-  "hitsPerPage": 10,
-}
-`;

--- a/src/connectors/hits-per-page/__tests__/__snapshots__/connectHitsPerPage-test.js.snap
+++ b/src/connectors/hits-per-page/__tests__/__snapshots__/connectHitsPerPage-test.js.snap
@@ -13,8 +13,9 @@ Array [
     "value": 10,
   },
   Object {
+    "default": true,
     "isRefined": true,
-    "label": "",
+    "label": "7 items per page",
     "value": 7,
   },
 ]
@@ -33,8 +34,9 @@ Array [
     "value": 10,
   },
   Object {
+    "default": true,
     "isRefined": false,
-    "label": "",
+    "label": "7 items per page",
     "value": 7,
   },
 ]

--- a/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
+++ b/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
@@ -529,7 +529,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       const widget = makeWidget({
         items: [
           { value: 3, label: '3 items per page' },
-          { value: 10, label: '10 items per page' },
+          { value: 22, label: '22 items per page' },
         ],
       });
 
@@ -552,7 +552,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       const widget = makeWidget({
         items: [
           { value: 3, label: '3 items per page' },
-          { value: 10, label: '10 items per page' },
+          { value: 22, label: '22 items per page' },
         ],
       });
 
@@ -577,7 +577,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       const widget = makeWidget({
         items: [
           { value: 3, label: '3 items per page' },
-          { value: 10, label: '10 items per page' },
+          { value: 22, label: '22 items per page' },
         ],
       });
 
@@ -595,7 +595,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       const widget = makeWidget({
         items: [
           { value: 3, label: '3 items per page', default: true },
-          { value: 10, label: '10 items per page' },
+          { value: 22, label: '22 items per page' },
         ],
       });
 
@@ -612,8 +612,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       const helper = algoliasearchHelper({}, 'indexName');
       const widget = makeWidget({
         items: [
-          { value: 3, label: '3 items per page', default: true },
-          { value: 10, label: '10 items per page' },
+          { value: 3, label: '3 items per page' },
+          { value: 22, label: '22 items per page' },
         ],
       });
 
@@ -635,7 +635,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       const widget = makeWidget({
         items: [
           { value: 3, label: '3 items per page' },
-          { value: 10, label: '10 items per page' },
+          { value: 22, label: '22 items per page' },
         ],
       });
 

--- a/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
+++ b/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
@@ -18,6 +18,33 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
 `);
     });
 
+    it('throws with empty items', () => {
+      expect(() => {
+        connectHitsPerPage(() => {})({
+          items: [],
+        });
+      }).toThrowErrorMatchingInlineSnapshot(`
+"A default value must be specified in \`items\`.
+
+See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-page/js/#connector"
+`);
+    });
+
+    it('throws without default item', () => {
+      expect(() => {
+        connectHitsPerPage(() => {})({
+          items: [
+            { value: 3, label: '3 items per page' },
+            { value: 10, label: '10 items per page' },
+          ],
+        });
+      }).toThrowErrorMatchingInlineSnapshot(`
+"A default value must be specified in \`items\`.
+
+See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-page/js/#connector"
+`);
+    });
+
     it('throws with multiple default items', () => {
       expect(() => {
         connectHitsPerPage(() => {})({
@@ -33,12 +60,25 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
 `);
     });
 
+    it('does not throw with items and one default value', () => {
+      expect(() => {
+        connectHitsPerPage(() => {})({
+          items: [
+            { value: 3, label: '3 items per page', default: true },
+            { value: 10, label: '10 items per page' },
+          ],
+        });
+      }).not.toThrow();
+    });
+
     it('is a widget', () => {
       const render = jest.fn();
       const unmount = jest.fn();
 
       const customHitsPerPage = connectHitsPerPage(render, unmount);
-      const widget = customHitsPerPage({ items: [] });
+      const widget = customHitsPerPage({
+        items: [{ label: '10 items per page', value: 10, default: true }],
+      });
 
       expect(widget).toEqual(
         expect.objectContaining({
@@ -59,13 +99,15 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
     const makeWidget = connectHitsPerPage(renderFn);
     const widget = makeWidget({
       items: [
-        { value: 3, label: '3 items per page' },
+        { value: 3, label: '3 items per page', default: true },
         { value: 10, label: '10 items per page' },
       ],
     });
 
     expect(widget.getConfiguration(new SearchParameters({}))).toEqual(
-      new SearchParameters({})
+      new SearchParameters({
+        hitsPerPage: 3,
+      })
     );
 
     expect(renderFn).toHaveBeenCalledTimes(0);
@@ -86,7 +128,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       expect.objectContaining({
         widgetParams: {
           items: [
-            { value: 3, label: '3 items per page' },
+            { value: 3, label: '3 items per page', default: true },
             { value: 10, label: '10 items per page' },
           ],
         },
@@ -106,7 +148,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       expect.objectContaining({
         widgetParams: {
           items: [
-            { value: 3, label: '3 items per page' },
+            { value: 3, label: '3 items per page', default: true },
             { value: 10, label: '10 items per page' },
           ],
         },
@@ -120,7 +162,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
     const makeWidget = connectHitsPerPage(renderFn);
     const widget = makeWidget({
       items: [
-        { value: 3, label: '3 items per page' },
+        { value: 3, label: '3 items per page', default: true },
         { value: 10, label: '10 items per page' },
       ],
       transformItems: items =>
@@ -200,21 +242,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
     );
   });
 
-  it('Does not configures the search when there is no default value', () => {
-    const renderFn = jest.fn();
-    const makeWidget = connectHitsPerPage(renderFn);
-    const widget = makeWidget({
-      items: [
-        { value: 3, label: '3 items per page' },
-        { value: 10, label: '10 items per page' },
-      ],
-    });
-
-    expect(widget.getConfiguration(new SearchParameters({}))).toEqual(
-      new SearchParameters({})
-    );
-  });
-
   it('Provide a function to change the current hits per page, and provide the current value', () => {
     const renderFn = jest.fn();
     const makeWidget = connectHitsPerPage(renderFn);
@@ -222,7 +249,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       items: [
         { value: 3, label: '3 items per page' },
         { value: 10, label: '10 items per page' },
-        { value: 11, label: '' },
+        { value: 11, label: '11 items per page', default: true },
       ],
     });
 
@@ -266,7 +293,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       items: [
         { value: 3, label: '3 items per page' },
         { value: 10, label: '10 items per page' },
-        { value: 20, label: '20 items per page' },
+        { value: 20, label: '20 items per page', default: true },
       ],
     });
 
@@ -304,7 +331,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       items: [
         { value: 3, label: '3 items per page' },
         { value: 10, label: '10 items per page' },
-        { value: 7, label: '' },
+        { value: 7, label: '7 items per page', default: true },
       ],
     });
 
@@ -339,7 +366,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
     const makeWidget = connectHitsPerPage(renderFn);
     const widget = makeWidget({
       items: [
-        { value: 3, label: '3 items per page' },
+        { value: 3, label: '3 items per page', default: true },
         { value: 10, label: '10 items per page' },
       ],
     });
@@ -381,7 +408,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
     const makeWidget = connectHitsPerPage(renderFn);
     const widget = makeWidget({
       items: [
-        { value: 3, label: '3 items per page' },
+        { value: 3, label: '3 items per page', default: true },
         { value: 10, label: '10 items per page' },
       ],
     });
@@ -423,7 +450,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
     const makeWidget = connectHitsPerPage(renderFn);
     const widget = makeWidget({
       items: [
-        { value: 3, label: '3 items per page' },
+        { value: 3, label: '3 items per page', default: true },
         { value: 10, label: '10 items per page' },
       ],
     });
@@ -469,7 +496,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       const makeWidget = connectHitsPerPage(renderFn, unmountFn);
       const widget = makeWidget({
         items: [
-          { value: 3, label: '3 items per page' },
+          { value: 3, label: '3 items per page', default: true },
           { value: 10, label: '10 items per page' },
         ],
       });
@@ -488,7 +515,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       const makeWidget = connectHitsPerPage(renderFn);
       const widget = makeWidget({
         items: [
-          { value: 3, label: '3 items per page' },
+          { value: 3, label: '3 items per page', default: true },
           { value: 10, label: '10 items per page' },
         ],
       });
@@ -508,7 +535,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       const makeWidget = connectHitsPerPage(renderFn, unmountFn);
       const widget = makeWidget({
         items: [
-          { value: 3, label: '3 items per page' },
+          { value: 3, label: '3 items per page', default: true },
           { value: 10, label: '10 items per page' },
         ],
       });
@@ -528,7 +555,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       const helper = algoliasearchHelper({}, 'indexName');
       const widget = makeWidget({
         items: [
-          { value: 3, label: '3 items per page' },
+          { value: 3, label: '3 items per page', default: true },
           { value: 22, label: '22 items per page' },
         ],
       });
@@ -551,7 +578,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       });
       const widget = makeWidget({
         items: [
-          { value: 3, label: '3 items per page' },
+          { value: 3, label: '3 items per page', default: true },
           { value: 22, label: '22 items per page' },
         ],
       });
@@ -570,24 +597,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
   });
 
   describe('getWidgetSearchParameters', () => {
-    test('returns the `SearchParameters` with the initial value', () => {
-      const render = jest.fn();
-      const makeWidget = connectHitsPerPage(render);
-      const helper = algoliasearchHelper({}, 'indexName');
-      const widget = makeWidget({
-        items: [
-          { value: 3, label: '3 items per page' },
-          { value: 22, label: '22 items per page' },
-        ],
-      });
-
-      const actual = widget.getWidgetSearchParameters(helper.state, {
-        uiState: {},
-      });
-
-      expect(actual.hitsPerPage).toBeUndefined();
-    });
-
     test('returns the `SearchParameters` with the default value', () => {
       const render = jest.fn();
       const makeWidget = connectHitsPerPage(render);
@@ -612,7 +621,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       const helper = algoliasearchHelper({}, 'indexName');
       const widget = makeWidget({
         items: [
-          { value: 3, label: '3 items per page' },
+          { value: 3, label: '3 items per page', default: true },
           { value: 22, label: '22 items per page' },
         ],
       });
@@ -634,7 +643,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       });
       const widget = makeWidget({
         items: [
-          { value: 3, label: '3 items per page' },
+          { value: 3, label: '3 items per page', default: true },
           { value: 22, label: '22 items per page' },
         ],
       });

--- a/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
+++ b/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
@@ -585,7 +585,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
         uiState: {},
       });
 
-      expect(actual.hitsPerPage).toEqual(undefined);
+      expect(actual.hitsPerPage).toBeUndefined();
     });
 
     test('returns the `SearchParameters` with the default value', () => {

--- a/src/connectors/hits-per-page/connectHitsPerPage.js
+++ b/src/connectors/hits-per-page/connectHitsPerPage.js
@@ -230,6 +230,8 @@ You may want to add another entry to the \`items\` option with this value.`
           uiState.hitsPerPage || (defaultItem && defaultItem.value);
 
         return searchParameters.setQueryParameters({
+          // @TODO: make this value deterministic by enforcing a default value
+          // in the `items` option.
           hitsPerPage,
         });
       },

--- a/src/connectors/hits-per-page/connectHitsPerPage.js
+++ b/src/connectors/hits-per-page/connectHitsPerPage.js
@@ -108,25 +108,25 @@ export default function connectHitsPerPage(renderFn, unmountFn = noop) {
       );
     }
 
-    const defaultValues = items.filter(item => item.default);
-    if (defaultValues.length > 1) {
+    const defaultItems = items.filter(item => item.default);
+    if (defaultItems.length > 1) {
       throw new Error(
         withUsage('More than one default value is specified in `items`.')
       );
     }
 
-    const defaultValue = find(userItems, item => item.default === true);
+    const defaultItem = find(userItems, item => item.default === true);
 
     return {
       $$type: 'ais.hitsPerPage',
 
       getConfiguration(state) {
-        if (!defaultValue) {
+        if (!defaultItem) {
           return state;
         }
 
         return state.setQueryParameters({
-          hitsPerPage: state.hitsPerPage || defaultValue.value,
+          hitsPerPage: state.hitsPerPage || defaultItem.value,
         });
       },
 
@@ -214,11 +214,8 @@ You may want to add another entry to the \`items\` option with this value.`
 
       getWidgetState(uiState, { searchParameters }) {
         const hitsPerPage = searchParameters.hitsPerPage;
-        if (
-          (defaultValue && hitsPerPage === defaultValue.value) ||
-          hitsPerPage === undefined ||
-          uiState.hitsPerPage === hitsPerPage
-        ) {
+
+        if (hitsPerPage === undefined) {
           return uiState;
         }
 
@@ -229,19 +226,12 @@ You may want to add another entry to the \`items\` option with this value.`
       },
 
       getWidgetSearchParameters(searchParameters, { uiState }) {
-        const hitsPerPage = uiState.hitsPerPage;
-        if (hitsPerPage)
-          return searchParameters.setQueryParameter(
-            'hitsPerPage',
-            uiState.hitsPerPage
-          );
-        if (defaultValue) {
-          return searchParameters.setQueryParameter(
-            'hitsPerPage',
-            defaultValue.value
-          );
-        }
-        return searchParameters.setQueryParameter('hitsPerPage', undefined);
+        const hitsPerPage =
+          uiState.hitsPerPage || (defaultItem && defaultItem.value);
+
+        return searchParameters.setQueryParameters({
+          hitsPerPage,
+        });
       },
     };
   };

--- a/src/connectors/hits-per-page/connectHitsPerPage.js
+++ b/src/connectors/hits-per-page/connectHitsPerPage.js
@@ -108,14 +108,15 @@ export default function connectHitsPerPage(renderFn, unmountFn = noop) {
       );
     }
 
-    const defaultItems = items.filter(item => item.default);
+    const defaultItems = items.filter(item => item.default === true);
+
     if (defaultItems.length > 1) {
       throw new Error(
         withUsage('More than one default value is specified in `items`.')
       );
     }
 
-    const defaultItem = find(userItems, item => item.default === true);
+    const defaultItem = defaultItems[0];
 
     return {
       $$type: 'ais.hitsPerPage',

--- a/src/connectors/hits-per-page/connectHitsPerPage.js
+++ b/src/connectors/hits-per-page/connectHitsPerPage.js
@@ -109,6 +109,12 @@ export default function connectHitsPerPage(renderFn, unmountFn = noop) {
 
     const defaultItems = items.filter(item => item.default === true);
 
+    if (defaultItems.length === 0) {
+      throw new Error(
+        withUsage(`A default value must be specified in \`items\`.`)
+      );
+    }
+
     if (defaultItems.length > 1) {
       throw new Error(
         withUsage('More than one default value is specified in `items`.')
@@ -121,10 +127,6 @@ export default function connectHitsPerPage(renderFn, unmountFn = noop) {
       $$type: 'ais.hitsPerPage',
 
       getConfiguration(state) {
-        if (!defaultItem) {
-          return state;
-        }
-
         return state.setQueryParameters({
           hitsPerPage: state.hitsPerPage || defaultItem.value,
         });
@@ -226,13 +228,8 @@ You may want to add another entry to the \`items\` option with this value.`
       },
 
       getWidgetSearchParameters(searchParameters, { uiState }) {
-        const hitsPerPage =
-          uiState.hitsPerPage || (defaultItem && defaultItem.value);
-
         return searchParameters.setQueryParameters({
-          // @TODO: make this value deterministic by enforcing a default value
-          // in the `items` option.
-          hitsPerPage,
+          hitsPerPage: uiState.hitsPerPage || defaultItem.value,
         });
       },
     };

--- a/src/connectors/hits-per-page/connectHitsPerPage.js
+++ b/src/connectors/hits-per-page/connectHitsPerPage.js
@@ -2,7 +2,6 @@ import {
   checkRendering,
   warning,
   createDocumentationMessageGenerator,
-  find,
   noop,
 } from '../../lib/utils';
 

--- a/src/widgets/hits-per-page/__tests__/__snapshots__/hits-per-page-test.js.snap
+++ b/src/widgets/hits-per-page/__tests__/__snapshots__/hits-per-page-test.js.snap
@@ -16,6 +16,7 @@ exports[`hitsPerPage() calls twice render(<Selector props />, container) 1`] = `
     options={
       Array [
         Object {
+          "default": true,
           "isRefined": true,
           "label": "10 results",
           "value": 10,

--- a/src/widgets/hits-per-page/__tests__/hits-per-page-test.js
+++ b/src/widgets/hits-per-page/__tests__/hits-per-page-test.js
@@ -34,7 +34,7 @@ describe('hitsPerPage()', () => {
   beforeEach(() => {
     container = document.createElement('div');
     items = [
-      { value: 10, label: '10 results' },
+      { value: 10, label: '10 results', default: true },
       { value: 20, label: '20 results' },
     ];
     cssClasses = {
@@ -61,14 +61,7 @@ describe('hitsPerPage()', () => {
     render.mockClear();
   });
 
-  it('does not configure the default hits per page if not specified', () => {
-    expect(typeof widget.getConfiguration).toEqual('function');
-    expect(widget.getConfiguration(new SearchParameters({}))).toEqual(
-      new SearchParameters({})
-    );
-  });
-
-  it('does configures the default hits per page if specified', () => {
+  it('configures the default hits per page', () => {
     const widgetWithDefaults = hitsPerPage({
       container: document.createElement('div'),
       items: [

--- a/stories/hits-per-page.stories.js
+++ b/stories/hits-per-page.stories.js
@@ -9,24 +9,8 @@ storiesOf('HitsPerPage', module)
         instantsearch.widgets.hitsPerPage({
           container,
           items: [
-            { value: 3, label: '3 per page' },
-            { value: 4, label: '4 per page' },
+            { value: 3, label: '3 per page', default: true },
             { value: 5, label: '5 per page' },
-            { value: 10, label: '10 per page' },
-          ],
-        })
-      );
-    })
-  )
-  .add(
-    'with default hitPerPage to 5',
-    withHits(({ search, container, instantsearch }) => {
-      search.addWidget(
-        instantsearch.widgets.hitsPerPage({
-          container,
-          items: [
-            { value: 3, label: '3 per page' },
-            { value: 5, label: '5 per page', default: true },
             { value: 10, label: '10 per page' },
           ],
         })


### PR DESCRIPTION
This updates `hitsPerPage` lifecycle methods to support the new routing system.

## `getWidgetState` changes

This method ignores previous UI state values. Otherwise, new values gets skipped.

## `getWidgetSearchParameters` changes

This is only a refactor.

---

_`getConfiguration` will be removed later to not break everything._