### PR TITLE
feat(hitsPerPage): enforce default value

### DIFF
--- a/src/connectors/hits-per-page/__tests__/__snapshots__/connectHitsPerPage-test.js.snap
+++ b/src/connectors/hits-per-page/__tests__/__snapshots__/connectHitsPerPage-test.js.snap
@@ -13,8 +13,9 @@ Array [
     "value": 10,
   },
   Object {
+    "default": true,
     "isRefined": true,
-    "label": "",
+    "label": "7 items per page",
     "value": 7,
   },
 ]
@@ -33,8 +34,9 @@ Array [
     "value": 10,
   },
   Object {
+    "default": true,
     "isRefined": false,
-    "label": "",
+    "label": "7 items per page",
     "value": 7,
   },
 ]

--- a/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
+++ b/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
@@ -18,6 +18,29 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
 `);
     });
 
+    it('does not throw without items', () => {
+      expect(() => {
+        connectHitsPerPage(() => {})({
+          items: [],
+        });
+      }).not.toThrow();
+    });
+
+    it('throws without default item', () => {
+      expect(() => {
+        connectHitsPerPage(() => {})({
+          items: [
+            { value: 3, label: '3 items per page' },
+            { value: 10, label: '10 items per page' },
+          ],
+        });
+      }).toThrowErrorMatchingInlineSnapshot(`
+"A default value must be specified in \`items\`.
+
+See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-page/js/#connector"
+`);
+    });
+
     it('throws with multiple default items', () => {
       expect(() => {
         connectHitsPerPage(() => {})({
@@ -31,6 +54,17 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
 
 See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-page/js/#connector"
 `);
