### PR TITLE
fix(configure): merge with the previous parameters

### DIFF
--- a/src/connectors/configure/__tests__/connectConfigure-test.ts
+++ b/src/connectors/configure/__tests__/connectConfigure-test.ts
@@ -389,6 +389,40 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
       );
     });
 
+    it('merges with the previous parameters', () => {
+      const makeWidget = connectConfigure();
+      const widget = makeWidget({
+        searchParameters: {
+          disjunctiveFacets: ['brand'],
+          disjunctiveFacetsRefinements: {
+            brand: ['Apple'],
+          },
+        },
+      });
+
+      const sp = widget.getWidgetSearchParameters!(
+        new SearchParameters({
+          disjunctiveFacets: ['categories'],
+          disjunctiveFacetsRefinements: {
+            categories: ['Phone'],
+          },
+        }),
+        {
+          uiState: {},
+        }
+      );
+
+      expect(sp).toEqual(
+        new SearchParameters({
+          disjunctiveFacets: ['categories', 'brand'],
+          disjunctiveFacetsRefinements: {
+            brand: ['Apple'],
+            categories: ['Phone'],
+          },
+        })
+      );
+    });
+
     it('stores refined state', () => {
       const renderFn = jest.fn();
       const makeWidget = connectConfigure(renderFn);

--- a/src/connectors/configure/connectConfigure.ts
+++ b/src/connectors/configure/connectConfigure.ts
@@ -142,10 +142,13 @@ const connectConfigure: ConfigureConnector = (
       },
 
       getWidgetSearchParameters(state, { uiState }) {
-        return state.setQueryParameters({
-          ...uiState.configure,
-          ...widgetParams.searchParameters,
-        });
+        return mergeSearchParameters(
+          state,
+          new algoliasearchHelper.SearchParameters({
+            ...uiState.configure,
+            ...widgetParams.searchParameters,
+          })
+        );
       },
 
       getWidgetState(uiState) {


### PR DESCRIPTION
This PR uses the `mergeSearchParameters` for `getWidgetSearchParameters` within `configure`. With the changes introduced recently, we don't merge the parameters auto-magically. This logic is now managed by each widget itself. For `configure` this behavior was handy because it allowed us to use it for initial refinement. 

It's not possible anymore because we use `setQueryParameters` which overrides the previous parameters. The facets configuration of the current widget is erased and we're not able to refine anymore. To ease the transition between the two versions and keep the widget powerful enough we'll mimic the previous implementation.