### PR TITLE
refactor(showMore): introduce `createShowMore` enhancer

### DIFF
--- a/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.js
+++ b/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.js
@@ -952,66 +952,66 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
         createURL: () => '#',
       });
 
-      const { toggleShowMore } = rendering.mock.calls[1][0];
+      const firstRenderProps = rendering.mock.calls[1][0];
 
-      expect(rendering).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          items: [
-            {
-              label: 'a',
-              value: 'a',
-              count: 880,
-              isRefined: false,
-              data: null,
-            },
-            {
-              label: 'b',
-              value: 'b',
-              count: 880,
-              isRefined: false,
-              data: null,
-            },
-          ],
-        }),
-        expect.anything()
-      );
+      expect(firstRenderProps.isShowingMore).toEqual(false);
+      expect(firstRenderProps.items).toEqual([
+        {
+          label: 'a',
+          value: 'a',
+          count: 880,
+          isRefined: false,
+          data: null,
+        },
+        {
+          label: 'b',
+          value: 'b',
+          count: 880,
+          isRefined: false,
+          data: null,
+        },
+      ]);
 
-      toggleShowMore();
+      firstRenderProps.toggleShowMore();
 
-      expect(rendering).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          items: [
-            {
-              label: 'a',
-              value: 'a',
-              count: 880,
-              isRefined: false,
-              data: null,
-            },
-            {
-              label: 'b',
-              value: 'b',
-              count: 880,
-              isRefined: false,
-              data: null,
-            },
-            {
-              label: 'c',
-              value: 'c',
-              count: 880,
-              isRefined: false,
-              data: null,
-            },
-            {
-              label: 'd',
-              value: 'd',
-              count: 880,
-              isRefined: false,
-              data: null,
-            },
-          ],
-        }),
-        expect.anything()
+      const secondRenderProps = rendering.mock.calls[2][0];
+
+      expect(secondRenderProps.isShowingMore).toEqual(true);
+      expect(secondRenderProps.items).toEqual([
+        {
+          label: 'a',
+          value: 'a',
+          count: 880,
+          isRefined: false,
+          data: null,
+        },
+        {
+          label: 'b',
+          value: 'b',
+          count: 880,
+          isRefined: false,
+          data: null,
+        },
+        {
+          label: 'c',
+          value: 'c',
+          count: 880,
+          isRefined: false,
+          data: null,
+        },
+        {
+          label: 'd',
+          value: 'd',
+          count: 880,
+          isRefined: false,
+          data: null,
+        },
+      ]);
+
+      // The reference of the function should stay the same
+      // to bind the function only once userland.
+      expect(firstRenderProps.toggleShowMore).toBe(
+        secondRenderProps.toggleShowMore
       );
     });
 
@@ -1069,60 +1069,54 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
         createURL: () => '#',
       });
 
-      const { toggleShowMore } = rendering.mock.calls[1][0];
+      const firstRenderProps = rendering.mock.calls[1][0];
 
-      expect(rendering).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          items: [
-            {
-              label: 'a',
-              value: 'a',
-              count: 880,
-              isRefined: false,
-              data: null,
-            },
-            {
-              label: 'b',
-              value: 'b',
-              count: 880,
-              isRefined: false,
-              data: null,
-            },
-          ],
-        }),
-        expect.anything()
-      );
+      expect(firstRenderProps.isShowingMore).toEqual(false);
+      expect(firstRenderProps.items).toEqual([
+        {
+          label: 'a',
+          value: 'a',
+          count: 880,
+          isRefined: false,
+          data: null,
+        },
+        {
+          label: 'b',
+          value: 'b',
+          count: 880,
+          isRefined: false,
+          data: null,
+        },
+      ]);
 
-      toggleShowMore();
+      firstRenderProps.toggleShowMore();
 
