### PR TITLE
fix: display warnings only in development

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,7 @@
 /* eslint-disable import/no-commonjs */
 
+const wrapWarningWithDevCheck = require('./scripts/babel/wrap-warning-with-dev-check');
+
 const isCJS = process.env.BABEL_ENV === 'cjs';
 const isES = process.env.BABEL_ENV === 'es';
 
@@ -33,6 +35,7 @@ module.exports = api => {
     '@babel/plugin-transform-react-constant-elements',
     'babel-plugin-transform-react-remove-prop-types',
     'babel-plugin-transform-react-pure-class-to-function',
+    wrapWarningWithDevCheck,
     (isCJS || isES) && [
       'inline-replace-variables',
       {

--- a/babel.config.js
+++ b/babel.config.js
@@ -20,6 +20,7 @@ module.exports = api => {
 
   const testPlugins = [
     '@babel/plugin-proposal-class-properties',
+    wrapWarningWithDevCheck,
     [
       'module-resolver',
       {

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
   "bundlesize": [
     {
       "path": "./dist/instantsearch.production.min.js",
-      "maxSize": "69 kB"
+      "maxSize": "66 kB"
     },
     {
       "path": "./dist/instantsearch.development.js",

--- a/scripts/babel/__tests__/wrap-warning-with-dev-check-test.js
+++ b/scripts/babel/__tests__/wrap-warning-with-dev-check-test.js
@@ -11,7 +11,7 @@ function babelTransform(code) {
 describe('wrap-warning-with-dev-check', () => {
   test('should wrap warning calls', () => {
     expect(babelTransform("warning(condition, 'message');")).toEqual(
-      "__DEV__ ? !condition ? warning(false, 'message') : void 0 : void 0;"
+      "__DEV__ ? warning(condition, 'message') : void 0;"
     );
   });
 

--- a/scripts/babel/__tests__/wrap-warning-with-dev-check-test.js
+++ b/scripts/babel/__tests__/wrap-warning-with-dev-check-test.js
@@ -1,0 +1,23 @@
+import { transformSync } from '@babel/core';
+import wrapWarningWithDevCheck from '../wrap-warning-with-dev-check';
+
+function babelTransform(code) {
+  return transformSync(code, {
+    configFile: false,
+    plugins: [wrapWarningWithDevCheck],
+  }).code;
+}
+
+describe('wrap-warning-with-dev-check', () => {
+  test('should wrap warning calls', () => {
+    expect(babelTransform("warning(condition, 'message');")).toEqual(
+      "__DEV__ ? !condition ? warning(false, 'message') : void 0 : void 0;"
+    );
+  });
+
+  test('should not wrap other calls', () => {
+    expect(babelTransform("deprecate(fn, 'message');")).toEqual(
+      "deprecate(fn, 'message');"
+    );
+  });
+});

--- a/scripts/babel/wrap-warning-with-dev-check.js
+++ b/scripts/babel/wrap-warning-with-dev-check.js
@@ -1,0 +1,68 @@
+/**
+ * Babel plugin that wraps `warning` calls with development check to be
+ * completely stripped from the production bundle.
+ *
+ * In the development bundle, warnings get wrapped with their condition
+ * and their condition becomes false to trigger them without evaluating twice.
+ *
+ * Input:
+ *
+ * ```
+ * warning(condition, message);
+ * ```
+ *
+ * Output:
+ *
+ * ```
+ * if (__DEV__) {
+ *   if (!condition) {
+ *     warning(false, message);
+ *   }
+ * }
+ * ```
+ */
+
+function wrapWarningInDevCheck(babel) {
+  const t = babel.types;
+
+  const DEV_EXPRESSION = t.identifier('__DEV__');
+  const SEEN_SYMBOL = Symbol('expression.seen');
+
+  return {
+    visitor: {
+      CallExpression: {
+        exit(path) {
+          const node = path.node;
+
+          if (node[SEEN_SYMBOL]) {
+            return;
+          }
+
+          if (path.get('callee').isIdentifier({ name: 'warning' })) {
+            const [condition, message] = node.arguments;
+            const newNode = t.callExpression(
+              node.callee,
+              [t.booleanLiteral(false)].concat(message)
+            );
+
+            newNode[SEEN_SYMBOL] = true;
+
+            path.replaceWith(
+              t.ifStatement(
+                DEV_EXPRESSION,
+                t.blockStatement([
+                  t.ifStatement(
+                    t.unaryExpression('!', condition),
+                    t.expressionStatement(newNode)
+                  ),
+                ])
+              )
+            );
+          }
+        },
+      },
+    },
+  };
+}
+
+export default wrapWarningInDevCheck;

--- a/scripts/babel/wrap-warning-with-dev-check.js
+++ b/scripts/babel/wrap-warning-with-dev-check.js
@@ -1,3 +1,5 @@
+/* eslint-disable import/no-commonjs */
+
 /**
  * Babel plugin that wraps `warning` calls with development check to be
  * completely stripped from the production bundle.
@@ -65,4 +67,4 @@ function wrapWarningInDevCheck(babel) {
   };
 }
 
-export default wrapWarningInDevCheck;
+module.exports = wrapWarningInDevCheck;

--- a/scripts/babel/wrap-warning-with-dev-check.js
+++ b/scripts/babel/wrap-warning-with-dev-check.js
@@ -17,9 +17,7 @@
  *
  * ```
  * if (__DEV__) {
- *   if (!condition) {
- *     warning(false, message);
- *   }
+ *   warning(condition, message);
  * }
  * ```
  */
@@ -41,23 +39,12 @@ function wrapWarningInDevCheck(babel) {
           }
 
           if (path.get('callee').isIdentifier({ name: 'warning' })) {
-            const [condition, message] = node.arguments;
-            const newNode = t.callExpression(
-              node.callee,
-              [t.booleanLiteral(false)].concat(message)
-            );
-
-            newNode[SEEN_SYMBOL] = true;
+            node[SEEN_SYMBOL] = true;
 
             path.replaceWith(
               t.ifStatement(
                 DEV_EXPRESSION,
-                t.blockStatement([
-                  t.ifStatement(
-                    t.unaryExpression('!', condition),
-                    t.expressionStatement(newNode)
-                  ),
-                ])
+                t.blockStatement([t.expressionStatement(node)])
               )
             );
           }

--- a/scripts/rollup/config.js
+++ b/scripts/rollup/config.js
@@ -4,6 +4,7 @@ import babel from 'rollup-plugin-babel';
 import replace from 'rollup-plugin-replace';
 import { uglify } from 'rollup-plugin-uglify';
 import filesize from 'rollup-plugin-filesize';
+import wrapWarningWithDevCheck from '../babel/wrap-warning-with-dev-check';
 
 const version =
   process.env.VERSION || `UNRELEASED (${new Date().toUTCString()})`;
@@ -20,6 +21,7 @@ const plugins = [
   babel({
     exclude: 'node_modules/**',
     extensions: ['.js', '.ts', '.tsx'],
+    plugins: [wrapWarningWithDevCheck],
   }),
   commonjs(),
   filesize({

--- a/scripts/rollup/config.js
+++ b/scripts/rollup/config.js
@@ -4,7 +4,6 @@ import babel from 'rollup-plugin-babel';
 import replace from 'rollup-plugin-replace';
 import { uglify } from 'rollup-plugin-uglify';
 import filesize from 'rollup-plugin-filesize';
-import wrapWarningWithDevCheck from '../babel/wrap-warning-with-dev-check';
 
 const version =
   process.env.VERSION || `UNRELEASED (${new Date().toUTCString()})`;
@@ -21,7 +20,6 @@ const plugins = [
   babel({
     exclude: 'node_modules/**',
     extensions: ['.js', '.ts', '.tsx'],
-    plugins: [wrapWarningWithDevCheck],
   }),
   commonjs(),
   filesize({


### PR DESCRIPTION
This fixes warnings being part of the production bundle. This usage is similar to how React strips their warnings in production.

Rollup couldn't infer from the `warning` usage that they should be stripped from the bundle. This PR adds a Babel plugin for wrapping the `warning` calls with the `__DEV__` check, that our tools evaluate to `false` in production and therefore strip in the bundle.

This fix can get backported to v3 so that next versions' bundles are also smaller.