### PR TITLE
fix(hitsPerPage): avoid sync default value

### DIFF
--- a/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
+++ b/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.js
@@ -570,6 +570,30 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       expect(actual).toEqual({});
     });
 
+    test('returns the `uiState` empty with default value selected', () => {
+      const render = jest.fn();
+      const makeWidget = connectHitsPerPage(render);
+      const helper = algoliasearchHelper({}, 'indexName', {
+        hitsPerPage: 3,
+      });
+
+      const widget = makeWidget({
+        items: [
+          { value: 3, label: '3 items per page', default: true },
+          { value: 22, label: '22 items per page' },
+        ],
+      });
+
+      const actual = widget.getWidgetState(
+        {},
+        {
+          searchParameters: helper.state,
+        }
+      );
+
+      expect(actual).toEqual({});
+    });
+
     test('returns the `uiState` with a refinement', () => {
       const render = jest.fn();
       const makeWidget = connectHitsPerPage(render);

--- a/src/connectors/hits-per-page/connectHitsPerPage.js
+++ b/src/connectors/hits-per-page/connectHitsPerPage.js
@@ -217,7 +217,7 @@ You may want to add another entry to the \`items\` option with this value.`
       getWidgetState(uiState, { searchParameters }) {
         const hitsPerPage = searchParameters.hitsPerPage;
 
-        if (hitsPerPage === undefined) {
+        if (hitsPerPage === undefined || hitsPerPage === defaultItem.value) {
           return uiState;
         }
 


### PR DESCRIPTION
This PR avoid to sync the default value into the `uiState`. This behavior is consistent with the one from `sortBy`. The default value doesn't have to be inside the `uiState` because as the name suggests it's the default one. The option is defined statically, it can't change.