### PR TITLE
fix: widget name in documentation link for index

### DIFF
--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -97,7 +97,7 @@ describe('index', () => {
     }).toThrowErrorMatchingInlineSnapshot(`
 "The \`indexName\` option is required.
 
-See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
+See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widget/js/"
 `);
   });
 
@@ -107,7 +107,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
     }).toThrowErrorMatchingInlineSnapshot(`
 "The \`indexName\` option is required.
 
-See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
+See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widget/js/"
 `);
   });
 
@@ -169,7 +169,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
       }).toThrowErrorMatchingInlineSnapshot(`
 "The \`addWidgets\` method expects an array of widgets.
 
-See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
+See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widget/js/"
 `);
     });
 
@@ -181,7 +181,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
       }).toThrowErrorMatchingInlineSnapshot(`
 "The widget definition expects a \`render\` and/or an \`init\` method.
 
-See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
+See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widget/js/"
 `);
     });
 
@@ -366,7 +366,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
       }).toThrowErrorMatchingInlineSnapshot(`
 "The \`removeWidgets\` method expects an array of widgets.
 
-See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
+See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widget/js/"
 `);
     });
 
@@ -378,7 +378,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
       }).toThrowErrorMatchingInlineSnapshot(`
 "The widget definition expects a \`dispose\` method.
 
-See documentation: https://www.algolia.com/doc/api-reference/widgets/index/js/"
+See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widget/js/"
 `);
     });
 

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -26,7 +26,7 @@ import {
 } from '../../lib/utils';
 
 const withUsage = createDocumentationMessageGenerator({
-  name: 'index',
+  name: 'index-widget',
 });
 
 type IndexProps = {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

For technical reason we were not able to use `index` as widget name in
the docs, so we picked instead `index-widget`.

When you misuse a widget, we output an error message with a link to the
documentation generated from the name of the widget.

**Result**

N/A
<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

