### PR TITLE
feat(instantsearch): add onStateChange method

### DIFF
--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -471,7 +471,7 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
     }
   }
 
-  public onChange = () => {
+  public onStateChange = () => {
     // @TODO: Provide `nextUiState` to all middlewares (eg. routing)
     // const nextUiState = this.mainIndex.getWidgetState({});
   };

--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -471,6 +471,11 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
     }
   }
 
+  public onChange = defer(() => {
+    // @TODO: Provide `nextUiState` to all middlewares (eg. routing)
+    // const nextUiState = this.mainIndex.getWidgetState({});
+  });
+
   public createURL(params: PlainSearchParameters): string {
     if (!this._createURL) {
       throw new Error(

--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -471,10 +471,10 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
     }
   }
 
-  public onChange = defer(() => {
+  public onChange = () => {
     // @TODO: Provide `nextUiState` to all middlewares (eg. routing)
     // const nextUiState = this.mainIndex.getWidgetState({});
-  });
+  };
 
   public createURL(params: PlainSearchParameters): string {
     if (!this._createURL) {

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -443,12 +443,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
           })
         );
 
-        // `instantSearchInstance` must have been notified 4 times of the `uiState` changes:
-        // 1. By the widget, for the widget initialization
-        // 2. By the helper `change` event callback, for the change to the query parameters
-        // 3. By the widget, for the children widget disposal
-        // 4. By the helper `change` event callback, also for the children widget disposal
-        expect(instantSearchInstance.onChange).toHaveBeenCalledTimes(4);
+        // `instantSearchInstance` must have been notified 2 times of the `uiState` changes:
+        // 1. By the helper `change` event callback, for the change to the query parameters
+        // 2. By the helper `change` event callback, for the children widget disposal
+        expect(instantSearchInstance.onChange).toHaveBeenCalledTimes(2);
       });
 
       it('calls `dispose` on the removed widgets', () => {
@@ -1474,11 +1472,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
           },
         });
 
-        // `instantSearchInstance` must have been notified 3 times of the `uiState` changes:
-        // 1. By the widget, for the widget initialization
-        // 2. By the helper `change` event callback, for the 1st change to the query parameters
-        // 3. By the helper `change` event callback, for the 2nd change to the query parameters
-        expect(instantSearchInstance.onChange).toHaveBeenCalledTimes(3);
+        // `instantSearchInstance` must have been notified 2 times of the `uiState` changes:
+        // 1. By the helper `change` event callback, for the 1st change to the query parameters
+        // 2. By the helper `change` event callback, for the 2nd change to the query parameters
+        expect(instantSearchInstance.onChange).toHaveBeenCalledTimes(2);
       });
 
       it('does not update the local `uiState` on state changes in `init`', () => {
@@ -1519,7 +1516,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
           indexName: {},
         });
 
