### PR TITLE
fix(InstantSearch): remove useless walk/duplicate request

### DIFF
--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -394,7 +394,6 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
     });
 
     if (this._routingManager) {
-      this._routingManager.applySearchParameters(this._routingManager.read());
       this._routingManager.subscribe();
     }
 

--- a/src/lib/RoutingManager.ts
+++ b/src/lib/RoutingManager.ts
@@ -34,30 +34,6 @@ class RoutingManager {
     this.instantSearchInstance = instantSearchInstance;
 
     this.createURL = this.createURL.bind(this);
-    this.applySearchParameters = this.applySearchParameters.bind(this);
-  }
-
-  public applySearchParameters(uiState: UiState): void {
-    walk(this.instantSearchInstance.mainIndex, current => {
-      const widgets = current.getWidgets();
-      const indexUiState = uiState[current.getIndexId()] || {};
-
-      const searchParameters = widgets.reduce((parameters, widget) => {
-        if (!widget.getWidgetSearchParameters) {
-          return parameters;
-        }
-
-        return widget.getWidgetSearchParameters(parameters, {
-          uiState: indexUiState,
-        });
-      }, current.getHelper()!.state);
-
-      current
-        .getHelper()!
-        .overrideStateWithoutTriggeringChangeEvent(searchParameters);
-
-      this.instantSearchInstance.scheduleSearch();
-    });
   }
 
   public read(): UiState {
@@ -76,7 +52,26 @@ class RoutingManager {
     this.router.onUpdate(route => {
       const uiState = this.stateMapping.routeToState(route);
 
-      this.applySearchParameters(uiState);
+      walk(this.instantSearchInstance.mainIndex, current => {
+        const widgets = current.getWidgets();
+        const indexUiState = uiState[current.getIndexId()] || {};
+
+        const searchParameters = widgets.reduce((parameters, widget) => {
+          if (!widget.getWidgetSearchParameters) {
+            return parameters;
+          }
+
+          return widget.getWidgetSearchParameters(parameters, {
+            uiState: indexUiState,
+          });
+        }, current.getHelper()!.state);
+
+        current
+          .getHelper()!
+          .overrideStateWithoutTriggeringChangeEvent(searchParameters);
+
+        this.instantSearchInstance.scheduleSearch();
+      });
     });
   }
 

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -450,6 +450,23 @@ describe('start', () => {
     expect(widget.init).toHaveBeenCalledTimes(1);
   });
 
+  it('triggers a single search with `routing`', async () => {
+    const searchClient = createSearchClient();
+    const search = new InstantSearch({
+      indexName: 'indexName',
+      routing: true,
+      searchClient,
+    });
+
+    expect(searchClient.search).toHaveBeenCalledTimes(0);
+
+    search.start();
+
+    await runAllMicroTasks();
+
+    expect(searchClient.search).toHaveBeenCalledTimes(1);
+  });
+
   it('triggers a search without errors', () => {
     const searchClient = createSearchClient();
     const search = new InstantSearch({

--- a/src/lib/__tests__/RoutingManager-test.ts
+++ b/src/lib/__tests__/RoutingManager-test.ts
@@ -139,7 +139,7 @@ describe('RoutingManager', () => {
       search.once('render', () => {
         // initialization is done at this point
         expect(widget.render).toHaveBeenCalledTimes(1);
-        expect(widget.getWidgetSearchParameters).toHaveBeenCalledTimes(2);
+        expect(widget.getWidgetSearchParameters).toHaveBeenCalledTimes(1);
 
         expect(router.write).toHaveBeenCalledTimes(0);
 


### PR DESCRIPTION
**Summary**

This PR removes a useless walk on the indices to apply the `SearchParameters`, it also removes a useless duplicate request (since we walk two times, we call search two times). At the `init` step we walk on the tree of indices to create each instance with their `uiState` and `SearchParameters`. It means that the state is already set, we don't have to trigger another walk.

The extra walk was called with the result of `read` which is not correct. Inside the constructor we already merge both `initialUiState` & `read`. If an `initialUiState` is present with refinements they are all overridden by `read`. With Storybook we mock the router to always return an empty object. It means that we always remove the `initialUiState` (see below).

You can also see the difference for the duplicate request on the e-commerce example. Here is the [link](https://5d81f53123e91200085f41ae--instantsearchjs.netlify.com/examples/e-commerce/) for the version prior to this PR. Open the DevTools you'll notice two identical requests on start. Here is the [link](https://deploy-preview-4127--instantsearchjs.netlify.com/examples/e-commerce/) for the version with this PR. Open the DevTools you'll notice only one request on start.

**Before**

![Screenshot 2019-09-17 at 15 37 36](https://user-images.githubusercontent.com/6513513/65046859-ac764d00-d961-11e9-9b7f-f76dae19fa28.png)

You can check the live version on [Storybook](https://5d81f53123e91200085f41ae--instantsearchjs.netlify.com/stories/?path=/story/currentrefinements--with-refinementlist).

**After**

![Screenshot 2019-09-17 at 15 38 57](https://user-images.githubusercontent.com/6513513/65046865-af713d80-d961-11e9-9c54-ce9c10878aaf.png)

You can check the live version on [Storybook](https://deploy-preview-4127--instantsearchjs.netlify.com/stories/?path=/story/currentrefinements--with-refinementlist).