### PR TITLE
fix(insights): move 'insightsClient not provided error' to wrapper level

### DIFF
--- a/src/lib/__tests__/insights-client-test.ts
+++ b/src/lib/__tests__/insights-client-test.ts
@@ -86,10 +86,11 @@ describe('withInsights', () => {
       expect(renderProps).toHaveProperty('insights');
       expect(renderProps.insights).toBeInstanceOf(Function);
     });
-
-    it('should not expose the insights client wrapper to renderOptions if not passed to instantSearchInstance', () => {
+    it('should expose the insights client wrapper even when insightsClient was not provided', () => {
       const renderFn = jest.fn();
-      const instantSearchInstance = { insightsClient: undefined };
+      const instantSearchInstance = {
+        /* insightsClient was not passed */
+      };
       const results = {
         index: 'theIndex',
         hits: [
@@ -102,7 +103,34 @@ describe('withInsights', () => {
       createWidgetWithInsights({ renderFn, instantSearchInstance, results });
 
       const [renderProps] = renderFn.mock.calls[0];
-      expect(renderProps).not.toHaveProperty('insights');
+      expect(renderProps).toHaveProperty('insights');
+      expect(renderProps.insights).toBeInstanceOf(Function);
+    });
+    it('should expose the insights client wrapper that throws when insightsClient was not provided', () => {
+      const renderFn = jest.fn();
+      const instantSearchInstance = {
+        /* insightsClient was not passed */
+      };
+      const results = {
+        index: 'theIndex',
+        hits: [
+          { objectID: '1', __queryID: 'theQueryID', __position: 9 },
+          { objectID: '2', __queryID: 'theQueryID', __position: 10 },
+          { objectID: '3', __queryID: 'theQueryID', __position: 11 },
+          { objectID: '4', __queryID: 'theQueryID', __position: 12 },
+        ],
+      };
+      createWidgetWithInsights({ renderFn, instantSearchInstance, results });
+
+      const [renderProps] = renderFn.mock.calls[0];
+      expect(() => {
+        renderProps.insights('clickedObjectIDsAfterSearch', {
+          eventName: 'add to favorites',
+          objectIDs: ['1'],
+        });
+      }).toThrowErrorMatchingInlineSnapshot(
+        `"The \`insightsClient\` option has not been provided to \`instantsearch\`."`
+      );
     });
   });
 

--- a/src/lib/__tests__/insights-client-test.ts
+++ b/src/lib/__tests__/insights-client-test.ts
@@ -128,9 +128,11 @@ describe('withInsights', () => {
           eventName: 'add to favorites',
           objectIDs: ['1'],
         });
-      }).toThrowErrorMatchingInlineSnapshot(
-        `"The \`insightsClient\` option has not been provided to \`instantsearch\`."`
-      );
+      }).toThrowErrorMatchingInlineSnapshot(`
+"The \`insightsClient\` option has not been provided to \`instantsearch\`.
+
+See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/"
+`);
     });
   });
 

--- a/src/lib/insights/client.ts
+++ b/src/lib/insights/client.ts
@@ -1,5 +1,5 @@
 import { SearchResults } from 'algoliasearch-helper';