+    });
+
+    it('does not throw with items and one default value', () => {
+      expect(() => {
+        connectHitsPerPage(() => {})({
+          items: [
+            { value: 3, label: '3 items per page', default: true },
+            { value: 10, label: '10 items per page' },
+          ],
+        });
+      }).not.toThrow();
     });
 
     it('is a widget', () => {
@@ -59,13 +93,15 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
     const makeWidget = connectHitsPerPage(renderFn);
     const widget = makeWidget({
       items: [
-        { value: 3, label: '3 items per page' },
+        { value: 3, label: '3 items per page', default: true },
         { value: 10, label: '10 items per page' },
       ],
     });
 
     expect(widget.getConfiguration(new SearchParameters({}))).toEqual(
-      new SearchParameters({})
+      new SearchParameters({
+        hitsPerPage: 3,
+      })
     );
 
     expect(renderFn).toHaveBeenCalledTimes(0);
@@ -86,7 +122,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       expect.objectContaining({
         widgetParams: {
           items: [
-            { value: 3, label: '3 items per page' },
+            { value: 3, label: '3 items per page', default: true },
             { value: 10, label: '10 items per page' },
           ],
         },
@@ -106,7 +142,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       expect.objectContaining({
         widgetParams: {
           items: [
-            { value: 3, label: '3 items per page' },
+            { value: 3, label: '3 items per page', default: true },
             { value: 10, label: '10 items per page' },
           ],
         },
@@ -120,7 +156,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
     const makeWidget = connectHitsPerPage(renderFn);
     const widget = makeWidget({
       items: [
-        { value: 3, label: '3 items per page' },
+        { value: 3, label: '3 items per page', default: true },
         { value: 10, label: '10 items per page' },
       ],
       transformItems: items =>
@@ -200,21 +236,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
     );
   });
 
-  it('Does not configures the search when there is no default value', () => {
-    const renderFn = jest.fn();
-    const makeWidget = connectHitsPerPage(renderFn);
-    const widget = makeWidget({
-      items: [
-        { value: 3, label: '3 items per page' },
-        { value: 10, label: '10 items per page' },
-      ],
-    });
-
-    expect(widget.getConfiguration(new SearchParameters({}))).toEqual(
-      new SearchParameters({})
-    );
-  });
-
   it('Provide a function to change the current hits per page, and provide the current value', () => {
     const renderFn = jest.fn();
     const makeWidget = connectHitsPerPage(renderFn);
@@ -222,7 +243,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       items: [
         { value: 3, label: '3 items per page' },
         { value: 10, label: '10 items per page' },
-        { value: 11, label: '' },
+        { value: 11, label: '11 items per page', default: true },
       ],
     });
 
@@ -266,7 +287,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       items: [
         { value: 3, label: '3 items per page' },
         { value: 10, label: '10 items per page' },
-        { value: 20, label: '20 items per page' },
+        { value: 20, label: '20 items per page', default: true },
       ],
     });
 
@@ -304,7 +325,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       items: [
         { value: 3, label: '3 items per page' },
         { value: 10, label: '10 items per page' },
-        { value: 7, label: '' },
+        { value: 7, label: '7 items per page', default: true },
       ],
     });
 
@@ -339,7 +360,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
     const makeWidget = connectHitsPerPage(renderFn);
     const widget = makeWidget({
       items: [
-        { value: 3, label: '3 items per page' },
+        { value: 3, label: '3 items per page', default: true },
         { value: 10, label: '10 items per page' },
       ],
     });
@@ -381,7 +402,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
     const makeWidget = connectHitsPerPage(renderFn);
     const widget = makeWidget({
       items: [
-        { value: 3, label: '3 items per page' },
+        { value: 3, label: '3 items per page', default: true },
         { value: 10, label: '10 items per page' },
       ],
     });
@@ -423,7 +444,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
     const makeWidget = connectHitsPerPage(renderFn);
     const widget = makeWidget({
       items: [
-        { value: 3, label: '3 items per page' },
+        { value: 3, label: '3 items per page', default: true },
         { value: 10, label: '10 items per page' },
       ],
     });
@@ -469,7 +490,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       const makeWidget = connectHitsPerPage(renderFn, unmountFn);
       const widget = makeWidget({
         items: [
-          { value: 3, label: '3 items per page' },
+          { value: 3, label: '3 items per page', default: true },
           { value: 10, label: '10 items per page' },
         ],
       });
@@ -488,7 +509,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       const makeWidget = connectHitsPerPage(renderFn);
       const widget = makeWidget({
         items: [
-          { value: 3, label: '3 items per page' },
+          { value: 3, label: '3 items per page', default: true },
           { value: 10, label: '10 items per page' },
         ],
       });
@@ -508,7 +529,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       const makeWidget = connectHitsPerPage(renderFn, unmountFn);
       const widget = makeWidget({
         items: [
-          { value: 3, label: '3 items per page' },
+          { value: 3, label: '3 items per page', default: true },
           { value: 10, label: '10 items per page' },
         ],
       });
@@ -528,7 +549,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       const helper = algoliasearchHelper({}, 'indexName');
       const widget = makeWidget({
         items: [
-          { value: 3, label: '3 items per page' },
+          { value: 3, label: '3 items per page', default: true },
           { value: 22, label: '22 items per page' },
         ],
       });
@@ -551,7 +572,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       });
       const widget = makeWidget({
         items: [
-          { value: 3, label: '3 items per page' },
+          { value: 3, label: '3 items per page', default: true },
           { value: 22, label: '22 items per page' },
         ],
       });
@@ -570,24 +591,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
   });
 
   describe('getWidgetSearchParameters', () => {
-    test('returns the `SearchParameters` with the initial value', () => {
-      const render = jest.fn();
-      const makeWidget = connectHitsPerPage(render);
-      const helper = algoliasearchHelper({}, 'indexName');
-      const widget = makeWidget({
-        items: [
-          { value: 3, label: '3 items per page' },
-          { value: 22, label: '22 items per page' },
-        ],
-      });
-
-      const actual = widget.getWidgetSearchParameters(helper.state, {
-        uiState: {},
-      });
-
-      expect(actual.hitsPerPage).toBeUndefined();
-    });
-
     test('returns the `SearchParameters` with the default value', () => {
       const render = jest.fn();
       const makeWidget = connectHitsPerPage(render);
@@ -612,7 +615,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       const helper = algoliasearchHelper({}, 'indexName');
       const widget = makeWidget({
         items: [
-          { value: 3, label: '3 items per page' },
+          { value: 3, label: '3 items per page', default: true },
           { value: 22, label: '22 items per page' },
         ],
       });
@@ -634,7 +637,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       });
       const widget = makeWidget({
         items: [
-          { value: 3, label: '3 items per page' },
+          { value: 3, label: '3 items per page', default: true },
           { value: 22, label: '22 items per page' },
         ],
       });

--- a/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
+++ b/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
@@ -18,12 +18,16 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
 `);
     });
 
-    it('does not throw without items', () => {
+    it('throws with empty items', () => {
       expect(() => {
         connectHitsPerPage(() => {})({
           items: [],
         });
-      }).not.toThrow();
+      }).toThrowErrorMatchingInlineSnapshot(`
+"A default value must be specified in \`items\`.
+
+See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-page/js/#connector"
+`);
     });
 
     it('throws without default item', () => {
@@ -72,7 +76,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       const unmount = jest.fn();
 
       const customHitsPerPage = connectHitsPerPage(render, unmount);
-      const widget = customHitsPerPage({ items: [] });
+      const widget = customHitsPerPage({
+        items: [{ label: '10 items per page', value: 10, default: true }],
+      });
 
       expect(widget).toEqual(
         expect.objectContaining({

--- a/src/connectors/hits-per-page/connectHitsPerPage.js
+++ b/src/connectors/hits-per-page/connectHitsPerPage.js
@@ -114,7 +114,9 @@ export default function connectHitsPerPage(renderFn, unmountFn = noop) {
       throw new Error(
         withUsage(`A default value must be specified in \`items\`.`)
       );
