### PR TITLE
chore(typescript): add type-check:js command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,9 +55,6 @@ jobs:
       - run:
           name: Type Checking
           command: yarn run type-check
-      - run:
-          name: Type Checking including JS files
-          command: yarn run type-check:js || echo ''
 
   test_unit:
     <<: *defaults
@@ -85,6 +82,18 @@ jobs:
             yarn run website:build
             yarn run test:e2e:saucelabs
 
+  test_type_check_js:
+    <<: *defaults
+    steps:
+      - checkout
+      - run: *install_yarn_version
+      - restore_cache: *restore_yarn_cache
+      - run: *run_yarn_install
+      - save_cache: *save_yarn_cache
+      - run:
+          name: Type Checking including JS files
+          command: yarn run type-check:js
+
 workflows:
   version: 2
   ci:
@@ -92,4 +101,5 @@ workflows:
       - test_build
       - test_unit
       - test_lint
+      - test_type_check_js
       - test_e2e

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
             yarn run website:build
             yarn run test:e2e:saucelabs
 
-  test_type_check_js:
+  'type check js (optional)':
     <<: *defaults
     steps:
       - checkout
@@ -101,5 +101,5 @@ workflows:
       - test_build
       - test_unit
       - test_lint
-      - test_type_check_js
+      - type check js (optional)
       - test_e2e

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,9 @@ jobs:
       - run:
           name: Type Checking
           command: yarn run type-check
+      - run:
+          name: Type Checking including JS files
+          command: yarn run type-check:js || echo ''
 
   test_unit:
     <<: *defaults

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "lint": "eslint --ext .js,.ts,.tsx .",
     "lint:fix": "eslint --ext .js,.ts,.tsx --fix .",
     "type-check": "tsc",
+    "type-check:js": "tsc -p tsconfig.checkjs.json",
     "type-check:watch": "yarn type-check --watch",
     "test": "jest",
     "test:watch": "jest --watch --bail",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lint": "eslint --ext .js,.ts,.tsx .",
     "lint:fix": "eslint --ext .js,.ts,.tsx --fix .",
     "type-check": "tsc",
-    "type-check:js": "tsc -p tsconfig.checkjs.json",
+    "type-check:js": "tsc --project tsconfig.checkjs.json",
     "type-check:watch": "yarn type-check --watch",
     "test": "jest",
     "test:watch": "jest --watch --bail",

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true
+  },
+  "include": ["src", "./global.d.ts"],
+  "exclude": ["**/__tests__"]
+}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

Following https://github.com/algolia/instantsearch.js/pull/4220 this change adds a new `type-check:js` command that run `tsc` on all TypeScript and JavaScript files. This will allow us to see the remaining errors in the JavaScript files and fix them progressively (by updating the JSDocs or migrating JS files to TS).

This command is run by the CI and always pass ([We cannot allow a test to fail on CircleCI](https://discuss.circleci.com/t/can-we-allow-a-job-to-fail-in-a-workflow/23343)) so we do not block the CI with the existing errors.

When all errors will be fixed the `tsconfig.checkjs.json` config will be merged with the default `tsconfig.json` and this command removed.
