### PR TITLE
fix(history): avoid empty query string

### DIFF
--- a/src/lib/__tests__/RoutingManager-test.ts
+++ b/src/lib/__tests__/RoutingManager-test.ts
@@ -564,4 +564,32 @@ describe('RoutingManager', () => {
       expect(parsedUrl.refinementList.brand).toBeInstanceOf(Array);
     });
   });
+
+  describe('createURL', () => {
+    it('returns an URL for a `routeState` with refinements', () => {
+      const router = historyRouter();
+      const actual = router.createURL({
+        query: 'iPhone',
+        page: 5,
+      });
+
+      expect(actual).toBe('https://website.com/?query=iPhone&page=5');
+    });
+
+    it('returns an URL for an empty `routeState` with index', () => {
+      const router = historyRouter();
+      const actual = router.createURL({
+        indexName: {},
+      });
+
+      expect(actual).toBe('https://website.com/');
+    });
+
+    it('returns an URL for an empty `routeState`', () => {
+      const router = historyRouter();
+      const actual = router.createURL({});
+
+      expect(actual).toBe('https://website.com/');
+    });
+  });
 });

--- a/src/lib/routers/history.ts
+++ b/src/lib/routers/history.ts
@@ -32,7 +32,7 @@ const defaultCreateURL: CreateURL = ({ qsModule, routeState, location }) => {
   const portWithPrefix = port === '' ? '' : `:${port}`;
 
   // IE <= 11 has no proper `location.origin` so we cannot rely on it.
-  if (!routeState || Object.keys(routeState).length === 0) {
+  if (!queryString) {
     return `${protocol}//${hostname}${portWithPrefix}${pathname}${hash}`;
   }
 


### PR DESCRIPTION
**Summary**

This PR fixes an issue with the `historyRouter` + `simpleStateMapping`. They push an empty query string into the URL. The problem arise because we now always have an object with at least on key which is the top level index. The condition to add or not the query string is done on the `routeState` but it could be done on the query string itself since we already have computed it.

**Before**

![before](https://user-images.githubusercontent.com/6513513/65231669-2f1d1a80-dad0-11e9-8184-bd0ab3a8430d.gif)

**After**

![after](https://user-images.githubusercontent.com/6513513/65231680-32b0a180-dad0-11e9-9928-6a5231dfee60.gif)
