### PR TITLE
fix(range): apply min/max to getWidgetSearchParameters

### DIFF
--- a/src/connectors/range/__tests__/connectRange-test.js
+++ b/src/connectors/range/__tests__/connectRange-test.js
@@ -26,6 +26,16 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
 `);
     });
 
+    it('throws with `max` lower than `min`', () => {
+      expect(() => {
+        connectRange(() => {})({ attribute: 'price', min: 100, max: 50 });
+      }).toThrowErrorMatchingInlineSnapshot(`
+"The \`max\` option can't be lower than \`min\`.
+
+See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input/js/#connector, https://www.algolia.com/doc/api-reference/widgets/range-slider/js/#connector"
+`);
+    });
+
     it('is a widget', () => {
       const render = jest.fn();
       const unmount = jest.fn();
@@ -1346,24 +1356,6 @@ describe('getWidgetSearchParameters', () => {
         },
       })
     );
-  });
-
-  // @TODO: gWSP does not yet take min & max in account
-  it.skip('expect to return default configuration if the given min bound are greater than max bound', () => {
-    const widget = connectRange(rendering)({
-      attribute,
-      min: 1000,
-      max: 500,
-    });
-
-    const expectation = new SearchParameters({
-      disjunctiveFacets: ['price'],
-    });
-    const actual = widget.getWidgetSearchParameters(new SearchParameters(), {
-      uiState: {},
-    });
-
-    expect(actual).toEqual(expectation);
   });
 
   it('expect to return configuration with min numeric refinement', () => {

--- a/src/connectors/range/__tests__/connectRange-test.js
+++ b/src/connectors/range/__tests__/connectRange-test.js
@@ -140,8 +140,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
     }
   });
 
-  // @TODO: gWSP does not yet take min & max in account
-  it.skip('Accepts some user bounds', () => {
+  it('Accepts some user bounds', () => {
     const makeWidget = connectRange(() => {});
 
     const attribute = 'price';
@@ -266,8 +265,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
     }
   });
 
-  // @TODO: gWSP does not yet take min & max in account
-  it.skip('should add numeric refinement when refining min boundary without previous configuration', () => {
+  it('should add numeric refinement when refining min boundary without previous configuration', () => {
     const rendering = jest.fn();
     const makeWidget = connectRange(rendering);
 
@@ -307,8 +305,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
     }
   });
 
-  // @TODO: gWSP does not yet take min & max in account
-  it.skip('should add numeric refinement when refining min boundary with previous configuration', () => {
+  it('should add numeric refinement when refining min boundary with previous configuration', () => {
     const rendering = jest.fn();
     const makeWidget = connectRange(rendering);
 
@@ -1303,8 +1300,7 @@ describe('getWidgetSearchParameters', () => {
   const attribute = 'price';
   const rendering = () => {};
 
-  // @TODO: gWSP does not yet take min & max in account
-  it.skip('expect to return default configuration', () => {
+  it('expect to return default configuration', () => {
     const widget = connectRange(rendering)({
       attribute,
     });
@@ -1314,12 +1310,16 @@ describe('getWidgetSearchParameters', () => {
     });
 
     expect(actual).toEqual(
-      new SearchParameters({ disjunctiveFacets: ['price'] })
+      new SearchParameters({
+        disjunctiveFacets: ['price'],
+        numericRefinements: {
+          price: {},
+        },
+      })
     );
   });
 
-  // @TODO: gWSP does not yet take min & max in account
-  it.skip('expect to return default configuration if previous one has already numeric refinements', () => {
+  it('expect to return default configuration if previous one has already numeric refinements', () => {
     const widget = connectRange(rendering)({
       attribute,
       max: 500,
@@ -1366,8 +1366,7 @@ describe('getWidgetSearchParameters', () => {
     expect(actual).toEqual(expectation);
   });
 
-  // @TODO: gWSP does not yet take min & max in account
-  it.skip('expect to return configuration with min numeric refinement', () => {
+  it('expect to return configuration with min numeric refinement', () => {
     const widget = connectRange(rendering)({
       attribute,
       min: 10,
@@ -1389,8 +1388,7 @@ describe('getWidgetSearchParameters', () => {
     expect(actual).toEqual(expectation);
   });
 
-  // @TODO: gWSP does not yet take min & max in account
-  it.skip('expect to return configuration with max numeric refinement', () => {
+  it('expect to return configuration with max numeric refinement', () => {
     const widget = connectRange(rendering)({
       attribute,
       max: 10,
@@ -1412,8 +1410,7 @@ describe('getWidgetSearchParameters', () => {
     expect(actual).toEqual(expectation);
   });
 
-  // @TODO: gWSP does not yet take min & max in account
-  it.skip('expect to return configuration with both numeric refinements', () => {
+  it('expect to return configuration with both numeric refinements', () => {
     const widget = connectRange(rendering)({
       attribute,
       min: 10,

--- a/src/connectors/range/connectRange.js
+++ b/src/connectors/range/connectRange.js
@@ -53,12 +53,16 @@ export default function connectRange(renderFn, unmountFn = noop) {
       precision = 0,
     } = widgetParams;
 
+    const hasMinBound = isFiniteNumber(minBound);
+    const hasMaxBound = isFiniteNumber(maxBound);
+
     if (!attribute) {
       throw new Error(withUsage('The `attribute` option is required.'));
     }
 
-    const hasMinBound = isFiniteNumber(minBound);
-    const hasMaxBound = isFiniteNumber(maxBound);
+    if (hasMinBound && hasMaxBound && minBound > maxBound) {
+      throw new Error(withUsage("The `max` option can't be lower than `min`."));
+    }
 
     const formatToNumber = v => Number(Number(v).toFixed(precision));
 

--- a/src/connectors/range/connectRange.js
+++ b/src/connectors/range/connectRange.js
@@ -275,13 +275,29 @@ export default function connectRange(renderFn, unmountFn = noop) {
 
       getWidgetSearchParameters(searchParameters, { uiState }) {
         let widgetSearchParameters = searchParameters
+          .addDisjunctiveFacet(attribute)
           .setQueryParameters({
             numericRefinements: {
               ...searchParameters.numericRefinements,
               [attribute]: {},
             },
-          })
-          .addDisjunctiveFacet(attribute);
+          });
+
+        if (hasMinBound) {
+          widgetSearchParameters = widgetSearchParameters.addNumericRefinement(
+            attribute,
+            '>=',
+            minBound
+          );
+        }
+
+        if (hasMaxBound) {
+          widgetSearchParameters = widgetSearchParameters.addNumericRefinement(
+            attribute,
+            '<=',
+            maxBound
+          );
+        }
 
         const value = uiState.range && uiState.range[attribute];
 

--- a/src/widgets/range-slider/__tests__/range-slider-test.js
+++ b/src/widgets/range-slider/__tests__/range-slider-test.js
@@ -62,8 +62,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-slide
     });
 
     describe('min option', () => {
-      // @TODO: gWSP does not yet take min & max in account
-      it.skip('refines when no previous configuration', () => {
+      it('refines when no previous configuration', () => {
         widget = rangeSlider({
           container,
           attribute,
@@ -83,33 +82,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-slide
         );
       });
 
-      it('does not refine when previous configuration', () => {
-        widget = rangeSlider({
-          container,
-          attribute: 'aNumAttr',
-          min: 100,
-          step: 1,
-          cssClasses: { root: '' },
-        });
-        expect(
-          widget.getWidgetSearchParameters(
-            new SearchParameters({
-              numericRefinements: { [attribute]: {} },
-            }),
-            { uiState: {} }
-          )
-        ).toEqual(
-          new SearchParameters({
-            disjunctiveFacets: [attribute],
-            numericRefinements: {
-              aNumAttr: {},
-            },
-          })
-        );
-      });
-
-      // @TODO: gWSP does not yet take min & max in account
-      it.skip('works along with max option', () => {
+      it('works along with max option', () => {
         widget = rangeSlider({
           container,
           attribute,
@@ -191,8 +164,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-slide
     });
 
     describe('max option', () => {
-      // @TODO: gWSP does not yet take min & max in account
-      it.skip('refines when no previous configuration', () => {
+      it('refines when no previous configuration', () => {
         widget = rangeSlider({
           container,
           attribute,
@@ -208,29 +180,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-slide
           new SearchParameters({
             disjunctiveFacets: [attribute],
             numericRefinements: { [attribute]: { '<=': [100] } },
-          })
-        );
-      });
-
-      it('does not refine when previous configuration', () => {
-        widget = rangeSlider({
-          container,
-          attribute,
-          max: 100,
-          step: 1,
-          cssClasses: { root: '' },
-        });
-        expect(
-          widget.getWidgetSearchParameters(
-            new SearchParameters({
-              numericRefinements: { [attribute]: {} },
-            }),
-            { uiState: {} }
-          )
-        ).toEqual(
-          new SearchParameters({
-            disjunctiveFacets: [attribute],
-            numericRefinements: { [attribute]: {} },
           })
         );
       });

--- a/stories/range-input.stories.js
+++ b/stories/range-input.stories.js
@@ -14,19 +14,6 @@ storiesOf('RangeInput', module)
     })
   )
   .add(
-    'disabled',
-    withHits(({ search, container, instantsearch }) => {
-      search.addWidget(
-        instantsearch.widgets.rangeInput({
-          container,
-          attribute: 'price',
-          min: 500,
-          max: 0,
-        })
-      );
-    })
-  )
-  .add(
     'with floating number',
     withHits(({ search, container, instantsearch }) => {
       search.addWidget(

--- a/stories/range-slider.stories.js
+++ b/stories/range-slider.stories.js
@@ -22,27 +22,6 @@ storiesOf('RangeSlider', module)
     })
   )
   .add(
-    'disabled',
-    withHits(({ search, container, instantsearch }) => {
-      search.addWidget(
-        instantsearch.widgets.rangeSlider({
-          container,
-          attribute: 'price',
-          templates: {
-            header: 'Price',
-          },
-          min: 100,
-          max: 50,
-          tooltips: {
-            format(rawValue) {
-              return `$${Math.round(rawValue).toLocaleString()}`;
-            },
-          },
-        })
-      );
-    })
-  )
-  .add(
     'with step',
     withHits(({ search, container, instantsearch }) => {
       search.addWidget(


### PR DESCRIPTION
This PR fixes a regression we've introduced with the migration to `getWidgetSearchParameters`. The widget accepts `min`/`max` options that represent the lower/upper bound for the attribute. Those bounds were ignored with our new implementation.

I've changed one behavior that is a breaking change but shouldn't impact most of our users. The widget can accept a `max` option lower than `min`. With such configuration, the widget ignores the options. Now it does throw an error, it makes no sense to provide such options.