### PR TITLE
fix(examples): fix IE11 compatibility for e-commerce demo

### DIFF
--- a/examples/e-commerce/src/ui.ts
+++ b/examples/e-commerce/src/ui.ts
@@ -1,9 +1,9 @@
-const filtersButtons = [
-  ...document.querySelectorAll('[data-action="open-overlay"]'),
-];
-const closeOverlayButtons = [
-  ...document.querySelectorAll('[data-action="close-overlay"]'),
-];
+const filtersButtons = Array.prototype.slice.call(
+  document.querySelectorAll('[data-action="open-overlay"]')
+);
+const closeOverlayButtons = Array.prototype.slice.call(
+  document.querySelectorAll('[data-action="close-overlay"]')
+);
 const header = document.querySelector('#header');
 const resultsContainer = document.querySelector('.container-results');
 

--- a/examples/e-commerce/src/widgets/HitsPerPage.ts
+++ b/examples/e-commerce/src/widgets/HitsPerPage.ts
@@ -24,7 +24,7 @@ export const hitsPerPage = hitsPerPageWidget({
 export function getFallbackHitsPerPageRoutingValue(
   hitsPerPageValue: string
 ): string | undefined {
-  if (items.map(item => item.value).includes(Number(hitsPerPageValue))) {
+  if (items.map(item => item.value).indexOf(Number(hitsPerPageValue)) !== -1) {
     return hitsPerPageValue;
   }
 

--- a/examples/e-commerce/src/widgets/SortBy.ts
+++ b/examples/e-commerce/src/widgets/SortBy.ts
@@ -24,7 +24,7 @@ export const sortBy = sortByWidget({
 export function getFallbackSortByRoutingValue(
   sortByValue: string
 ): string | undefined {
-  if (items.map(item => item.value).includes(sortByValue)) {
+  if (items.map(item => item.value).indexOf(sortByValue) !== -1) {
     return sortByValue;
   }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

This PR fixes some compatibility issues on IE11 for the e-commerce demo:

* Spreading a NodeList does not work on IE11 (https://github.com/babel/babel/issues/9993): fixed by replacing it with `Array.prototype.slice.call(NodeList)`.
* `Array.prototype.includes` is not available on IE11: fixed by replacing it with `Array.prototype.indexOf` .

Both issues could have been fixed by updating Babel configuration to add the required polyfills but FMPOV it would have made the resulting bundles heavier for little to no benefits.

