### PR TITLE
feat(places): add Places widget

### DIFF
--- a/.storybook/static/storybook.css
+++ b/.storybook/static/storybook.css
@@ -115,7 +115,7 @@ body {
 
 .algolia-places {
   display: block !important;
-  width: 850px;
+  width: 100%;
   margin: 0 auto;
 }
 

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "jscodeshift": "0.6.4",
     "jsdom-global": "3.0.2",
     "mversion": "1.13.0",
-    "places.js": "1.16.4",
+    "places.js": "1.16.6",
     "prettier": "1.18.2",
     "rollup": "1.21.4",
     "rollup-plugin-babel": "4.3.3",
@@ -139,7 +139,7 @@
   "bundlesize": [
     {
       "path": "./dist/instantsearch.production.min.js",
-      "maxSize": "62 kB"
+      "maxSize": "63 kB"
     },
     {
       "path": "./dist/instantsearch.development.js",

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -104,6 +104,15 @@ export type IndexUiState = {
   page?: number;
   hitsPerPage?: number;
   configure?: PlainSearchParameters;
+  places?: {
+    query: string;
+    /**
+     * The central geolocation.
+     *
+     * @example '48.8546,2.3477'
+     */
+    position: string;
+  };
 };
 
 export type UiState = {
@@ -130,6 +139,7 @@ export interface Widget {
     | 'ais.menu'
     | 'ais.numericMenu'
     | 'ais.pagination'
+    | 'ais.places'
     | 'ais.poweredBy'
     | 'ais.queryRules'
     | 'ais.range'

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -38,3 +38,4 @@ export {
   default as queryRuleContext,
 } from './query-rule-context/query-rule-context';
 export { default as index } from './index/index';
+export { default as places } from './places/places';

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -380,6 +380,7 @@ const index = (props: IndexProps): Index => {
             page: ['ais.pagination', 'ais.infiniteHits'],
             hitsPerPage: ['ais.hitsPerPage'],
             configure: ['ais.configure'],
+            places: ['ais.places'],
           };
 
           const mountedWidgets = this.getWidgets()

--- a/src/widgets/places/__tests__/places-test.ts
+++ b/src/widgets/places/__tests__/places-test.ts
@@ -1,0 +1,506 @@
+import algoliasearchHelper, { SearchParameters } from 'algoliasearch-helper';
+import algoliaPlaces from 'places.js';
+import places from '../places';
+import { createSearchClient } from '../../../../test/mock/createSearchClient';
+import { createInitOptions } from '../../../../test/mock/createWidget';
+import { SearchClient } from '../../../types';
+
+jest.mock('places.js', () => {
+  const module = jest.fn(() => {
+    const instance = {
+      on: jest.fn(),
+      setVal: jest.fn(),
+      close: jest.fn(),
+    };
+    (module as any).__instance = instance;
+
+    return instance;
+  });
+
+  return module;
+});
+
+const createFakeHelper = (
+  searchClient: SearchClient,
+  searchParameters: Partial<SearchParameters> = {}
+) => {
+  const helper = algoliasearchHelper(
+    searchClient,
+    'indexName',
+    searchParameters
+  );
+
+  helper.search = jest.fn();
+
+  return helper;
+};
+
+describe('places', () => {
+  const container = document.createElement('input');
+  const defaultOptions = {
+    placesClient: algoliaPlaces,
+    container,
+  };
+
+  describe('Usage', () => {
+    test('creates a places instance', () => {
+      const searchClient = createSearchClient();
+      const helper = createFakeHelper(searchClient);
+      const widget = places({
+        ...defaultOptions,
+        defaultPosition: ['1', '1'],
+      });
+
+      widget.init!(createInitOptions({ helper }));
+
+      expect(algoliaPlaces).toHaveBeenCalledTimes(1);
+      expect(algoliaPlaces).toHaveBeenCalledWith({ container });
+    });
+
+    test('throws without parameters', () => {
+      // @ts-ignore
+      expect(() => places()).toThrowErrorMatchingInlineSnapshot(
+        `"The \`placesClient\` option requires a valid Places.js reference."`
+      );
+    });
+  });
+
+  describe('Lifecycle', () => {
+    describe('init', () => {
+      test('does not call `setQueryParameter` during the init step', () => {
+        // Using `setQueryParameter` to change a filter value during the init step
+        // has unintented consequences such as resetting the pagination to 0.
+        const searchClient = createSearchClient();
+        const helper = createFakeHelper(searchClient);
+        const widget = places(defaultOptions);
+
+        helper.setQueryParameter = jest.fn();
+        widget.init!(createInitOptions({ helper }));
+
+        expect(helper.setQueryParameter).toHaveBeenCalledTimes(0);
+      });
+
+      test('configures `aroundLatLng` on change event', () => {
+        const searchClient = createSearchClient();
+        const helper = createFakeHelper(searchClient);
+        const widget = places({
+          ...defaultOptions,
+        });
+
+        widget.init!(createInitOptions({ helper }));
+
+        const [
+          changeEventName,
+          changeEventListener,
+        ] = (algoliaPlaces as any).__instance.on.mock.calls[0];
+
+        expect(changeEventName).toEqual('change');
+
+        changeEventListener({
+          suggestion: {
+            latlng: {
+              lat: '123',
+              lng: '456',
+            },
+          },
+        });
+
+        expect(helper.search).toHaveBeenCalledTimes(1);
+        expect(helper.state).toEqual(
+          new SearchParameters({
+            index: 'indexName',
+            aroundLatLng: '123,456',
+            aroundLatLngViaIP: false,
+            insideBoundingBox: undefined,
+          })
+        );
+      });
+
+      test('configures `aroundLatLng` with `defaultPosition` on clear event', () => {
+        const searchClient = createSearchClient();
+        const helper = createFakeHelper(searchClient, {
+          aroundLatLngViaIP: true,
+        });
+        const widget = places({
+          ...defaultOptions,
+          defaultPosition: ['2', '2'],
+        });
+
+        widget.init!(createInitOptions({ helper }));
+
+        const [
+          clearEventName,
+          clearEventListener,
+        ] = (algoliaPlaces as any).__instance.on.mock.calls[1];
+
+        expect(clearEventName).toEqual('clear');
+
+        clearEventListener();
+
+        expect(helper.search).toHaveBeenCalledTimes(1);
+        expect(helper.state).toEqual(
+          new SearchParameters({
+            index: 'indexName',
+            aroundLatLngViaIP: false,
+            aroundLatLng: '2,2',
+            insideBoundingBox: undefined,
+          })
+        );
+      });
+
+      test('restores `aroundLatLngViaIP` without `defaultPosition` on clear event', () => {
+        const searchClient = createSearchClient();
+        const helper = createFakeHelper(searchClient, {
+          aroundLatLngViaIP: true,
+        });
+        const widget = places({
+          ...defaultOptions,
+        });
+
+        widget.init!(createInitOptions({ helper }));
+        // Trigger the initialization of `aroundLatLngViaIP`.
+        widget.getWidgetSearchParameters!(helper.state, { uiState: {} });
+
+        expect(helper.state.aroundLatLngViaIP).toBe(true);
+
+        const [
+          changeEventName,
+          changeEventListener,
+        ] = (algoliaPlaces as any).__instance.on.mock.calls[0];
+
+        expect(changeEventName).toEqual('change');
+
+        changeEventListener({
+          suggestion: {
+            latlng: {
+              lat: '123',
+              lng: '456',
+            },
+          },
+        });
+
+        expect(helper.search).toHaveBeenCalledTimes(1);
+        expect(helper.state.aroundLatLngViaIP).toBe(false);
+
+        const [
+          clearEventName,
+          clearEventListener,
+        ] = (algoliaPlaces as any).__instance.on.mock.calls[1];
+
+        expect(clearEventName).toEqual('clear');
+
+        clearEventListener();
+
+        expect(helper.search).toHaveBeenCalledTimes(2);
+        expect(helper.state.aroundLatLngViaIP).toBe(true);
+      });
+    });
+
+    describe('getWidgetSearchParameters', () => {
+      test('returns default search parameters with default UI state', () => {
+        const searchClient = createSearchClient();
+        const helper = createFakeHelper(searchClient);
+        const widget = places({
+          ...defaultOptions,
+        });
+
+        widget.init!(createInitOptions({ helper }));
+
+        const nextSearchParameters = widget.getWidgetSearchParameters!(
+          helper.state,
+          {
+            uiState: {},
+          }
+        );
+
+        expect(nextSearchParameters).toEqual(
+          new SearchParameters({
+            index: 'indexName',
+            aroundLatLngViaIP: false,
+          })
+        );
+      });
+
+      test('returns the search parameters with values from the UI state', () => {
+        const searchClient = createSearchClient();
+        const helper = createFakeHelper(searchClient);
+        const widget = places({
+          ...defaultOptions,
+        });
+
+        widget.init!(createInitOptions({ helper }));
+
+        const nextSearchParameters = widget.getWidgetSearchParameters!(
+          helper.state,
+          {
+            uiState: {
+              places: {
+                query: 'Paris, Île-de-France, France',
+                position: '48.8546,2.3477',
+              },
+            },
+          }
+        );
+
+        expect(nextSearchParameters).toEqual(
+          new SearchParameters({
+            index: 'indexName',
+            aroundLatLng: '48.8546,2.3477',
+            aroundLatLngViaIP: false,
+          })
+        );
+      });
+
+      test('returns the search parameters with values from the UI state if using `defaultPosition`', () => {
+        const searchClient = createSearchClient();
+        const helper = createFakeHelper(searchClient);
+        const widget = places({
+          ...defaultOptions,
+          defaultPosition: ['1', '1'],
+        });
+
+        widget.init!(createInitOptions({ helper }));
+
+        const nextSearchParameters = widget.getWidgetSearchParameters!(
+          helper.state,
+          {
+            uiState: {
+              places: {
+                query: 'Paris, Île-de-France, France',
+                position: '48.8546,2.3477',
+              },
+            },
+          }
+        );
+
+        expect(nextSearchParameters).toEqual(
+          new SearchParameters({
+            index: 'indexName',
+            aroundLatLng: '48.8546,2.3477',
+            aroundLatLngViaIP: false,
+          })
+        );
+      });
+
+      test('returns the search parameters with `defaultPosition` when empty UI state', () => {
+        const searchClient = createSearchClient();
+        const helper = createFakeHelper(searchClient);
+        const widget = places({
+          ...defaultOptions,
+          defaultPosition: ['1', '1'],
+        });
+
+        widget.init!(createInitOptions({ helper }));
+
+        const nextSearchParameters = widget.getWidgetSearchParameters!(
+          helper.state,
+          {
+            uiState: {},
+          }
+        );
+
+        expect(nextSearchParameters).toEqual(
+          new SearchParameters({
+            index: 'indexName',
+            aroundLatLng: '1,1',
+            aroundLatLngViaIP: false,
+          })
+        );
+      });
+
+      test('restores `aroundLatLngViaIP` on clear event', () => {
+        const searchClient = createSearchClient();
+        const helper = createFakeHelper(searchClient);
+        const widget = places({
+          ...defaultOptions,
+        });
+
+        const previousSearchParameters = new SearchParameters({
+          aroundLatLngViaIP: true,
+        });
+
+        const uiState = {
+          places: {
+            query: 'Paris',
+            position: '123,123',
+          },
+        };
+
+        widget.getWidgetSearchParameters!(previousSearchParameters, {
+          uiState,
+        });
+
+        widget.init!(createInitOptions({ helper }));
+
+        expect(helper.state.aroundLatLngViaIP).toBeUndefined();
+
+        const [
+          ,
+          clearEventListener,
+        ] = (algoliaPlaces as any).__instance.on.mock.calls[1];
+
+        clearEventListener();
+
+        expect(helper.search).toHaveBeenCalledTimes(1);
+        expect(helper.state.aroundLatLngViaIP).toBe(true);
+      });
+
+      test('should close the dropdown', () => {
+        const searchClient = createSearchClient();
+        const helper = createFakeHelper(searchClient);
+        const widget = places({
+          ...defaultOptions,
+        });
+
+        widget.init!(createInitOptions({ helper }));
+
+        expect((algoliaPlaces as any).__instance.close).toHaveBeenCalledTimes(
+          0
+        );
+
+        widget.getWidgetSearchParameters!(helper.state, {
+          uiState: {
+            places: {
+              query: 'Paris, Île-de-France, France',
+              position: '48.8546,2.3477',
+            },
+          },
+        });
+
+        expect((algoliaPlaces as any).__instance.close).toHaveBeenCalledTimes(
+          1
+        );
+      });
+    });
+
+    describe('getWidgetState', () => {
+      test('returns the default state empty', () => {
+        const searchClient = createSearchClient();
+        const helper = createFakeHelper(searchClient);
+        const widget = places({
+          ...defaultOptions,
+        });
+
+        const previousUiState = {};
+        const nextUiState = widget.getWidgetState!(previousUiState, {
+          helper,
+          searchParameters: helper.state,
+        });
+
+        expect(nextUiState).toEqual({});
+      });
+
+      test('returns the state with `position` when using `defaultPosition`', () => {
+        const searchClient = createSearchClient();
+        const helper = createFakeHelper(searchClient);
+        const widget = places({
+          ...defaultOptions,
+          defaultPosition: ['2', '2'],
+        });
+
+        const previousUiState = {};
+        const nextUiState = widget.getWidgetState!(previousUiState, {
+          helper,
+          searchParameters: helper.state,
+        });
+
+        expect(nextUiState).toEqual({});
+      });
+
+      test('returns an exhaustive state on `change`', () => {
+        const searchClient = createSearchClient();
+        const helper = createFakeHelper(searchClient);
+        const widget = places({
+          ...defaultOptions,
+        });
+
+        widget.init!(createInitOptions({ helper }));
+
+        const [
+          changeEventName,
+          changeEventListener,
+        ] = (algoliaPlaces as any).__instance.on.mock.calls[0];
+
+        expect(changeEventName).toEqual('change');
+
+        changeEventListener({
+          suggestion: {
+            value: 'Paris',
+            latlng: {
+              lat: '123',
+              lng: '456',
+            },
+          },
+        });
+
+        const previousUiState = {};
+        const nextUiState = widget.getWidgetState!(previousUiState, {
+          helper,
+          searchParameters: helper.state,
+        });
+
+        expect(nextUiState).toEqual({
+          places: {
+            query: 'Paris',
+            position: '123,456',
+          },
+        });
+      });
+
+      test('returns an empty state on `clear`', () => {
+        const searchClient = createSearchClient();
+        const helper = createFakeHelper(searchClient);
+        const widget = places({
+          ...defaultOptions,
+        });
+
+        widget.init!(createInitOptions({ helper }));
+
+        const [
+          clearEventName,
+          clearEventListener,
+        ] = (algoliaPlaces as any).__instance.on.mock.calls[1];
+
+        expect(clearEventName).toEqual('clear');
+
+        clearEventListener();
+
+        const previousUiState = {};
+        const nextUiState = widget.getWidgetState!(previousUiState, {
+          helper,
+          searchParameters: helper.state,
+        });
+
+        expect(nextUiState).toEqual({});
+      });
+
+      test('returns an empty state on `clear` with `defaultPosition`', () => {
+        const searchClient = createSearchClient();
+        const helper = createFakeHelper(searchClient);
+        const widget = places({
+          ...defaultOptions,
+          defaultPosition: ['2', '2'],
+        });
+
+        widget.init!(createInitOptions({ helper }));
+
+        const [
+          clearEventName,
+          clearEventListener,
+        ] = (algoliaPlaces as any).__instance.on.mock.calls[1];
+
+        expect(clearEventName).toEqual('clear');
+
+        clearEventListener();
+
+        const previousUiState = {};
+        const nextUiState = widget.getWidgetState!(previousUiState, {
+          helper,
+          searchParameters: helper.state,
+        });
+
+        expect(nextUiState).toEqual({});
+      });
+    });
+  });
+});

--- a/src/widgets/places/__tests__/places-test.ts
+++ b/src/widgets/places/__tests__/places-test.ts
@@ -38,7 +38,7 @@ const createFakeHelper = (
 describe('places', () => {
   const container = document.createElement('input');
   const defaultOptions = {
-    placesClient: algoliaPlaces,
+    placesReference: algoliaPlaces,
     container,
   };
 
@@ -60,7 +60,7 @@ describe('places', () => {
     test('throws without parameters', () => {
       // @ts-ignore
       expect(() => places()).toThrowErrorMatchingInlineSnapshot(
-        `"The \`placesClient\` option requires a valid Places.js reference."`
+        `"The \`placesReference\` option requires a valid Places.js reference."`
       );
     });
   });

--- a/src/widgets/places/places.ts
+++ b/src/widgets/places/places.ts
@@ -1,0 +1,136 @@
+import {
+  StaticOptions,
+  ChangeEvent,
+  PlacesInstance,
+  ReconfigurableOptions,
+} from 'places.js';
+import { WidgetFactory } from '../../types';
+
+interface PlacesWidgetOptions extends StaticOptions {
+  /**
+   * The Algolia Places client to use.
+   *
+   * @see https://github.com/algolia/places
+   */
+  placesClient: (
+    options: StaticOptions & ReconfigurableOptions
+  ) => PlacesInstance;
+  /**
+   * The default position when the input is empty.
+   */
+  defaultPosition?: string[];
+}
+
+interface PlacesWidgetState {
+  query: string;
+  initialLatLngViaIP: boolean | undefined;
+  isInitialLatLngViaIPSet: boolean;
+}
+
+/**
+ * This widget sets the geolocation value for the search based on the selected
+ * result in the Algolia Places autocomplete.
+ */
+const placesWidget: WidgetFactory<PlacesWidgetOptions> = (
+  widgetOptions: PlacesWidgetOptions
+) => {
+  const { placesClient = undefined, defaultPosition = [], ...placesOptions } =
+    widgetOptions || {};
+
+  if (typeof placesClient !== 'function') {
+    throw new Error(
+      'The `placesClient` option requires a valid Places.js reference.'
+    );
+  }
+
+  const placesAutocomplete = placesClient(placesOptions);
+
+  const state: PlacesWidgetState = {
+    query: '',
+    initialLatLngViaIP: undefined,
+    isInitialLatLngViaIPSet: false,
+  };
+
+  return {
+    $$type: 'ais.places',
+
+    init({ helper }) {
+      placesAutocomplete.on('change', (eventOptions: ChangeEvent) => {
+        const {
+          suggestion: {
+            value,
+            latlng: { lat, lng },
+          },
+        } = eventOptions;
+
+        state.query = value;
+
+        helper
+          .setQueryParameter('insideBoundingBox', undefined)
+          .setQueryParameter('aroundLatLngViaIP', false)
+          .setQueryParameter('aroundLatLng', `${lat},${lng}`)
+          .search();
+      });
+
+      placesAutocomplete.on('clear', () => {
+        state.query = '';
+
+        helper.setQueryParameter('insideBoundingBox', undefined);
+
+        if (defaultPosition.length > 1) {
+          helper
+            .setQueryParameter('aroundLatLngViaIP', false)
+            .setQueryParameter('aroundLatLng', defaultPosition.join(','));
+        } else {
+          helper
+            .setQueryParameter('aroundLatLngViaIP', state.initialLatLngViaIP)
+            .setQueryParameter('aroundLatLng', undefined);
+        }
+
+        helper.search();
+      });
+    },
+
+    getWidgetState(uiState, { searchParameters }) {
+      const position =
+        searchParameters.aroundLatLng || defaultPosition.join(',');
+      const hasPositionSet = position !== defaultPosition.join(',');
+
+      if (!hasPositionSet && !state.query) {
+        const { places, ...uiStateWithoutPlaces } = uiState;
+
+        return uiStateWithoutPlaces;
+      }
+
+      return {
+        ...uiState,
+        places: {
+          query: state.query,
+          position,
+        },
+      };
+    },
+
+    getWidgetSearchParameters(searchParameters, { uiState }) {
+      const { query = '', position = defaultPosition.join(',') } =
+        uiState.places || {};
+
+      state.query = query;
+
+      if (!state.isInitialLatLngViaIPSet) {
+        state.isInitialLatLngViaIPSet = true;
+        state.initialLatLngViaIP = searchParameters.aroundLatLngViaIP;
+      }
+
+      placesAutocomplete.setVal(query);
+      placesAutocomplete.close();
+
+      return searchParameters
+        .setQueryParameter('insideBoundingBox', undefined)
+        .setQueryParameter('aroundLatLngViaIP', false)
+        .setQueryParameter('aroundLatLng', position || undefined);
+    },
+  };
+};
+
+export default placesWidget;

--- a/src/widgets/places/places.ts
+++ b/src/widgets/places/places.ts
@@ -8,11 +8,11 @@ import { WidgetFactory } from '../../types';
 
 interface PlacesWidgetOptions extends StaticOptions {
   /**
-   * The Algolia Places client to use.
+   * The Algolia Places reference to use.
    *
    * @see https://github.com/algolia/places
    */
-  placesClient: (
+  placesReference: (
     options: StaticOptions & ReconfigurableOptions
   ) => PlacesInstance;
   /**
@@ -34,16 +34,19 @@ interface PlacesWidgetState {
 const placesWidget: WidgetFactory<PlacesWidgetOptions> = (
   widgetOptions: PlacesWidgetOptions
 ) => {
-  const { placesClient = undefined, defaultPosition = [], ...placesOptions } =
-    widgetOptions || {};
+  const {
+    placesReference = undefined,
+    defaultPosition = [],
+    ...placesOptions
+  } = widgetOptions || {};
 
-  if (typeof placesClient !== 'function') {
+  if (typeof placesReference !== 'function') {
     throw new Error(
-      'The `placesClient` option requires a valid Places.js reference.'
+      'The `placesReference` option requires a valid Places.js reference.'
     );
   }
 
-  const placesAutocomplete = placesClient(placesOptions);
+  const placesAutocomplete = placesReference(placesOptions);
 
   const state: PlacesWidgetState = {
     query: '',

--- a/stories/geo-search.stories.js
+++ b/stories/geo-search.stories.js
@@ -111,7 +111,7 @@ stories.add(
         }),
 
         places({
-          placesClient: algoliaPlaces,
+          placesReference: algoliaPlaces,
           container: placesElement,
           defaultPosition: ['37.7793', '-122.419'],
         }),

--- a/stories/geo-search.stories.js
+++ b/stories/geo-search.stories.js
@@ -2,7 +2,8 @@ import { storiesOf } from '@storybook/html';
 import { action } from '@storybook/addon-actions';
 import { withHits, withLifecycle } from '../.storybook/decorators';
 import createInfoBox from '../.storybook/utils/create-info-box';
-// import instantsearchPlacesWidget from 'places.js/instantsearchWidget';
+import algoliaPlaces from 'places.js';
+import places from '../src/widgets/places/places';
 import injectScript from 'scriptjs';
 
 const API_KEY = 'AIzaSyBawL8VbstJDdU5397SUX7pEt9DslAwWgQ';
@@ -93,38 +94,38 @@ stories
   );
 
 // With Places
-// @TODO reactivate story once the widget is compatible with 4.x.
-// stories.add(
-//   'with position from Places',
-//   withHitsAndConfigure(({ search, container, instantsearch }) =>
-//     injectGoogleMaps(() => {
-//       const placesElement = document.createElement('input');
-//       const mapElement = document.createElement('div');
-//       mapElement.style.marginTop = '20px';
+stories.add(
+  'with position from Places',
+  withHitsAndConfigure(({ search, container, instantsearch }) =>
+    injectGoogleMaps(() => {
+      const placesElement = document.createElement('input');
+      const mapElement = document.createElement('div');
+      mapElement.style.marginTop = '20px';
 
-//       container.appendChild(placesElement);
-//       container.appendChild(mapElement);
+      container.appendChild(placesElement);
+      container.appendChild(mapElement);
 
-//       search.addWidgets([
-//         instantsearch.widgets.configure({
-//           aroundRadius: 20000,
-//         }),
+      search.addWidgets([
+        instantsearch.widgets.configure({
+          aroundRadius: 20000,
+        }),
 
-//         instantsearchPlacesWidget({
-//           container: placesElement,
-//           defaultPosition: ['37.7793', '-122.419'],
-//         }),
+        places({
+          placesClient: algoliaPlaces,
+          container: placesElement,
+          defaultPosition: ['37.7793', '-122.419'],
+        }),
 
-//         instantsearch.widgets.geoSearch({
-//           googleReference: window.google,
-//           container: mapElement,
-//           enableClearMapRefinement: false,
-//           initialZoom,
-//         }),
-//       ]);
-//     })
-//   )
-// );
+        instantsearch.widgets.geoSearch({
+          googleReference: window.google,
+          container: mapElement,
+          enableClearMapRefinement: false,
+          initialZoom,
+        }),
+      ]);
+    })
+  )
+);
 
 // Only UI
 stories

--- a/yarn.lock
+++ b/yarn.lock
@@ -2733,10 +2733,10 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-autocomplete.js@^0.36.0:
-  version "0.36.0"
-  resolved "https://registry.yarnpkg.com/autocomplete.js/-/autocomplete.js-0.36.0.tgz#94fe775fe64b6cd42e622d076dc7fd26bedd837b"
-  integrity sha512-jEwUXnVMeCHHutUt10i/8ZiRaCb0Wo+ZyKxeGsYwBDtw6EJHqEeDrq4UwZRD8YBSvp3g6klP678il2eeiVXN2Q==
+autocomplete.js@^0.37.0:
+  version "0.37.0"
+  resolved "https://registry.yarnpkg.com/autocomplete.js/-/autocomplete.js-0.37.0.tgz#bcfbfd7bcabe90e90fad4c2b1aaa931379a10c38"
+  integrity sha512-MxYfNb89sl7IRhNdEJv6z8dSfA7lVeU7Dk6m/+/ih0/tPLsbxIM7uPVsnWEUh4j7dFqJktlM7hCeU7jmx6VC8A==
   dependencies:
     immediate "^3.2.3"
 
@@ -9641,14 +9641,14 @@ pkg-up@2.0.0:
   dependencies:
     find-up "^2.1.0"
 
-places.js@1.16.4:
-  version "1.16.4"
-  resolved "https://registry.yarnpkg.com/places.js/-/places.js-1.16.4.tgz#96616ce63dc675c2e60aa016633a03e9e43b2c86"
-  integrity sha512-W0AMzQyy/SD5MS6DmDuIbXJXUJ/tuBidYLywOJwPCDBz+MowPOoRaallSWgt/QwiJFDFYCePMAGMVAfW+eO5Tg==
+places.js@1.16.6:
+  version "1.16.6"
+  resolved "https://registry.yarnpkg.com/places.js/-/places.js-1.16.6.tgz#bce243f7d1a1072f9d1a60c9dccdf1c739c82ae2"
+  integrity sha512-SGDYijNL8oPBr52avj81+HL/u//Igvv6V4KmL9umkbLufgh/hbT+tl0RyaCIxt4tKtnxoFInKFiewVq4xygqrQ==
   dependencies:
     algolia-aerial "^1.5.3"
     algoliasearch "^3.31.0"
-    autocomplete.js "^0.36.0"
+    autocomplete.js "^0.37.0"
     events "^3.0.0"
     insert-css "^2.0.0"
 


### PR DESCRIPTION
## Description

The [Places.js widget for InstantSearch](https://github.com/algolia/places/blob/f9f7aa47e73d46866d71dd4d32f80d31234f86f8/src/instantsearch/widget.js) was not longer compatible with InstantSearch 4 because the widget lifecycle changed.

We'll no longer maintain the widget on the Places.js repo but rather provide a Places widget as part of InstantSearch itself. The reasoning behind this decision is that the widget hosted in Place.js couldn't be updated without also bumping Place.js to a major version. We are now more in control of when to release this widget.

This is a port of the existing widget with updated lifecycles and technical stack (TypeScript).

## Usage

```ts
import algoliaPlaces from 'places.js';

const search = instantsearch({
  /* ... */
});

search.addWidgets([
  places({
    placesReference: algoliaPlaces,
    container: '#places',
    defaultPosition: ['37.7793', '-122.419'],
  }),
]);
```

## API

So that Places.js isn't loaded with InstantSearch even though you don't use this widget, Places reference is now passed to the widget itself (similar to what we do for `searchClient`, `insightsClient` and `googleReference`).

### `placesReference`

> Places reference | required

The Algolia Places reference to use.

### `defaultPosition`

> `string[]` | optional

The default position when the input is empty.

## Preview

[See stories →](https://deploy-preview-4167--instantsearchjs.netlify.com/stories/?path=/story/results-geosearch--with-position-from-places)

## Impact

- Document the widget API on [the documentation website](https://www.algolia.com/doc/)
- Update the documentation for Place.js with InstantSearch.js 4