### PR TITLE
feat: introduce initialUiState option

### DIFF
--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -392,6 +392,7 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
     this.mainIndex.init({
       instantSearchInstance: this,
       parent: null,
+      uiState: {},
     });
 
     mainHelper.search();

--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -102,6 +102,14 @@ export type InstantSearchOptions<TRouteState = UiState> = {
   searchParameters?: PlainSearchParameters;
 
   /**
+   * Injects an `uiState` to the `instantsearch` instance. You can use this option
+   * to provide an initial state to a widget. Note that the state is only used
+   * for the first search. To unconditionally pass additional parameters to the
+   * Algolia API, take a look at the `configure` widget.
+   */
+  initialUiState?: UiState;
+
+  /**
    * Time before a search is considered stalled. The default is 200ms
    */
   stalledSearchDelay?: number;
@@ -137,6 +145,7 @@ class InstantSearch extends EventEmitter {
   public _searchStalledTimer: any;
   public _isSearchStalled: boolean;
   public _searchParameters: PlainSearchParameters;
+  public _initialUiState: UiState;
   public _searchFunction?: InstantSearchOptions['searchFunction'];
   public _createURL?: (params: SearchParameters) => string;
   public _createAbsoluteURL?: (params: SearchParameters) => string;
@@ -150,6 +159,7 @@ class InstantSearch extends EventEmitter {
       indexName = null,
       numberLocale,
       searchParameters = {},
+      initialUiState = {},
       routing = null,
       searchFunction,
       stalledSearchDelay = 200,
@@ -215,6 +225,7 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
     this._stalledSearchDelay = stalledSearchDelay;
     this._searchStalledTimer = null;
     this._isSearchStalled = false;
+    this._initialUiState = initialUiState;
     this._searchParameters = {
       ...searchParameters,
       index: indexName,

--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -403,7 +403,7 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
     this.mainIndex.init({
       instantSearchInstance: this,
       parent: null,
-      uiState: {},
+      uiState: this._initialUiState,
     });
 
     mainHelper.search();

--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -102,7 +102,7 @@ export type InstantSearchOptions<TRouteState = UiState> = {
   searchParameters?: PlainSearchParameters;
 
   /**
-   * Injects an `uiState` to the `instantsearch` instance. You can use this option
+   * Injects a `uiState` to the `instantsearch` instance. You can use this option
    * to provide an initial state to a widget. Note that the state is only used
    * for the first search. To unconditionally pass additional parameters to the
    * Algolia API, take a look at the `configure` widget.

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -172,7 +172,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
 
   it('throws if createURL is called before start', () => {
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient: createSearchClient(),
     });
 
@@ -185,7 +185,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
 
   it('throws if refresh is called before start', () => {
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient: createSearchClient(),
     });
 
@@ -205,7 +205,7 @@ describe('InstantSearch', () => {
 
     // eslint-disable-next-line no-new
     new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient,
     });
 
@@ -218,7 +218,7 @@ describe('InstantSearch', () => {
   it('does not call algoliasearchHelper', () => {
     // eslint-disable-next-line no-new
     new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient: createSearchClient(),
     });
 
@@ -228,7 +228,7 @@ describe('InstantSearch', () => {
   it('does store insightsClient on the instance', () => {
     const insightsClient = () => {};
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient: createSearchClient(),
       insightsClient,
     });
@@ -242,7 +242,7 @@ describe('InstantSearch', () => {
     const facetsRefinements = disjunctiveFacetsRefinements;
 
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient: createSearchClient(),
       searchParameters: {
         disjunctiveFacetsRefinements,
@@ -272,7 +272,7 @@ describe('addWidget(s)', () => {
   it('forwards the call to `addWidget` to the main index', () => {
     const searchClient = createSearchClient();
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient,
     });
 
@@ -286,7 +286,7 @@ describe('addWidget(s)', () => {
   it('forwards the call to `addWidgets` to the main index', () => {
     const searchClient = createSearchClient();
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient,
     });
 
@@ -302,7 +302,7 @@ describe('removeWidget(s)', () => {
   it('forwards the call to `removeWidget` to the main index', () => {
     const searchClient = createSearchClient();
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient,
     });
 
@@ -320,7 +320,7 @@ describe('removeWidget(s)', () => {
   it('forwards the call to `removeWidgets` to the main index', () => {
     const searchClient = createSearchClient();
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient,
     });
 
@@ -339,7 +339,7 @@ describe('removeWidget(s)', () => {
 describe('start', () => {
   it('creates two Helper one for the instance + one for the index', () => {
     const searchClient = createSearchClient();
-    const indexName = 'my_index_name';
+    const indexName = 'indexName';
     const search = new InstantSearch({
       indexName,
       searchClient,
@@ -356,7 +356,7 @@ describe('start', () => {
   it('replaces the regular `search` with `searchOnlyWithDerivedHelpers`', () => {
     const searchClient = createSearchClient();
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient,
     });
 
@@ -371,7 +371,7 @@ describe('start', () => {
     const searchFunction = jest.fn(helper => helper.setQuery('test').search());
     const searchClient = createSearchClient();
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchFunction,
       searchClient,
     });
@@ -389,7 +389,7 @@ describe('start', () => {
   it('calls the provided `searchFunction` with multiple requests', () => {
     const searchClient = createSearchClient();
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient,
       searchFunction(helper) {
         helper.addDisjunctiveFacetRefinement('brand', 'Apple');
@@ -408,7 +408,7 @@ describe('start', () => {
 
   it('forwards the `searchParameters` to the main index', () => {
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient: createSearchClient(),
       searchParameters: {
         hitsPerPage: 5,
@@ -421,7 +421,7 @@ describe('start', () => {
 
     expect(search.mainIndex.getHelper().state).toEqual(
       algoliasearchHelper.SearchParameters.make({
-        index: 'index_name',
+        index: 'indexName',
         hitsPerPage: 5,
         disjunctiveFacetsRefinements: { brand: ['Apple'] },
         disjunctiveFacets: ['brand'],
@@ -431,7 +431,7 @@ describe('start', () => {
 
   it('calls `init` on the added widgets', () => {
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient: createSearchClient(),
     });
 
@@ -447,7 +447,7 @@ describe('start', () => {
   it('triggers a search without errors', () => {
     const searchClient = createSearchClient();
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient,
     });
 
@@ -464,7 +464,7 @@ describe('start', () => {
     });
 
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient,
     });
 
@@ -482,7 +482,7 @@ describe('start', () => {
   it('does start without widgets', () => {
     const searchClient = createSearchClient();
     const instance = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient,
     });
 
@@ -492,7 +492,7 @@ describe('start', () => {
   it('does not to start twice', () => {
     const searchClient = createSearchClient();
     const instance = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient,
     });
 
@@ -510,7 +510,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
 describe('dispose', () => {
   it('cancels the scheduled search', async () => {
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient: createSearchClient(),
     });
 
@@ -533,7 +533,7 @@ describe('dispose', () => {
 
   it('cancels the scheduled render', async () => {
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient: createSearchClient(),
     });
 
@@ -556,7 +556,7 @@ describe('dispose', () => {
   it('cancels the scheduled stalled render', async () => {
     const { searches, searchClient } = createControlledSearchClient();
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient,
     });
 
@@ -586,7 +586,7 @@ describe('dispose', () => {
 
   it('removes the widgets from the main index', () => {
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient: createSearchClient(),
     });
 
@@ -603,7 +603,7 @@ describe('dispose', () => {
 
   it('calls `dispose` on the main index', () => {
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient: createSearchClient(),
     });
 
@@ -620,7 +620,7 @@ describe('dispose', () => {
 
   it('stops the instance', () => {
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient: createSearchClient(),
     });
 
@@ -638,7 +638,7 @@ describe('dispose', () => {
   it('removes the listeners on the main Helper', () => {
     const onEventName = jest.fn();
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient: createSearchClient(),
     });
 
@@ -662,7 +662,7 @@ describe('dispose', () => {
   it('removes the listeners on the instance', async () => {
     const onRender = jest.fn();
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient: createSearchClient(),
     });
 
@@ -689,7 +689,7 @@ describe('dispose', () => {
 
   it('removes the Helpers references', () => {
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient: createSearchClient(),
     });
 
@@ -713,7 +713,7 @@ describe('dispose', () => {
 describe('scheduleSearch', () => {
   it('defers the call to the `search` method', async () => {
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient: createSearchClient(),
     });
 
@@ -734,7 +734,7 @@ describe('scheduleSearch', () => {
 
   it('deduplicates the calls to the `search` method', async () => {
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient: createSearchClient(),
     });
 
@@ -760,7 +760,7 @@ describe('scheduleSearch', () => {
 describe('scheduleRender', () => {
   it('defers the call to the `render` method', async () => {
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient: createSearchClient(),
     });
 
@@ -779,7 +779,7 @@ describe('scheduleRender', () => {
 
   it('deduplicates the calls to the `render` method', async () => {
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient: createSearchClient(),
     });
 
@@ -803,7 +803,7 @@ describe('scheduleRender', () => {
 
   it('emits a `render` event once the render is complete', done => {
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient: createSearchClient(),
     });
 
@@ -826,7 +826,7 @@ describe('scheduleStalledRender', () => {
   it('calls the `render` method on the main index', async () => {
     const { searches, searchClient } = createControlledSearchClient();
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient,
     });
 
@@ -859,7 +859,7 @@ describe('scheduleStalledRender', () => {
   it('deduplicates the calls to the `render` method', async () => {
     const { searches, searchClient } = createControlledSearchClient();
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient,
     });
 
@@ -895,7 +895,7 @@ describe('scheduleStalledRender', () => {
   it('triggers a `render` once the search expires the delay', async () => {
     const { searches, searchClient } = createControlledSearchClient();
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient,
     });
 
@@ -976,7 +976,7 @@ describe('createURL', () => {
     router.createURL.mockImplementation(() => 'http://algolia.com');
 
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient: createSearchClient(),
       routing: {
         router,
@@ -1006,7 +1006,7 @@ describe('createURL', () => {
     router.createURL.mockImplementation(() => 'http://algolia.com');
 
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient: createSearchClient(),
       routing: {
         router,
@@ -1042,7 +1042,7 @@ describe('refresh', () => {
     });
 
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient,
     });
 
@@ -1058,7 +1058,7 @@ describe('refresh', () => {
   it('triggers a `search` with the cache emptied', () => {
     const searchClient = createSearchClient();
     const search = new InstantSearch({
-      indexName: 'index_name',
+      indexName: 'indexName',
       searchClient,
     });
 

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -429,6 +429,30 @@ describe('start', () => {
     );
   });
 
+  it('forwards the `initialUiState` to the main index', () => {
+    const search = new InstantSearch({
+      indexName: 'indexName',
+      searchClient: createSearchClient(),
+      initialUiState: {
+        indexName: {
+          refinementList: {
+            brand: ['Apple'],
+          },
+        },
+      },
+    });
+
+    search.start();
+
+    expect(search.mainIndex.getWidgetState()).toEqual({
+      indexName: {
+        refinementList: {
+          brand: ['Apple'],
+        },
+      },
+    });
+  });
+
   it('calls `init` on the added widgets', () => {
     const search = new InstantSearch({
       indexName: 'indexName',

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -10,6 +10,7 @@ import { InstantSearch } from './instantsearch';
 export interface InitOptions {
   instantSearchInstance: InstantSearch;
   parent: Index | null;
+  uiState: UiState;
   state: SearchParameters;
   helper: Helper;
   templatesConfig: object;

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -1354,28 +1354,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
     });
 
     describe('with uiState', () => {
-      it('updates the local `uiState` when the state changes', () => {
-        const instance = index({ indexName: 'indexName' });
-        const widgets = [createSearchBox(), createPagination()];
-
-        instance.addWidgets(widgets);
-
-        instance.init(createInitOptions());
-
-        // Simulate a state change
-        instance
-          .getHelper()!
-          .setQueryParameter('query', 'Apple')
-          .setQueryParameter('page', 5);
-
-        expect(instance.getWidgetState({})).toEqual({
-          indexName: {
-            query: 'Apple',
-            page: 5,
-          },
-        });
-      });
-
       it('uses `indexId` for scope key', () => {
         const instance = index({ indexName: 'indexName', indexId: 'indexId' });
         const widgets = [createSearchBox(), createPagination()];
@@ -1392,6 +1370,86 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
 
         expect(instance.getWidgetState({})).toEqual({
           indexId: {
+            query: 'Apple',
+            page: 5,
+          },
+        });
+      });
+
+      it('uses `uiState` for the local `uiState`', () => {
+        const topLevelInstance = index({ indexName: 'topLevelIndexName' });
+        const subLevelInstance = index({ indexName: 'subLevelIndexName' });
+
+        topLevelInstance.addWidgets([subLevelInstance]);
+
+        topLevelInstance.init(
+          createInitOptions({
+            uiState: {
+              // @TODO: remove once we have updated UiState
+              // @ts-ignore
+              topLevelIndexName: {
+                configure: {
+                  hitsPerPage: 5,
+                },
+                refinementList: {
+                  brand: ['Apple'],
+                },
+              },
+              // @ts-ignore
+              subLevelIndexName: {
+                configure: {
+                  hitsPerPage: 2,
+                },
+                menu: {
+                  categgories: 'Phone',
+                },
+                refinementList: {
+                  brand: ['Samsung'],
+                },
+              },
+            },
+          })
+        );
+
+        expect(topLevelInstance.getWidgetState({})).toEqual({
+          topLevelIndexName: {
+            configure: {
+              hitsPerPage: 5,
+            },
+            refinementList: {
+              brand: ['Apple'],
+            },
+          },
+          subLevelIndexName: {
+            configure: {
+              hitsPerPage: 2,
+            },
+            menu: {
+              categgories: 'Phone',
+            },
+            refinementList: {
+              brand: ['Samsung'],
+            },
+          },
+        });
+      });
+
+      it('updates the local `uiState` when the state changes', () => {
+        const instance = index({ indexName: 'indexName' });
+        const widgets = [createSearchBox(), createPagination()];
+
+        instance.addWidgets(widgets);
+
+        instance.init(createInitOptions());
+
+        // Simulate a state change
+        instance
+          .getHelper()!
+          .setQueryParameter('query', 'Apple')
+          .setQueryParameter('page', 5);
+
+        expect(instance.getWidgetState({})).toEqual({
+          indexName: {
             query: 'Apple',
             page: 5,
           },

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -1376,7 +1376,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
         });
       });
 
-      it('uses `uiState` for the local `uiState`', () => {
+      it('uses the provided `uiState` for the local `uiState`', () => {
         const topLevelInstance = index({ indexName: 'topLevelIndexName' });
         const subLevelInstance = index({ indexName: 'subLevelIndexName' });
 

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -234,6 +234,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
           expect(widget.init).toHaveBeenCalledWith({
             instantSearchInstance,
             parent: instance,
+            uiState: {},
             helper: instance.getHelper(),
             state: instance.getHelper()!.state,
             templatesConfig: instantSearchInstance.templatesConfig,
@@ -879,6 +880,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
         expect(widget.init).toHaveBeenCalledWith({
           instantSearchInstance,
           parent: instance,
+          uiState: {},
           helper: instance.getHelper(),
           state: instance.getHelper()!.state,
           templatesConfig: instantSearchInstance.templatesConfig,

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -1401,7 +1401,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
                   hitsPerPage: 2,
                 },
                 menu: {
-                  categgories: 'Phone',
+                  categories: 'Phone',
                 },
                 refinementList: {
                   brand: ['Samsung'],
@@ -1425,7 +1425,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
               hitsPerPage: 2,
             },
             menu: {
-              categgories: 'Phone',
+              categories: 'Phone',
             },
             refinementList: {
               brand: ['Samsung'],

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -276,9 +276,10 @@ const index = (props: IndexProps): Index => {
       return this;
     },
 
-    init({ instantSearchInstance, parent }: IndexInitOptions) {
+    init({ instantSearchInstance, parent, uiState }: IndexInitOptions) {
       localInstantSearchInstance = instantSearchInstance;
       localParent = parent;
+      localUiState = uiState[indexId] || {};
 
       // The `mainHelper` is already defined at this point. The instance is created
       // inside InstantSearch at the `start` method, which occurs before the `init`
@@ -357,9 +358,9 @@ const index = (props: IndexProps): Index => {
       localWidgets.forEach(widget => {
         if (widget.init) {
           widget.init({
+            uiState,
             helper: helper!,
             parent: this,
-            uiState: localUiState,
             instantSearchInstance,
             state: helper!.state,
             templatesConfig: instantSearchInstance.templatesConfig,

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -31,7 +31,11 @@ type IndexProps = {
   indexId?: string;
 };
 
-type IndexInitOptions = Pick<InitOptions, 'instantSearchInstance' | 'parent'>;
+type IndexInitOptions = Pick<
+  InitOptions,
+  'instantSearchInstance' | 'parent' | 'uiState'
+>;
+
 type IndexRenderOptions = Pick<RenderOptions, 'instantSearchInstance'>;
 
 type LocalWidgetSearchParametersOptions = WidgetSearchParametersOptions & {
@@ -212,6 +216,7 @@ const index = (props: IndexProps): Index => {
             widget.init({
               helper: helper!,
               parent: this,
+              uiState: {},
               instantSearchInstance: localInstantSearchInstance,
               state: helper!.state,
               templatesConfig: localInstantSearchInstance.templatesConfig,
@@ -354,6 +359,7 @@ const index = (props: IndexProps): Index => {
           widget.init({
             helper: helper!,
             parent: this,
+            uiState: localUiState,
             instantSearchInstance,
             state: helper!.state,
             templatesConfig: instantSearchInstance.templatesConfig,

--- a/stories/instantsearch.stories.js
+++ b/stories/instantsearch.stories.js
@@ -1,17 +1,31 @@
 import { storiesOf } from '@storybook/html';
 import { withHits } from '../.storybook/decorators';
 
-storiesOf('InstantSearch', module).add(
-  'with searchfunction to prevent search',
-  withHits(() => {}, {
-    searchFunction: helper => {
-      const query = helper.state.query;
+storiesOf('InstantSearch', module)
+  .add(
+    'with searchfunction to prevent search',
+    withHits(() => {}, {
+      searchFunction: helper => {
+        const query = helper.state.query;
 
-      if (query === '') {
-        return;
-      }
+        if (query === '') {
+          return;
+        }
 
-      helper.search();
-    },
-  })
-);
+        helper.search();
+      },
+    })
+  )
+  .add(
+    'with initialUiState',
+    withHits(() => {}, {
+      initialUiState: {
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        instant_search: {
+          refinementList: {
+            brand: ['Apple'],
+          },
+        },
+      },
+    })
+  );

--- a/test/mock/createInstantSearch.ts
+++ b/test/mock/createInstantSearch.ts
@@ -37,6 +37,7 @@ export const createInstantSearch = (
     _stalledSearchDelay: 200,
     _searchStalledTimer: null,
     _searchParameters: {},
+    _initialUiState: {},
     _createURL: jest.fn(() => '#'),
     _createAbsoluteURL: jest.fn(() => '#'),
     createURL: jest.fn(() => '#'),

--- a/test/mock/createWidget.ts
+++ b/test/mock/createWidget.ts
@@ -11,7 +11,7 @@ import { createInstantSearch } from './createInstantSearch';
 export const createInitOptions = (
   args: Partial<InitOptions> = {}
 ): InitOptions => {
-  const instantSearchInstance = createInstantSearch();
+  const { instantSearchInstance = createInstantSearch(), ...rest } = args;
 
   return {
     instantSearchInstance,
@@ -21,14 +21,14 @@ export const createInitOptions = (
     helper: instantSearchInstance.helper!,
     state: instantSearchInstance.helper!.state,
     createURL: jest.fn(() => '#'),
-    ...args,
+    ...rest,
   };
 };
 
 export const createRenderOptions = (
   args: Partial<RenderOptions> = {}
 ): RenderOptions => {
-  const instantSearchInstance = createInstantSearch();
+  const { instantSearchInstance = createInstantSearch(), ...rest } = args;
   const response = createMultiSearchResponse();
   const results = new algolisearchHelper.SearchResults(
     instantSearchInstance.helper!.state,
@@ -52,7 +52,7 @@ export const createRenderOptions = (
       isSearchStalled: false,
     },
     createURL: jest.fn(() => '#'),
-    ...args,
+    ...rest,
   };
 };
 

--- a/test/mock/createWidget.ts
+++ b/test/mock/createWidget.ts
@@ -16,7 +16,7 @@ export const createInitOptions = (
   return {
     instantSearchInstance,
     parent: null,
-    uiState: {},
+    uiState: instantSearchInstance._initialUiState,
     templatesConfig: instantSearchInstance.templatesConfig,
     helper: instantSearchInstance.helper!,
     state: instantSearchInstance.helper!.state,

--- a/test/mock/createWidget.ts
+++ b/test/mock/createWidget.ts
@@ -16,6 +16,7 @@ export const createInitOptions = (
   return {
     instantSearchInstance,
     parent: null,
+    uiState: {},
     templatesConfig: instantSearchInstance.templatesConfig,
     helper: instantSearchInstance.helper!,
     state: instantSearchInstance.helper!.state,


### PR DESCRIPTION
**Summary**

This PR introduces the `initialUiState` option at the `InstantSearch` level. The option allows users to provide an `uiState` used for the initial request. Only for the **initial request**. I've chosen to name the option `initialXXX` rather than `uiState` to have a clear intent. At some point, we might want to introduce the concept of controlled state (like React InstantSearch) that could use the option `uiState`.

At the moment the type definitions are incorrect. We have only one type that defines the `uiState` but we have to define two different types. The first is one is the "global" `uiState` and the second one is the "local" to each index. The "global" `uiState` is built on multiple "local" `uiState`. We'll update the definition in a separate PR.


**Usage**

```js
const search = instantsearch({
  // ...
  initialUiState: {
    instant_search: {
      query: "Apple"
    },
    instant_search_price_asc: {
      refinementList: {
        brand: ["Apple"]
      }
    }
  }
});
```

Checkout the example on [Storybook](https://deploy-preview-4074--instantsearchjs.netlify.com/stories/?path=/story/instantsearch--with-initialuistate).