### PR TITLE
Implement partials, render function parameter

### DIFF
--- a/src/lib/utils/__tests__/index-test.js
+++ b/src/lib/utils/__tests__/index-test.js
@@ -149,6 +149,82 @@ describe('utils.renderTemplate', () => {
     expect(actual).toBe(expectation);
   });
 
+  it('expect to process templates as string using a partial', () => {
+    const templateKey = 'test';
+    const templates = {
+      test: '{{> partial}}',
+      partial: 'it works with {{type}} using partial',
+    };
+    const data = { type: 'strings' };
+
+    const actual = utils.renderTemplate({
+      templateKey,
+      templates,
+      data,
+    });
+
+    const expectation = 'it works with strings using partial';
+
+    expect(actual).toBe(expectation);
+  });
+
+  it('expect to process templates as function using render', () => {
+    const templateKey = 'test';
+    const templates = {
+      test: (data, render) => render(`it works with {{ type }} using render`),
+    };
+    const data = { type: 'functions' };
+
+    const actual = utils.renderTemplate({
+      templateKey,
+      templates,
+      data,
+    });
+
+    const expectation = 'it works with functions using render';
+
+    expect(actual).toBe(expectation);
+  });
+
+  it('expect to process templates as function using render to render a string using a partial', () => {
+    const templateKey = 'test';
+    const templates = {
+      test: (data, render) =>
+        render(`it works with {{> partial }} using render and partial`),
+      partial: `{{ type }}`,
+    };
+    const data = { type: 'functions' };
+
+    const actual = utils.renderTemplate({
+      templateKey,
+      templates,
+      data,
+    });
+
+    const expectation = 'it works with functions using render and partial';
+
+    expect(actual).toBe(expectation);
+  });
+
+  it('expect to process templates as function using render passing new data context', () => {
+    const templateKey = 'test';
+    const templates = {
+      test: (data, render) =>
+        render(`it works with {{ typeName }} using render and data`, data.type),
+    };
+    const data = { type: { typeName: 'functions' } };
+
+    const actual = utils.renderTemplate({
+      templateKey,
+      templates,
+      data,
+    });
+
+    const expectation = 'it works with functions using render and data';
+
+    expect(actual).toBe(expectation);
+  });
+
   it('expect to use custom compiler options', () => {
     const templateKey = 'test';
     const templates = { test: 'it works with <%options%>' };

--- a/src/lib/utils/__tests__/index-test.js
+++ b/src/lib/utils/__tests__/index-test.js
@@ -168,63 +168,6 @@ describe('utils.renderTemplate', () => {
     expect(actual).toBe(expectation);
   });
 
-  it('expect to process templates as function using render', () => {
-    const templateKey = 'test';
-    const templates = {
-      test: (data, render) => render(`it works with {{ type }} using render`),
-    };
-    const data = { type: 'functions' };
-
-    const actual = utils.renderTemplate({
-      templateKey,
-      templates,
-      data,
-    });
-
-    const expectation = 'it works with functions using render';
-
-    expect(actual).toBe(expectation);
-  });
-
-  it('expect to process templates as function using render to render a string using a partial', () => {
-    const templateKey = 'test';
-    const templates = {
-      test: (data, render) =>
-        render(`it works with {{> partial }} using render and partial`),
-      partial: `{{ type }}`,
-    };
-    const data = { type: 'functions' };
-
-    const actual = utils.renderTemplate({
-      templateKey,
-      templates,
-      data,
-    });
-
-    const expectation = 'it works with functions using render and partial';
-
-    expect(actual).toBe(expectation);
-  });
-
-  it('expect to process templates as function using render passing new data context', () => {
-    const templateKey = 'test';
-    const templates = {
-      test: (data, render) =>
-        render(`it works with {{ typeName }} using render and data`, data.type),
-    };
-    const data = { type: { typeName: 'functions' } };
-
-    const actual = utils.renderTemplate({
-      templateKey,
-      templates,
-      data,
-    });
-
-    const expectation = 'it works with functions using render and data';
-
-    expect(actual).toBe(expectation);
-  });
-
   it('expect to use custom compiler options', () => {
     const templateKey = 'test';
     const templates = { test: 'it works with <%options%>' };

--- a/src/lib/utils/renderTemplate.js
+++ b/src/lib/utils/renderTemplate.js
@@ -39,26 +39,37 @@ function renderTemplate({
     );
   }
 
-  if (isTemplateFunction) {
-    return template(data);
+  function internalRender(_template, _data) {
+    if (_data === undefined) {
+      _data = data;
+    }
+
+    const transformedHelpers = transformHelpersToHogan(
+      helpers,
+      compileOptions,
+      data
+    );
+
+    return hogan
+      .compile(_template, compileOptions)
+      .render(
+        {
+          ..._data,
+          helpers: transformedHelpers,
+        },
+        templates
+      )
+      .replace(/[ \n\r\t\f\xA0]+/g, spaces =>
+        spaces.replace(/(^|\xA0+)[^\xA0]+/g, '$1 ')
+      )
+      .trim();
   }
 
-  const transformedHelpers = transformHelpersToHogan(
-    helpers,
-    compileOptions,
-    data
-  );
-
-  return hogan
-    .compile(template, compileOptions)
-    .render({
-      ...data,
-      helpers: transformedHelpers,
-    })
-    .replace(/[ \n\r\t\f\xA0]+/g, spaces =>
-      spaces.replace(/(^|\xA0+)[^\xA0]+/g, '$1 ')
-    )
-    .trim();
+  if (isTemplateFunction) {
+    return template(data, internalRender);
+  } else {
+    return internalRender(template);
+  }
 }
 
 export default renderTemplate;

--- a/src/lib/utils/renderTemplate.js
+++ b/src/lib/utils/renderTemplate.js
@@ -39,37 +39,29 @@ function renderTemplate({
     );
   }
 
-  function internalRender(_template, _data) {
-    if (_data === undefined) {
-      _data = data;
-    }
-
-    const transformedHelpers = transformHelpersToHogan(
-      helpers,
-      compileOptions,
-      data
-    );
-
-    return hogan
-      .compile(_template, compileOptions)
-      .render(
-        {
-          ..._data,
-          helpers: transformedHelpers,
-        },
-        templates
-      )
-      .replace(/[ \n\r\t\f\xA0]+/g, spaces =>
-        spaces.replace(/(^|\xA0+)[^\xA0]+/g, '$1 ')
-      )
-      .trim();
-  }
-
   if (isTemplateFunction) {
-    return template(data, internalRender);
-  } else {
-    return internalRender(template);
+    return template(data);
   }
+
+  const transformedHelpers = transformHelpersToHogan(
+    helpers,
+    compileOptions,
+    data
+  );
+
+  return hogan
+    .compile(template, compileOptions)
+    .render(
+      {
+        ...data,
+        helpers: transformedHelpers,
+      },
+      templates
+    )
+    .replace(/[ \n\r\t\f\xA0]+/g, spaces =>
+      spaces.replace(/(^|\xA0+)[^\xA0]+/g, '$1 ')
+    )
+    .trim();
 }
 
 export default renderTemplate;


### PR DESCRIPTION
**Summary**

1. Implement the mustache partial feature.
2. Add a render parameter to render functions. 

**Result**

1. Allows scenarios like this:

```
instantsearch.widgets.hits({
      ...
      templates: {
        item: 'Template using {{> partial }}',
        partial: 'Partial template {{variable }}'
      }
  });
```

2. Allows scenarios like this:

```
instantsearch.widgets.hits({
     ...
      templates: {
        item: (function($item, $render) {
          var template = generic_template;
          if ($item.type == "special") {
            template = special_template
          }
          return $render(template);
      })
  });
```

Or this:

```
instantsearch.widgets.hits({
     ...
      templates: {
        item: (function($data, $render) {
          return $render('My template with a {{> partial }}', data.partial_data);
       }),
       partial: partial_template,
      }
  });
```