-        expect(instantSearchInstance.onChange).toHaveBeenCalledTimes(1);
+        expect(instantSearchInstance.onChange).not.toHaveBeenCalled();
       });
 
       it('updates the local `uiState` only with widgets not indices', () => {

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -397,9 +397,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
 
       it('updates the local `uiState` with removed widgets', () => {
         const instance = index({ indexName: 'indexName' });
-        const instantSearchInstance = createInstantSearch({
-          onChange: jest.fn() as any,
-        });
+        const instantSearchInstance = createInstantSearch();
 
         const configureTopLevel = createConfigure({
           distinct: true,
@@ -1446,9 +1444,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
 
       it('updates the local `uiState` when the state changes', () => {
         const instance = index({ indexName: 'indexName' });
-        const instantSearchInstance = createInstantSearch({
-          onChange: jest.fn() as any,
-        });
+        const instantSearchInstance = createInstantSearch();
         const widgets = [createSearchBox(), createPagination()];
 
         instance.addWidgets(widgets);
@@ -1480,9 +1476,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
 
       it('does not update the local `uiState` on state changes in `init`', () => {
         const instance = index({ indexName: 'indexName' });
-        const instantSearchInstance = createInstantSearch({
-          onChange: jest.fn() as any,
-        });
+        const instantSearchInstance = createInstantSearch();
 
         const widgets = [
           createSearchBox(),

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -444,7 +444,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
         // `instantSearchInstance` must have been notified 2 times of the `uiState` changes:
         // 1. By the helper `change` event callback, for the change to the query parameters
         // 2. By the helper `change` event callback, for the child widgets being disposed
-        expect(instantSearchInstance.onChange).toHaveBeenCalledTimes(2);
+        expect(instantSearchInstance.onStateChange).toHaveBeenCalledTimes(2);
       });
 
       it('calls `dispose` on the removed widgets', () => {
@@ -1471,7 +1471,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
         // `instantSearchInstance` must have been notified 2 times of the `uiState` changes:
         // 1. By the helper `change` event callback, for the 1st change to the query parameters
         // 2. By the helper `change` event callback, for the 2nd change to the query parameters
-        expect(instantSearchInstance.onChange).toHaveBeenCalledTimes(2);
+        expect(instantSearchInstance.onStateChange).toHaveBeenCalledTimes(2);
       });
 
       it('does not update the local `uiState` on state changes in `init`', () => {
@@ -1510,7 +1510,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
           indexName: {},
         });
 
-        expect(instantSearchInstance.onChange).not.toHaveBeenCalled();
+        expect(instantSearchInstance.onStateChange).not.toHaveBeenCalled();
       });
 
       it('updates the local `uiState` only with widgets not indices', () => {

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -397,6 +397,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
 
       it('updates the local `uiState` with removed widgets', () => {
         const instance = index({ indexName: 'indexName' });
+        const instantSearchInstance = createInstantSearch({
+          onChange: jest.fn() as any,
+        });
+
         const configureTopLevel = createConfigure({
           distinct: true,
         });
@@ -411,7 +415,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
           createSearchBox(),
         ]);
 
-        instance.init(createInitOptions());
+        instance.init(
+          createInitOptions({
+            instantSearchInstance,
+          })
+        );
 
         // Simulate a state change
         instance.getHelper()!.setQueryParameter('query', 'Apple iPhone');
@@ -434,6 +442,13 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
             distinct: true,
           })
         );
+
+        // `instantSearchInstance` must have been notified 4 times of the `uiState` changes:
+        // 1. By the widget, for the widget initialization
+        // 2. By the helper `change` event callback, for the change to the query parameters
+        // 3. By the widget, for the children widget disposal
+        // 4. By the helper `change` event callback, also for the children widget disposal
+        expect(instantSearchInstance.onChange).toHaveBeenCalledTimes(4);
       });
 
       it('calls `dispose` on the removed widgets', () => {
@@ -1433,11 +1448,18 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
 
       it('updates the local `uiState` when the state changes', () => {
         const instance = index({ indexName: 'indexName' });
+        const instantSearchInstance = createInstantSearch({
+          onChange: jest.fn() as any,
+        });
         const widgets = [createSearchBox(), createPagination()];
 
         instance.addWidgets(widgets);
 
-        instance.init(createInitOptions());
+        instance.init(
+          createInitOptions({
+            instantSearchInstance,
+          })
+        );
 
         // Simulate a state change
         instance
@@ -1451,10 +1473,20 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
             page: 5,
           },
         });
+
+        // `instantSearchInstance` must have been notified 3 times of the `uiState` changes:
+        // 1. By the widget, for the widget initialization
+        // 2. By the helper `change` event callback, for the 1st change to the query parameters
+        // 3. By the helper `change` event callback, for the 2nd change to the query parameters
+        expect(instantSearchInstance.onChange).toHaveBeenCalledTimes(3);
       });
 
       it('does not update the local `uiState` on state changes in `init`', () => {
         const instance = index({ indexName: 'indexName' });
+        const instantSearchInstance = createInstantSearch({
+          onChange: jest.fn() as any,
+        });
+
         const widgets = [
           createSearchBox(),
           createPagination(),
@@ -1469,7 +1501,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
 
         instance.addWidgets(widgets);
 
-        instance.init(createInitOptions());
+        instance.init(
+          createInitOptions({
+            instantSearchInstance,
+          })
+        );
 
         expect(instance.getHelper()!.state).toEqual(
           new SearchParameters({
@@ -1482,6 +1518,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
         expect(instance.getWidgetState({})).toEqual({
           indexName: {},
         });
+
+        expect(instantSearchInstance.onChange).toHaveBeenCalledTimes(1);
       });
 
       it('updates the local `uiState` only with widgets not indices', () => {

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -443,7 +443,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
 
         // `instantSearchInstance` must have been notified 2 times of the `uiState` changes:
         // 1. By the helper `change` event callback, for the change to the query parameters
-        // 2. By the helper `change` event callback, for the children widget disposal
+        // 2. By the helper `change` event callback, for the child widgets being disposed
         expect(instantSearchInstance.onChange).toHaveBeenCalledTimes(2);
       });
 

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -381,7 +381,7 @@ const index = (props: IndexProps): Index => {
           searchParameters: state,
           helper: helper!,
         });
-        instantSearchInstance.onChange();
+        instantSearchInstance.onStateChange();
       });
     },
 

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -261,7 +261,6 @@ const index = (props: IndexProps): Index => {
           searchParameters: nextState,
           helper: helper!,
         });
-        localInstantSearchInstance.onChange();
 
         helper!.setState(
           getLocalWidgetsSearchParameters(localWidgets, {
@@ -282,7 +281,6 @@ const index = (props: IndexProps): Index => {
       localInstantSearchInstance = instantSearchInstance;
       localParent = parent;
       localUiState = uiState[indexId] || {};
-      instantSearchInstance.onChange();
 
       // The `mainHelper` is already defined at this point. The instance is created
       // inside InstantSearch at the `start` method, which occurs before the `init`

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -261,6 +261,7 @@ const index = (props: IndexProps): Index => {
           searchParameters: nextState,
           helper: helper!,
         });
+        localInstantSearchInstance.onChange();
 
         helper!.setState(
           getLocalWidgetsSearchParameters(localWidgets, {
@@ -281,6 +282,7 @@ const index = (props: IndexProps): Index => {
       localInstantSearchInstance = instantSearchInstance;
       localParent = parent;
       localUiState = uiState[indexId] || {};
+      instantSearchInstance.onChange();
 
       // The `mainHelper` is already defined at this point. The instance is created
       // inside InstantSearch at the `start` method, which occurs before the `init`
@@ -381,6 +383,7 @@ const index = (props: IndexProps): Index => {
           searchParameters: state,
           helper: helper!,
         });
+        instantSearchInstance.onChange();
       });
     },
 

--- a/test/mock/createInstantSearch.ts
+++ b/test/mock/createInstantSearch.ts
@@ -40,7 +40,7 @@ export const createInstantSearch = (
     _initialUiState: {},
     _createURL: jest.fn(() => '#'),
     _createAbsoluteURL: jest.fn(() => '#'),
-    onChange: jest.fn(),
+    onStateChange: jest.fn(),
     createURL: jest.fn(() => '#'),
     routing: undefined,
     addWidget: jest.fn(),

--- a/test/mock/createInstantSearch.ts
+++ b/test/mock/createInstantSearch.ts
@@ -40,6 +40,7 @@ export const createInstantSearch = (
     _initialUiState: {},
     _createURL: jest.fn(() => '#'),
     _createAbsoluteURL: jest.fn(() => '#'),
+    onChange: defer(jest.fn()),
     createURL: jest.fn(() => '#'),
     routing: undefined,
     addWidget: jest.fn(),

--- a/test/mock/createInstantSearch.ts
+++ b/test/mock/createInstantSearch.ts
@@ -40,7 +40,7 @@ export const createInstantSearch = (
     _initialUiState: {},
     _createURL: jest.fn(() => '#'),
     _createAbsoluteURL: jest.fn(() => '#'),
-    onChange: defer(jest.fn()),
+    onChange: jest.fn(),
     createURL: jest.fn(() => '#'),
     routing: undefined,
     addWidget: jest.fn(),


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

IFW-932

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Implement the (for now empty) `onStateChange` method on `InstantSearch`.

This method is called by the `index` widget every time its `localUiState` is updated and will in the future notify the middlewares (like the routing) of any change in the widgets state.

The tests for the `index` widget were updated to check if `onStateChange` was called as expected.

