### PR TITLE
refactor(router): remove widget dependency

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -193,3 +193,17 @@ router.write = state => {
   originalWrite(state)
 }
 ```
+
+## router
+
+The `dispose` function on the `router` interface is now required. Its signature has also be updated (see below). Those changes shouldn't impact most codebases because the implementation of a custom router is not that common. The previous signature was tied to how widgets are working but a router is not a widget. We've updated the API to use a simpler signature that matches the actual usage better.
+
+```ts
+interface Router {
+  // ...
+  // Before
+  dispose?({ helper, state }: { helper: AlgoliaSearchHelper, state: SearchParameters }): SearchParameters | void
+  // After
+  dispose(): void
+}
+```

--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -134,7 +134,7 @@ class InstantSearch extends EventEmitter {
   public _createURL?(nextState: UiState): string;
   public _mainHelperSearch?: AlgoliaSearchHelper['search'];
   public routing?: Routing;
-  private _routingManager?;
+  private _routingManager?: RoutingManager;
 
   public constructor(options: InstantSearchOptions) {
     super();
@@ -396,7 +396,7 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
       uiState: this._initialUiState,
     });
 
-    if (this.routing) {
+    if (this._routingManager && this.routing) {
       this._routingManager.applyStateFromRoute(this.routing.router.read());
     }
 
@@ -437,7 +437,7 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
     this.mainHelper = null;
     this.helper = null;
 
-    if (this.routing) {
+    if (this._routingManager) {
       this._routingManager.dispose();
     }
   }
@@ -471,7 +471,8 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
 
   public onStateChange = () => {
     const nextUiState = this.mainIndex.getWidgetState({});
-    if (this.routing) {
+
+    if (this._routingManager) {
       this._routingManager.write({ state: nextUiState });
     }
   };

--- a/src/lib/RoutingManager.ts
+++ b/src/lib/RoutingManager.ts
@@ -71,9 +71,7 @@ class RoutingManager {
   }
 
   public dispose(): void {
-    if (this.router.dispose) {
-      this.router.dispose();
-    }
+    this.router.dispose();
   }
 
   public createURL(nextState: UiState): string {

--- a/src/lib/RoutingManager.ts
+++ b/src/lib/RoutingManager.ts
@@ -70,9 +70,9 @@ class RoutingManager {
     this.router.write(route);
   }
 
-  public dispose({ helper, state }): void {
+  public dispose(): void {
     if (this.router.dispose) {
-      this.router.dispose({ helper, state });
+      this.router.dispose();
     }
   }
 

--- a/src/types/instantsearch.ts
+++ b/src/types/instantsearch.ts
@@ -1,6 +1,6 @@
 import { SearchParameters } from 'algoliasearch-helper';
 import { Client as AlgoliaSearchClient } from 'algoliasearch';
-import { Widget, UiState } from './widget';
+import { UiState } from './widget';
 export {
   default as InstantSearch,
   InstantSearchOptions,
@@ -90,7 +90,7 @@ export type Refinement = FacetRefinement | NumericRefinement;
  * The router is the part that saves and reads the object from the storage.
  * Usually this is the URL.
  */
-export interface Router<TRouteState = UiState> extends Widget {
+export interface Router<TRouteState = UiState> {
   /**
    * onUpdate Sets an event listener that is triggered when the storage is updated.
    * The function should accept a callback to trigger when the update happens.
@@ -116,6 +116,11 @@ export interface Router<TRouteState = UiState> extends Widget {
    * return a string. It may return an empty string.
    */
   createURL(state: TRouteState): string;
+
+  /**
+   * Called when InstantSearch is disposed. Used to remove subscriptions.
+   */
+  dispose?(): void;
 }
 
 /**

--- a/src/types/instantsearch.ts
+++ b/src/types/instantsearch.ts
@@ -120,7 +120,7 @@ export interface Router<TRouteState = UiState> {
   /**
    * Called when InstantSearch is disposed. Used to remove subscriptions.
    */
-  dispose?(): void;
+  dispose(): void;
 }
 
 /**


### PR DESCRIPTION
This PR removes the dependency of `Widget` on the type `Router`. The only method that both have in common is `dispose` but with a different signature. The `Router` doesn't have to receive `Helper`, `State`. The only data structures it has to care about are: `UiState`, `RouteState`. 

The update of the signature is indeed a breaking change but it shouldn't have an impact on user-land. The implementation of a custom router is rare. The usage of the arguments of `dispose` would be even rarer.