### PR TITLE
docs(example): fix html for hits

### DIFF
--- a/examples/e-commerce/src/widgets/Products.ts
+++ b/examples/e-commerce/src/widgets/Products.ts
@@ -9,7 +9,7 @@ export const products = hits({
     <img src="{{image}}" alt="{{name}}" class="hit-image">
   </header>
 
-  <main class="hit-info-container">
+  <div class="hit-info-container">
     <p class="hit-category">{{categories.0}}</p>
     <h1>{{#helpers.highlight}}{ "attribute": "name" }{{/helpers.highlight}}</h1>
     <p class="hit-description">{{#helpers.snippet}}{ "attribute": "description" }{{/helpers.snippet}}</p>
@@ -25,7 +25,7 @@ export const products = hits({
         </span>
       </p>
     </footer>
-  </main>
+  </div>
 </article>
 `,
     empty(searchResults) {


### PR DESCRIPTION
There can only be one main element per page:

> A document mustn't have more than one <main> element that doesn't have the hidden attribute specified.
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main

Found  this running an audit on the demo: 

<img width="582" alt="Screenshot 2019-08-28 at 12 53 55" src="https://user-images.githubusercontent.com/6270048/63849823-1f0f9080-c993-11e9-9400-0bd4cfd7c556.png">

(to check, do we use `main` in css? let's see in the preview)
