### PR TITLE
fix(sortBy): ensure a return value for getWidgetSearchParameters

### DIFF
--- a/src/connectors/sort-by/__tests__/connectSortBy-test.js
+++ b/src/connectors/sort-by/__tests__/connectSortBy-test.js
@@ -530,7 +530,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
         );
       });
 
-      test('should enforce the default value on empty UiState', () => {
+      test('should retrun the initial index on empty UiState with widget initialized', () => {
         const [widget, helper, refine] = getInitializedWidget();
 
         refine('other');
@@ -545,6 +545,32 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
         expect(searchParametersAfter).toEqual(
           new SearchParameters({
             // note that this isn't the refined value, but the default
+            index: 'relevance',
+          })
+        );
+      });
+
+      test('should retrun the current index on empty UiState without widget initialized', () => {
+        const sortBy = connectSortBy(() => {});
+        const widget = sortBy({
+          items: [
+            { label: 'Sort products by relevance', value: 'relevance' },
+            { label: 'Sort products by price', value: 'priceASC' },
+            { label: 'Sort products by magic', value: 'other' },
+          ],
+        });
+
+        const actual = widget.getWidgetSearchParameters(
+          new SearchParameters({
+            index: 'relevance',
+          }),
+          {
+            uiState: {},
+          }
+        );
+
+        expect(actual).toEqual(
+          new SearchParameters({
             index: 'relevance',
           })
         );

--- a/src/connectors/sort-by/__tests__/connectSortBy-test.js
+++ b/src/connectors/sort-by/__tests__/connectSortBy-test.js
@@ -530,7 +530,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
         );
       });
 
-      test('should retrun the initial index on empty UiState with widget initialized', () => {
+      test('should return the initial index on empty UiState with widget initialized', () => {
         const [widget, helper, refine] = getInitializedWidget();
 
         refine('other');
@@ -550,7 +550,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
         );
       });
 
-      test('should retrun the current index on empty UiState without widget initialized', () => {
+      test('should return the current index on empty UiState without widget initialized', () => {
         const sortBy = connectSortBy(() => {});
         const widget = sortBy({
           items: [

--- a/src/connectors/sort-by/connectSortBy.js
+++ b/src/connectors/sort-by/connectSortBy.js
@@ -170,7 +170,7 @@ export default function connectSortBy(renderFn, unmountFn = noop) {
       getWidgetSearchParameters(searchParameters, { uiState }) {
         return searchParameters.setQueryParameter(
           'index',
-          uiState.sortBy || this.initialIndex
+          uiState.sortBy || this.initialIndex || searchParameters.index
         );
       },
     };


### PR DESCRIPTION
This PR ensures that the `sortBy` widget always return a value for `index` (or at least don't remove the current one). The call to `getWidgetSearchParameters` might happen once before the `init` step. The current implementation relies on the `init` step (`this.initialIndex`) when no value is found in the `uiState`. When the widget is not initialized the value set is `undefined` which means that it removes the current index.

To avoid this problem we fall back on the current index when none of the conditions are met. It's the responsibility of the widget to set a value. It doesn't make sense to return `SearchParameters` without an index.