### PR TITLE
fix(infiniteHits): correct widget options types

### DIFF
--- a/src/widgets/infinite-hits/infinite-hits.tsx
+++ b/src/widgets/infinite-hits/infinite-hits.tsx
@@ -88,18 +88,18 @@ export type InfiniteHitsRendererWidgetParams = {
    *
    * @default `true`
    */
-  escapeHTML: boolean;
+  escapeHTML?: boolean;
   /**
    * Enable the button to load previous results.
    *
    * @default `false`
    */
-  showPrevious: boolean;
+  showPrevious?: boolean;
   /**
    * Receives the items, and is called before displaying them.
    * Useful for mapping over the items to transform, and remove or reorder them.
    */
-  transformItems: (items: any[]) => any[];
+  transformItems?: (items: any[]) => any[];
 };
 
 interface InfiniteHitsWidgetParams extends InfiniteHitsRendererWidgetParams {
@@ -125,7 +125,7 @@ const renderer = ({
   renderState,
   templates,
   showPrevious: hasShowPrevious,
-}): InfiniteHitsRenderer<InfiniteHitsRendererWidgetParams> => (
+}): InfiniteHitsRenderer<Required<InfiniteHitsRendererWidgetParams>> => (
   {
     hits,
     results,

--- a/stories/infinite-hits.stories.ts
+++ b/stories/infinite-hits.stories.ts
@@ -2,36 +2,15 @@ import { storiesOf } from '@storybook/html';
 import { action } from '@storybook/addon-actions';
 import { withHits } from '../.storybook/decorators';
 import insights from '../src/helpers/insights';
+import { infiniteHits, configure } from '../src/widgets';
 
 storiesOf('Results|InfiniteHits', module)
   .add(
     'default',
-    withHits(({ search, container, instantsearch }) => {
+    withHits(({ search, container }) => {
       search.addWidgets([
-        instantsearch.widgets.infiniteHits({
+        infiniteHits({
           container,
-          templates: {
-            item: '{{name}}',
-          },
-        }),
-      ]);
-    })
-  )
-  .add(
-    'with custom css classes',
-    withHits(({ search, container, instantsearch }) => {
-      const style = window.document.createElement('style');
-      window.document.head.appendChild(style);
-      style.sheet.insertRule(
-        '.button button{border: 1px solid black; background: #fff;}'
-      );
-
-      search.addWidgets([
-        instantsearch.widgets.infiniteHits({
-          container,
-          cssClasses: {
-            loadMore: 'button',
-          },
           templates: {
             item: '{{name}}',
           },
@@ -41,9 +20,9 @@ storiesOf('Results|InfiniteHits', module)
   )
   .add(
     'with custom "showMoreText" template',
-    withHits(({ search, container, instantsearch }) => {
+    withHits(({ search, container }) => {
       search.addWidgets([
-        instantsearch.widgets.infiniteHits({
+        infiniteHits({
           container,
           templates: {
             item: '{{name}}',
@@ -55,9 +34,9 @@ storiesOf('Results|InfiniteHits', module)
   )
   .add(
     'with transformed items',
-    withHits(({ search, container, instantsearch }) => {
+    withHits(({ search, container }) => {
       search.addWidgets([
-        instantsearch.widgets.infiniteHits({
+        infiniteHits({
           container,
           templates: {
             item: '{{name}}',
@@ -74,16 +53,16 @@ storiesOf('Results|InfiniteHits', module)
   .add(
     'with insights helper',
     withHits(
-      ({ search, container, instantsearch }) => {
+      ({ search, container }) => {
         search.addWidgets([
-          instantsearch.widgets.configure({
+          configure({
             attributesToSnippet: ['name', 'description'],
             clickAnalytics: true,
           }),
         ]);
 
         search.addWidgets([
-          instantsearch.widgets.infiniteHits({
+          infiniteHits({
             container,
             templates: {
               item: item => `
@@ -107,9 +86,9 @@ storiesOf('Results|InfiniteHits', module)
   .add(
     'with previous button enabled',
     withHits(
-      ({ search, container, instantsearch }) => {
+      ({ search, container }) => {
         search.addWidgets([
-          instantsearch.widgets.infiniteHits({
+          infiniteHits({
             container,
             showPrevious: true,
             templates: {


### PR DESCRIPTION
Some options types were marked as required while they were not. In the stories, we should use the direct import to make sure that we leverage our types and spot this kind of issues.