### PR TITLE
fix(insights): export Insights helper in the ESM build

### DIFF
--- a/src/index.es.ts
+++ b/src/index.es.ts
@@ -1,7 +1,7 @@
 import { InstantSearchOptions } from './types';
 import InstantSearch from './lib/InstantSearch';
 import version from './lib/version';
-import { snippet, highlight } from './helpers';
+import { snippet, highlight, insights } from './helpers';
 
 const instantsearch = (options: InstantSearchOptions): InstantSearch =>
   new InstantSearch(options);
@@ -9,6 +9,7 @@ const instantsearch = (options: InstantSearchOptions): InstantSearch =>
 instantsearch.version = version;
 instantsearch.snippet = snippet;
 instantsearch.highlight = highlight;
+instantsearch.insights = insights;
 
 Object.defineProperty(instantsearch, 'widgets', {
   get() {


### PR DESCRIPTION
We never exported the `insights` helper in the ESM build, so the function was never usable. This fixes it by exporting the `insights` helper as we do for `highlight` and `snippet`.