### PR TITLE
fix(connectInfiniteHits): fix state when navigating or adding/removing widgets

### DIFF
--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -130,11 +130,16 @@ const connectInfiniteHits: InfiniteHitsConnector = (
         // if we only change pages.
         const {
           page = 0,
+          facets,
           hierarchicalFacets,
           disjunctiveFacets,
+          maxValuesPerFacet,
           ...currentState
         } = state;
 
+        currentState.facetsRefinements = filterEmptyRefinements(
+          currentState.facetsRefinements
+        );
         currentState.hierarchicalFacetsRefinements = filterEmptyRefinements(
           currentState.hierarchicalFacetsRefinements
         );
@@ -242,20 +247,11 @@ const connectInfiniteHits: InfiniteHitsConnector = (
           );
         }
 
-        if (!hasShowPrevious) {
-          return widgetSearchParameters;
-        }
+        // The page in the search parameters is decremented by one
+        // to get to the actual parameter value from the UI state.
+        const page = hasShowPrevious && uiState.page ? uiState.page - 1 : 0;
 
-        if (uiState.page) {
-          // The page in the search parameters is decremented by one
-          // to get to the actual parameter value from the UI state.
-          return widgetSearchParameters.setQueryParameter(
-            'page',
-            uiState.page - 1
-          );
-        }
-
-        return widgetSearchParameters.setQueryParameter('page', 0);
+        return widgetSearchParameters.setQueryParameter('page', page);
       },
     };
   };

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -226,7 +226,7 @@ const connectInfiniteHits: InfiniteHitsConnector = (
       getWidgetState(uiState, { searchParameters }) {
         const page = searchParameters.page || 0;
 
-        if (!hasShowPrevious || !page) {
+        if (!page) {
           return uiState;
         }
 
@@ -249,7 +249,7 @@ const connectInfiniteHits: InfiniteHitsConnector = (
 
         // The page in the search parameters is decremented by one
         // to get to the actual parameter value from the UI state.
-        const page = hasShowPrevious && uiState.page ? uiState.page - 1 : 0;
+        const page = uiState.page ? uiState.page - 1 : 0;
 
         return widgetSearchParameters.setQueryParameter('page', page);
       },

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -226,7 +226,7 @@ const connectInfiniteHits: InfiniteHitsConnector = (
       getWidgetState(uiState, { searchParameters }) {
         const page = searchParameters.page || 0;
 
-        if (!page) {
+        if (!hasShowPrevious || !page) {
           return uiState;
         }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR fix multiple issues that were spotted after the merge of https://github.com/algolia/instantsearch.js/pull/4104:

* Set `page` to `0` by default so the widget does not get controlled by its parent (fixes https://github.com/algolia/instantsearch.js/pull/4104#discussion_r324602461).
* Excludes `facets`, `maxValuesPerFacet` and filter `facetsRefinements` when comparing the currentState with the prevState (fixes https://github.com/algolia/instantsearch.js/pull/4104#discussion_r324602609).
