### PR TITLE
fix(instantsearch): warn deprecated usage of `searchParameters`

### DIFF
--- a/.storybook/decorators.ts
+++ b/.storybook/decorators.ts
@@ -28,12 +28,6 @@ export const withHits = (
   const search = instantsearch({
     indexName,
     searchClient: algoliasearch(appId, apiKey),
-    searchParameters: {
-      hitsPerPage: 4,
-      attributesToSnippet: ['description:15'],
-      snippetEllipsisText: '[…]',
-      ...searchParameters,
-    },
     routing: {
       router: {
         write: (routeState: object) => {
@@ -46,6 +40,15 @@ export const withHits = (
     },
     ...instantsearchOptions,
   });
+
+  search.addWidget(
+    instantsearch.widgets.configure({
+      hitsPerPage: 4,
+      attributesToSnippet: ['description:15'],
+      snippetEllipsisText: '[…]',
+      ...searchParameters,
+    })
+  );
 
   const containerElement = document.createElement('div');
 

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -7,10 +7,12 @@ import version from './version';
 import createHelpers from './createHelpers';
 import {
   createDocumentationMessageGenerator,
+  createDocumentationLink,
   findIndex,
   isPlainObject,
   mergeDeep,
   noop,
+  warning,
 } from './utils';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -48,7 +50,7 @@ class InstantSearch extends EventEmitter {
     const {
       indexName = null,
       numberLocale,
-      searchParameters = {},
+      searchParameters,
       routing = null,
       searchFunction,
       stalledSearchDelay = 200,
@@ -87,6 +89,15 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
     if (insightsClient && typeof insightsClient !== 'function') {
       throw new Error('The provided `insightsClient` must be a function.');
     }
+
+    warning(
+      !searchParameters,
+      `The \`searchParameters\` option is deprecated and will not be supported in InstantSearch.js 4.x.
+
+You can replace it with the \`configure\` widget: ${createDocumentationLink({
+        name: 'configure',
+      })}`
+    );
 
     this.client = searchClient;
     this.insightsClient = insightsClient;

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -94,7 +94,15 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
       !searchParameters,
       `The \`searchParameters\` option is deprecated and will not be supported in InstantSearch.js 4.x.
 
-You can replace it with the \`configure\` widget: ${createDocumentationLink({
+You can replace it with the \`configure\` widget:
+
+\`\`\`
+search.addWidgets([
+  configure(${JSON.stringify(searchParameters, null, 2)})
+]);
+\`\`\`
+
+See ${createDocumentationLink({
         name: 'configure',
       })}`
     );

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -227,6 +227,7 @@ describe('InstantSearch lifecycle', () => {
         indexName,
         searchClient: algoliasearch(appId, apiKey),
         searchParameters: {
+          disjunctiveFacets: ['brand'],
           disjunctiveFacetsRefinements: {
             brand: ['Samsung'],
           },
@@ -235,7 +236,24 @@ describe('InstantSearch lifecycle', () => {
     })
       .toWarnDev(`[InstantSearch.js]: The \`searchParameters\` option is deprecated and will not be supported in InstantSearch.js 4.x.
 
-You can replace it with the \`configure\` widget: https://www.algolia.com/doc/api-reference/widgets/configure/js/`);
+You can replace it with the \`configure\` widget:
+
+\`\`\`
+search.addWidgets([
+  configure({
+  "disjunctiveFacets": [
+    "brand"
+  ],
+  "disjunctiveFacetsRefinements": {
+    "brand": [
+      "Samsung"
+    ]
+  }
+})
+]);
+\`\`\`
+
+See https://www.algolia.com/doc/api-reference/widgets/configure/js/`);
   });
 
   it('does not fail when passing same references inside multiple searchParameters props', () => {

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -1,6 +1,7 @@
 import algoliaSearchHelper from 'algoliasearch-helper';
 import InstantSearch from '../InstantSearch';
 import version from '../version';
+import { warning } from '../utils';
 
 jest.mock('algoliasearch-helper', () => {
   const module = require.requireActual('algoliasearch-helper');
@@ -215,6 +216,26 @@ describe('InstantSearch lifecycle', () => {
 
   it('does not call algoliasearchHelper', () => {
     expect(algoliaSearchHelper).not.toHaveBeenCalled();
+  });
+
+  it('warns deprecated usage of `searchParameters`', () => {
+    warning.cache = {};
+
+    expect(() => {
+      // eslint-disable-next-line no-new
+      new InstantSearch({
+        indexName,
+        searchClient: algoliasearch(appId, apiKey),
+        searchParameters: {
+          disjunctiveFacetsRefinements: {
+            brand: ['Samsung'],
+          },
+        },
+      });
+    })
+      .toWarnDev(`[InstantSearch.js]: The \`searchParameters\` option is deprecated and will not be supported in InstantSearch.js 4.x.
+
+You can replace it with the \`configure\` widget: https://www.algolia.com/doc/api-reference/widgets/configure/js/`);
   });
 
   it('does not fail when passing same references inside multiple searchParameters props', () => {


### PR DESCRIPTION
> This PR targets the `develop` branch, thus InstantSearch.js 3.

This displays a development warning when using `searchParameters` on InstantSearch.js 3. This option doesn't exist anymore on v4 and therefore it's better to warn users before reading the migration guide. We instead advise for using the `configure` widget.