### PR TITLE
feat(autocomplete): provide indexId

### DIFF
--- a/src/connectors/autocomplete/__tests__/connectAutocomplete-test.ts
+++ b/src/connectors/autocomplete/__tests__/connectAutocomplete-test.ts
@@ -156,20 +156,20 @@ search.addWidgets([
     const secondIndexHits = [{ name: 'Hit 1' }, { name: 'Hit 2' }];
     const scopedResults = [
       {
-        indexId: 'index0',
+        indexId: 'indexId0',
         results: new SearchResults(helper.state, [
           createSingleSearchResponse({
-            index: 'index0',
+            index: 'indexName0',
             hits: firstIndexHits,
           }),
         ]),
         helper,
       },
       {
-        indexId: 'index1',
+        indexId: 'indexId1',
         results: new SearchResults(helper.state, [
           createSingleSearchResponse({
-            index: 'index1',
+            index: 'indexName1',
             hits: secondIndexHits,
           }),
         ]),
@@ -183,13 +183,15 @@ search.addWidgets([
 
     expect(render).toHaveBeenCalledTimes(2);
     expect(secondRenderOptions.indices).toHaveLength(2);
-    expect(secondRenderOptions.indices[0].indexName).toEqual('index0');
+    expect(secondRenderOptions.indices[0].indexId).toEqual('indexId0');
+    expect(secondRenderOptions.indices[0].indexName).toEqual('indexName0');
     expect(secondRenderOptions.indices[0].hits).toEqual(firstIndexHits);
-    expect(secondRenderOptions.indices[0].results.index).toEqual('index0');
+    expect(secondRenderOptions.indices[0].results.index).toEqual('indexName0');
     expect(secondRenderOptions.indices[0].results.hits).toEqual(firstIndexHits);
-    expect(secondRenderOptions.indices[1].indexName).toEqual('index1');
+    expect(secondRenderOptions.indices[1].indexId).toEqual('indexId1');
+    expect(secondRenderOptions.indices[1].indexName).toEqual('indexName1');
     expect(secondRenderOptions.indices[1].hits).toEqual(secondIndexHits);
-    expect(secondRenderOptions.indices[1].results.index).toEqual('index1');
+    expect(secondRenderOptions.indices[1].results.index).toEqual('indexName1');
     expect(secondRenderOptions.indices[1].results.hits).toEqual(
       secondIndexHits
     );

--- a/src/connectors/autocomplete/connectAutocomplete.ts
+++ b/src/connectors/autocomplete/connectAutocomplete.ts
@@ -127,6 +127,7 @@ search.addWidgets([
             : scopedResult.results.hits;
 
           return {
+            indexId: scopedResult.indexId,
             indexName: scopedResult.results.index,
             hits: scopedResult.results.hits,
             results: scopedResult.results,


### PR DESCRIPTION
This PR adds the `indexId` attribute to the `indices` provided by `autocomplete`.

Only the `indexName` was provided but its value is not stable. The value changes when the index changes e.g. with `sortBy`. A possible use case for stable value is a list of labels. Users might want to have labels on their indices. Without stable values, you can't predict which label you'll have.  The `indexId` solve this problem.