### PR TITLE
fix(helper): expose .lastResults to .helper

### DIFF
--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -239,6 +239,24 @@ describe('InstantSearch', () => {
 
     expect(search.insightsClient).toBe(insightsClient);
   });
+
+  it("exposes helper's last results", async () => {
+    const searchClient = createSearchClient();
+
+    const search = new InstantSearch({
+      indexName: 'indexName',
+      searchClient,
+    });
+
+    expect(search.helper).toBe(null);
+
+    search.start();
+
+    await runAllMicroTasks();
+
+    // could be null if we don't pretend the main helper is the one who searched
+    expect(search.helper.lastResults).not.toBe(null);
+  });
 });
 
 describe('addWidget(s)', () => {

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -459,11 +459,16 @@ See https://www.algolia.com/doc/guides/building-search-ui/widgets/customize-an-e
         }
       });
 
-      derivedHelper.on('result', () => {
+      derivedHelper.on('result', ({ results }) => {
         // The index does not render the results it schedules a new render
         // to let all the other indices emit their own results. It allows us to
         // run the render process in one pass.
         instantSearchInstance.scheduleRender();
+
+        // the derived helper is the one which actually searches, but the 'main'
+        // helper is exposed e.g. via instance.helper, which needs to have the
+        // results accessible as well.
+        helper!.lastResults = results;
       });
 
       localWidgets.forEach(widget => {

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -465,9 +465,10 @@ See https://www.algolia.com/doc/guides/building-search-ui/widgets/customize-an-e
         // run the render process in one pass.
         instantSearchInstance.scheduleRender();
 
-        // the derived helper is the one which actually searches, but the 'main'
-        // helper is exposed e.g. via instance.helper, which needs to have the
-        // results accessible as well.
+        // the derived helper is the one which actually searches, but the helper
+        // which is exposed e.g. via instance.helper, doesn't search, and thus
+        // does not have access to lastResults, which it used to in pre-federated
+        // search behavior.
         helper!.lastResults = results;
       });
 


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

In v3, the helper exposed on the instance is the same helper as the one who searches. This means that lastResults is set as expected.

However, with v4 we split this up in the derived helper which actually searches and the exposed helper.

This is fixed now by just setting the last results once the search is done on the derived helper.


**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

`search.helper.lastResults` is defined in cases like these: https://codesandbox.io/s/instantsearchjs-app-tkp7h
