### PR TITLE
fix(index): warn for inconsistent UI state in development mode

### DIFF
--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -1223,6 +1223,9 @@ describe('UI state', () => {
           range: {
             price: '100:200',
           },
+          menu: {
+            category: 'Hardware',
+          },
         },
       },
     });
@@ -1245,6 +1248,7 @@ To fully reflect the state, some widgets need to be added to the index "indexNam
 - \`refinementList\` needs one of these widgets: "refinementList"
 - \`hierarchicalMenu\` needs one of these widgets: "hierarchicalMenu"
 - \`range\` needs one of these widgets: "rangeInput", "rangeSlider"
+- \`menu\` needs one of these widgets: "menu", "menuSelect"
 
 If you do not wish to display widgets but still want to support their search parameters, you can mount "virtual widgets" that don't render anything:
 
@@ -1253,12 +1257,14 @@ const virtualPagination = connectPagination(() => null);
 const virtualRefinementList = connectRefinementList(() => null);
 const virtualHierarchicalMenu = connectHierarchicalMenu(() => null);
 const virtualRange = connectRange(() => null);
+const virtualMenu = connectMenu(() => null);
 
 search.addWidgets([
   virtualPagination({ /* ... */ }),
   virtualRefinementList({ /* ... */ }),
   virtualHierarchicalMenu({ /* ... */ }),
-  virtualRange({ /* ... */ })
+  virtualRange({ /* ... */ }),
+  virtualMenu({ /* ... */ })
 ]);
 \`\`\`
 

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -1234,7 +1234,7 @@ describe('UI state', () => {
     })
       .toWarnDev(`[InstantSearch.js]: The UI state for the index "indexName" is not consistent with the widgets mounted.
 
-This can happen when the UI state is specified via \`initialUiState\` or \`routing\` but that the widgets responsible for this state were not added. This results in query parameters not being sent to the API.
+This can happen when the UI state is specified via \`initialUiState\` or \`routing\` but that the widgets responsible for this state were not added. This results in those query parameters not being sent to the API.
 
 To fully reflect the state, some widgets need to be added to the index "indexName":
 

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -1220,6 +1220,9 @@ describe('UI state', () => {
           hierarchicalMenu: {
             categories: 'Mobile',
           },
+          range: {
+            price: '100:200',
+          },
         },
       },
     });
@@ -1241,6 +1244,7 @@ To fully reflect the state, some widgets need to be added to the index "indexNam
 - \`page\` needs one of these widgets: "pagination", "infiniteHits"
 - \`refinementList\` needs one of these widgets: "refinementList"
 - \`hierarchicalMenu\` needs one of these widgets: "hierarchicalMenu"
+- \`range\` needs one of these widgets: "rangeInput", "rangeSlider"
 
 If you do not wish to display widgets but still want to support their search parameters, you can mount "virtual widgets" that don't render anything:
 
@@ -1248,11 +1252,13 @@ If you do not wish to display widgets but still want to support their search par
 const virtualPagination = connectPagination(() => null);
 const virtualRefinementList = connectRefinementList(() => null);
 const virtualHierarchicalMenu = connectHierarchicalMenu(() => null);
+const virtualRange = connectRange(() => null);
 
 search.addWidgets([
   virtualPagination({ /* ... */ }),
   virtualRefinementList({ /* ... */ }),
-  virtualHierarchicalMenu({ /* ... */ })
+  virtualHierarchicalMenu({ /* ... */ }),
+  virtualRange({ /* ... */ })
 ]);
 \`\`\`
 

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -115,7 +115,31 @@ export type UiState = {
  * have at least a `render` or a `init` function.
  */
 export interface Widget {
-  $$type?: string;
+  $$type?:
+    | 'ais.autocomplete'
+    | 'ais.breadcrumb'
+    | 'ais.clearRefinements'
+    | 'ais.configure'
+    | 'ais.currentRefinements'
+    | 'ais.geoSearch'
+    | 'ais.hierarchicalMenu'
+    | 'ais.hits'
+    | 'ais.hitsPerPage'
+    | 'ais.index'
+    | 'ais.infiniteHits'
+    | 'ais.menu'
+    | 'ais.numericMenu'
+    | 'ais.pagination'
+    | 'ais.poweredBy'
+    | 'ais.queryRules'
+    | 'ais.range'
+    | 'ais.ratingMenu'
+    | 'ais.refinementList'
+    | 'ais.searchBox'
+    | 'ais.sortBy'
+    | 'ais.stats'
+    | 'ais.toggleRefinement'
+    | 'ais.voiceSearch';
   /**
    * Called once before the first search
    */

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -348,6 +348,7 @@ const index = (props: IndexProps): Index => {
         if (__DEV__) {
           // Some connectors are responsible for multiple widgets so we need
           // to map them.
+          // eslint-disable-next-line no-inner-declarations
           function getWidgetNames(connectorName: string): string[] {
             switch (connectorName) {
               case 'range':

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -393,7 +393,7 @@ const index = (props: IndexProps): Index => {
             missingWidgets.length === 0,
             `The UI state for the index "${this.getIndexId()}" is not consistent with the widgets mounted.
 
