### PR TITLE
chore(release): publish `experimental-typescript`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -224,10 +224,13 @@ To generate the experimental TypeScript version for a particular release, run:
 
 ```sh
 git checkout v4.X.X
-VERSION=4.X.X-experimental-typescript.X node ./scripts/release/bump-package-version.js
-yarn build
-yarn build:types
-sed -i '/"main":/ a \ "types": "es/index.d.ts",' package.json # Add `types` entry in `package.json`
+./scripts/release/build-experimental-typescript.js
+```
+
+To publish it, run:
+
+```
 npm publish --tag experimental-typescript
-git checkout .
+# or
+yarn publish --no-git-tag-version --non-interactive --tag experimental-typescript
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,10 +220,9 @@ An experimental version containing the TypeScript declaration files is available
 
 Since some of these declaration files are generated from the JSDoc comments, they can contain some typing errors. This version will stay experimental until we are confident enough in the generated declarations to put them in a stable release.
 
-To generate the experimental TypeScript version for a particular release, run:
+To generate the experimental TypeScript version for a particular (stable) release, run:
 
 ```sh
-git checkout v4.X.X
 ./scripts/release/build-experimental-typescript.js
 ```
 

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "scriptjs": "2.5.9",
     "semver": "6.3.0",
     "shelljs": "0.8.3",
-    "shipjs": "0.14.0",
+    "shipjs": "0.14.1",
     "typescript": "3.7.5",
     "webpack": "4.41.5"
   },

--- a/scripts/release/build-experimental-typescript.js
+++ b/scripts/release/build-experimental-typescript.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+/* eslint-disable import/no-commonjs */
+const fs = require('fs');
+const path = require('path');
+const shell = require('shelljs');
+
+const packageJsonPath = path.resolve('package.json');
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath).toString());
+const { version: currentVersion } = packageJson;
+const newVersion = `${currentVersion}-experimental-typescript`;
+packageJson.version = newVersion;
+packageJson.types = 'es/index.d.ts';
+fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+
+fs.writeFileSync(
+  path.resolve('src', 'lib', 'version.ts'),
+  `export default '${newVersion}';\n`
+);
+
+shell.exec('yarn build');
+shell.exec('yarn build:types');

--- a/ship.config.js
+++ b/ship.config.js
@@ -14,11 +14,13 @@ module.exports = {
     exec('yarn doctoc');
   },
   pullRequestTeamReviewer: ['instantsearch-for-websites'],
-  afterPublish: ({ exec }) => {
-    exec('./scripts/release/build-experimental-typescript.js');
-    exec(
-      `yarn publish --no-git-tag-version --non-interactive --tag experimental-typescript`
-    );
+  afterPublish: ({ exec, version, releaseTag }) => {
+    if (releaseTag === 'latest' && version.startsWith('4.')) {
+      exec('./scripts/release/build-experimental-typescript.js');
+      exec(
+        `yarn publish --no-git-tag-version --non-interactive --tag experimental-typescript`
+      );
+    }
   },
   slack: {
     // disable slack notification for `prepared` and `releaseStart` lifecycle.

--- a/ship.config.js
+++ b/ship.config.js
@@ -14,6 +14,12 @@ module.exports = {
     exec('yarn doctoc');
   },
   pullRequestTeamReviewer: ['instantsearch-for-websites'],
+  afterPublish: ({ exec }) => {
+    exec('./scripts/release/build-experimental-typescript.js');
+    exec(
+      `yarn publish --no-git-tag-version --non-interactive --tag experimental-typescript`
+    );
+  },
   slack: {
     // disable slack notification for `prepared` and `releaseStart` lifecycle.
     // Ship.js will send slack message only for `releaseSuccess`.

--- a/yarn.lock
+++ b/yarn.lock
@@ -13100,10 +13100,10 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-shipjs-lib@0.14.0:
-  version "0.14.0"
-  resolved "https://registry.npmjs.org/shipjs-lib/-/shipjs-lib-0.14.0.tgz#3c06bb520bc1c8074d617ff97d8488ae71257c00"
-  integrity sha512-3knIgkIMQLRLRdfryL2mPwnnOENAOG+3ooHajclA4fPYzVfZsBriNrf9/n1ejWv7ZYayUXMlvon/NawjxmJOPA==
+shipjs-lib@0.14.1:
+  version "0.14.1"
+  resolved "https://registry.npmjs.org/shipjs-lib/-/shipjs-lib-0.14.1.tgz#6392e64b9e14c9c5c6c97e5d472463896100c6c4"
+  integrity sha512-xoNF8u5TiVN5K7ao1As1Bh++dELLdc8Kf9Poq6Fa81DuhmLo4HVnolaGo/Z+oakbfg/Sa6jTiPQvX03d6tO1hg==
   dependencies:
     deepmerge "^4.2.2"
     dotenv "^8.1.0"
@@ -13111,10 +13111,10 @@ shipjs-lib@0.14.0:
     semver "6.3.0"
     shelljs "0.8.3"
 
-shipjs@0.14.0:
-  version "0.14.0"
-  resolved "https://registry.npmjs.org/shipjs/-/shipjs-0.14.0.tgz#acd094feed177d02b94786b132cf8bbabb971966"
-  integrity sha512-nyyEfW+DXDYowhKM0hxh99Y4Uew1CWDqOuIweQtDGnNYb+dXSjyeqD7uwjaqXZ22T5miMMUOeVZQiYiB03O0VA==
+shipjs@0.14.1:
+  version "0.14.1"
+  resolved "https://registry.npmjs.org/shipjs/-/shipjs-0.14.1.tgz#927c8cf30392b4519c223b43728d8486573a548c"
+  integrity sha512-7zG1ZlCqQhk2V8XTnYjJ+DAAFyuQYj/v/Ihjt4U93jw//WA46+u+Qyey5KdOcsXggk7ePQZkpKwmyFapW2KcWw==
   dependencies:
     "@babel/runtime" "^7.6.3"
     "@octokit/rest" "^16.35.0"
@@ -13135,7 +13135,7 @@ shipjs@0.14.0:
     prettier "^1.18.2"
     serialize-javascript "^2.1.0"
     shell-quote "^1.7.2"
-    shipjs-lib "0.14.0"
+    shipjs-lib "0.14.1"
     temp-write "4.0.0"
     tempfile "^3.0.0"
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR updates the release flow to publish `experimental-typescript` build by default after publishing a normal version.

The addition in `ship.config.js` is the following:

```js
  afterPublish: ({ exec }) => {
    exec('./scripts/release/build-experimental-typescript.js');
    exec(
      `yarn publish --no-git-tag-version --non-interactive --tag experimental-typescript`
    );
  },
```

If you want, you can run `./scripts/release/build-experimental-typescript.js` on your computer. It will create a build with the typescript definition files.

To actually publish it, you can run either

`yarn publish --no-git-tag-version --non-interactive --tag experimental-typescript`
or
`npm publish --tag experimental-typescript`

We normally use yarn, so I put the yarn version in `ship.config.js`.