### PR TITLE
fix(instantsearch): return instance in widgets methods

### DIFF
--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -258,9 +258,7 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
       'addWidget will still be supported in 4.x releases, but not further. It is replaced by `addWidgets([widget])`'
     );
 
-    this.addWidgets([widget]);
-
-    return this;
+    return this.addWidgets([widget]);
   }
 
   /**
@@ -309,9 +307,7 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
       'removeWidget will still be supported in 4.x releases, but not further. It is replaced by `removeWidgets([widget])`'
     );
 
-    this.removeWidgets([widget]);
-
-    return this;
+    return this.removeWidgets([widget]);
   }
 
   /**

--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -257,7 +257,10 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
       false,
       'addWidget will still be supported in 4.x releases, but not further. It is replaced by `addWidgets([widget])`'
     );
+
     this.addWidgets([widget]);
+
+    return this;
   }
 
   /**
@@ -289,6 +292,8 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
     }
 
     this.mainIndex.addWidgets(widgets);
+
+    return this;
   }
 
   /**
@@ -303,7 +308,10 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
       false,
       'removeWidget will still be supported in 4.x releases, but not further. It is replaced by `removeWidgets([widget])`'
     );
+
     this.removeWidgets([widget]);
+
+    return this;
   }
 
   /**
@@ -328,6 +336,8 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
     }
 
     this.mainIndex.removeWidgets(widgets);
+
+    return this;
   }
 
   /**

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -271,6 +271,26 @@ describe('addWidget(s)', () => {
 
     expect(search.mainIndex.getWidgets()).toHaveLength(1);
   });
+
+  it('returns the search instance when calling `addWidget`', () => {
+    const searchClient = createSearchClient();
+    const search = new InstantSearch({
+      indexName: 'indexName',
+      searchClient,
+    });
+
+    expect(search.addWidget(createWidget())).toBe(search);
+  });
+
+  it('returns the search instance when calling `addWidgets`', () => {
+    const searchClient = createSearchClient();
+    const search = new InstantSearch({
+      indexName: 'indexName',
+      searchClient,
+    });
+
+    expect(search.addWidgets([createWidget()])).toBe(search);
+  });
 });
 
 describe('removeWidget(s)', () => {
@@ -310,6 +330,32 @@ describe('removeWidget(s)', () => {
     search.removeWidgets([widget]);
 
     expect(search.mainIndex.getWidgets()).toHaveLength(0);
+  });
+
+  it('returns the search instance when calling `removeWidget`', () => {
+    const searchClient = createSearchClient();
+    const search = new InstantSearch({
+      indexName: 'indexName',
+      searchClient,
+    });
+
+    const widget = createWidget();
+    search.addWidget(widget);
+
+    expect(search.removeWidget(widget)).toBe(search);
+  });
+
+  it('returns the search instance when calling `removeWidgets`', () => {
+    const searchClient = createSearchClient();
+    const search = new InstantSearch({
+      indexName: 'indexName',
+      searchClient,
+    });
+
+    const widget = createWidget();
+    search.addWidgets([widget]);
+
+    expect(search.removeWidgets([widget])).toBe(search);
   });
 });
 


### PR DESCRIPTION
An `index` widget returns its own reference when calling `addWidgets()` and `removeWidgets()`. This makes chainable calls possible.

https://github.com/algolia/instantsearch.js/blob/443cb0610e77ff87b9d054e3b3bf43586fc31810/src/widgets/index/index.ts#L53-L54

However, `instantsearch` widgets methods didn't return the search instance, which was not intuitive when you're used to the `index` behavior.

This PR returns the search instance when calling these methods, so that this becomes possible:

```ts
const search = instantsearch({ /* ... */ });

search
  .addWidgets(widgets)
  .start();
```