-import { uniq, find } from '../utils';
+import { uniq, find, createDocumentationMessageGenerator } from '../utils';
 import {
   Hits,
   InsightsClient,
@@ -83,8 +83,13 @@ const wrapInsightsClient = (
   payload: Partial<InsightsClientPayload>
 ) => {
   if (!aa) {
+    const withInstantSearchUsage = createDocumentationMessageGenerator({
+      name: 'instantsearch',
+    });
     throw new Error(
-      'The `insightsClient` option has not been provided to `instantsearch`.'
+      withInstantSearchUsage(
+        'The `insightsClient` option has not been provided to `instantsearch`.'
+      )
     );
   }
   if (!Array.isArray(payload.objectIDs)) {

--- a/src/lib/insights/client.ts
+++ b/src/lib/insights/client.ts
@@ -75,13 +75,18 @@ export const inferPayload = ({
 };
 
 const wrapInsightsClient = (
-  aa: InsightsClient,
+  aa: InsightsClient | null,
   results: SearchResults,
   hits: Hits
 ): InsightsClientWrapper => (
   method: InsightsClientMethod,
   payload: Partial<InsightsClientPayload>
 ) => {
+  if (!aa) {
+    throw new Error(
+      'The `insightsClient` option has not been provided to `instantsearch`.'
+    );
+  }
   if (!Array.isArray(payload.objectIDs)) {
     throw new TypeError('Expected `objectIDs` to be an array.');
   }
@@ -109,12 +114,7 @@ export default function withInsights(
     isFirstRender: boolean
   ) => {
     const { results, hits, instantSearchInstance } = renderOptions;
-    if (
-      results &&
-      hits &&
-      instantSearchInstance &&
-      instantSearchInstance.insightsClient /* providing the insightsClient is optional */
-    ) {
+    if (results && hits && instantSearchInstance) {
       const insights = wrapInsightsClient(
         instantSearchInstance.insightsClient,
         results,

--- a/src/lib/insights/listener.tsx
+++ b/src/lib/insights/listener.tsx
@@ -26,11 +26,6 @@ const findInsightsTarget = (
 const insightsListener = (BaseComponent: any) => {
   function WithInsightsListener(props: WithInsightsListenerProps) {
     const handleClick = (event: MouseEvent): void => {
-      if (!props.insights) {
-        throw new Error(
-          'The `insightsClient` option has not been provided to `instantsearch`.'
-        );
-      }
       const insightsTarget = findInsightsTarget(
         event.target as HTMLElement | null,
         event.currentTarget as HTMLElement | null

--- a/src/widgets/infinite-hits/__tests__/__snapshots__/infinite-hits-test.ts.snap
+++ b/src/widgets/infinite-hits/__tests__/__snapshots__/infinite-hits-test.ts.snap
@@ -239,7 +239,7 @@ Object {
       "transformed": true,
     },
   ],
-  "insights": undefined,
+  "insights": [Function],
   "isFirstPage": true,
   "isLastPage": false,
   "results": Object {

--- a/stories/hits.stories.js
+++ b/stories/hits.stories.js
@@ -140,4 +140,36 @@ storiesOf('Results|Hits', module)
           action(`[InsightsClient] sent ${method} with payload`)(payload),
       }
     )
+  )
+  .add(
+    'with insights helper when insightsClient has not been provided',
+    withHits(
+      ({ search, container, instantsearch }) => {
+        search.addWidgets([
+          instantsearch.widgets.configure({
+            attributesToSnippet: ['name', 'description'],
+            clickAnalytics: true,
+          }),
+        ]);
+
+        search.addWidgets([
+          instantsearch.widgets.hits({
+            container,
+            templates: {
+              item: item => `
+          <h4>${item.name}</h4>
+          <button
+            ${insights('clickedObjectIDsAfterSearch', {
+              objectIDs: [item.objectID],
+              eventName: 'Add to cart',
+            })} >Add to cart</button>
+          `,
+            },
+          }),
+        ]);
+      },
+      {
+        /* insightsClient not provided */
+      }
+    )
   );

--- a/stories/hits.stories.js
+++ b/stories/hits.stories.js
@@ -140,36 +140,4 @@ storiesOf('Results|Hits', module)
           action(`[InsightsClient] sent ${method} with payload`)(payload),
       }
     )
-  )
-  .add(
-    'with insights helper when insightsClient has not been provided',
-    withHits(
-      ({ search, container, instantsearch }) => {
-        search.addWidgets([
-          instantsearch.widgets.configure({
-            attributesToSnippet: ['name', 'description'],
-            clickAnalytics: true,
-          }),
-        ]);
-
-        search.addWidgets([
-          instantsearch.widgets.hits({
-            container,
-            templates: {
-              item: item => `
-          <h4>${item.name}</h4>
-          <button
-            ${insights('clickedObjectIDsAfterSearch', {
-              objectIDs: [item.objectID],
-              eventName: 'Add to cart',
-            })} >Add to cart</button>
-          `,
-            },
-          }),
-        ]);
-      },
-      {
-        /* insightsClient not provided */
-      }
-    )
   );


### PR DESCRIPTION
**Summary**

Prior to this change, this error was fired in the click listeners. As a result, users who used a custom component (and therefore a custom listeners) could never see it (they saw instead: insights is `TypeError: insights is not a function`).

Now the insightsClient wrapper itself is responsible for throwing this error.

This also fixes a bug introduced in https://github.com/algolia/instantsearch.js/pull/4197 when the `if (!props.insights) { ... }` was accidentaly brought on top of the handler.

This is not breaking change.

fixes #4269 

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

[View Story →](https://deploy-preview-4254--instantsearchjs.netlify.com/stories/?path=/story/results-hits--with-insights-helper-when-insightsclient-has-not-been-provided)