### PR TITLE
chore: use tagName instead of releaseTag in link to release in slack notification

### DIFF
--- a/ship.config.js
+++ b/ship.config.js
@@ -22,7 +22,7 @@ module.exports = {
     releaseSuccess: ({
       appName,
       version,
-      releaseTag,
+      tagName,
       latestCommitHash,
       latestCommitUrl,
       repoURL,
@@ -50,7 +50,7 @@ module.exports = {
         },
         {
           title: 'Release',
-          value: `${repoURL}/releases/tag/${releaseTag}`,
+          value: `${repoURL}/releases/tag/${tagName}`,
         },
       ],
     }),


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

Fix link to release in slack notification as in 
https://github.com/algolia/shipjs/pull/609

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

