### PR TITLE
feat: update UiState definition

### DIFF
--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -1021,7 +1021,9 @@ describe('createURL', () => {
 
     expect(search.createURL()).toBe('http://algolia.com');
     expect(router.createURL).toHaveBeenCalledWith({
-      query: 'Apple',
+      indexName: {
+        query: 'Apple',
+      },
     });
   });
 
@@ -1052,8 +1054,10 @@ describe('createURL', () => {
 
     expect(search.createURL({ page: 5 })).toBe('http://algolia.com');
     expect(router.createURL).toHaveBeenCalledWith({
-      query: 'Apple',
-      page: 5,
+      indexName: {
+        query: 'Apple',
+        page: 5,
+      },
     });
   });
 });

--- a/src/lib/__tests__/RoutingManager-test.ts
+++ b/src/lib/__tests__/RoutingManager-test.ts
@@ -4,7 +4,7 @@ import qs from 'qs';
 import { createSearchClient } from '../../../test/mock/createSearchClient';
 import { createWidget } from '../../../test/mock/createWidget';
 import { runAllMicroTasks } from '../../../test/utils/runAllMicroTasks';
-import { Router, Widget, StateMapping, RouteState } from '../../types';
+import { Router, Widget, UiState, StateMapping, RouteState } from '../../types';
 import historyRouter from '../routers/history';
 import RoutingManager from '../RoutingManager';
 import instantsearch from '../main';
