### PR TITLE
feat(index): replicate searchFunction hack

### DIFF
--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -139,22 +139,24 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
     });
 
     it('returns the instance to be able to chain the calls', () => {
-      const topLevelIndex = index({ indexName: 'topLevelIndexName' });
-      const subLevelIndex = index({ indexName: 'subLevelIndexName' });
+      const topLevelInstance = index({ indexName: 'topLevelIndexName' });
+      const subLevelInstance = index({ indexName: 'subLevelIndexName' });
 
-      topLevelIndex.addWidgets([
-        subLevelIndex.addWidgets([createSearchBox(), createPagination()]),
+      topLevelInstance.addWidgets([
+        subLevelInstance.addWidgets([createSearchBox(), createPagination()]),
       ]);
 
-      expect(topLevelIndex.getWidgets()).toHaveLength(1);
-      expect(topLevelIndex.getWidgets()).toEqual([subLevelIndex]);
+      expect(topLevelInstance.getWidgets()).toHaveLength(1);
+      expect(topLevelInstance.getWidgets()).toEqual([subLevelInstance]);
     });
 
     it('does not throw an error without the `init` step', () => {
-      const topLevelIndex = index({ indexName: 'topLevelIndexName' });
-      const subLevelIndex = index({ indexName: 'subLevelIndexName' });
+      const topLevelInstance = index({ indexName: 'topLevelIndexName' });
+      const subLevelInstance = index({ indexName: 'subLevelIndexName' });
 
-      expect(() => topLevelIndex.addWidgets([subLevelIndex])).not.toThrow();
+      expect(() =>
+        topLevelInstance.addWidgets([subLevelInstance])
+      ).not.toThrow();
     });
 
     it('throws an error with a value different than `array`', () => {
@@ -333,12 +335,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
 
     it('does not throw an error without the `init` step', () => {
       const topLevelInstance = index({ indexName: 'topLevelIndexName' });
-      const subLevelIndex = index({ indexName: 'subLevelIndexName' });
+      const subLevelInstance = index({ indexName: 'subLevelIndexName' });
 
-      topLevelInstance.addWidgets([subLevelIndex]);
+      topLevelInstance.addWidgets([subLevelInstance]);
 
       expect(() =>
-        topLevelInstance.removeWidgets([subLevelIndex])
+        topLevelInstance.removeWidgets([subLevelInstance])
       ).not.toThrow();
     });
 
@@ -1566,33 +1568,33 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
       });
 
       it('does not update the local `uiState` on first render for children indices', async () => {
-        const topLevelIndex = index({ indexName: 'topLevelIndexName' });
-        const subLevelIndex = index({ indexName: 'subLevelIndexName' });
+        const topLevelInstance = index({ indexName: 'topLevelIndexName' });
+        const subLevelInstance = index({ indexName: 'subLevelIndexName' });
         const instantSearchInstance = createInstantSearch({
           onStateChange: jest.fn(),
         });
 
-        topLevelIndex.addWidgets([
+        topLevelInstance.addWidgets([
           createSearchBox(),
-          subLevelIndex.addWidgets([createSearchBox()]),
+          subLevelInstance.addWidgets([createSearchBox()]),
         ]);
 
-        topLevelIndex.init(
+        topLevelInstance.init(
           createInitOptions({
             instantSearchInstance,
             parent: null,
           })
         );
 
-        expect(subLevelIndex.getWidgetState({})).toEqual({
+        expect(subLevelInstance.getWidgetState({})).toEqual({
           subLevelIndexName: {},
         });
 
-        subLevelIndex
+        subLevelInstance
           .getHelper()!
           // Simulate a change that does not emit (like `searchFunction`)
           .overrideStateWithoutTriggeringChangeEvent({
-            ...subLevelIndex.getHelper()!.state,
+            ...subLevelInstance.getHelper()!.state,
             query: 'Apple iPhone',
           })
           // Simulate a call to search from a widget - this step is required otherwise
@@ -1602,14 +1604,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
 
         await runAllMicroTasks();
 
-        topLevelIndex.render(
+        topLevelInstance.render(
           createRenderOptions({
             instantSearchInstance,
           })
         );
 
         expect(instantSearchInstance.onStateChange).not.toHaveBeenCalled();
-        expect(subLevelIndex.getWidgetState({})).toEqual({
+        expect(subLevelInstance.getWidgetState({})).toEqual({
           subLevelIndexName: {},
         });
       });

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -31,10 +31,7 @@ describe('index', () => {
         };
       }),
       getWidgetSearchParameters: jest.fn((searchParameters, { uiState }) => {
-        return searchParameters.setQueryParameter(
-          'query',
-          uiState.query || 'Apple'
-        );
+        return searchParameters.setQueryParameter('query', uiState.query || '');
       }),
       ...args,
     });
@@ -55,7 +52,7 @@ describe('index', () => {
         };
       }),
       getWidgetSearchParameters: jest.fn((searchParameters, { uiState }) => {
-        return searchParameters.setQueryParameter('page', uiState.page || 5);
+        return searchParameters.setQueryParameter('page', uiState.page || 0);
       }),
       ...args,
     });
@@ -192,7 +189,13 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
       it('updates the internal state with added widgets', () => {
         const instance = index({ indexName: 'indexName' });
 
-        instance.addWidgets([createSearchBox()]);
+        instance.addWidgets([
+          createSearchBox({
+            getWidgetSearchParameters(state) {
+              return state.setQueryParameter('query', 'Apple');
+            },
+          }),
+        ]);
 
         instance.init(createInitOptions({ parent: null }));
 
@@ -203,7 +206,13 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
           })
         );
 
-        instance.addWidgets([createPagination()]);
+        instance.addWidgets([
+          createPagination({
+            getWidgetSearchParameters(state) {
+              return state.setQueryParameter('page', 5);
+            },
+          }),
+        ]);
 
         expect(instance.getHelper()!.state).toEqual(
           new SearchParameters({
@@ -376,9 +385,20 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
     describe('with a started instance', () => {
       it('updates the internal state with removed widgets', () => {
         const instance = index({ indexName: 'indexName' });
-        const pagination = createPagination();
+        const pagination = createPagination({
+          getWidgetSearchParameters(state) {
+            return state.setQueryParameter('page', 5);
+          },
+        });
 
-        instance.addWidgets([createSearchBox(), pagination]);
+        instance.addWidgets([
+          createSearchBox({
+            getWidgetSearchParameters(state) {
+              return state.setQueryParameter('query', 'Apple');
+            },
+          }),
+          pagination,
+        ]);
 
         instance.init(createInitOptions({ parent: null }));
 
@@ -625,7 +645,18 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
         mainHelper,
       });
 
-      instance.addWidgets([createSearchBox(), createPagination()]);
+      instance.addWidgets([
+        createSearchBox({
+          getWidgetSearchParameters(state) {
+            return state.setQueryParameter('query', 'Apple');
+          },
+        }),
+        createPagination({
+          getWidgetSearchParameters(state) {
+            return state.setQueryParameter('page', 5);
+          },
+        }),
+      ]);
 
       instance.init(
         createInitOptions({
@@ -753,7 +784,18 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
         mainHelper,
       });
 
-      instance.addWidgets([createSearchBox(), createPagination()]);
+      instance.addWidgets([
+        createSearchBox({
+          getWidgetSearchParameters(state) {
+            return state.setQueryParameter('query', 'Apple');
+          },
+        }),
+        createPagination({
+          getWidgetSearchParameters(state) {
+            return state.setQueryParameter('page', 5);
+          },
+        }),
+      ]);
 
       instance.init(
         createInitOptions({

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -21,6 +21,7 @@ import {
   createDocumentationMessageGenerator,
   resolveSearchParameters,
   mergeSearchParameters,
+  isEqual,
 } from '../../lib/utils';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -147,6 +148,7 @@ const index = (props: IndexProps): Index => {
   let localParent: Index | null = null;
   let helper: Helper | null = null;
   let derivedHelper: DerivedHelper | null = null;
+  let isFirstRender = true;
 
   return {
     $$type: 'ais.index',
@@ -380,6 +382,7 @@ const index = (props: IndexProps): Index => {
           searchParameters: state,
           helper: helper!,
         });
+
         instantSearchInstance.onStateChange();
       });
     },
@@ -408,6 +411,29 @@ const index = (props: IndexProps): Index => {
           });
         }
       });
+
+      // Hack for backward compatibily with `searchFunction` + `routing`
+      // https://github.com/algolia/instantsearch.js/blob/509513c0feafaad522f6f18d87a441559f4aa050/src/lib/RoutingManager.ts#L113-L130
+      if (localParent === null && isFirstRender) {
+        isFirstRender = false;
+        // Compare initial state and first render state to see if the query has been
+        // changed by the `searchFunction`. It's required because the helper of the
+        // `searchFunction` does not trigger change event (not the same instance).
+        const firstRenderState = getLocalWidgetsState(localWidgets, {
+          helper: helper!,
+          searchParameters: helper!.state,
+        });
+
+        if (!isEqual(localUiState, firstRenderState)) {
+          // Force update the URL, if the state has changed since the initial read.
+          // We do this in order to make the URL update when there is `searchFunction`
+          // that prevents the search of the initial rendering.
+          // See: https://github.com/algolia/instantsearch.js/issues/2523#issuecomment-339356157
+          localUiState = firstRenderState;
+
+          instantSearchInstance.onStateChange();
+        }
+      }
     },
 
     dispose() {

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -418,16 +418,16 @@ const index = (props: IndexProps): Index => {
         isFirstRender = false;
         // Compare initial state and first render state to see if the query has been
         // changed by the `searchFunction`. It's required because the helper of the
-        // `searchFunction` does not trigger change event (not the same instance).
+        // `searchFunction` does not trigger change events (not the same instance).
         const firstRenderState = getLocalWidgetsState(localWidgets, {
           helper: helper!,
           searchParameters: helper!.state,
         });
 
         if (!isEqual(localUiState, firstRenderState)) {
-          // Force update the URL, if the state has changed since the initial read.
-          // We do this in order to make the URL update when there is `searchFunction`
-          // that prevents the search of the initial rendering.
+          // Force update the URL if the state has changed since the initial read.
+          // We do this to trigger a URL update when `searchFunction` prevents
+          // the search on the initial render.
           // See: https://github.com/algolia/instantsearch.js/issues/2523#issuecomment-339356157
           localUiState = firstRenderState;
 


### PR DESCRIPTION
This PR replicates [the hack](https://github.com/algolia/instantsearch.js/blob/509513c0feafaad522f6f18d87a441559f4aa050/src/lib/RoutingManager.ts#L113-L130) implemented inside `RoutingManager` for the `searchFunction`. The `uiState` is now a first-class citizen so we have to apply this logic to the index. I've tried to keep the same process: the update is triggered once all the widgets of the index are rendered like it was the case inside the manager (since it was always the last widget).

At the moment the call to notify the instance that a change occurs isn't implemented because we don't expose the function (yet). Once the API is available I'll update the PR. The pieces that need to be updated are commented.