### PR TITLE
chore(stories): move panel to bottom

### DIFF
--- a/.storybook/config.ts
+++ b/.storybook/config.ts
@@ -20,6 +20,7 @@ addParameters({
       brandTitle: 'InstantSearch.js',
       brandUrl: 'https://github.com/algolia/instantsearch.js',
     }),
+    panelPosition: 'bottom',
     storySort(a: any[], b: any[]) {
       const categoryA = a[1].kind.split('|')[0];
       const categoryB = b[1].kind.split('|')[0];


### PR DESCRIPTION
This sets the Storybook panel position (for addons) to the bottom instead of the right. This is easier to use and to read.