### PR TITLE
chore: do not run test again before publish

### DIFF
--- a/ship.config.js
+++ b/ship.config.js
@@ -14,6 +14,7 @@ module.exports = {
     exec('yarn doctoc');
   },
   pullRequestTeamReviewer: ['instantsearch-for-websites'],
+  testCommandBeforeRelease: () => 'echo "No need to test again."',
   afterPublish: ({ exec, version, releaseTag }) => {
     if (releaseTag === 'latest' && version.startsWith('4.')) {
       exec('./scripts/release/build-experimental-typescript.js');


### PR DESCRIPTION
if not given, its default value is:

```js
testCommandBeforeRelease: ({ isYarn }) =>
    isYarn ? 'yarn test' : 'npm run test',
```