### PR TITLE
refactor(InstantSearch): RoutingManager integration

### DIFF
--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -398,6 +398,7 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
 
     if (this._routingManager && this.routing) {
       this._routingManager.applyStateFromRoute(this.routing.router.read());
+      this._routingManager.subscribe();
     }
 
     mainHelper.search();

--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -396,8 +396,8 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
       uiState: this._initialUiState,
     });
 
-    if (this._routingManager && this.routing) {
-      this._routingManager.applyStateFromRoute(this.routing.router.read());
+    if (this._routingManager) {
+      this._routingManager.applySearchParameters(this._routingManager.read());
       this._routingManager.subscribe();
     }
 

--- a/src/lib/RoutingManager.ts
+++ b/src/lib/RoutingManager.ts
@@ -35,8 +35,6 @@ class RoutingManager {
 
     this.createURL = this.createURL.bind(this);
     this.applyStateFromRoute = this.applyStateFromRoute.bind(this);
-
-    this.router.onUpdate(this.applyStateFromRoute);
   }
 
   public applyStateFromRoute(route: UiState): void {
@@ -74,6 +72,10 @@ class RoutingManager {
     const route = this.stateMapping.stateToRoute(state);
 
     this.router.write(route);
+  }
+
+  public subscribe(): void {
+    this.router.onUpdate(this.applyStateFromRoute);
   }
 
   public dispose(): void {

--- a/src/lib/RoutingManager.ts
+++ b/src/lib/RoutingManager.ts
@@ -64,6 +64,12 @@ class RoutingManager {
     });
   }
 
+  public read(): UiState {
+    const route = this.router.read();
+
+    return this.stateMapping.routeToState(route);
+  }
+
   public write({ state }: { state: UiState }) {
     const route = this.stateMapping.stateToRoute(state);
 

--- a/src/lib/RoutingManager.ts
+++ b/src/lib/RoutingManager.ts
@@ -34,15 +34,13 @@ class RoutingManager {
     this.instantSearchInstance = instantSearchInstance;
 
     this.createURL = this.createURL.bind(this);
-    this.applyStateFromRoute = this.applyStateFromRoute.bind(this);
+    this.applySearchParameters = this.applySearchParameters.bind(this);
   }
 
-  public applyStateFromRoute(route: UiState): void {
-    const currentUiState = this.stateMapping.routeToState(route);
-
+  public applySearchParameters(uiState: UiState): void {
     walk(this.instantSearchInstance.mainIndex, current => {
       const widgets = current.getWidgets();
-      const indexUiState = currentUiState[current.getIndexId()] || {};
+      const indexUiState = uiState[current.getIndexId()] || {};
 
       const searchParameters = widgets.reduce((parameters, widget) => {
         if (!widget.getWidgetSearchParameters) {
@@ -75,7 +73,11 @@ class RoutingManager {
   }
 
   public subscribe(): void {
-    this.router.onUpdate(this.applyStateFromRoute);
+    this.router.onUpdate(route => {
+      const uiState = this.stateMapping.routeToState(route);
+
+      this.applySearchParameters(uiState);
+    });
   }
 
   public dispose(): void {

--- a/test/mock/createInstantSearch.ts
+++ b/test/mock/createInstantSearch.ts
@@ -40,7 +40,6 @@ export const createInstantSearch = (
     _createURL: jest.fn(() => '#'),
     onStateChange: jest.fn(),
     createURL: jest.fn(() => '#'),
-    routing: undefined,
     addWidget: jest.fn(),
     addWidgets: jest.fn(),
     removeWidget: jest.fn(),


### PR DESCRIPTION
This updates how the `RoutingManager` and `InstantSearch` interact together. 

`InstantSearch` is aware of `stateMapping` and `RouteState` which should not be the case. The only part that is concerned by those details is `RoutingManager`. The `InstantSearch` instance only cares about `UiState`. The `write` part of the  `router` is correctly abstracted behind a `write` method. We have now a `read` function exposed by the manager to avoid manipulate `router` and `stateMapping`.

The subscription to `onUpdate` function is a side effect of `RoutingManager` constructor. While it might be ok, it blocks us to move the declaration of the manager earlier inside the constructor. We already subscribe to the router a bit earlier than before but we don't want to subscribe if the instance does not start. We have now a `subscribe` function exposed by the manager that triggers the subscription to `onUpdate`.