### PR TITLE
fix(range): clear widget state on empty refinements

### DIFF
--- a/src/connectors/range/__tests__/connectRange-test.js
+++ b/src/connectors/range/__tests__/connectRange-test.js
@@ -962,8 +962,8 @@ describe('getWidgetState', () => {
       disjunctiveFacets: ['price'],
       numericRefinements: {
         price: {
-          '<=': [],
           '>=': [],
+          '<=': [],
         },
       },
     });
@@ -1065,6 +1065,66 @@ describe('getWidgetState', () => {
     expect(actual).toEqual({
       range: {
         price: '100:1000',
+      },
+    });
+  });
+
+  test('returns the `uiState` with an empty upper refinement', () => {
+    const render = jest.fn();
+    const makeWidget = connectRange(render);
+    const helper = jsHelper({}, 'indexName', {
+      disjunctiveFacets: ['price'],
+      numericRefinements: {
+        price: {
+          '>=': [100],
+          '<=': [],
+        },
+      },
+    });
+    const widget = makeWidget({
+      attribute: 'price',
+    });
+
+    const actual = widget.getWidgetState(
+      {},
+      {
+        searchParameters: helper.state,
+      }
+    );
+
+    expect(actual).toEqual({
+      range: {
+        price: '100:',
+      },
+    });
+  });
+
+  test('returns the `uiState` with an empty lower refinement', () => {
+    const render = jest.fn();
+    const makeWidget = connectRange(render);
+    const helper = jsHelper({}, 'indexName', {
+      disjunctiveFacets: ['price'],
+      numericRefinements: {
+        price: {
+          '>=': [],
+          '<=': [1000],
+        },
+      },
+    });
+    const widget = makeWidget({
+      attribute: 'price',
+    });
+
+    const actual = widget.getWidgetState(
+      {},
+      {
+        searchParameters: helper.state,
+      }
+    );
+
+    expect(actual).toEqual({
+      range: {
+        price: ':1000',
       },
     });
   });

--- a/src/connectors/range/__tests__/connectRange-test.js
+++ b/src/connectors/range/__tests__/connectRange-test.js
@@ -955,6 +955,32 @@ describe('getWidgetState', () => {
     expect(actual).toEqual({});
   });
 
