### PR TITLE
chore(deps): bump algolia/instantsearch-e2e-tests from 1.2.0 to 1.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "eslint-plugin-prettier": "3.1.0",
     "eslint-plugin-react": "7.14.3",
     "inquirer": "6.5.2",
-    "instantsearch-e2e-tests": "algolia/instantsearch-e2e-tests#v1.2.0",
+    "instantsearch-e2e-tests": "algolia/instantsearch-e2e-tests#v1.2.2",
     "jest": "24.9.0",
     "jest-diff": "24.9.0",
     "jest-environment-jsdom": "24.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7118,9 +7118,9 @@ insert-css@^2.0.0:
   resolved "https://registry.yarnpkg.com/insert-css/-/insert-css-2.0.0.tgz#eb5d1097b7542f4c79ea3060d3aee07d053880f4"
   integrity sha1-610Ql7dUL0x56jBg067gfQU4gPQ=
 
-instantsearch-e2e-tests@algolia/instantsearch-e2e-tests#v1.2.0:
-  version "1.2.0"
-  resolved "https://codeload.github.com/algolia/instantsearch-e2e-tests/tar.gz/f92fbc13999dd6a511f63f0a02ffe3ebaadcdc39"
+instantsearch-e2e-tests@algolia/instantsearch-e2e-tests#v1.2.2:
+  version "1.2.2"
+  resolved "https://codeload.github.com/algolia/instantsearch-e2e-tests/tar.gz/4339bcea72b17cd6c5c0a0fb016424e10dcb0195"
   dependencies:
     dotenv "^8.0.0"
     ts-node "^8.3.0"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR updates `algolia/instantsearch-e2e-tests` to v1.2.2 (see [CHANGELOG](https://github.com/algolia/instantsearch-e2e-tests/blob/master/CHANGELOG.md)).
