### PR TITLE
fix(core): display correct object types in messages

### DIFF
--- a/src/connectors/autocomplete/__tests__/connectAutocomplete-test.ts
+++ b/src/connectors/autocomplete/__tests__/connectAutocomplete-test.ts
@@ -42,7 +42,7 @@ describe('connectAutocomplete', () => {
       // @ts-ignore
       connectAutocomplete();
     }).toThrowErrorMatchingInlineSnapshot(`
-"The render function is not valid (got type \\"undefined\\").
+"The render function is not valid (received type Undefined).
 
 See documentation: https://www.algolia.com/doc/api-reference/widgets/autocomplete/js/#connector"
 `);

--- a/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.js
+++ b/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.js
@@ -11,7 +11,7 @@ describe('connectBreadcrumb', () => {
       expect(() => {
         connectBreadcrumb()({});
       }).toThrowErrorMatchingInlineSnapshot(`
-"The render function is not valid (got type \\"undefined\\").
+"The render function is not valid (received type Undefined).
 
 See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/js/#connector"
 `);

--- a/src/connectors/clear-refinements/__tests__/connectClearRefinements-test.js
+++ b/src/connectors/clear-refinements/__tests__/connectClearRefinements-test.js
@@ -11,7 +11,7 @@ describe('connectClearRefinements', () => {
       expect(() => {
         connectClearRefinements()({});
       }).toThrowErrorMatchingInlineSnapshot(`
-"The render function is not valid (got type \\"undefined\\").
+"The render function is not valid (received type Undefined).
 
 See documentation: https://www.algolia.com/doc/api-reference/widgets/clear-refinements/js/#connector"
 `);

--- a/src/connectors/geo-search/__tests__/connectGeoSearch-test.js
+++ b/src/connectors/geo-search/__tests__/connectGeoSearch-test.js
@@ -40,7 +40,7 @@ describe('connectGeoSearch', () => {
       expect(() => {
         connectGeoSearch()({});
       }).toThrowErrorMatchingInlineSnapshot(`
-"The render function is not valid (got type \\"undefined\\").
+"The render function is not valid (received type Undefined).
 
 See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/js/#connector"
 `);

--- a/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.js
+++ b/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.js
@@ -11,7 +11,7 @@ describe('connectHierarchicalMenu', () => {
       expect(() => {
         connectHierarchicalMenu()({});
       }).toThrowErrorMatchingInlineSnapshot(`
-"The render function is not valid (got type \\"undefined\\").
+"The render function is not valid (received type Undefined).
 
 See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchical-menu/js/#connector"
 `);

--- a/src/connectors/hits/__tests__/connectHits-test.js
+++ b/src/connectors/hits/__tests__/connectHits-test.js
@@ -17,7 +17,7 @@ describe('connectHits', () => {
     expect(() => {
       connectHits()({});
     }).toThrowErrorMatchingInlineSnapshot(`
-"The render function is not valid (got type \\"undefined\\").
+"The render function is not valid (received type Undefined).
 
 See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#connector"
 `);

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -26,7 +26,7 @@ describe('connectInfiniteHits', () => {
       // @ts-ignore: test connectInfiniteHits with invalid parameters
       connectInfiniteHits()({});
     }).toThrowErrorMatchingInlineSnapshot(`
-"The render function is not valid (got type \\"undefined\\").
+"The render function is not valid (received type Undefined).
 
 See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hits/js/#connector"
 `);

--- a/src/connectors/menu/__tests__/connectMenu-test.js
+++ b/src/connectors/menu/__tests__/connectMenu-test.js
@@ -19,7 +19,7 @@ describe('connectMenu', () => {
       expect(() => {
         connectMenu()({});
       }).toThrowErrorMatchingInlineSnapshot(`
-"The render function is not valid (got type \\"undefined\\").
+"The render function is not valid (received type Undefined).
 
 See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#connector"
 `);

--- a/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.js
+++ b/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.js
@@ -44,7 +44,7 @@ describe('connectNumericMenu', () => {
       expect(() => {
         connectNumericMenu()({});
       }).toThrowErrorMatchingInlineSnapshot(`
-"The render function is not valid (got type \\"undefined\\").
+"The render function is not valid (received type Undefined).
 
 See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-menu/js/#connector"
 `);

--- a/src/connectors/pagination/__tests__/connectPagination-test.js
+++ b/src/connectors/pagination/__tests__/connectPagination-test.js
@@ -30,7 +30,7 @@ describe('connectPagination', () => {
       expect(() => {
         connectPagination()({});
       }).toThrowErrorMatchingInlineSnapshot(`
-"The render function is not valid (got type \\"undefined\\").
+"The render function is not valid (received type Undefined).
 
 See documentation: https://www.algolia.com/doc/api-reference/widgets/pagination/js/#connector"
 `);

--- a/src/connectors/powered-by/__tests__/connectPoweredBy-test.js
+++ b/src/connectors/powered-by/__tests__/connectPoweredBy-test.js
@@ -6,7 +6,7 @@ describe('connectPoweredBy', () => {
     expect(() => {
       connectPoweredBy();
     }).toThrowErrorMatchingInlineSnapshot(`
-"The render function is not valid (got type \\"undefined\\").
+"The render function is not valid (received type Undefined).
 
 See documentation: https://www.algolia.com/doc/api-reference/widgets/powered-by/js/#connector"
 `);

--- a/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
+++ b/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
@@ -41,7 +41,7 @@ describe('connectQueryRules', () => {
         // @ts-ignore
         connectQueryRules()({});
       }).toThrowErrorMatchingInlineSnapshot(`
-"The render function is not valid (got type \\"undefined\\").
+"The render function is not valid (received type Undefined).
 
 See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules/js/#connector"
 `);

--- a/src/connectors/range/__tests__/connectRange-test.js
+++ b/src/connectors/range/__tests__/connectRange-test.js
@@ -10,7 +10,7 @@ describe('connectRange', () => {
       expect(() => {
         connectRange()({});
       }).toThrowErrorMatchingInlineSnapshot(`
-"The render function is not valid (got type \\"undefined\\").
+"The render function is not valid (received type Undefined).
 
 See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input/js/#connector, https://www.algolia.com/doc/api-reference/widgets/range-slider/js/#connector"
 `);

--- a/src/connectors/rating-menu/__tests__/connectRatingMenu-test.js
+++ b/src/connectors/rating-menu/__tests__/connectRatingMenu-test.js
@@ -38,7 +38,7 @@ describe('connectRatingMenu', () => {
       expect(() => {
         connectRatingMenu()({});
       }).toThrowErrorMatchingInlineSnapshot(`
-"The render function is not valid (got type \\"undefined\\").
+"The render function is not valid (received type Undefined).
 
 See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu/js/#connector"
 `);

--- a/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
+++ b/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
@@ -14,7 +14,7 @@ describe('connectRefinementList', () => {
 
   it('throws on bad usage', () => {
     expect(connectRefinementList).toThrowErrorMatchingInlineSnapshot(`
-"The render function is not valid (got type \\"undefined\\").
+"The render function is not valid (received type Undefined).
 
 See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-list/js/#connector"
 `);
@@ -24,7 +24,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
         operator: 'and',
       })
     ).toThrowErrorMatchingInlineSnapshot(`
-"The render function is not valid (got type \\"object\\").
+"The render function is not valid (received type Object).
 
 See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-list/js/#connector"
 `);

--- a/src/connectors/search-box/__tests__/connectSearchBox-test.js
+++ b/src/connectors/search-box/__tests__/connectSearchBox-test.js
@@ -32,7 +32,7 @@ describe('connectSearchBox', () => {
       expect(() => {
         connectSearchBox()({});
       }).toThrowErrorMatchingInlineSnapshot(`
-"The render function is not valid (got type \\"undefined\\").
+"The render function is not valid (received type Undefined).
 
 See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/js/#connector"
 `);

--- a/src/connectors/sort-by/__tests__/connectSortBy-test.js
+++ b/src/connectors/sort-by/__tests__/connectSortBy-test.js
@@ -18,7 +18,7 @@ describe('connectSortBy', () => {
       expect(() => {
         connectSortBy()({});
       }).toThrowErrorMatchingInlineSnapshot(`
-"The render function is not valid (got type \\"undefined\\").
+"The render function is not valid (received type Undefined).
 
 See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/#connector"
 `);

--- a/src/connectors/stats/__tests__/connectStats-test.js
+++ b/src/connectors/stats/__tests__/connectStats-test.js
@@ -9,7 +9,7 @@ describe('connectStats', () => {
       expect(() => {
         connectStats()({});
       }).toThrowErrorMatchingInlineSnapshot(`
-"The render function is not valid (got type \\"undefined\\").
+"The render function is not valid (received type Undefined).
 
 See documentation: https://www.algolia.com/doc/api-reference/widgets/stats/js/#connector"
 `);

--- a/src/connectors/toggle-refinement/__tests__/connectToggleRefinement-test.js
+++ b/src/connectors/toggle-refinement/__tests__/connectToggleRefinement-test.js
@@ -10,7 +10,7 @@ describe('connectToggleRefinement', () => {
       expect(() => {
         connectToggleRefinement()({});
       }).toThrowErrorMatchingInlineSnapshot(`
-"The render function is not valid (got type \\"undefined\\").
+"The render function is not valid (received type Undefined).
 
 See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refinement/js/#connector"
 `);

--- a/src/connectors/voice-search/__tests__/connectVoiceSearch-test.js
+++ b/src/connectors/voice-search/__tests__/connectVoiceSearch-test.js
@@ -40,7 +40,7 @@ describe('connectVoiceSearch', () => {
       expect(() => {
         connectVoiceSearch()({});
       }).toThrowErrorMatchingInlineSnapshot(`
-"The render function is not valid (got type \\"undefined\\").
+"The render function is not valid (received type Undefined).
 
 See documentation: https://www.algolia.com/doc/api-reference/widgets/voice-search/js/#connector"
 `);

--- a/src/lib/utils/__tests__/getObjectType-test.ts
+++ b/src/lib/utils/__tests__/getObjectType-test.ts
@@ -1,0 +1,40 @@
+import getObjectType from '../getObjectType';
+
+describe('getObjectType', () => {
+  test('returns the type of a string', () => {
+    expect(getObjectType('string')).toEqual('String');
+  });
+
+  test('returns the type of a number', () => {
+    expect(getObjectType(2)).toEqual('Number');
+  });
+
+  test('returns the type of a boolean', () => {
+    expect(getObjectType(true)).toEqual('Boolean');
+    expect(getObjectType(false)).toEqual('Boolean');
+  });
+
+  test('returns the type of an object', () => {
+    expect(getObjectType({})).toEqual('Object');
+  });
+
+  test('returns the type of an array', () => {
+    expect(getObjectType([])).toEqual('Array');
+  });
+
+  test('returns the type of a date', () => {
+    expect(getObjectType(new Date())).toEqual('Date');
+  });
+
+  test('returns the type of a function', () => {
+    expect(getObjectType(function() {})).toEqual('Function');
+  });
+
+  test('returns the type of undefined', () => {
+    expect(getObjectType(undefined)).toEqual('Undefined');
+  });
+
+  test('returns the type of null', () => {
+    expect(getObjectType(null)).toEqual('Null');
+  });
+});

--- a/src/lib/utils/checkRendering.ts
+++ b/src/lib/utils/checkRendering.ts
@@ -1,8 +1,11 @@
 import { Renderer } from '../../types/connector';
+import getObjectType from './getObjectType';
 
 function checkRendering(rendering: Renderer, usage: string): void {
   if (rendering === undefined || typeof rendering !== 'function') {
-    throw new Error(`The render function is not valid (got type "${typeof rendering}").
+    throw new Error(`The render function is not valid (received type ${getObjectType(
+      rendering
+    )}).
 
 ${usage}`);
   }

--- a/src/lib/utils/getObjectType.ts
+++ b/src/lib/utils/getObjectType.ts
@@ -1,0 +1,5 @@
+function getObjectType(object: unknown): string {
+  return Object.prototype.toString.call(object).slice(8, -1);
+}
+
+export default getObjectType;

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -11,6 +11,7 @@ export { default as escapeRefinement } from './escapeRefinement';
 export { default as unescapeRefinement } from './unescapeRefinement';
 export { default as checkRendering } from './checkRendering';
 export { default as getPropertyByPath } from './getPropertyByPath';
+export { default as getObjectType } from './getObjectType';
 export { default as noop } from './noop';
 export { default as isFiniteNumber } from './isFiniteNumber';
 export { default as isPlainObject } from './isPlainObject';

--- a/src/widgets/panel/__tests__/panel-test.js
+++ b/src/widgets/panel/__tests__/panel-test.js
@@ -50,7 +50,7 @@ describe('Usage', () => {
         hidden: true,
       });
     }).toWarnDev(
-      '[InstantSearch.js]: The `hidden` option in the "panel" widget expects a function returning a boolean (received "boolean" type).'
+      '[InstantSearch.js]: The `hidden` option in the "panel" widget expects a function returning a boolean (received type Boolean).'
     );
   });
 
@@ -60,7 +60,7 @@ describe('Usage', () => {
         collapsed: true,
       });
     }).toWarnDev(
-      '[InstantSearch.js]: The `collapsed` option in the "panel" widget expects a function returning a boolean (received "boolean" type).'
+      '[InstantSearch.js]: The `collapsed` option in the "panel" widget expects a function returning a boolean (received type Boolean).'
     );
   });
 

--- a/src/widgets/panel/panel.js
+++ b/src/widgets/panel/panel.js
@@ -7,6 +7,7 @@ import {
   prepareTemplateProps,
   warning,
   createDocumentationMessageGenerator,
+  getObjectType,
 } from '../../lib/utils';
 import { component } from '../../lib/suit';
 import Panel from '../../components/Panel/Panel';
@@ -90,12 +91,16 @@ export default function panel({
 } = {}) {
   warning(
     typeof hidden === 'function',
-    `The \`hidden\` option in the "panel" widget expects a function returning a boolean (received "${typeof hidden}" type).`
+    `The \`hidden\` option in the "panel" widget expects a function returning a boolean (received type ${getObjectType(
+      hidden
+    )}).`
   );
 
   warning(
     typeof collapsed === 'undefined' || typeof collapsed === 'function',
-    `The \`collapsed\` option in the "panel" widget expects a function returning a boolean (received "${typeof collapsed}" type).`
+    `The \`collapsed\` option in the "panel" widget expects a function returning a boolean (received type ${getObjectType(
+      collapsed
+    )}).`
   );
 
   const bodyContainerNode = document.createElement('div');


### PR DESCRIPTION
This PR a follow-up on https://github.com/algolia/instantsearch.js/pull/4233#discussion_r354507001 and aims at displaying more accurate error messages when users don't provide right data types in widgets.

The way we extract the object types is similar to what [Redux Devtools does](https://github.com/reduxjs/redux-devtools/blob/03d1448dc3c47ffd75a8cf07f21399b86d557988/packages/react-json-tree/src/objType.js).