### PR TITLE
 feat(RoutingManager): remove RoutingManager from the render process 

### DIFF
--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -139,7 +139,7 @@ class InstantSearch extends EventEmitter {
   public _createURL?(nextState: UiState): string;
   public _mainHelperSearch?: AlgoliaSearchHelper['search'];
   public routing?: Routing;
-  public routingManager?;
+  private _routingManager?;
 
   public constructor(options: InstantSearchOptions) {
     super();
@@ -322,11 +322,11 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
     }
 
     if (this.routing) {
-      this.routingManager = new RoutingManager({
+      this._routingManager = new RoutingManager({
         ...this.routing,
         instantSearchInstance: this,
       });
-      this._createURL = this.routingManager.createURL;
+      this._createURL = this._routingManager.createURL;
     } else {
       this._createURL = defaultCreateURL;
     }
@@ -389,7 +389,7 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
     });
 
     if (this.routing) {
-      this.routingManager.setupRouting();
+      this._routingManager.setupRouting();
     }
 
     mainHelper.search();
@@ -430,7 +430,7 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
     this.helper = null;
 
     if (this.routing) {
-      this.routingManager.dispose();
+      this._routingManager.dispose();
     }
   }
 
@@ -464,7 +464,7 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
   public onStateChange = () => {
     const nextUiState = this.mainIndex.getWidgetState({});
     if (this.routing) {
-      this.routingManager.write({ state: nextUiState });
+      this._routingManager.write({ state: nextUiState });
     }
   };
 

--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -389,7 +389,7 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
     });
 
     if (this.routing) {
-      this._routingManager.setupRouting();
+      this._routingManager.applyStateFromRoute();
     }
 
     mainHelper.search();

