### PR TITLE
fix(InstantSearch): fix initialUIState when refinements are already present in the route

### DIFF
--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -213,7 +213,6 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
     this._stalledSearchDelay = stalledSearchDelay;
     this._searchStalledTimer = null;
     this._isSearchStalled = false;
-    this._initialUiState = initialUiState;
 
     if (searchFunction) {
       this._searchFunction = searchFunction;
@@ -226,6 +225,15 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
         ...ROUTING_DEFAULT_OPTIONS,
         ...routing,
       };
+    }
+
+    if (this.routing) {
+      this._initialUiState = {
+        ...initialUiState,
+        ...this.routing.stateMapping.routeToState(this.routing.router.read()),
+      };
+    } else {
+      this._initialUiState = initialUiState;
     }
   }
 

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -402,6 +402,39 @@ describe('start', () => {
     });
   });
 
+  it('forwards the router state to the main index', () => {
+    const router = {
+      read: jest.fn(() => ({
+        indexName: {
+          hierarchicalMenu: {
+            'hierarchicalCategories.lvl0': ['Cell Phones'],
+          },
+        },
+      })),
+      write: jest.fn(),
+      onUpdate: jest.fn(),
+      createURL: jest.fn(() => '#'),
+    };
+
+    const search = new InstantSearch({
+      indexName: 'indexName',
+      searchClient: createSearchClient(),
+      routing: {
+        router,
+      },
+    });
+
+    search.start();
+
+    expect(search.mainIndex.getWidgetState()).toEqual({
+      indexName: {
+        hierarchicalMenu: {
+          'hierarchicalCategories.lvl0': ['Cell Phones'],
+        },
+      },
+    });
+  });
+
   it('calls `init` on the added widgets', () => {
     const search = new InstantSearch({
       indexName: 'indexName',


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

When initializing the `mainIndex` we're using `initialUIState` as initial state. It can be an empty object (default) or a user defined object (see https://github.com/algolia/instantsearch.js/pull/4074).

The issue is that after this initialization we apply the state from the route to all indexes **without triggering a change event**. https://github.com/algolia/instantsearch.js/blob/448146c4dabbd659e6735f4fb25b50fc4f8fe135/src/lib/RoutingManager.ts#L56-L58
Since no events were triggered, the `mainIndex` still has the `initialUIState` value as `localUiState` and is no longer in sync with the widgets state.

This issue was identified in https://github.com/algolia/instantsearch.js/pull/4074#issuecomment-525649188.

This PR fix this by using the route state as the `initialUIState`, so we initialize the `mainIndex` with the correct value. This is a simple override and not a deep merge but it should do the trick for now.
