### PR TITLE
fix(index): support custom UI params in inconsistent UI state warning

### DIFF
--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -1226,6 +1226,13 @@ describe('UI state', () => {
           menu: {
             category: 'Hardware',
           },
+          // `places` is a UI parameter that is not supported by default but that
+          // can be added when using custom widgets. Having it in `initialUiState`
+          // makes sure that it doesn't throw if it happens.
+          places: {
+            query: 'Paris',
+            location: ['1', '1'],
+          },
         },
       },
     });

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -394,6 +394,10 @@ const index = (props: IndexProps): Index => {
             const requiredWidgets: Array<Widget['$$type']> =
               stateToWidgetsMap[parameter];
 
+            if (!requiredWidgets) {
+              return acc;
+            }
+
             if (
               !requiredWidgets.some(requiredWidget =>
                 mountedWidgets.includes(requiredWidget)


### PR DESCRIPTION
## Description

When developing the new [Places.js](https://github.com/algolia/places) widget for InstantSearch 4, I realized that having a non-supported key in the UI state mapping throws in development mode because of the inconsistent UI state warning. This fix makes sure that custom widgets that enhance the UI state does not throw in development mode.

## Related

- #4140