### PR TITLE
fix(configureRelatedItems): use `facetFilters` to exclude `objectID`

### DIFF
--- a/src/connectors/configure-related-items/__tests__/connectConfigureRelatedItems-test-bridge.ts
+++ b/src/connectors/configure-related-items/__tests__/connectConfigureRelatedItems-test-bridge.ts
@@ -29,7 +29,7 @@ describe('connectConfigureRelatedItems - bridge', () => {
     expect(makeWidget).toHaveBeenCalledTimes(1);
     expect(makeWidget).toHaveBeenCalledWith({
       searchParameters: expect.objectContaining({
-        filters: 'NOT objectID:1',
+        facetFilters: ['objectID:-1'],
         optionalFilters: [],
         sumOrFiltersScores: true,
       }),

--- a/src/connectors/configure-related-items/__tests__/connectConfigureRelatedItems-test.ts
+++ b/src/connectors/configure-related-items/__tests__/connectConfigureRelatedItems-test.ts
@@ -121,7 +121,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure-r
           indexName: 'indexName',
           params: {
             facets: [],
-            filters: 'NOT objectID:1',
+            facetFilters: ['objectID:-1'],
             tagFilters: '',
             sumOrFiltersScores: true,
             optionalFilters: [
@@ -167,7 +167,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure-r
           indexName: 'indexName',
           params: {
             facets: [],
-            filters: 'NOT objectID:1',
+            facetFilters: ['objectID:-1'],
             tagFilters: '',
             sumOrFiltersScores: true,
             optionalFilters: [
@@ -228,7 +228,7 @@ See https://www.algolia.com/doc/api-reference/api-parameters/optionalFilters/`);
           indexName: 'indexName',
           params: {
             facets: [],
-            filters: 'NOT objectID:1',
+            facetFilters: ['objectID:-1'],
             tagFilters: '',
             sumOrFiltersScores: true,
             optionalFilters: [

--- a/src/connectors/configure-related-items/connectConfigureRelatedItems.ts
+++ b/src/connectors/configure-related-items/connectConfigureRelatedItems.ts
@@ -136,7 +136,7 @@ See https://www.algolia.com/doc/api-reference/api-parameters/optionalFilters/
           // `sumOrFiltersScores`.
           // See https://github.com/algolia/algoliasearch-helper-js/pull/753
           sumOrFiltersScores: true,
-          filters: `NOT objectID:${hit.objectID}`,
+          facetFilters: [`objectID:-${hit.objectID}`],
           // @ts-ignore @TODO algoliasearch-helper@3.0.1 will contain the type
           // `optionalFilters`.
           // See https://github.com/algolia/algoliasearch-helper-js/pull/754


### PR DESCRIPTION
This changes how we exclude the `objectID` when using `ConfigureRelatedItems`.

## Problem

`objectID`s can contain many special characters:

- `\`
- `"`
- `<`
- `>`
- `\n`
- etc.

These special characters don't play well with the `filters` search parameter because they cannot be escaped without the engine to interpret them differently.

## Using `facetFilters`

Escaping is challenging and somehow impossible when excluding a refinement using [`filters`](https://www.algolia.com/doc/api-reference/api-parameters/filters/):

```
{ filters: NOT objectID:123 }
```

The SQL-like syntax makes the engine less flexible as to what characters to accept.

Using [`facetFilters`](https://www.algolia.com/doc/api-reference/api-parameters/facetFilters/) makes it easier because the syntax is less ambiguous:

```
{ facetFilters: ['objectID:-123'] }
```

With this syntax, the engine understand the values as longed as they're escaped.

We don't need to escape any values because the following would exclude the object ID `-123` as expected:

```
{ facetFilters: ['objectID:--123'] }
```

## Escaping

When using `facetFilters` and `optionalFilters`, all generated refinements will be correctly escaped by our stack and sent to the API:

- `"` → `\"`
- `\` → `\\`
- `\n` → `\n` (we need to keep it)
- `<` → `<` (we need to keep it even for `optionalFilters`)
- `>` → `>` (we need to keep it even for `optionalFilters`)

If some of these values were passed to `filters`, the Algolia API would return an error.