-This can happen when the UI state is specified via \`initialUiState\` or \`routing\` but that the widgets responsible for this state were not added. This results in query parameters not being sent to the API.
+This can happen when the UI state is specified via \`initialUiState\` or \`routing\` but that the widgets responsible for this state were not added. This results in those query parameters not being sent to the API.
 
 To fully reflect the state, some widgets need to be added to the index "${this.getIndexId()}":
 

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -377,8 +377,8 @@ const index = (props: IndexProps): Index => {
               stateToWidgetsMap[parameter];
 
             if (
-              requiredWidgets.every(
-                requiredWidget => !mountedWidgets.includes(requiredWidget)
+              !requiredWidgets.some(requiredWidget =>
+                mountedWidgets.includes(requiredWidget)
               )
             ) {
               acc.push({

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -21,6 +21,8 @@ import {
   createDocumentationMessageGenerator,
   resolveSearchParameters,
   mergeSearchParameters,
+  warning,
+  capitalize,
 } from '../../lib/utils';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -342,6 +344,105 @@ const index = (props: IndexProps): Index => {
         // it at the index level because it's either: all of them or none of them
         // that are stalled. The queries are performed into a single network request.
         instantSearchInstance.scheduleStalledRender();
+
+        if (__DEV__) {
+          type StateToWidgets = {
+            [TParameter in keyof IndexUiState]: Array<Widget['$$type']>;
+          };
+
+          const stateToWidgetsMap: StateToWidgets = {
+            query: ['ais.searchBox', 'ais.autocomplete', 'ais.voiceSearch'],
+            refinementList: ['ais.refinementList'],
+            menu: ['ais.menu'],
+            hierarchicalMenu: ['ais.hierarchicalMenu'],
+            numericMenu: ['ais.numericMenu'],
+            ratingMenu: ['ais.ratingMenu'],
+            range: ['ais.range'],
+            toggle: ['ais.toggleRefinement'],
+            geoSearch: ['ais.geoSearch'],
+            sortBy: ['ais.sortBy'],
+            page: ['ais.pagination', 'ais.infiniteHits'],
+            hitsPerPage: ['ais.hitsPerPage'],
+            configure: ['ais.configure'],
+          };
+
+          const mountedWidgets = this.getWidgets()
+            .map(widget => widget.$$type)
+            .filter(Boolean);
+
+          const missingWidgets = Object.keys(localUiState).reduce<
+            Array<Partial<StateToWidgets>>
+          >((acc, parameter) => {
+            const requiredWidgets: Array<Widget['$$type']> =
+              stateToWidgetsMap[parameter];
+
+            if (
+              requiredWidgets.every(
+                requiredWidget => !mountedWidgets.includes(requiredWidget)
+              )
+            ) {
+              acc.push({
+                [parameter]: stateToWidgetsMap[parameter],
+              });
+            }
+
+            return acc;
+          }, []);
+
+          warning(
+            missingWidgets.length === 0,
+            `The UI state for the index "${this.getIndexId()}" is not consistent with the widgets mounted.
+
+This can happen when the UI state is specified via \`initialUiState\` or \`routing\` but that the widgets responsible for this state were not added. This results in query parameters not being sent to the API.
+
+To fully reflect the state, some widgets need to be added to the index "${this.getIndexId()}":
+
+${missingWidgets
+  .map(widget => {
+    const stateParameter = Object.keys(widget)[0];
+    const neededWidgets = stateToWidgetsMap[stateParameter]
+      .map(
+        (widgetIdentifier: string) => `"${widgetIdentifier.split('ais.')[1]}"`
+      )
+      .join(', ');
+
+    return `- \`${stateParameter}\` needs one of these widgets: ${neededWidgets}`;
+  })
+  .join('\n')}
+
+If you do not wish to display widgets but still want to support their search parameters, you can mount "virtual widgets" that don't render anything:
+
+\`\`\`
+${missingWidgets
+  .map(widget => {
+    const stateParameter = Object.keys(widget)[0];
+    const capitalizedWidget = capitalize(
+      stateToWidgetsMap[stateParameter][0].split('ais.')[1]
+    );
+
+    return `const virtual${capitalizedWidget} = connect${capitalizedWidget}(() => null);`;
+  })
+  .join('\n')}
+
+search.addWidgets([
+  ${missingWidgets
+    .map(widget => {
+      const stateParameter = Object.keys(widget)[0];
+      const capitalizedWidget = capitalize(
+        stateToWidgetsMap[stateParameter][0].split('ais.')[1]
+      );
+
+      return `virtual${capitalizedWidget}({ /* ... */ })`;
+    })
+    .join(',\n  ')}
+]);
+\`\`\`
+
+If you're using custom widgets that do set these query parameters, we recommend using connectors instead.
+
+See https://www.algolia.com/doc/guides/building-search-ui/widgets/customize-an-existing-widget/js/#customize-the-complete-ui-of-the-widgets`
+          );
+        }
       });
 
       derivedHelper.on('result', () => {

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -354,6 +354,9 @@ const index = (props: IndexProps): Index => {
               case 'range':
                 return ['rangeInput', 'rangeSlider'];
 
+              case 'menu':
+                return ['menu', 'menuSelect'];
+
               default:
                 return [connectorName];
             }


### PR DESCRIPTION
This adds a development warning when the UI state is inconsistent with the widgets mounted on the instance.

## Why

We often have users not understanding why certain parameters are not sent to the API. The reason is because widgets drive search parameters. Certain widgets need to be added to the instance for some search parameters to be applied. See a typical issue in #4129.

On support, we often advise to create "virtual widgets" to activate the search parameter, without displaying the widget on the page. This development warning is meant for them to understand why something might look like broken, *and* provide a solution for them.

I suspect this error to happen even more often with InstantSearch.js v4, where UI state is a predominant concept. My hope is that such a warning reduces to support load that we have regarding this use case.

## Warning preview

[InstantSearch.js]: The UI state for the index "instant_search" is not consistent with the widgets mounted.

This can happen when the UI state is specified via `initialUiState` or `routing` but that the widgets responsible for this state were not added. This results in query parameters not being sent to the API.

To fully reflect the state, some widgets need to be added to the index "instant_search":

- `page` needs one of these widgets: "pagination", "infiniteHits"
- `refinementList` needs one of these widgets: "refinementList"
- `hierarchicalMenu` needs one of these widgets: "hierarchicalMenu"

If you do not wish to display widgets but still want to support their search parameters, you can mount "virtual widgets" that don't render anything:

```
const virtualPagination = connectPagination(() => null);
const virtualRefinementList = connectRefinementList(() => null);
const virtualHierarchicalMenu = connectHierarchicalMenu(() => null);

search.addWidgets([
  virtualPagination({ /* ... */ }),
  virtualRefinementList({ /* ... */ }),
  virtualHierarchicalMenu({ /* ... */ })
]);
```

If you're using custom widgets that do set these query parameters, we recommend using connectors instead.

See https://www.algolia.com/doc/guides/building-search-ui/widgets/customize-an-existing-widget/js/#customize-the-complete-ui-of-the-widgets

## Implementation details

The implementation is at the index level. When the `search` event is triggered by the helper, the index reports if its UI state is not synced with its widgets.

This is detected with the `$$type` property that defines the type of the widget. If a UI state key is present but that none of the mounted widgets support this key, the warning appears.

## Cons of this solution

- The mapping between the UI parameters and the widgets that control them is written manually. We need to maintain that list. Could we make this a private connector API?
- Users creating custom widgets will see this warning because they aren't aware of the `$$type` property. I don't think this is a bad thing because the warning give them clues that they should use connectors instead (this is what we recommend).
- Users creating custom connectors will likely see this message because they aren't aware of the `$$type` property.

## Possible improvements

- We could think of improving this DX later by even checking if the attributes match in the UI state (not possible right now because we cannot read the `attribute` option from outside the widget)