### PR TITLE
fix(index): ensure that we always use the index set by widgets

### DIFF
--- a/src/lib/__tests__/RoutingManager-test.ts
+++ b/src/lib/__tests__/RoutingManager-test.ts
@@ -127,7 +127,9 @@ describe('RoutingManager', () => {
           ...uiState,
           q: searchParameters.query,
         })),
-        getWidgetSearchParameters: jest.fn(),
+        getWidgetSearchParameters: jest.fn(
+          searchParameters => searchParameters
+        ),
       };
 
       search.addWidget(widget);
@@ -240,13 +242,15 @@ describe('RoutingManager', () => {
 
       search.addWidget(
         createWidget({
-          getWidgetSearchParameters: jest.fn(),
           getWidgetState(uiState, { searchParameters }) {
             return {
               ...uiState,
               query: searchParameters.query,
             };
           },
+          getWidgetSearchParameters: jest.fn(
+            searchParameters => searchParameters
+          ),
         })
       );
 

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -681,6 +681,42 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
       );
     });
 
+    it('uses the index set by the widget for the queries', () => {
+      const instance = index({ indexName: 'indexName' });
+      const searchClient = createSearchClient();
+      const mainHelper = algoliasearchHelper(searchClient, '', {});
+      const instantSearchInstance = createInstantSearch({
+        mainHelper,
+      });
+
+      instance.addWidgets([
+        createWidget({
+          getWidgetSearchParameters(state) {
+            return state.setQueryParameter('index', 'widgetIndexName');
+          },
+        }),
+      ]);
+
+      instance.init(
+        createInitOptions({
+          instantSearchInstance,
+          parent: null,
+        })
+      );
+
+      // Simulate a call to search from a widget
+      instance.getHelper()!.search();
+
+      expect(searchClient.search).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          {
+            indexName: 'widgetIndexName',
+            params: expect.any(Object),
+          },
+        ])
+      );
+    });
+
     it('inherits from the parent states for the queries', () => {
       const level0 = index({ indexName: 'level0IndexName' });
       const level1 = index({ indexName: 'level1IndexName' });

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -288,18 +288,17 @@ const index = (props: IndexProps): Index => {
       // inside InstantSearch at the `start` method, which occurs before the `init`
       // step.
       const mainHelper = instantSearchInstance.mainHelper!;
+      const parameters = getLocalWidgetsSearchParameters(localWidgets, {
+        uiState: localUiState,
+        initialSearchParameters: new algoliasearchHelper.SearchParameters({
+          index: indexName,
+        }),
+      });
 
       // This Helper is only used for state management we do not care about the
       // `searchClient`. Only the "main" Helper created at the `InstantSearch`
       // level is aware of the client.
-      helper = algoliasearchHelper(
-        {} as Client,
-        indexName,
-        getLocalWidgetsSearchParameters(localWidgets, {
-          uiState: localUiState,
-          initialSearchParameters: new algoliasearchHelper.SearchParameters(),
-        })
-      );
+      helper = algoliasearchHelper({} as Client, parameters.index, parameters);
 
       // We forward the call to `search` to the "main" instance of the Helper
       // which is responsible for managing the queries (it's the only one that is


### PR DESCRIPTION
This PR fixes an issue where the initial index name is not correctly set. When a widget manages the `index` (e.g. `sortBy`),  the first computation of the `SearchParameters` could be incorrect. This is because the `Helper` **always override** the `index` provided by the last argument (see [L124](https://github.com/algolia/algoliasearch-helper-js/blob/5a0352aa233c5ea932df6b054a16989c8d302404/src/algoliasearch.helper.js#L124)). The value set by the widget will be overridden anyway.

We now first compute the `SearchParameters` from the widgets with an initial value that contains the top-level `indexName`. If one of the widgets overrides it the return value will contain the correct index if not the original index is preserved (this is not true at the moment, `connectSortBy` will be fixed in a separate https://github.com/algolia/instantsearch.js/pull/4126). Then we use the return value for both arguments of the Helper.