@@ -119,7 +119,7 @@ describe('RoutingManager', () => {
     test('reads the state of widgets with a getWidgetState implementation', () => {
       const searchClient = createSearchClient();
       const search = instantsearch({
-        indexName: '',
+        indexName: 'indexName',
         searchClient,
       });
 
@@ -135,7 +135,9 @@ describe('RoutingManager', () => {
       search.addWidget(widget);
 
       const actualInitialState = {
-        query: 'query',
+        indexName: {
+          query: 'query',
+        },
       };
 
       search.start();
@@ -156,7 +158,9 @@ describe('RoutingManager', () => {
         searchParameters: search.mainIndex.getHelper()!.state,
       });
 
-      expect(uiStates).toEqual(widgetState);
+      expect(uiStates).toEqual({
+        indexName: widgetState,
+      });
 
       expect(widget.getWidgetState).toHaveBeenCalledTimes(1);
       expect(widget.getWidgetState).toHaveBeenCalledWith(
@@ -171,7 +175,7 @@ describe('RoutingManager', () => {
     test('Does not read UI state from widgets without an implementation of getWidgetState', () => {
       const searchClient = createSearchClient();
       const search = instantsearch({
-        indexName: '',
+        indexName: 'indexName',
         searchClient,
       });
 
@@ -182,7 +186,9 @@ describe('RoutingManager', () => {
       search.start();
 
       const actualInitialState = {
-        query: 'query',
+        indexName: {
+          query: 'query',
+        },
       };
 
       const router = new RoutingManager({
@@ -201,7 +207,9 @@ describe('RoutingManager', () => {
         searchParameters: search.mainIndex.getHelper()!.state,
       });
 
-      expect(uiStates).toEqual({});
+      expect(uiStates).toEqual({
+        indexName: {},
+      });
     });
   });
 
@@ -209,7 +217,7 @@ describe('RoutingManager', () => {
     test('should get searchParameters from widget that implements getWidgetSearchParameters', () => {
       const searchClient = createSearchClient();
       const search = instantsearch({
-        indexName: '',
+        indexName: 'indexName',
         searchClient,
       });
 
@@ -221,7 +229,9 @@ describe('RoutingManager', () => {
       search.addWidget(widget);
 
       const actualInitialState = {
-        query: 'query',
+        indexName: {
+          query: 'query',
+        },
       };
 
       search.start();
@@ -299,7 +309,7 @@ describe('RoutingManager', () => {
       });
 
       const search = instantsearch({
-        indexName: 'instant_search',
+        indexName: 'indexName',
         searchClient,
         routing: {
           router,
@@ -330,7 +340,9 @@ describe('RoutingManager', () => {
 
         expect(router.write).toHaveBeenCalledTimes(1);
         expect(router.write).toHaveBeenCalledWith({
-          q: 'q',
+          indexName: {
+            q: 'q',
+          },
         });
 
         done();
@@ -340,7 +352,7 @@ describe('RoutingManager', () => {
     test('should update the searchParameters on router state update', done => {
       const searchClient = createSearchClient();
 
-      let onRouterUpdateCallback: (args: object) => void;
+      let onRouterUpdateCallback: (args: UiState) => void;
       const router = createFakeRouter({
         onUpdate: fn => {
           onRouterUpdateCallback = fn;
@@ -348,7 +360,7 @@ describe('RoutingManager', () => {
       });
 
       const search = instantsearch({
-        indexName: 'instant_search',
+        indexName: 'indexName',
         searchClient,
         routing: {
           router,
@@ -358,9 +370,10 @@ describe('RoutingManager', () => {
       const widget = {
         render: jest.fn(),
         getWidgetSearchParameters: jest.fn((searchParameters, { uiState }) =>
-          searchParameters.setQuery(uiState.q)
+          searchParameters.setQuery(uiState.query)
         ),
       };
+
       search.addWidget(widget);
 
       search.start();
@@ -370,9 +383,11 @@ describe('RoutingManager', () => {
 
         expect(search.mainIndex.getHelper()!.state.query).toBeUndefined();
 
-        // this simulates a router update with a uiState of {q: 'a'}
+        // this simulates a router update with a uiState of {query: 'a'}
         onRouterUpdateCallback({
-          q: 'a',
+          indexName: {
+            query: 'a',
+          },
         });
 
         search.once('render', () => {
@@ -393,14 +408,21 @@ describe('RoutingManager', () => {
 
       const stateMapping = createFakeStateMapping({
         stateToRoute(uiState) {
-          return {
-            query: uiState.query && uiState.query.toUpperCase(),
-          };
+          return Object.keys(uiState).reduce((state, indexId) => {
+            const indexState = uiState[indexId];
+
+            return {
+              ...state,
+              [indexId]: {
+                query: indexState.query && indexState.query.toUpperCase(),
+              },
+            };
+          }, {});
         },
       });
 
       const search = instantsearch({
-        indexName: 'instant_search',
+        indexName: 'indexName',
         searchFunction: helper => {
           helper.setQuery('test').search();
         },
@@ -431,7 +453,9 @@ describe('RoutingManager', () => {
         expect(search.mainIndex.getHelper()!.state.query).toEqual('test');
 
         expect(router.write).toHaveBeenLastCalledWith({
-          query: 'TEST',
+          indexName: {
+            query: 'TEST',
+          },
         });
 
         done();
@@ -446,7 +470,7 @@ describe('RoutingManager', () => {
       });
 
       const search = instantsearch({
-        indexName: 'instant_search',
+        indexName: 'indexName',
         searchClient,
         routing: {
           stateMapping,
@@ -469,7 +493,9 @@ describe('RoutingManager', () => {
 
       expect(router.write).toHaveBeenCalledTimes(1);
       expect(router.write).toHaveBeenLastCalledWith({
-        query: 'Apple',
+        indexName: {
+          query: 'Apple',
+        },
       });
 
       await runAllMicroTasks();
@@ -481,7 +507,9 @@ describe('RoutingManager', () => {
 
       expect(router.write).toHaveBeenCalledTimes(2);
       expect(router.write).toHaveBeenLastCalledWith({
-        query: 'Apple',
+        indexName: {
+          query: 'Apple',
+        },
       });
     });
 
@@ -493,7 +521,7 @@ describe('RoutingManager', () => {
       });
 
       const search = instantsearch({
-        indexName: 'instant_search',
+        indexName: 'indexName',
         searchFunction(helper) {
           // Force the value of the query
           helper.setQuery('Apple iPhone').search();
@@ -518,7 +546,9 @@ describe('RoutingManager', () => {
 
       expect(router.write).toHaveBeenCalledTimes(1);
       expect(router.write).toHaveBeenLastCalledWith({
-        query: 'Apple iPhone',
+        indexName: {
+          query: 'Apple iPhone',
+        },
       });
 
       // Trigger getConfiguration
@@ -528,7 +558,9 @@ describe('RoutingManager', () => {
 
       expect(router.write).toHaveBeenCalledTimes(2);
       expect(router.write).toHaveBeenLastCalledWith({
-        query: 'Apple iPhone',
+        indexName: {
+          query: 'Apple iPhone',
+        },
       });
     });
 
@@ -548,7 +580,7 @@ describe('RoutingManager', () => {
       });
 
       const search = instantsearch({
-        indexName: 'instant_search',
+        indexName: 'indexName',
         searchClient,
         routing: {
           router,
@@ -571,7 +603,9 @@ describe('RoutingManager', () => {
 
       expect(router.write).toHaveBeenCalledTimes(1);
       expect(router.write).toHaveBeenLastCalledWith({
-        query: 'Apple',
+        indexName: {
+          query: 'Apple',
+        },
       });
 
       // Trigger an update - push a change
@@ -579,7 +613,9 @@ describe('RoutingManager', () => {
 
       expect(router.write).toHaveBeenCalledTimes(2);
       expect(router.write).toHaveBeenLastCalledWith({
-        query: 'Apple iPhone',
+        indexName: {
+          query: 'Apple iPhone',
+        },
       });
 
       await runAllMicroTasks();
@@ -596,7 +632,9 @@ describe('RoutingManager', () => {
 
       expect(router.write).toHaveBeenCalledTimes(3);
       expect(router.write).toHaveBeenLastCalledWith({
-        query: 'Apple',
+        indexName: {
+          query: 'Apple',
+        },
       });
     });
   });

--- a/src/lib/stateMappings/__tests__/simple-test.ts
+++ b/src/lib/stateMappings/__tests__/simple-test.ts
@@ -1,29 +1,32 @@
 import simpleStateMapping from '../simple';
-import { UiState } from '../../../types';
 
 describe('simpleStateMapping', () => {
   describe('stateToRoute', () => {
     it('passes normal state through', () => {
       const stateMapping = simpleStateMapping();
-      expect(
-        stateMapping.stateToRoute({
+      const actual = stateMapping.stateToRoute({
+        indexName: {
           query: 'zamboni',
           refinementList: {
             color: ['red'],
           },
-        })
-      ).toEqual({
-        query: 'zamboni',
-        refinementList: {
-          color: ['red'],
+        },
+      });
+
+      expect(actual).toEqual({
+        indexName: {
+          query: 'zamboni',
+          refinementList: {
+            color: ['red'],
+          },
         },
       });
     });
 
     it('removes configure', () => {
       const stateMapping = simpleStateMapping();
-      expect(
-        stateMapping.stateToRoute({
+      const actual = stateMapping.stateToRoute({
+        indexName: {
           query: 'zamboni',
           refinementList: {
             color: ['red'],
@@ -31,31 +34,40 @@ describe('simpleStateMapping', () => {
           configure: {
             advancedSyntax: false,
           },
-        })
-      ).toEqual({
-        query: 'zamboni',
-        refinementList: {
-          color: ['red'],
+        },
+      });
+
+      expect(actual).toEqual({
+        indexName: {
+          query: 'zamboni',
+          refinementList: {
+            color: ['red'],
+          },
         },
       });
     });
 
     it('passes non-UiState through', () => {
       const stateMapping = simpleStateMapping();
-      expect(
-        stateMapping.stateToRoute({
+      const actual = stateMapping.stateToRoute({
+        indexName: {
+          query: 'zamboni',
+          refinementList: {
+            color: ['red'],
+          },
+          // @ts-ignore
+          spy: ['stealing', 'all', 'your', 'searches'],
+        },
+      });
+
+      expect(actual).toEqual({
+        indexName: {
           query: 'zamboni',
           refinementList: {
             color: ['red'],
           },
           spy: ['stealing', 'all', 'your', 'searches'],
-        } as UiState)
-      ).toEqual({
-        query: 'zamboni',
-        refinementList: {
-          color: ['red'],
         },
-        spy: ['stealing', 'all', 'your', 'searches'],
       });
     });
   });
@@ -63,25 +75,29 @@ describe('simpleStateMapping', () => {
   describe('routeToState', () => {
     it('passes normal state through', () => {
       const stateMapping = simpleStateMapping();
-      expect(
-        stateMapping.routeToState({
+      const actual = stateMapping.routeToState({
+        indexName: {
           query: 'zamboni',
           refinementList: {
             color: ['red'],
           },
-        })
-      ).toEqual({
-        query: 'zamboni',
-        refinementList: {
-          color: ['red'],
+        },
+      });
+
+      expect(actual).toEqual({
+        indexName: {
+          query: 'zamboni',
+          refinementList: {
+            color: ['red'],
+          },
         },
       });
     });
 
     it('removes configure', () => {
       const stateMapping = simpleStateMapping();
-      expect(
-        stateMapping.routeToState({
+      const actual = stateMapping.routeToState({
+        indexName: {
           query: 'zamboni',
           refinementList: {
             color: ['red'],
@@ -89,31 +105,40 @@ describe('simpleStateMapping', () => {
           configure: {
             advancedSyntax: false,
           },
-        })
-      ).toEqual({
-        query: 'zamboni',
-        refinementList: {
-          color: ['red'],
+        },
+      });
+
+      expect(actual).toEqual({
+        indexName: {
+          query: 'zamboni',
+          refinementList: {
+            color: ['red'],
+          },
         },
       });
     });
 
     it('passes non-UiState through', () => {
       const stateMapping = simpleStateMapping();
-      expect(
-        stateMapping.routeToState({
+      const actual = stateMapping.routeToState({
+        indexName: {
+          query: 'zamboni',
+          refinementList: {
+            color: ['red'],
+          },
+          // @ts-ignore
+          spy: ['stealing', 'all', 'your', 'searches'],
+        },
+      });
+
+      expect(actual).toEqual({
+        indexName: {
           query: 'zamboni',
           refinementList: {
             color: ['red'],
           },
           spy: ['stealing', 'all', 'your', 'searches'],
-        } as UiState)
-      ).toEqual({
-        query: 'zamboni',
-        refinementList: {
-          color: ['red'],
         },
-        spy: ['stealing', 'all', 'your', 'searches'],
       });
     });
   });

--- a/src/lib/stateMappings/simple.ts
+++ b/src/lib/stateMappings/simple.ts
@@ -1,4 +1,9 @@
-import { UiState, StateMapping } from '../../types';
+import { UiState, IndexUiState, StateMapping } from '../../types';
+
+function indexStateWithoutConfigure(uiState: IndexUiState): IndexUiState {
+  const { configure, ...trackedUiState } = uiState;
+  return trackedUiState;
+}
 
 // technically a URL could contain any key, since users provide it,
 // which is why the input to this function is UiState, not something
@@ -6,13 +11,23 @@ import { UiState, StateMapping } from '../../types';
 export default function simpleStateMapping(): StateMapping<UiState> {
   return {
     stateToRoute(uiState) {
-      const { configure, ...trackedRouteState } = uiState;
-      return trackedRouteState;
+      return Object.keys(uiState).reduce<UiState>(
+        (state, indexId) => ({
+          ...state,
+          [indexId]: indexStateWithoutConfigure(uiState[indexId]),
+        }),
+        {}
+      );
     },
 
     routeToState(routeState) {
-      const { configure, ...trackedUiState } = routeState;
-      return trackedUiState;
+      return Object.keys(routeState).reduce<UiState>(
+        (state, indexId) => ({
+          ...state,
+          [indexId]: indexStateWithoutConfigure(routeState[indexId]),
+        }),
+        {}
+      );
     },
   };
 }

--- a/src/lib/stateMappings/simple.ts
+++ b/src/lib/stateMappings/simple.ts
@@ -1,6 +1,6 @@
 import { UiState, IndexUiState, StateMapping } from '../../types';
 
-function indexStateWithoutConfigure(uiState: IndexUiState): IndexUiState {
+function getIndexStateWithoutConfigure(uiState: IndexUiState): IndexUiState {
   const { configure, ...trackedUiState } = uiState;
   return trackedUiState;
 }
@@ -14,7 +14,7 @@ export default function simpleStateMapping(): StateMapping<UiState> {
       return Object.keys(uiState).reduce<UiState>(
         (state, indexId) => ({
           ...state,
-          [indexId]: indexStateWithoutConfigure(uiState[indexId]),
+          [indexId]: getIndexStateWithoutConfigure(uiState[indexId]),
         }),
         {}
       );
@@ -24,7 +24,7 @@ export default function simpleStateMapping(): StateMapping<UiState> {
       return Object.keys(routeState).reduce<UiState>(
         (state, indexId) => ({
           ...state,
-          [indexId]: indexStateWithoutConfigure(routeState[indexId]),
+          [indexId]: getIndexStateWithoutConfigure(routeState[indexId]),
         }),
         {}
       );

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -47,10 +47,10 @@ export interface WidgetStateOptions {
 }
 
 export interface WidgetSearchParametersOptions {
-  uiState: UiState;
+  uiState: IndexUiState;
 }
 
-export type UiState = {
+export type IndexUiState = {
   query?: string;
   refinementList?: {
     [attribute: string]: string[];
@@ -106,6 +106,10 @@ export type UiState = {
   configure?: PlainSearchParameters;
 };
 
+export type UiState = {
+  [indexId: string]: IndexUiState;
+};
+
 /**
  * Widgets are the building blocks of InstantSearch.js. Any valid widget must
  * have at least a `render` or a `init` function.
@@ -127,9 +131,9 @@ export interface Widget {
   dispose?(options: DisposeOptions): SearchParameters | void;
   getConfiguration?(previousConfiguration: SearchParameters): SearchParameters;
   getWidgetState?(
-    uiState: UiState,
+    uiState: IndexUiState,
     widgetStateOptions: WidgetStateOptions
-  ): UiState;
+  ): IndexUiState;
   getWidgetSearchParameters?(
     state: SearchParameters,
     widgetSearchParametersOptions: WidgetSearchParametersOptions

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -1385,8 +1385,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
         topLevelInstance.init(
           createInitOptions({
             uiState: {
-              // @TODO: remove once we have updated UiState
-              // @ts-ignore
               topLevelIndexName: {
                 configure: {
                   hitsPerPage: 5,
@@ -1395,7 +1393,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
                   brand: ['Apple'],
                 },
               },
-              // @ts-ignore
               subLevelIndexName: {
                 configure: {
                   hitsPerPage: 2,

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -9,6 +9,7 @@ import { Client } from 'algoliasearch';
 import {
   InstantSearch,
   UiState,
+  IndexUiState,
   Widget,
   InitOptions,
   RenderOptions,
@@ -63,10 +64,10 @@ function isIndexWidget(widget: Widget): widget is Index {
 function getLocalWidgetsState(
   widgets: Widget[],
   widgetStateOptions: WidgetStateOptions
-): UiState {
+): IndexUiState {
   return widgets
     .filter(widget => !isIndexWidget(widget))
-    .reduce<UiState>((uiState, widget) => {
+    .reduce<IndexUiState>((uiState, widget) => {
       if (!widget.getWidgetState) {
         return uiState;
       }
@@ -140,7 +141,7 @@ const index = (props: IndexProps): Index => {
   const { indexName, indexId = indexName } = props;
 
   let localWidgets: Widget[] = [];
-  let localUiState: UiState = {};
+  let localUiState: IndexUiState = {};
   let localInstantSearchInstance: InstantSearch | null = null;
   let localParent: Index | null = null;
   let helper: Helper | null = null;


### PR DESCRIPTION
This PR updates the type definitions to match the new format of the `UiState`. We introduce a new type called `IndexUiState`. The `UiState` is the global structure that represents the InstantSearch instance with each indices. The `IndexUiState` is the previous version of the `UiState`, it represents the state of an "index". Here is their definitions:

```ts
export type IndexUiState = {
  query?: string;
  hitsPerPage?: number;
  // ...
};

export type UiState = {
  [indexId: string]: IndexUiState;
};
```

The introduction of this type mainly impact the `StateMapping` & `RoutingManager`. Both have been updated. The changes applied to `RoutingManager` are there to make the tests pass don't pay too much attention to them since we'll rework this part soon.

**Note**: Name are just a proposition, we could use something else like `WidgetsState`, ... ideas are welcome! We could rename `UiState` for consistency if we find a better name for both.

