### PR TITLE
feat(index): use uiState driven SearchParameters

### DIFF
--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -441,7 +441,6 @@ describe('start', () => {
 
     search.start();
 
-    expect(widget.getConfiguration).toHaveBeenCalledTimes(1);
     expect(widget.init).toHaveBeenCalledTimes(1);
   });
 

--- a/src/lib/__tests__/RoutingManager-test.ts
+++ b/src/lib/__tests__/RoutingManager-test.ts
@@ -247,7 +247,7 @@ describe('RoutingManager', () => {
         search.mainIndex.getHelper()!.state.setQuery('test')
       );
 
-      expect(widget.getWidgetSearchParameters).toHaveBeenCalledTimes(1);
+      expect(widget.getWidgetSearchParameters).toHaveBeenCalledTimes(2);
       expect(widget.getWidgetSearchParameters).toHaveBeenCalledWith(
         search.mainIndex.getHelper()!.state,
         {

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -14,11 +14,6 @@ import index from '../index';
 describe('index', () => {
   const createSearchBox = (args: Partial<Widget> = {}): Widget =>
     createWidget({
-      getConfiguration: jest.fn(() => {
-        return new SearchParameters({
-          query: 'Apple',
-        });
-      }),
       dispose: jest.fn(({ state }) => {
         return state.setQueryParameter('query', undefined);
       }),
@@ -43,11 +38,6 @@ describe('index', () => {
 
   const createPagination = (args: Partial<Widget> = {}): Widget =>
     createWidget({
-      getConfiguration: jest.fn(() => {
-        return new SearchParameters({
-          page: 5,
-        });
-      }),
       dispose: jest.fn(({ state }) => {
         return state.setQueryParameter('page', undefined);
       }),

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -688,10 +688,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
       });
 
       level0.addWidgets([
-        createWidget({
-          getWidgetSearchParameters(searchParameters) {
-            return searchParameters.setQueryParameter('hitsPerPage', 5);
-          },
+        createConfigure({
+          hitsPerPage: 5,
         }),
 
         createSearchBox({
@@ -902,10 +900,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
         });
 
         level0.addWidgets([
-          createWidget({
-            getWidgetSearchParameters(searchParameters) {
-              return searchParameters.setQueryParameter('hitsPerPage', 5);
-            },
+          createConfigure({
+            hitsPerPage: 5,
           }),
 
           createSearchBox({
@@ -1120,10 +1116,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
         });
 
         level0.addWidgets([
-          createWidget({
-            getWidgetSearchParameters(searchParameters) {
-              return searchParameters.setQueryParameter('hitsPerPage', 5);
-            },
+          createConfigure({
+            hitsPerPage: 5,
           }),
 
           createSearchBox({
@@ -1251,10 +1245,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
         });
 
         level0.addWidgets([
-          createWidget({
-            getWidgetSearchParameters(searchParameters) {
-              return searchParameters.setQueryParameter('hitsPerPage', 5);
-            },
+          createConfigure({
+            hitsPerPage: 5,
           }),
 
           createSearchBox({

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -32,6 +32,12 @@ describe('index', () => {
           query: searchParameters.query,
         };
       }),
+      getWidgetSearchParameters: jest.fn((searchParameters, { uiState }) => {
+        return searchParameters.setQueryParameter(
+          'query',
+          uiState.query || 'Apple'
+        );
+      }),
       ...args,
     });
 
@@ -54,6 +60,9 @@ describe('index', () => {
           ...uiState,
           page: searchParameters.page,
         };
+      }),
+      getWidgetSearchParameters: jest.fn((searchParameters, { uiState }) => {
+        return searchParameters.setQueryParameter('page', uiState.page || 5);
       }),
       ...args,
     });
@@ -613,52 +622,46 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
 
       level0.addWidgets([
         createWidget({
-          getConfiguration() {
-            return new SearchParameters({
-              hitsPerPage: 5,
-            });
+          getWidgetSearchParameters(searchParameters) {
+            return searchParameters.setQueryParameter('hitsPerPage', 5);
           },
         }),
 
         createSearchBox({
-          getConfiguration() {
-            return new SearchParameters({
-              query: 'Apple',
-            });
+          getWidgetSearchParameters(searchParameters) {
+            return searchParameters.setQueryParameter('query', 'Apple');
           },
         }),
 
         createPagination({
-          getConfiguration() {
-            return new SearchParameters({
-              page: 1,
-            });
+          getWidgetSearchParameters(searchParameters) {
+            return searchParameters.setQueryParameter('page', 1);
           },
         }),
 
         level1.addWidgets([
           createSearchBox({
-            getConfiguration() {
-              return new SearchParameters({
-                query: 'Apple iPhone',
-              });
+            getWidgetSearchParameters(searchParameters) {
+              return searchParameters.setQueryParameter(
+                'query',
+                'Apple iPhone'
+              );
             },
           }),
 
           createPagination({
-            getConfiguration() {
-              return new SearchParameters({
-                page: 2,
-              });
+            getWidgetSearchParameters(searchParameters) {
+              return searchParameters.setQueryParameter('page', 2);
             },
           }),
 
           level2.addWidgets([
             createSearchBox({
-              getConfiguration() {
-                return new SearchParameters({
-                  query: 'Apple iPhone XS',
-                });
+              getWidgetSearchParameters(searchParameters) {
+                return searchParameters.setQueryParameter(
+                  'query',
+                  'Apple iPhone XS'
+                );
               },
             }),
           ]),
@@ -833,77 +836,68 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
 
         level0.addWidgets([
           createWidget({
-            getConfiguration() {
-              return new SearchParameters({
-                hitsPerPage: 5,
-              });
+            getWidgetSearchParameters(searchParameters) {
+              return searchParameters.setQueryParameter('hitsPerPage', 5);
             },
           }),
 
           createSearchBox({
-            getConfiguration() {
-              return new SearchParameters({
-                query: 'Apple',
-              });
+            getWidgetSearchParameters(searchParameters) {
+              return searchParameters.setQueryParameter('query', 'Apple');
             },
           }),
 
           createPagination({
-            getConfiguration() {
-              return new SearchParameters({
-                page: 1,
-              });
+            getWidgetSearchParameters(searchParameters) {
+              return searchParameters.setQueryParameter('page', 1);
             },
           }),
 
           level1.addWidgets([
             createSearchBox({
-              getConfiguration() {
-                return new SearchParameters({
-                  query: 'Apple iPhone',
-                });
+              getWidgetSearchParameters(searchParameters) {
+                return searchParameters.setQueryParameter(
+                  'query',
+                  'Apple iPhone'
+                );
               },
             }),
 
             createPagination({
-              getConfiguration() {
-                return new SearchParameters({
-                  page: 2,
-                });
+              getWidgetSearchParameters(searchParameters) {
+                return searchParameters.setQueryParameter('page', 2);
               },
             }),
 
             level2.addWidgets([
               createSearchBox({
-                getConfiguration() {
-                  return new SearchParameters({
-                    query: 'Apple iPhone XS',
-                  });
+                getWidgetSearchParameters(searchParameters) {
+                  return searchParameters.setQueryParameter(
+                    'query',
+                    'Apple iPhone XS'
+                  );
                 },
               }),
 
               createPagination({
-                getConfiguration() {
-                  return new SearchParameters({
-                    page: 3,
-                  });
+                getWidgetSearchParameters(searchParameters) {
+                  return searchParameters.setQueryParameter('page', 3);
                 },
               }),
 
               level3.addWidgets([
                 createSearchBox({
-                  getConfiguration() {
-                    return new SearchParameters({
-                      query: 'Apple iPhone XS Red',
-                    });
+                  getWidgetSearchParameters(searchParameters) {
+                    return searchParameters.setQueryParameter(
+                      'query',
+                      'Apple iPhone XS Red'
+                    );
                   },
                 }),
 
                 createPagination({
-                  getConfiguration() {
-                    return new SearchParameters({
-                      page: 4,
-                    });
+                  getWidgetSearchParameters(searchParameters) {
+                    return searchParameters.setQueryParameter('page', 4);
                   },
                 }),
               ]),
@@ -1060,77 +1054,68 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
 
         level0.addWidgets([
           createWidget({
-            getConfiguration() {
-              return new SearchParameters({
-                hitsPerPage: 5,
-              });
+            getWidgetSearchParameters(searchParameters) {
+              return searchParameters.setQueryParameter('hitsPerPage', 5);
             },
           }),
 
           createSearchBox({
-            getConfiguration() {
-              return new SearchParameters({
-                query: 'Apple',
-              });
+            getWidgetSearchParameters(searchParameters) {
+              return searchParameters.setQueryParameter('query', 'Apple');
             },
           }),
 
           createPagination({
-            getConfiguration() {
-              return new SearchParameters({
-                page: 1,
-              });
+            getWidgetSearchParameters(searchParameters) {
+              return searchParameters.setQueryParameter('page', 1);
             },
           }),
 
           level1.addWidgets([
             createSearchBox({
-              getConfiguration() {
-                return new SearchParameters({
-                  query: 'Apple iPhone',
-                });
+              getWidgetSearchParameters(searchParameters) {
+                return searchParameters.setQueryParameter(
+                  'query',
+                  'Apple iPhone'
+                );
               },
             }),
 
             createPagination({
-              getConfiguration() {
-                return new SearchParameters({
-                  page: 2,
-                });
+              getWidgetSearchParameters(searchParameters) {
+                return searchParameters.setQueryParameter('page', 2);
               },
             }),
 
             level2.addWidgets([
               createSearchBox({
-                getConfiguration() {
-                  return new SearchParameters({
-                    query: 'Apple iPhone XS',
-                  });
+                getWidgetSearchParameters(searchParameters) {
+                  return searchParameters.setQueryParameter(
+                    'query',
+                    'Apple iPhone XS'
+                  );
                 },
               }),
 
               createPagination({
-                getConfiguration() {
-                  return new SearchParameters({
-                    page: 3,
-                  });
+                getWidgetSearchParameters(searchParameters) {
+                  return searchParameters.setQueryParameter('page', 3);
                 },
               }),
 
               level3.addWidgets([
                 createSearchBox({
-                  getConfiguration() {
-                    return new SearchParameters({
-                      query: 'Apple iPhone XS Red',
-                    });
+                  getWidgetSearchParameters(searchParameters) {
+                    return searchParameters.setQueryParameter(
+                      'query',
+                      'Apple iPhone XS Red'
+                    );
                   },
                 }),
 
                 createPagination({
-                  getConfiguration() {
-                    return new SearchParameters({
-                      page: 4,
-                    });
+                  getWidgetSearchParameters(searchParameters) {
+                    return searchParameters.setQueryParameter('page', 4);
                   },
                 }),
               ]),
@@ -1200,61 +1185,56 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
 
         level0.addWidgets([
           createWidget({
-            getConfiguration() {
-              return new SearchParameters({
-                hitsPerPage: 5,
-              });
+            getWidgetSearchParameters(searchParameters) {
+              return searchParameters.setQueryParameter('hitsPerPage', 5);
             },
           }),
 
           createSearchBox({
-            getConfiguration() {
-              return new SearchParameters({
-                query: 'Apple',
-              });
+            getWidgetSearchParameters(searchParameters) {
+              return searchParameters.setQueryParameter('query', 'Apple');
             },
           }),
 
           createPagination({
-            getConfiguration() {
-              return new SearchParameters({
-                page: 1,
-              });
+            getWidgetSearchParameters(searchParameters) {
+              return searchParameters.setQueryParameter('page', 1);
             },
           }),
 
           level1.addWidgets([
             createSearchBox({
-              getConfiguration() {
-                return new SearchParameters({
-                  query: 'Apple iPhone',
-                });
+              getWidgetSearchParameters(searchParameters) {
+                return searchParameters.setQueryParameter(
+                  'query',
+                  'Apple iPhone'
+                );
               },
             }),
 
             createPagination({
-              getConfiguration() {
-                return new SearchParameters({
-                  page: 2,
-                });
+              getWidgetSearchParameters(searchParameters) {
+                return searchParameters.setQueryParameter('page', 2);
               },
             }),
 
             level2.addWidgets([
               createSearchBox({
-                getConfiguration() {
-                  return new SearchParameters({
-                    query: 'Apple iPhone XS',
-                  });
+                getWidgetSearchParameters(searchParameters) {
+                  return searchParameters.setQueryParameter(
+                    'query',
+                    'Apple iPhone XS'
+                  );
                 },
               }),
 
               level3.addWidgets([
                 createSearchBox({
-                  getConfiguration() {
-                    return new SearchParameters({
-                      query: 'Apple iPhone XS Red',
-                    });
+                  getWidgetSearchParameters(searchParameters) {
+                    return searchParameters.setQueryParameter(
+                      'query',
+                      'Apple iPhone XS Red'
+                    );
                   },
                 }),
               ]),

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -2,6 +2,7 @@ import algoliasearchHelper, {
   AlgoliaSearchHelper as Helper,
   DerivedHelper,
   PlainSearchParameters,
+  SearchParameters,
   SearchResults,
 } from 'algoliasearch-helper';
 import { Client } from 'algoliasearch';
@@ -12,6 +13,7 @@ import {
   InitOptions,
   RenderOptions,
   WidgetStateOptions,
+  WidgetSearchParametersOptions,
   ScopedResult,
 } from '../../types';
 import {
@@ -32,6 +34,10 @@ type IndexProps = {
 
 type IndexInitOptions = Pick<InitOptions, 'instantSearchInstance' | 'parent'>;
 type IndexRenderOptions = Pick<RenderOptions, 'instantSearchInstance'>;
+
+type LocalWidgetSearchParametersOptions = WidgetSearchParametersOptions & {
+  initialSearchParameters: SearchParameters;
+};
 
 export type Index = Widget & {
   getIndexId(): string;
@@ -64,6 +70,23 @@ function getLocalWidgetsState(
 
       return widget.getWidgetState(uiState, widgetStateOptions);
     }, {});
+}
+
+function getLocalWidgetsSearchParameters(
+  widgets: Widget[],
+  widgetSearchParametersOptions: LocalWidgetSearchParametersOptions
+): SearchParameters {
+  const { initialSearchParameters, ...rest } = widgetSearchParametersOptions;
+
+  return widgets
+    .filter(widget => !isIndexWidget(widget))
+    .reduce<SearchParameters>((state, widget) => {
+      if (!widget.getWidgetSearchParameters) {
+        return state;
+      }
+
+      return widget.getWidgetSearchParameters(state, rest);
+    }, initialSearchParameters);
 }
 
 function resetPageFromWidgets(widgets: Widget[]): void {
@@ -257,7 +280,10 @@ const index = (props?: IndexProps): Index => {
       helper = algoliasearchHelper(
         {} as Client,
         indexName,
-        localWidgets.reduce(enhanceConfiguration, initialSearchParameters)
+        getLocalWidgetsSearchParameters(localWidgets, {
+          uiState: localUiState,
+          initialSearchParameters,
+        })
       );
 
       // We forward the call to `search` to the "main" instance of the Helper

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -19,7 +19,6 @@ import {
 import {
   createDocumentationMessageGenerator,
   resolveSearchParameters,
-  enhanceConfiguration,
   mergeSearchParameters,
 } from '../../lib/utils';
 
@@ -252,7 +251,17 @@ const index = (props?: IndexProps): Index => {
           return next || state;
         }, helper!.state);
 
-        helper!.setState(localWidgets.reduce(enhanceConfiguration, nextState));
+        localUiState = getLocalWidgetsState(localWidgets, {
+          searchParameters: nextState,
+          helper: helper!,
+        });
+
+        helper!.setState(
+          getLocalWidgetsSearchParameters(localWidgets, {
+            uiState: localUiState,
+            initialSearchParameters: nextState,
+          })
+        );
 
         if (localWidgets.length) {
           localInstantSearchInstance.scheduleSearch();

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -202,7 +202,10 @@ const index = (props?: IndexProps): Index => {
 
       if (localInstantSearchInstance && Boolean(widgets.length)) {
         helper!.setState(
-          localWidgets.reduce(enhanceConfiguration, helper!.state)
+          getLocalWidgetsSearchParameters(localWidgets, {
+            uiState: localUiState,
+            initialSearchParameters: helper!.state,
+          })
         );
 
         widgets.forEach(widget => {


### PR DESCRIPTION
**Summary**

This PR replaces the usage of `getConfiguration` for `getWidgetSearchParameters`. The widgets are now driven by the `uiState`. Note that widgets that don't implement the lifecycle can still write on `SearchParameters`, but if a widget that implements the lifecycle use the same parameter it will be always overridden.

The lifecycle is now called on `init`, `add` (when the instance is started), `remove` (when the instance is started). On `init` we currently always provide an empty `uiState` (but it will change soon). On `add`/`remove` we provide the local `uiState` of the index to drive the `SearchParameters`.