--- a/src/lib/RoutingManager.ts
+++ b/src/lib/RoutingManager.ts
@@ -24,8 +24,6 @@ class RoutingManager {
   private readonly router: Router;
   private readonly stateMapping: StateMapping;
 
-  private currentUiState: UiState;
-
   public constructor({
     router,
     stateMapping,
@@ -34,15 +32,16 @@ class RoutingManager {
     this.router = router;
     this.stateMapping = stateMapping;
     this.instantSearchInstance = instantSearchInstance;
-    this.currentUiState = this.stateMapping.routeToState(this.router.read());
 
     this.createURL = this.createURL.bind(this);
   }
 
-  public setupRouting(): void {
+  public applyStateFromRoute(): void {
+    const currentUiState = this.stateMapping.routeToState(this.router.read());
+
     walk(this.instantSearchInstance.mainIndex, current => {
       const widgets = current.getWidgets();
-      const indexUiState = this.currentUiState[current.getIndexId()] || {};
+      const indexUiState = currentUiState[current.getIndexId()] || {};
 
       const searchParameters = widgets.reduce((parameters, widget) => {
         if (!widget.getWidgetSearchParameters) {

--- a/src/lib/RoutingManager.ts
+++ b/src/lib/RoutingManager.ts
@@ -1,14 +1,5 @@
-import { SearchParameters } from 'algoliasearch-helper';
-import { isEqual } from './utils';
-import {
-  InstantSearch,
-  UiState,
-  IndexUiState,
-  Router,
-  StateMapping,
-  Widget,
-  HelperChangeEvent,
-} from '../types';
+import { InstantSearch, UiState, Router, StateMapping } from '../types';
+import { Index } from '../widgets/index/index';
 
 type RoutingManagerProps = {
   instantSearchInstance: InstantSearch;
@@ -16,16 +7,24 @@ type RoutingManagerProps = {
   stateMapping: StateMapping;
 };
 
-class RoutingManager implements Widget {
+const walk = (current: Index, callback: (index: Index) => void) => {
+  callback(current);
+  current
+    .getWidgets()
+    .filter(function(widget): widget is Index {
+      return widget.$$type === 'ais.index';
+    })
+    .forEach(innerIndex => {
+      walk(innerIndex, callback);
+    });
+};
+
+class RoutingManager {
   private readonly instantSearchInstance: InstantSearch;
   private readonly router: Router;
   private readonly stateMapping: StateMapping;
 
-  private isFirstRender: boolean = true;
-  private indexId: string;
   private currentUiState: UiState;
-  private initState?: UiState;
-  private renderURLFromState?: (event: HelperChangeEvent) => void;
 
   public constructor({
     router,
@@ -35,139 +34,44 @@ class RoutingManager implements Widget {
     this.router = router;
     this.stateMapping = stateMapping;
     this.instantSearchInstance = instantSearchInstance;
-    this.indexId = this.instantSearchInstance.indexName;
     this.currentUiState = this.stateMapping.routeToState(this.router.read());
+
+    this.createURL = this.createURL.bind(this);
   }
 
-  private getAllSearchParameters({
-    currentSearchParameters,
-    uiState,
-  }: {
-    currentSearchParameters: SearchParameters;
-    uiState: UiState;
-  }): SearchParameters {
-    const widgets = this.instantSearchInstance.mainIndex.getWidgets();
-    const indexUiState = uiState[this.indexId] || {};
+  public setupRouting(): void {
+    walk(this.instantSearchInstance.mainIndex, current => {
+      const widgets = current.getWidgets();
+      const indexUiState = this.currentUiState[current.getIndexId()] || {};
 
-    return widgets.reduce((parameters, widget) => {
-      if (!widget.getWidgetSearchParameters) {
-        return parameters;
-      }
-
-      return widget.getWidgetSearchParameters(parameters, {
-        uiState: indexUiState,
-      });
-    }, currentSearchParameters);
-  }
-
-  private getAllUiStates({
-    searchParameters,
-  }: {
-    searchParameters: SearchParameters;
-  }): UiState {
-    const widgets = this.instantSearchInstance.mainIndex.getWidgets();
-    const helper = this.instantSearchInstance.mainIndex.getHelper()!;
-
-    return {
-      [this.indexId]: widgets.reduce<IndexUiState>((state, widget) => {
-        if (!widget.getWidgetState) {
-          return state;
+      const searchParameters = widgets.reduce((parameters, widget) => {
+        if (!widget.getWidgetSearchParameters) {
+          return parameters;
         }
 
-        return widget.getWidgetState(state, {
-          helper,
-          searchParameters,
+        return widget.getWidgetSearchParameters(parameters, {
+          uiState: indexUiState,
         });
-      }, {}),
-    };
-  }
+      }, current.getHelper()!.state);
 
-  private setupRouting(state: SearchParameters): void {
-    const helper = this.instantSearchInstance.mainIndex.getHelper()!;
+      current
+        .getHelper()!
+        .overrideStateWithoutTriggeringChangeEvent(searchParameters);
 
-    this.router.onUpdate(route => {
-      const nextUiState = this.stateMapping.routeToState(route);
-      const widgetsUiState = this.getAllUiStates({
-        searchParameters: helper.state,
-      });
-
-      if (isEqual(nextUiState, widgetsUiState)) {
-        return;
-      }
-
-      this.currentUiState = nextUiState;
-
-      const searchParameters = this.getAllSearchParameters({
-        currentSearchParameters: state,
-        uiState: this.currentUiState,
-      });
-
-      helper
-        .overrideStateWithoutTriggeringChangeEvent(searchParameters)
-        .search();
+      this.instantSearchInstance.scheduleSearch();
     });
 
-    this.renderURLFromState = event => {
-      this.currentUiState = this.getAllUiStates({
-        searchParameters: event.state,
-      });
-
-      const route = this.stateMapping.stateToRoute(this.currentUiState);
-
-      this.router.write(route);
-    };
-
-    helper.on('change', this.renderURLFromState);
-
-    // Compare initial state and first render state to see if the query has been
-    // changed by the `searchFunction`. It's required because the helper of the
-    // `searchFunction` does not trigger change event (not the same instance).
-    const firstRenderState = this.getAllUiStates({
-      searchParameters: state,
-    });
-
-    if (!isEqual(this.initState, firstRenderState)) {
-      // Force update the URL, if the state has changed since the initial read.
-      // We do this in order to make the URL update when there is `searchFunction`
-      // that prevents the search of the initial rendering.
-      // See: https://github.com/algolia/instantsearch.js/issues/2523#issuecomment-339356157
-      this.currentUiState = firstRenderState;
-
-      const route = this.stateMapping.stateToRoute(this.currentUiState);
-
-      this.router.write(route);
-    }
+    // @TODO: Update state on external route update (popState)
+    // this.router.onUpdate(route => {});
   }
 
-  public getConfiguration(
-    currentConfiguration: SearchParameters
-  ): SearchParameters {
-    return this.getAllSearchParameters({
-      uiState: this.currentUiState,
-      currentSearchParameters: currentConfiguration,
-    });
-  }
+  public write({ state }: { state: UiState }) {
+    const route = this.stateMapping.stateToRoute(state);
 
-  public init({ state }: { state: SearchParameters }): void {
-    // Store the initial state from the storage to compare it with the state on next renders
-    // in case the `searchFunction` has modified it.
-    this.initState = this.getAllUiStates({
-      searchParameters: state,
-    });
-  }
-
-  public render({ state }: { state: SearchParameters }): void {
-    if (this.isFirstRender) {
-      this.isFirstRender = false;
-      this.setupRouting(state);
-    }
+    this.router.write(route);
   }
 
   public dispose({ helper, state }): void {
-    if (this.renderURLFromState) {
-      helper.removeListener('change', this.renderURLFromState);
-    }
-
     if (this.router.dispose) {
       this.router.dispose({ helper, state });
     }

--- a/src/lib/__tests__/RoutingManager-test.ts
+++ b/src/lib/__tests__/RoutingManager-test.ts
@@ -4,9 +4,8 @@ import qs from 'qs';
 import { createSearchClient } from '../../../test/mock/createSearchClient';
 import { createWidget } from '../../../test/mock/createWidget';
 import { runAllMicroTasks } from '../../../test/utils/runAllMicroTasks';
-import { Router, Widget, UiState, StateMapping, RouteState } from '../../types';
+import { Router, Widget, StateMapping, RouteState } from '../../types';
 import historyRouter from '../routers/history';
-import RoutingManager from '../RoutingManager';
 import instantsearch from '../main';
 
 const createFakeRouter = (args: Partial<Router> = {}): Router => ({
@@ -35,42 +34,6 @@ const createFakeStateMapping = (
   },
   ...args,
 });
-
-type HistoryState = {
-  index: number;
-  entries: object[];
-  listeners: Array<(value: object) => void>;
-};
-
-const createFakeHistory = (
-  {
-    index = -1,
-    entries = [],
-    listeners = [],
-  }: HistoryState = {} as HistoryState
-): any => {
-  const state: HistoryState = {
-    index,
-    entries,
-    listeners,
-  };
-
-  return {
-    subscribe(listener: () => void) {
-      state.listeners.push(listener);
-    },
-    push(value: object) {
-      state.entries.push(value);
-      state.index++;
-    },
-    back() {
-      state.index--;
-      listeners.forEach(listener => {
-        listener(state.entries[state.index]);
-      });
-    },
-  };
-};
 
 const createFakeSearchBox = (): Widget =>
   createWidget({
@@ -107,200 +70,6 @@ const createFakeHitsPerPage = (): Widget =>
   });
 
 describe('RoutingManager', () => {
-  const defaultRouter: Router = {
-    onUpdate: (..._args) => {},
-    read: () => ({}),
-    write: () => {},
-    createURL: () => '#',
-    dispose: () => {},
-  };
-
-  describe('getAllUiStates', () => {
-    test('reads the state of widgets with a getWidgetState implementation', () => {
-      const searchClient = createSearchClient();
-      const search = instantsearch({
-        indexName: 'indexName',
-        searchClient,
-      });
-
-      const widgetState = {
-        query: 'query',
-      };
-
-      const widget = {
-        render: () => {},
-        getWidgetState: jest.fn(() => widgetState),
-      };
-
-      search.addWidget(widget);
-
-      const actualInitialState = {
-        indexName: {
-          query: 'query',
-        },
-      };
-
-      search.start();
-
-      const router = new RoutingManager({
-        instantSearchInstance: search,
-        stateMapping: createFakeStateMapping({}),
-        router: {
-          ...defaultRouter,
-          read: () => actualInitialState,
-        },
-      });
-
-      // @ts-ignore: This method is considered private but we still use it
-      // in the test after the TypeScript migration.
-      // In a next refactor, we can consider changing this test implementation.
-      const uiStates = router.getAllUiStates({
-        searchParameters: search.mainIndex.getHelper()!.state,
-      });
-
-      expect(uiStates).toEqual({
-        indexName: widgetState,
-      });
-
-      expect(widget.getWidgetState).toHaveBeenCalledTimes(1);
-      expect(widget.getWidgetState).toHaveBeenCalledWith(
-        {},
-        {
-          helper: search.mainIndex.getHelper(),
-          searchParameters: search.mainIndex.getHelper()!.state,
-        }
-      );
-    });
-
-    test('Does not read UI state from widgets without an implementation of getWidgetState', () => {
-      const searchClient = createSearchClient();
-      const search = instantsearch({
-        indexName: 'indexName',
-        searchClient,
-      });
-
-      search.addWidget({
-        render: () => {},
-      });
-
-      search.start();
-
-      const actualInitialState = {
-        indexName: {
-          query: 'query',
-        },
-      };
-
-      const router = new RoutingManager({
-        instantSearchInstance: search,
-        stateMapping: createFakeStateMapping({}),
-        router: {
-          ...defaultRouter,
-          read: () => actualInitialState,
-        },
-      });
-
-      // @ts-ignore: This method is considered private but we still use it
-      // in the test after the TypeScript migration.
-      // In a next refactor, we can consider changing this test implementation.
-      const uiStates = router.getAllUiStates({
-        searchParameters: search.mainIndex.getHelper()!.state,
-      });
-
-      expect(uiStates).toEqual({
-        indexName: {},
-      });
-    });
-  });
-
-  describe('getAllSearchParameters', () => {
-    test('should get searchParameters from widget that implements getWidgetSearchParameters', () => {
-      const searchClient = createSearchClient();
-      const search = instantsearch({
-        indexName: 'indexName',
-        searchClient,
-      });
-
-      const widget = {
-        render: () => {},
-        getWidgetSearchParameters: jest.fn(sp => sp.setQuery('test')),
-      };
-
-      search.addWidget(widget);
-
-      const actualInitialState = {
-        indexName: {
-          query: 'query',
-        },
-      };
-
-      search.start();
-
-      const router = new RoutingManager({
-        instantSearchInstance: search,
-        stateMapping: createFakeStateMapping({}),
-        router: {
-          ...defaultRouter,
-          read: () => actualInitialState,
-        },
-      });
-
-      // @ts-ignore: This method is considered private but we still use it
-      // in the test after the TypeScript migration.
-      // In a next refactor, we can consider changing this test implementation.
-      const searchParameters = router.getAllSearchParameters({
-        currentSearchParameters: search.mainIndex.getHelper()!.state,
-        uiState: {},
-      });
-
-      expect(searchParameters).toEqual(
-        search.mainIndex.getHelper()!.state.setQuery('test')
-      );
-
-      expect(widget.getWidgetSearchParameters).toHaveBeenCalledTimes(2);
-      expect(widget.getWidgetSearchParameters).toHaveBeenCalledWith(
-        search.mainIndex.getHelper()!.state,
-        {
-          uiState: {},
-        }
-      );
-    });
-
-    test('should not change the searchParameters if no widget has a getWidgetSearchParameters', () => {
-      const searchClient = createSearchClient();
-      const search = instantsearch({
-        indexName: '',
-        searchClient,
-      });
-
-      const widget = {
-        render: () => {},
-      };
-      search.addWidget(widget);
-
-      search.start();
-
-      const router = new RoutingManager({
-        instantSearchInstance: search,
-        stateMapping: createFakeStateMapping({}),
-        router: {
-          ...defaultRouter,
-          read: () => ({}),
-        },
-      });
-
-      // @ts-ignore: This method is considered private but we still use it
-      // in the test after the TypeScript migration.
-      // In a next refactor, we can consider changing this test implementation.
-      const searchParameters = router.getAllSearchParameters({
-        currentSearchParameters: search.mainIndex.getHelper()!.state,
-        uiState: {},
-      });
-
-      expect(searchParameters).toEqual(search.mainIndex.getHelper()!.state);
-    });
-  });
-
   describe('within instantsearch', () => {
     test('should write in the router on searchParameters change', done => {
       const searchClient = createSearchClient();
@@ -332,7 +101,7 @@ describe('RoutingManager', () => {
       search.once('render', () => {
         // initialization is done at this point
         expect(widget.render).toHaveBeenCalledTimes(1);
-        expect(widget.getWidgetSearchParameters).toHaveBeenCalledTimes(1);
+        expect(widget.getWidgetSearchParameters).toHaveBeenCalledTimes(2);
 
         expect(router.write).toHaveBeenCalledTimes(0);
 
@@ -346,56 +115,6 @@ describe('RoutingManager', () => {
         });
 
         done();
-      });
-    });
-
-    test('should update the searchParameters on router state update', done => {
-      const searchClient = createSearchClient();
-
-      let onRouterUpdateCallback: (args: UiState) => void;
-      const router = createFakeRouter({
-        onUpdate: fn => {
-          onRouterUpdateCallback = fn;
-        },
-      });
-
-      const search = instantsearch({
-        indexName: 'indexName',
-        searchClient,
-        routing: {
-          router,
-        },
-      });
-
-      const widget = {
-        render: jest.fn(),
-        getWidgetSearchParameters: jest.fn((searchParameters, { uiState }) =>
-          searchParameters.setQuery(uiState.query)
-        ),
-      };
-
-      search.addWidget(widget);
-
-      search.start();
-
-      search.once('render', () => {
-        // initialization is done at this point
-
-        expect(search.mainIndex.getHelper()!.state.query).toBeUndefined();
-
-        // this simulates a router update with a uiState of {query: 'a'}
-        onRouterUpdateCallback({
-          indexName: {
-            query: 'a',
-          },
-        });
-
-        search.once('render', () => {
-          // the router update triggers a new search
-          // and given that the widget reads q as a query parameter
-          expect(search.mainIndex.getHelper()!.state.query).toEqual('a');
-          done();
-        });
       });
     });
 
@@ -560,80 +279,6 @@ describe('RoutingManager', () => {
       expect(router.write).toHaveBeenLastCalledWith({
         indexName: {
           query: 'Apple iPhone',
-        },
-      });
-    });
-
-    test('should keep the UI state up to date on router.update', async () => {
-      const searchClient = createSearchClient();
-      const stateMapping = createFakeStateMapping({});
-      const history = createFakeHistory();
-      const router = createFakeRouter({
-        onUpdate(fn) {
-          history.subscribe(state => {
-            fn(state);
-          });
-        },
-        write: jest.fn(state => {
-          history.push(state);
-        }),
-      });
-
-      const search = instantsearch({
-        indexName: 'indexName',
-        searchClient,
-        routing: {
-          router,
-          stateMapping,
-        },
-      });
-
-      const fakeSearchBox: any = createFakeSearchBox();
-      const fakeHitsPerPage = createFakeHitsPerPage();
-
-      search.addWidget(fakeSearchBox);
-      search.addWidget(fakeHitsPerPage);
-
-      search.start();
-
-      await runAllMicroTasks();
-
-      // Trigger an update - push a change
-      fakeSearchBox.refine('Apple');
-
-      expect(router.write).toHaveBeenCalledTimes(1);
-      expect(router.write).toHaveBeenLastCalledWith({
-        indexName: {
-          query: 'Apple',
-        },
-      });
-
-      // Trigger an update - push a change
-      fakeSearchBox.refine('Apple iPhone');
-
-      expect(router.write).toHaveBeenCalledTimes(2);
-      expect(router.write).toHaveBeenLastCalledWith({
-        indexName: {
-          query: 'Apple iPhone',
-        },
-      });
-
-      await runAllMicroTasks();
-
-      // Trigger an update - Apple iPhone → Apple
-      history.back();
-
-      await runAllMicroTasks();
-
-      // Trigger getConfiguration
-      search.removeWidget(fakeHitsPerPage);
-
-      await runAllMicroTasks();
-
-      expect(router.write).toHaveBeenCalledTimes(3);
-      expect(router.write).toHaveBeenLastCalledWith({
-        indexName: {
-          query: 'Apple',
         },
       });
     });

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -1570,8 +1570,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
           indexName: {},
         });
 
-        // Simulate a change that does not emit (like `searchFunction`)
-        instance.getHelper()!.overrideStateWithoutTriggeringChangeEvent({
+        // Simulate a change
+        instance.getHelper()!.setState({
           ...instance.getHelper()!.state,
           query: 'Apple iPhone',
         });
@@ -1589,8 +1589,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
           },
         });
 
-        // Simulate a change that does not emit (like `searchFunction`)
-        instance.getHelper()!.overrideStateWithoutTriggeringChangeEvent({
+        // Simulate a change
+        instance.getHelper()!.setState({
           ...instance.getHelper()!.state,
           query: 'Apple iPhone XS',
         });
@@ -1601,10 +1601,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
           })
         );
 
-        expect(instantSearchInstance.onStateChange).toHaveBeenCalledTimes(1);
+        expect(instantSearchInstance.onStateChange).toHaveBeenCalledTimes(2);
         expect(instance.getWidgetState({})).toEqual({
           indexName: {
-            query: 'Apple iPhone',
+            query: 'Apple iPhone XS',
           },
         });
       });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

IFW-935

This change removes RoutingManager from the render process, therefore it is no longer a widget. Updating state on external route update (popState) was not implemented, it will be done later in IFW-936.

List of changes:
* Remove all widget related methods from `RoutingManager`.
* Remove the hack to always have the `RoutingManager` widget last in the widget list.
* Replace https://github.com/algolia/instantsearch.js/pull/4078 by another fix (https://github.com/algolia/instantsearch.js/compare/next...feat/fs-routingmanager?expand=1#diff-1fc36c4ea042d2ecb5a498416e5e0357R366-R369. The reason is that with the original fix there was an issue with the configure widget (present in `firstRenderState` but absent from `localUiState`) forcing the URL to always be updated.
* Remove some tests: 
  * Tests about `getAllUiStates` and `getAllSearchParameters` (both methods were removed)
  * Tests about updating state on external route update (since it is not implemented yet), but they will be re-added in IFW-936.

**Note**: This PR includes https://github.com/algolia/instantsearch.js/pull/4082 and will be rebased once this one is merged. Since it can make harder to review the changes I advise you to start your review from https://github.com/algolia/instantsearch.js/commit/b55a1fa39f5ec61c1ac664527b93553914cf723e

