### PR TITLE
fix(pagination): update no refinement behavior

### DIFF
--- a/src/components/Pagination/Pagination.js
+++ b/src/components/Pagination/Pagination.js
@@ -113,7 +113,7 @@ class Pagination extends Component {
     return (
       <div
         className={cx(this.props.cssClasses.root, {
-          [this.props.cssClasses.noRefinementRoot]: this.props.isFirstPage,
+          [this.props.cssClasses.noRefinementRoot]: this.props.nbPages <= 1,
         })}
       >
         <ul className={this.props.cssClasses.list}>

--- a/src/components/Pagination/__tests__/Pagination-test.js
+++ b/src/components/Pagination/__tests__/Pagination-test.js
@@ -45,6 +45,15 @@ describe('Pagination', () => {
   it('should display the first/last link', () => {
     const wrapper = mount(<Pagination {...defaultProps} showFirst showLast />);
 
+    expect(wrapper.find('.firstPageItem')).toHaveLength(1);
+    expect(wrapper.find('.lastPageItem')).toHaveLength(1);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should add the noRefinement CSS class with a single page', () => {
+    const wrapper = mount(<Pagination {...defaultProps} nbPages={1} />);
+
+    expect(wrapper.find('.noRefinementRoot')).toHaveLength(1);
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -63,6 +72,7 @@ describe('Pagination', () => {
       />
     );
 
+    expect(wrapper.find('.lastPageItem').hasClass('disabledItem')).toBe(true);
     expect(wrapper).toMatchSnapshot();
   });
 

--- a/src/components/Pagination/__tests__/__snapshots__/Pagination-test.js.snap
+++ b/src/components/Pagination/__tests__/__snapshots__/Pagination-test.js.snap
@@ -1,5 +1,121 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Pagination should add the noRefinement CSS class with a single page 1`] = `
+<div
+  className="root noRefinementRoot"
+>
+  <ul
+    className="list"
+  >
+    <li
+      className="item pageItem selectedItem"
+    >
+      <a
+        aria-label={1}
+        className="link"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": 1,
+          }
+        }
+        href="[0]"
+        onClick={[Function]}
+      />
+    </li>
+    <li
+      className="item pageItem"
+    >
+      <a
+        aria-label={2}
+        className="link"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": 2,
+          }
+        }
+        href="[1]"
+        onClick={[Function]}
+      />
+    </li>
+    <li
+      className="item pageItem"
+    >
+      <a
+        aria-label={3}
+        className="link"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": 3,
+          }
+        }
+        href="[2]"
+        onClick={[Function]}
+      />
+    </li>
+    <li
+      className="item pageItem"
+    >
+      <a
+        aria-label={4}
+        className="link"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": 4,
+          }
+        }
+        href="[3]"
+        onClick={[Function]}
+      />
+    </li>
+    <li
+      className="item pageItem"
+    >
+      <a
+        aria-label={5}
+        className="link"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": 5,
+          }
+        }
+        href="[4]"
+        onClick={[Function]}
+      />
+    </li>
+    <li
+      className="item pageItem"
+    >
+      <a
+        aria-label={6}
+        className="link"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": 6,
+          }
+        }
+        href="[5]"
+        onClick={[Function]}
+      />
+    </li>
+    <li
+      className="item pageItem"
+    >
+      <a
+        aria-label={7}
+        className="link"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": 7,
+          }
+        }
+        href="[6]"
+        onClick={[Function]}
+      />
+    </li>
+  </ul>
+</div>
+`;
+
 exports[`Pagination should disable last page if already on it 1`] = `
 <div
   className="root"
@@ -172,7 +288,7 @@ exports[`Pagination should disable last page if already on it 1`] = `
 
 exports[`Pagination should display the first/last link 1`] = `
 <div
-  className="root noRefinementRoot"
+  className="root"
 >
   <ul
     className="list"
@@ -389,7 +505,7 @@ exports[`Pagination should have all buttons disabled if there are no results 1`]
 
 exports[`Pagination should render five elements 1`] = `
 <div
-  className="root noRefinementRoot"
+  className="root"
 >
   <ul
     className="list"


### PR DESCRIPTION
_This targets the `next` branch because this is a breaking change._

## Why

The logic behind the `noRefinement` CSS class differs from one flavor to another. Right now, `noRefinement` is added when on the first page of the search. This doesn't make sense and is incorrect. We want to add the CSS class when no refinements are possible (i.e. there's a single page).

Aligning these behaviors will make creating CSS themes easier because we can hide the pagination widget in CSS when there's no refinement possible. This is a request that we've had several times and using a Panel is necessary for this in InstantSearch.js. We should align these behaviors before next major releases.

## Inconsistencies

There are inconsistencies in the way we consider Pagination to be refinable in our flavors.

- InstantSearch.js: we add the `noRefinement` CSS class when on the first page ❌ ([see source](https://github.com/algolia/instantsearch.js/blob/9bb18cf6f9072044666c303b02496af8b9981f0f/src/components/Pagination/Pagination.js#L116))

- React InstantSearch: we add the `noRefinement` CSS class when it's impossible to refine ✅ ([see source](https://github.com/algolia/react-instantsearch/blob/7e34e69c59bb630ff710e6286120ec47a7171679/packages/react-instantsearch-dom/src/components/Pagination.js#L167))

- Vue InstantSearch: we don't add the `noRefinement` CSS class ❌ ([see source](https://github.com/algolia/vue-instantsearch/blob/3c8c6f18b6c8c3cfa427237c27e5755f1f12ffae/src/components/Pagination.vue#L4))

- Angular InstantSearch: we don't add the noRefinement CSS class ❌ ([see source](https://github.com/algolia/angular-instantsearch/blob/11ad85256dffcc3ea223a3aacec7933f103ff61e/src/pagination/pagination.ts#L11))

## This solution

The CSS class is computed based on the `nbPages` given by the connector. I didn't introduce another rendering option (e.g. `canRefine`) because we're not consistent yet.

## Related

- Pagination spec: https://instantsearch-css.netlify.com/widgets/pagination/

