### PR TITLE
fix(index): fix warning for widgets sharing connectors

### DIFF
--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -1506,12 +1506,15 @@ describe('UI state', () => {
           menu: {
             category: 'Hardware',
           },
+          places: {
+            query: 'Paris',
+            location: ['1', '1'],
+          },
           // This is a UI parameter that is not supported by default but that
           // can be added when using custom widgets. Having it in `initialUiState`
           // makes sure that it doesn't throw if it happens.
-          anotherWidget: {
-            query: 'Paris',
-            location: ['1', '1'],
+          customWidget: {
+            query: 'Custom query',
           },
         },
       },
@@ -1536,6 +1539,7 @@ To fully reflect the state, some widgets need to be added to the index "indexNam
 - \`hierarchicalMenu\` needs one of these widgets: "hierarchicalMenu"
 - \`range\` needs one of these widgets: "rangeInput", "rangeSlider"
 - \`menu\` needs one of these widgets: "menu", "menuSelect"
+- \`places\` needs one of these widgets: "places"
 
 If you do not wish to display widgets but still want to support their search parameters, you can mount "virtual widgets" that don't render anything:
 
@@ -1543,14 +1547,14 @@ If you do not wish to display widgets but still want to support their search par
 const virtualPagination = connectPagination(() => null);
 const virtualRefinementList = connectRefinementList(() => null);
 const virtualHierarchicalMenu = connectHierarchicalMenu(() => null);
-const virtualRange = connectRange(() => null);
+const virtualRangeInput = connectRange(() => null);
 const virtualMenu = connectMenu(() => null);
 
 search.addWidgets([
   virtualPagination({ /* ... */ }),
   virtualRefinementList({ /* ... */ }),
   virtualHierarchicalMenu({ /* ... */ }),
-  virtualRange({ /* ... */ }),
+  virtualRangeInput({ /* ... */ }),
   virtualMenu({ /* ... */ })
 ]);
 \`\`\`


### PR DESCRIPTION
The development warning about inconsistent states warned about wrong information since #4249 for the `range*` widgets. This happened because we were checking for a `$$type` of `ais.range` while they're now `ais.rangeInput` and `ais.rangeSlider`.

Since there's a bit more logic now, I included the `places` widget in the test to make sure the warning also worked with widgets that don't use a connector.