+  test('returns the `uiState` empty with empty refinements', () => {
+    const render = jest.fn();
+    const makeWidget = connectRange(render);
+    const helper = jsHelper({}, 'indexName', {
+      disjunctiveFacets: ['price'],
+      numericRefinements: {
+        price: {
+          '<=': [],
+          '>=': [],
+        },
+      },
+    });
+    const widget = makeWidget({
+      attribute: 'price',
+    });
+
+    const actual = widget.getWidgetState(
+      {},
+      {
+        searchParameters: helper.state,
+      }
+    );
+
+    expect(actual).toEqual({});
+  });
+
   test('returns the `uiState` with a lower refinement', () => {
     const render = jest.fn();
     const makeWidget = connectRange(render);

--- a/src/connectors/range/connectRange.js
+++ b/src/connectors/range/connectRange.js
@@ -260,11 +260,11 @@ export default function connectRange(renderFn, unmountFn = noop) {
 
       getWidgetState(uiState, { searchParameters }) {
         const {
-          '>=': min = '',
-          '<=': max = '',
+          '>=': min = [],
+          '<=': max = [],
         } = searchParameters.getNumericRefinements(attribute);
 
-        if (min === '' && max === '') {
+        if (min.length === 0 && max.length === 0) {
           return uiState;
         }
 

--- a/src/lib/utils/__tests__/clearRefinements-test.ts
+++ b/src/lib/utils/__tests__/clearRefinements-test.ts
@@ -162,6 +162,7 @@ describe('clearRefinements', () => {
     expect(
       clearRefinements({
         helper: algoliasearchHelper({} as Client, '', {
+          disjunctiveFacets: ['attr'],
           numericRefinements: {
             attr: {
               '=': [42],
@@ -172,6 +173,7 @@ describe('clearRefinements', () => {
       })
     ).toEqual(
       new SearchParameters({
+        disjunctiveFacets: ['attr'],
         numericRefinements: {
           attr: {
             '=': [],
@@ -187,6 +189,7 @@ describe('clearRefinements', () => {
     expect(
       clearRefinements({
         helper: algoliasearchHelper({} as Client, '', {
+          disjunctiveFacets: ['attr'],
           numericRefinements: {
             attr: {
               '=': [],
@@ -197,6 +200,7 @@ describe('clearRefinements', () => {
       })
     ).toEqual(
       new SearchParameters({
+        disjunctiveFacets: ['attr'],
         numericRefinements: {
           attr: {
             '=': [],
@@ -212,6 +216,7 @@ describe('clearRefinements', () => {
     expect(
       clearRefinements({
         helper: algoliasearchHelper({} as Client, '', {
+          disjunctiveFacets: ['attr'],
           numericRefinements: {
             attr: {
               '=': [42],
@@ -223,6 +228,7 @@ describe('clearRefinements', () => {
       })
     ).toEqual(
       new SearchParameters({
+        disjunctiveFacets: ['attr'],
         numericRefinements: {
           attr: {
             '=': [],

--- a/src/lib/utils/clearRefinements.ts
+++ b/src/lib/utils/clearRefinements.ts
@@ -19,6 +19,9 @@ function clearRefinements({
   let finalState = helper.state.setPage(0);
 
   finalState = attributesToClear.reduce((state, attribute) => {
+    if (finalState.isNumericRefined(attribute)) {
+      return state.removeNumericRefinement(attribute);
+    }
     if (finalState.isHierarchicalFacet(attribute)) {
       return state.removeHierarchicalFacetRefinement(attribute);
     }
@@ -28,9 +31,7 @@ function clearRefinements({
     if (finalState.isConjunctiveFacet(attribute)) {
       return state.removeFacetRefinement(attribute);
     }
-    if (finalState.isNumericRefined(attribute)) {
-      return state.removeNumericRefinement(attribute);
-    }
+
     return state;
   }, finalState);
 


### PR DESCRIPTION
## Description

`connectRange` does not clear its UI state when it receives empty refinements, but it only does when it _doesn't_ receive refinements.

## How to reproduce

1. Go to a [previous deployment](https://deploy-preview-4150--instantsearchjs.netlify.com/examples/e-commerce/search/?brands=Samsung&price=500%3A2000)
2. Notice "Samsung" and "Price" are refined in the URL
3. Click on "Clear filters"
4. **Price range is still in the URL**

## Why

In the `clearRefinements` tests, [we did not add the numeric filter attributes in the `disjunctiveFacets`](https://github.com/algolia/instantsearch.js/blob/67dee4ef8fa75d39f8a03d59a65a3a39ad8537b0/src/lib/utils/__tests__/clearRefinements-test.ts#L164-L170), which is a behavior that cannot happen in a real environment: they must be added to `disjunctiveFacets` for the Algolia API to process them. The tests were therefore lying because we actually never went to [this branch](https://github.com/algolia/instantsearch.js/blob/67dee4ef8fa75d39f8a03d59a65a3a39ad8537b0/src/lib/utils/clearRefinements.ts#L31-L33) in a real environment: the numeric filters were never cleared.

```diff
new SearchParameters({
+ disjunctiveFacets: ['attr'], // ← this is needed to be a correct helper state
  numericRefinements: {
    attr: {
      '=': [],
    },
  },
  index: '',
  page: 0,
});
```

If we want to effectively clear the numeric refinements, we need to move the check for numeric refinements _before_ the check for disjunctive facets.

## Solution

This fix makes sure that unit tests reflect a real environment by adding the numeric attribute in the `disjunctiveFacets`, using complete search parameters.

`connectRange` now considers empty refinements as no values in the UI state so that the URL is cleared.

## Result

1. Go to this PR [deployment](https://deploy-preview-4157--instantsearchjs.netlify.com/examples/e-commerce/search/?brands=Samsung&price=500%3A2000)
2. Notice "Samsung" and "Price" are refined in the URL
3. Click on "Clear filters"
4. **Price range is not in the URL**