-      expect(rendering).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          items: [
-            {
-              label: 'a',
-              value: 'a',
-              count: 880,
-              isRefined: false,
-              data: null,
-            },
-            {
-              label: 'b',
-              value: 'b',
-              count: 880,
-              isRefined: false,
-              data: null,
-            },
-            {
-              label: 'c',
-              value: 'c',
-              count: 880,
-              isRefined: false,
-              data: null,
-            },
-          ],
-        }),
-        expect.anything()
-      );
+      const secondRenderProps = rendering.mock.calls[2][0];
+
+      expect(secondRenderProps.isShowingMore).toEqual(true);
+      expect(secondRenderProps.items).toEqual([
+        {
+          label: 'a',
+          value: 'a',
+          count: 880,
+          isRefined: false,
+          data: null,
+        },
+        {
+          label: 'b',
+          value: 'b',
+          count: 880,
+          isRefined: false,
+          data: null,
+        },
+        {
+          label: 'c',
+          value: 'c',
+          count: 880,
+          isRefined: false,
+          data: null,
+        },
+      ]);
     });
   });
 });

--- a/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
+++ b/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
@@ -98,9 +98,11 @@ export default function connectHierarchicalMenu(renderFn, unmountFn = noop) {
       setToggleShowMore,
       getIsShowingMore,
       getCurrentLimit,
+      getMaxValuesPerFacet,
     } = createShowMore({
       limit,
       showMoreLimit,
+      showMore,
     });
 
     return {
@@ -250,7 +252,7 @@ export default function connectHierarchicalMenu(renderFn, unmountFn = noop) {
 
         const nextMaxValuesPerFacet = Math.max(
           currentMaxValuesPerFacet,
-          showMore ? showMoreLimit : limit
+          getMaxValuesPerFacet()
         );
 
         const withMaxValuesPerFacet = withFacetConfiguration.setQueryParameter(

--- a/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
+++ b/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
@@ -96,7 +96,7 @@ export default function connectHierarchicalMenu(renderFn, unmountFn = noop) {
     const {
       toggleShowMore,
       setToggleShowMore,
-      isShowingMore,
+      getIsShowingMore,
       getCurrentLimit,
     } = createShowMore({
       limit,
@@ -125,7 +125,7 @@ export default function connectHierarchicalMenu(renderFn, unmountFn = noop) {
             refine: this._refine,
             instantSearchInstance,
             widgetParams,
-            isShowingMore: isShowingMore(),
+            isShowingMore: getIsShowingMore(),
             toggleShowMore,
             canToggleShowMore: false,
           },
@@ -144,6 +144,7 @@ export default function connectHierarchicalMenu(renderFn, unmountFn = noop) {
         } = renderOptions;
 
         const currentLimit = getCurrentLimit();
+        const isShowingMore = getIsShowingMore();
         const facetValues =
           results.getFacetValues(hierarchicalFacetName, { sortBy }).data || [];
         const items = transformItems(
@@ -176,10 +177,10 @@ export default function connectHierarchicalMenu(renderFn, unmountFn = noop) {
             createURL: _createURL,
             instantSearchInstance,
             widgetParams,
-            isShowingMore: isShowingMore(),
+            isShowingMore,
             toggleShowMore,
             canToggleShowMore:
-              showMore && (isShowingMore() || !hasExhaustiveItems),
+              showMore && (isShowingMore || !hasExhaustiveItems),
           },
           false
         );

--- a/src/connectors/menu/connectMenu.js
+++ b/src/connectors/menu/connectMenu.js
@@ -118,7 +118,7 @@ export default function connectMenu(renderFn, unmountFn = noop) {
     const {
       toggleShowMore,
       setToggleShowMore,
-      isShowingMore,
+      getIsShowingMore,
       getCurrentLimit,
     } = createShowMore({
       limit,
@@ -153,7 +153,7 @@ export default function connectMenu(renderFn, unmountFn = noop) {
             instantSearchInstance,
             canRefine: false,
             widgetParams,
-            isShowingMore: isShowingMore(),
+            isShowingMore: getIsShowingMore(),
             toggleShowMore,
             canToggleShowMore: false,
           },
@@ -167,6 +167,7 @@ export default function connectMenu(renderFn, unmountFn = noop) {
         );
 
         const currentLimit = getCurrentLimit();
+        const isShowingMore = getIsShowingMore();
         const facetValues = results.getFacetValues(attribute, { sortBy });
         const facetItems =
           facetValues && facetValues.data ? facetValues.data : [];
@@ -189,10 +190,10 @@ export default function connectMenu(renderFn, unmountFn = noop) {
             instantSearchInstance,
             canRefine: items.length > 0,
             widgetParams,
-            isShowingMore: isShowingMore(),
+            isShowingMore,
             toggleShowMore,
             canToggleShowMore:
-              showMore && (isShowingMore() || facetItems.length > currentLimit),
+              showMore && (isShowingMore || facetItems.length > currentLimit),
           },
           false
         );

--- a/src/connectors/menu/connectMenu.js
+++ b/src/connectors/menu/connectMenu.js
@@ -120,9 +120,11 @@ export default function connectMenu(renderFn, unmountFn = noop) {
       setToggleShowMore,
       getIsShowingMore,
       getCurrentLimit,
+      getMaxValuesPerFacet,
     } = createShowMore({
       limit,
       showMoreLimit,
+      showMore,
     });
 
     return {
@@ -240,7 +242,7 @@ export default function connectMenu(renderFn, unmountFn = noop) {
 
         const nextMaxValuesPerFacet = Math.max(
           currentMaxValuesPerFacet,
-          showMore ? showMoreLimit : limit
+          getMaxValuesPerFacet()
         );
 
         const withMaxValuesPerFacet = withFacetConfiguration.setQueryParameter(

--- a/src/connectors/refinement-list/connectRefinementList.js
+++ b/src/connectors/refinement-list/connectRefinementList.js
@@ -164,9 +164,11 @@ export default function connectRefinementList(renderFn, unmountFn = noop) {
       setToggleShowMore,
       getIsShowingMore,
       getCurrentLimit,
+      getMaxValuesPerFacet,
     } = createShowMore({
       limit,
       showMoreLimit,
+      showMore,
     });
 
     const render = ({
@@ -394,7 +396,7 @@ export default function connectRefinementList(renderFn, unmountFn = noop) {
 
         const nextMaxValuesPerFacet = Math.max(
           currentMaxValuesPerFacet,
-          showMore ? showMoreLimit : limit
+          getMaxValuesPerFacet()
         );
 
         const withMaxValuesPerFacet = withFacetConfiguration.setQueryParameter(

--- a/src/connectors/refinement-list/connectRefinementList.js
+++ b/src/connectors/refinement-list/connectRefinementList.js
@@ -162,7 +162,7 @@ export default function connectRefinementList(renderFn, unmountFn = noop) {
     const {
       toggleShowMore,
       setToggleShowMore,
-      isShowingMore,
+      getIsShowingMore,
       getCurrentLimit,
     } = createShowMore({
       limit,
@@ -183,6 +183,8 @@ export default function connectRefinementList(renderFn, unmountFn = noop) {
       const _createURL = facetValue =>
         createURL(state.toggleRefinement(attribute, facetValue));
 
+      const isShowingMore = getIsShowingMore();
+
       // Do not mistake searchForFacetValues and searchFacetValues which is the actual search
       // function
       const searchFacetValues =
@@ -193,11 +195,11 @@ export default function connectRefinementList(renderFn, unmountFn = noop) {
           helperSpecializedSearchFacetValues,
           refine,
           instantSearchInstance,
-          isShowingMore()
+          isShowingMore
         );
 
       const canShowLess =
-        isShowingMore() && lastResultsFromMainSearch.length > limit;
+        isShowingMore && lastResultsFromMainSearch.length > limit;
       const canShowMore = showMore && !isFromSearch && !hasExhaustiveItems;
 
       const canToggleShowMore = canShowLess || canShowMore;
@@ -212,7 +214,7 @@ export default function connectRefinementList(renderFn, unmountFn = noop) {
           isFromSearch,
           canRefine: isFromSearch || items.length > 0,
           widgetParams,
-          isShowingMore: isShowingMore(),
+          isShowingMore,
           canToggleShowMore,
           toggleShowMore,
           hasExhaustiveItems,

--- a/src/lib/enhancers/__tests__/createShowMore-test.ts
+++ b/src/lib/enhancers/__tests__/createShowMore-test.ts
@@ -5,14 +5,14 @@ describe('createShowMore', () => {
     const {
       toggleShowMore,
       setToggleShowMore,
-      isShowingMore,
+      getIsShowingMore,
     } = createShowMore();
 
-    expect(isShowingMore).toBeInstanceOf(Function);
+    expect(getIsShowingMore).toBeInstanceOf(Function);
     expect(toggleShowMore).toBeInstanceOf(Function);
     expect(setToggleShowMore).toBeInstanceOf(Function);
 
-    expect(isShowingMore()).toEqual(false);
+    expect(getIsShowingMore()).toEqual(false);
 
     const onToggleSpy = jest.fn();
     const unsubscribeOnShowMore = setToggleShowMore(onToggleSpy);
@@ -22,7 +22,7 @@ describe('createShowMore', () => {
 
     toggleShowMore();
 
-    expect(isShowingMore()).toEqual(true);
+    expect(getIsShowingMore()).toEqual(true);
     // The `onToggle` spy is called without arguments
     expect(onToggleSpy).toHaveBeenCalledTimes(1);
     expect(onToggleSpy).toHaveBeenLastCalledWith();
@@ -30,7 +30,7 @@ describe('createShowMore', () => {
     unsubscribeOnShowMore();
     toggleShowMore();
 
-    expect(isShowingMore()).toEqual(false);
+    expect(getIsShowingMore()).toEqual(false);
     // The listener is unset, so it shouldn't be called anymore
     expect(onToggleSpy).toHaveBeenCalledTimes(1);
   });

--- a/src/lib/enhancers/__tests__/createShowMore-test.ts
+++ b/src/lib/enhancers/__tests__/createShowMore-test.ts
@@ -1,0 +1,54 @@
+import { createShowMore } from '../createShowMore';
+
+describe('createShowMore', () => {
+  test('goes through the lifecycle', () => {
+    const {
+      toggleShowMore,
+      setToggleShowMore,
+      isShowingMore,
+    } = createShowMore();
+
+    expect(isShowingMore).toBeInstanceOf(Function);
+    expect(toggleShowMore).toBeInstanceOf(Function);
+    expect(setToggleShowMore).toBeInstanceOf(Function);
+
+    expect(isShowingMore()).toEqual(false);
+
+    const onToggleSpy = jest.fn();
+    const unsubscribeOnShowMore = setToggleShowMore(onToggleSpy);
+
+    // The `onToggle` spy is not called before we toggle.
+    expect(onToggleSpy).toHaveBeenCalledTimes(0);
+
+    toggleShowMore();
+
+    expect(isShowingMore()).toEqual(true);
+    // The `onToggle` spy is called without arguments
+    expect(onToggleSpy).toHaveBeenCalledTimes(1);
+    expect(onToggleSpy).toHaveBeenLastCalledWith();
+
+    unsubscribeOnShowMore();
+    toggleShowMore();
+
+    expect(isShowingMore()).toEqual(false);
+    // The listener is unset, so it shouldn't be called anymore
+    expect(onToggleSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('toggles between `limit` and `showMoreLimit`', () => {
+    const { toggleShowMore, getCurrentLimit } = createShowMore({
+      limit: 10,
+      showMoreLimit: 20,
+    });
+
+    expect(getCurrentLimit()).toEqual(10);
+
+    toggleShowMore();
+
+    expect(getCurrentLimit()).toEqual(20);
+
+    toggleShowMore();
+
+    expect(getCurrentLimit()).toEqual(10);
+  });
+});

--- a/src/lib/enhancers/__tests__/createShowMore-test.ts
+++ b/src/lib/enhancers/__tests__/createShowMore-test.ts
@@ -51,4 +51,24 @@ describe('createShowMore', () => {
 
     expect(getCurrentLimit()).toEqual(10);
   });
+
+  test('returns the `limit` as `getMaxValuesPerFacet()` when show more is not activated', () => {
+    const { getMaxValuesPerFacet } = createShowMore({
+      limit: 10,
+      showMoreLimit: 20,
+      showMore: false,
+    });
+
+    expect(getMaxValuesPerFacet()).toEqual(10);
+  });
+
+  test('returns the `showMoreLimit` as `getMaxValuesPerFacet()` when show more is not activated', () => {
+    const { getMaxValuesPerFacet } = createShowMore({
+      limit: 10,
+      showMoreLimit: 20,
+      showMore: true,
+    });
+
+    expect(getMaxValuesPerFacet()).toEqual(20);
+  });
 });

--- a/src/lib/enhancers/createShowMore.ts
+++ b/src/lib/enhancers/createShowMore.ts
@@ -17,7 +17,7 @@ interface ShowMore {
   /**
    * Returns whether the widget is currently showing more values.
    */
-  isShowingMore(): boolean;
+  getIsShowingMore(): boolean;
   /**
    * Returns the current facets limit (`limit` or `showMoreLimit`)
    */
@@ -63,7 +63,7 @@ export const createShowMore: CreateShowMore = initialState => {
   return {
     toggleShowMore: enhancerState.toggleShowMore,
     setToggleShowMore,
-    isShowingMore: enhancerState.isShowingMore,
+    getIsShowingMore: enhancerState.isShowingMore,
     getCurrentLimit: enhancerState.getLimit,
   };
 };

--- a/src/lib/enhancers/createShowMore.ts
+++ b/src/lib/enhancers/createShowMore.ts
@@ -2,6 +2,7 @@ interface ShowMoreState {
   isShowingMore: boolean;
   limit: number | null;
   showMoreLimit: number | null;
+  showMore: boolean;
 }
 
 interface ShowMore {
@@ -22,6 +23,10 @@ interface ShowMore {
    * Returns the current facets limit (`limit` or `showMoreLimit`)
    */
   getCurrentLimit(): number | null;
+  /**
+   * Returns the number of facets to retrieve from the API.
+   */
+  getMaxValuesPerFacet(): number | null;
 }
 
 type CreateShowMore = (initialState?: Partial<ShowMoreState>) => ShowMore;
@@ -34,6 +39,7 @@ export const createShowMore: CreateShowMore = initialState => {
     isShowingMore: false,
     limit: null,
     showMoreLimit: null,
+    showMore: false,
     ...initialState,
   };
 
@@ -57,13 +63,17 @@ export const createShowMore: CreateShowMore = initialState => {
   const enhancerState = {
     toggleShowMore: () => toggleShowMore(),
     isShowingMore: () => state.isShowingMore,
-    getLimit: () => (state.isShowingMore ? state.showMoreLimit : state.limit),
+    getCurrentLimit: () =>
+      state.isShowingMore ? state.showMoreLimit : state.limit,
+    getMaxValuesPerFacet: () =>
+      state.showMore ? state.showMoreLimit : state.limit,
   };
 
   return {
     toggleShowMore: enhancerState.toggleShowMore,
     setToggleShowMore,
     getIsShowingMore: enhancerState.isShowingMore,
-    getCurrentLimit: enhancerState.getLimit,
+    getCurrentLimit: enhancerState.getCurrentLimit,
+    getMaxValuesPerFacet: enhancerState.getMaxValuesPerFacet,
   };
 };

--- a/src/lib/enhancers/createShowMore.ts
+++ b/src/lib/enhancers/createShowMore.ts
@@ -1,0 +1,69 @@
+interface ShowMoreState {
+  isShowingMore: boolean;
+  limit: number | null;
+  showMoreLimit: number | null;
+}
+
+interface ShowMore {
+  /**
+   * Toggles the widget to show more or less values.
+   */
+  toggleShowMore(): void;
+  /**
+   * Sets the listener function to call whenever `toggleShowMore` is called.
+   * It returns a function to unsubscribe the listener.
+   */
+  setToggleShowMore(listener: Listener): () => void;
+  /**
+   * Returns whether the widget is currently showing more values.
+   */
+  isShowingMore(): boolean;
+  /**
+   * Returns the current facets limit (`limit` or `showMoreLimit`)
+   */
+  getCurrentLimit(): number | null;
+}
+
+type CreateShowMore = (initialState?: Partial<ShowMoreState>) => ShowMore;
+type Listener = () => void;
+
+export const createShowMore: CreateShowMore = initialState => {
+  let onToggle: Listener | null = null;
+
+  const state: ShowMoreState = {
+    isShowingMore: false,
+    limit: null,
+    showMoreLimit: null,
+    ...initialState,
+  };
+
+  function toggleShowMore() {
+    state.isShowingMore = !state.isShowingMore;
+
+    if (onToggle) {
+      onToggle();
+    }
+  }
+
+  function setToggleShowMore(listener: Listener) {
+    onToggle = listener;
+
+    return () => {
+      onToggle = null;
+    };
+  }
+
+  // Get always a fresh state with values computed via functions.
+  const enhancerState = {
+    toggleShowMore: () => toggleShowMore(),
+    isShowingMore: () => state.isShowingMore,
+    getLimit: () => (state.isShowingMore ? state.showMoreLimit : state.limit),
+  };
+
+  return {
+    toggleShowMore: enhancerState.toggleShowMore,
+    setToggleShowMore,
+    isShowingMore: enhancerState.isShowingMore,
+    getCurrentLimit: enhancerState.getLimit,
+  };
+};

--- a/src/lib/enhancers/index.ts
+++ b/src/lib/enhancers/index.ts
@@ -1,0 +1,1 @@
+export { createShowMore } from './createShowMore';


### PR DESCRIPTION
This is me again, with another proposal similar to #4128 to share logic between connectors.

## Context

The InfiniteHits has been receiving some frustrations lately because we've made it more opinionated since we support [`showPrevious`](https://www.algolia.com/doc/api-reference/widgets/infinite-hits/js/#widget-param-showprevious) and users cannot recreate the widget easily.

Loading more items is _really_ complicated in our current codebase because we need to think about caching, paging, etc. I believe having a pattern like this enhancer proposal is a first step before wanting to implement it in other widgets.

This PR _is not_ about loading more items, it's about the **show more behavior**. This pattern is slightly easier than loading more items, which is why I start with this one.

## Why

As explained in #4128, the show more behavior was duplicated in all connectors and was hard to keep track of during the widget lifecycle.

This PR is a proposal to use "enhancers" that take care of managing this scoped state of each connector.

## Solution

This is a rework of #4128 with a simpler API that in the end resembles [React hooks](https://reactjs.org/docs/hooks-intro.html).

### Usage

```ts
function connectHierarchicalMenu(renderFn, unmountFn) {
  return widgetParams => {
    const {
      // ...
      limit = 10,
      showMoreLimit = 20,
    } = widgetParams;

    // We get the updated state of the show more behavior with as initial state
    // the `limit` and `showMoreLimit` coming from the connector options.
    const {
      toggleShowMore,
      setToggleShowMore,
      isShowingMore,
      getCurrentLimit,
    } = createShowMore({
      limit,
      showMoreLimit,
    });

    return {
      // ...

      init() {
        renderFn({
          toggleShowMore,
          isShowingMore: isShowingMore(),
        });
      },

      render(renderOptions) {
        setToggleShowMore(() => this.render(renderOptions));

        renderFn({
          toggleShowMore,
          isShowingMore: isShowingMore(),
          items: items.slice(0, getCurrentLimit()),
        });
      },
    };
  };
}
```

### Reference

```ts
interface ShowMoreState {
  isShowingMore: boolean;
  limit: number | null;
  showMoreLimit: number | null;
}

createShowMore(initialState?: Partial<ShowMoreState>)

// =>
//  {
//    toggleShowMore,
//    setToggleShowMore,
//    isShowingMore,
//    getCurrentLimit,
//  }
```

## Next steps

The previous proposal (#4128) received some push back because we thought we didn't need such a solution before removing the `init` lifecycle step. I believe we do.

**If we expose this kind of enhancers to users, they will be able to create their own advanced widgets easily**. Think about creating enhancers for:

- Search For Facet Values
- Caching hits
- Show more
- etc.

If you're keen on trying this new pattern, we can try to refactor the "show previous" and "show next" behavior in an enhancer so that users can leverage it to overcome the frustrations they have with the current InfiniteHits widget.
