### PR TITLE
fix(connectInfiniteHits): fix page state when adding or removing widgets

### DIFF
--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -141,7 +141,11 @@ const connectInfiniteHits: InfiniteHitsConnector = (
     };
     const filterEmptyRefinements = (refinements = {}) => {
       return Object.keys(refinements)
-        .filter(key => refinements[key].length)
+        .filter(key =>
+          Array.isArray(refinements[key])
+            ? refinements[key].length
+            : Object.keys(refinements[key]).length
+        )
         .reduce((obj, key) => {
           obj[key] = refinements[key];
           return obj;
@@ -206,6 +210,9 @@ const connectInfiniteHits: InfiniteHitsConnector = (
         );
         currentState.disjunctiveFacetsRefinements = filterEmptyRefinements(
           currentState.disjunctiveFacetsRefinements
+        );
+        currentState.numericRefinements = filterEmptyRefinements(
+          currentState.numericRefinements
         );
 
         if (!isEqual(currentState, prevState)) {

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -139,7 +139,7 @@ const connectInfiniteHits: InfiniteHitsConnector = (
     const getShowMore = (helper: Helper): (() => void) => () => {
       helper.setPage(lastReceivedPage + 1).search();
     };
-    const filterEmptyRefinements = refinements => {
+    const filterEmptyRefinements = (refinements = {}) => {
       return Object.keys(refinements)
         .filter(key => refinements[key].length)
         .reduce((obj, key) => {

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -139,6 +139,14 @@ const connectInfiniteHits: InfiniteHitsConnector = (
     const getShowMore = (helper: Helper): (() => void) => () => {
       helper.setPage(lastReceivedPage + 1).search();
     };
+    const filterEmptyRefinements = refinements => {
+      return Object.keys(refinements)
+        .filter(key => refinements[key].length)
+        .reduce((obj, key) => {
+          obj[key] = refinements[key];
+          return obj;
+        }, {});
+    };
 
     return {
       $$type: 'ais.infiniteHits',
@@ -186,7 +194,19 @@ const connectInfiniteHits: InfiniteHitsConnector = (
         // We're doing this to "reset" the widget if a refinement or the
         // query changes between renders, but we want to keep it as is
         // if we only change pages.
-        const { page = 0, ...currentState } = state;
+        const {
+          page = 0,
+          hierarchicalFacets,
+          disjunctiveFacets,
+          ...currentState
+        } = state;
+
+        currentState.hierarchicalFacetsRefinements = filterEmptyRefinements(
+          currentState.hierarchicalFacetsRefinements
+        );
+        currentState.disjunctiveFacetsRefinements = filterEmptyRefinements(
+          currentState.disjunctiveFacetsRefinements
+        );
 
         if (!isEqual(currentState, prevState)) {
           hitsCache = [];
@@ -285,7 +305,11 @@ const connectInfiniteHits: InfiniteHitsConnector = (
           );
         }
 
-        if (hasShowPrevious && uiState.page) {
+        if (!hasShowPrevious) {
+          return widgetSearchParameters;
+        }
+
+        if (uiState.page) {
           // The page in the search parameters is decremented by one
           // to get to the actual parameter value from the UI state.
           return widgetSearchParameters.setQueryParameter(


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

IFW-980

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

This PR fix multiple pagination reset issues with InfiniteHits:

* When requesting the `SearchParameters` from the InfiniteHits widget the page was always reset to `0` if `showPrevious` was `false`. We now return the original `searchParameters` (like it was the case before https://github.com/algolia/instantsearch.js/pull/4040).
* When comparing the currentState with the prevState (to know if we need to reset the widget internal cache) we now exlude `hierarchicalFacets`, `disjunctiveFacets` and filter `hierarchicalFacetsRefinements` and `disjunctiveFacetsRefinements` content to only keep the actual refinements. This is very hacky :nauseated_face: . Any idea to make this cleaner and/or more reliable is welcome :wink: .