-    } else if (defaultItemsCount > 1) {
+    }
+
+    if (defaultItemsCount > 1) {
       throw new Error(
         withUsage('More than one default value is specified in `items`.')
       );

--- a/src/connectors/hits-per-page/connectHitsPerPage.js
+++ b/src/connectors/hits-per-page/connectHitsPerPage.js
@@ -110,7 +110,7 @@ export default function connectHitsPerPage(renderFn, unmountFn = noop) {
     const defaultItems = items.filter(item => item.default === true);
     const defaultItemsCount = defaultItems.length;
 
-    if (items.length && defaultItemsCount === 0) {
+    if (defaultItemsCount === 0) {
       throw new Error(
         withUsage(`A default value must be specified in \`items\`.`)
       );

--- a/src/connectors/hits-per-page/connectHitsPerPage.js
+++ b/src/connectors/hits-per-page/connectHitsPerPage.js
@@ -108,8 +108,13 @@ export default function connectHitsPerPage(renderFn, unmountFn = noop) {
     }
 
     const defaultItems = items.filter(item => item.default === true);
+    const defaultItemsCount = defaultItems.length;
 
-    if (defaultItems.length > 1) {
+    if (items.length && defaultItemsCount === 0) {
+      throw new Error(
+        withUsage(`A default value must be specified in \`items\`.`)
+      );
+    } else if (defaultItemsCount > 1) {
       throw new Error(
         withUsage('More than one default value is specified in `items`.')
       );
@@ -121,10 +126,6 @@ export default function connectHitsPerPage(renderFn, unmountFn = noop) {
       $$type: 'ais.hitsPerPage',
 
       getConfiguration(state) {
-        if (!defaultItem) {
-          return state;
-        }
-
         return state.setQueryParameters({
           hitsPerPage: state.hitsPerPage || defaultItem.value,
         });
@@ -226,13 +227,8 @@ You may want to add another entry to the \`items\` option with this value.`
       },
 
       getWidgetSearchParameters(searchParameters, { uiState }) {
-        const hitsPerPage =
-          uiState.hitsPerPage || (defaultItem && defaultItem.value);
-
         return searchParameters.setQueryParameters({
-          // @TODO: make this value deterministic by enforcing a default value
-          // in the `items` option.
-          hitsPerPage,
+          hitsPerPage: uiState.hitsPerPage || defaultItem.value,
         });
       },
     };

--- a/src/connectors/hits-per-page/connectHitsPerPage.js
+++ b/src/connectors/hits-per-page/connectHitsPerPage.js
@@ -108,15 +108,14 @@ export default function connectHitsPerPage(renderFn, unmountFn = noop) {
     }
 
     const defaultItems = items.filter(item => item.default === true);
-    const defaultItemsCount = defaultItems.length;
 
-    if (defaultItemsCount === 0) {
+    if (defaultItems.length === 0) {
       throw new Error(
         withUsage(`A default value must be specified in \`items\`.`)
       );
     }
 
-    if (defaultItemsCount > 1) {
+    if (defaultItems.length > 1) {
       throw new Error(
         withUsage('More than one default value is specified in `items`.')
       );

--- a/src/widgets/hits-per-page/__tests__/__snapshots__/hits-per-page-test.js.snap
+++ b/src/widgets/hits-per-page/__tests__/__snapshots__/hits-per-page-test.js.snap
@@ -16,6 +16,7 @@ exports[`hitsPerPage() calls twice render(<Selector props />, container) 1`] = `
     options={
       Array [
         Object {
+          "default": true,
           "isRefined": true,
           "label": "10 results",
           "value": 10,

--- a/src/widgets/hits-per-page/__tests__/hits-per-page-test.js
+++ b/src/widgets/hits-per-page/__tests__/hits-per-page-test.js
@@ -61,7 +61,7 @@ describe('hitsPerPage()', () => {
     render.mockClear();
   });
 
-  it('does configures the default hits per page', () => {
+  it('configures the default hits per page', () => {
     const widgetWithDefaults = hitsPerPage({
       container: document.createElement('div'),
       items: [

--- a/src/widgets/hits-per-page/__tests__/hits-per-page-test.js
+++ b/src/widgets/hits-per-page/__tests__/hits-per-page-test.js
@@ -34,7 +34,7 @@ describe('hitsPerPage()', () => {
   beforeEach(() => {
     container = document.createElement('div');
     items = [
-      { value: 10, label: '10 results' },
+      { value: 10, label: '10 results', default: true },
       { value: 20, label: '20 results' },
     ];
     cssClasses = {
@@ -61,14 +61,7 @@ describe('hitsPerPage()', () => {
     render.mockClear();
   });
 
-  it('does not configure the default hits per page if not specified', () => {
-    expect(typeof widget.getConfiguration).toEqual('function');
-    expect(widget.getConfiguration(new SearchParameters({}))).toEqual(
-      new SearchParameters({})
-    );
-  });
-
-  it('does configures the default hits per page if specified', () => {
+  it('does configures the default hits per page', () => {
     const widgetWithDefaults = hitsPerPage({
       container: document.createElement('div'),
       items: [

--- a/stories/hits-per-page.stories.js
+++ b/stories/hits-per-page.stories.js
@@ -10,23 +10,7 @@ storiesOf('HitsPerPage', module)
           container,
           items: [
             { value: 3, label: '3 per page', default: true },
-            { value: 4, label: '4 per page' },
             { value: 5, label: '5 per page' },
-            { value: 10, label: '10 per page' },
-          ],
-        })
-      );
-    })
-  )
-  .add(
-    'with default hitPerPage to 5',
-    withHits(({ search, container, instantsearch }) => {
-      search.addWidget(
-        instantsearch.widgets.hitsPerPage({
-          container,
-          items: [
-            { value: 3, label: '3 per page' },
-            { value: 5, label: '5 per page', default: true },
             { value: 10, label: '10 per page' },
           ],
         })

--- a/stories/hits-per-page.stories.js
+++ b/stories/hits-per-page.stories.js
@@ -9,7 +9,7 @@ storiesOf('HitsPerPage', module)
         instantsearch.widgets.hitsPerPage({
           container,
           items: [
-            { value: 3, label: '3 per page' },
+            { value: 3, label: '3 per page', default: true },
             { value: 4, label: '4 per page' },
             { value: 5, label: '5 per page' },
             { value: 10, label: '10 per page' },


### PR DESCRIPTION
In InstantSearch.js, we don't enforce a default value in the [`hitsPerPage`](https://www.algolia.com/doc/api-reference/widgets/hits-per-page/js/#widget-param-items) widget. This means that we pick the first in the list when no `default` is specified.

The problem with not always having a default value is that it's not deterministic with multi-indexing: `getWidgetSearchParameters`' `hitsPerPage` value can be inherited from the parent index whereas we want it to be self contained (see #4038).

This PR enforces a default value (and a single one).

Long term, we can think moving toward an API similar to the [React version](https://www.algolia.com/doc/api-reference/widgets/hits-per-page/react/#widget-param-defaultrefinement), where another option (e.g. `defaultValue`) picks the right item in the list. The benefit of such an API is that it's less error prone for users and better type-checkable.