### PR TITLE
chore: update contributing guide for maintenance and next versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,14 +181,14 @@ JavaScript and TypeScript files are validated using a combination of [Prettier](
 To release a stable version, go on `master` (`git checkout master`) and use:
 
 ```sh
-npm run release
+npm run release:prepare
 ```
 
-_Make sure to use `npm run` instead of `yarn run` to avoid issues._
+It will create a pull-request for next release. When it's reviewed, approved and merged, then CircleCI will automatically publish it to NPM.
 
-### Maintenance version
+### Maintenance version (v3 or below)
 
-For the maintenance version, go on maintenance (`git checkout maintenance`) and use:
+For the maintenance version, go on a maintenance branch(e.g., `git checkout maintenance-v3`) and use:
 
 ```sh
 npm run release:maintenance
@@ -196,23 +196,16 @@ npm run release:maintenance
 
 _Make sure to use `npm run` instead of `yarn run` to avoid issues._
 
-#### Beta version
+#### `next` version
 
-Beta version release is available on any branch except `master`, `maintenance`. The main use cases are for releasing a patch before the official release, or create custom builds with new features (or friday releases).
-
-If you're on a feature branch (either for a fix or a new minor/major version), you can run:
+`next` version release is available on `next` branch. It is to release the next major version in beta.
 
 ```sh
-npm run release
+git checkout next
+npm run release:prepare
 ```
 
-You can release beta versions from any branch, using the beta flag in the command line:
-
-```sh
-npm run release -- --beta
-```
-
-_Make sure to use `npm run` instead of `yarn run` to avoid issues._
+The script will ask you a question about the next version. If it's wrong, you can say "No" and put something like "7.0.0-beta.0". Then it will create a pull-request for that release. When the pull-request is merged, CircleCI will publish it to NPM with `--tag beta` option.
 
 #### Experimental TypeScript version
 
@@ -226,10 +219,12 @@ To generate the experimental TypeScript version for a particular (stable) releas
 ./scripts/release/build-experimental-typescript.js
 ```
 
-To publish it, run:
+To publish it manually, run:
 
 ```
 npm publish --tag experimental-typescript
 # or
 yarn publish --no-git-tag-version --non-interactive --tag experimental-typescript
 ```
+
+_Note that this build will be automatically published along with stable version v4.x.x by Ship.js._

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,7 +181,7 @@ JavaScript and TypeScript files are validated using a combination of [Prettier](
 To release a stable version, go on `master` (`git checkout master`) and use:
 
 ```sh
-npm run release:prepare
+yarn run release:prepare
 ```
 
 It will create a pull request for the next release. When it's reviewed, approved and merged, then CircleCI will automatically publish it to npm.
@@ -202,7 +202,7 @@ _Make sure to use `npm run` instead of `yarn run` to avoid issues._
 
 ```sh
 git checkout next
-npm run release:prepare
+yarn run release:prepare
 ```
 
 The script will ask you a question about the next version. If it's wrong, you can say "No" and specify the version (e.g. "7.0.0-beta.0"). Then, it will open a pull request for that release. When the pull request is merged, CircleCI will publish it to npm with a `--tag beta` argument.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,11 +184,11 @@ To release a stable version, go on `master` (`git checkout master`) and use:
 npm run release:prepare
 ```
 
-It will create a pull-request for next release. When it's reviewed, approved and merged, then CircleCI will automatically publish it to NPM.
+It will create a pull request for the next release. When it's reviewed, approved and merged, then CircleCI will automatically publish it to npm.
 
-### Maintenance version (v3 or below)
+### Maintenance versions
 
-For the maintenance version, go on a maintenance branch(e.g., `git checkout maintenance-v3`) and use:
+For the maintenance versions, go to a previous version branch (e.g., `git checkout v3`) and use:
 
 ```sh
 npm run release:maintenance
@@ -198,14 +198,14 @@ _Make sure to use `npm run` instead of `yarn run` to avoid issues._
 
 #### `next` version
 
-`next` version release is available on `next` branch. It is to release the next major version in beta.
+`next` version release is available on the `next` branch. It is used to release the next major version in beta.
 
 ```sh
 git checkout next
 npm run release:prepare
 ```
 
-The script will ask you a question about the next version. If it's wrong, you can say "No" and put something like "7.0.0-beta.0". Then it will create a pull-request for that release. When the pull-request is merged, CircleCI will publish it to NPM with `--tag beta` option.
+The script will ask you a question about the next version. If it's wrong, you can say "No" and specify the version (e.g. "7.0.0-beta.0"). Then, it will open a pull request for that release. When the pull request is merged, CircleCI will publish it to npm with a `--tag beta` argument.
 
 #### Experimental TypeScript version
 
@@ -227,4 +227,4 @@ npm publish --tag experimental-typescript
 yarn publish --no-git-tag-version --non-interactive --tag experimental-typescript
 ```
 
-_Note that this build will be automatically published along with stable version v4.x.x by Ship.js._
+_Note that this build will be automatically published along with the current stable version by Ship.js._

--- a/ship.config.js
+++ b/ship.config.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const path = require('path');
 
 module.exports = {
-  mergeStrategy: { toSameBranch: ['master'] },
+  mergeStrategy: { toSameBranch: ['master', 'next'] },
   versionUpdated: ({ version, dir }) => {
     fs.writeFileSync(
       path.resolve(dir, 'src', 'lib', 'version.ts'),


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR updates the contributing guide for maintenance and next versions. The changes in the `CONTRIBUTING.md` isn't much, and the following is my rationale behind the changes.

## maintenance

If we check out `maintenance-v3` branch, there is no Ship.js, but there is still `publish-maintenance.sh`. So we can continue to use it. I don't know how many times we will publish the old versions. But, if you think we need Ship.js for `v3`, let me know. I will create another PR to add Ship.js to `maintenance-v3` branch.

## next

For now, the major is v4. If we start preparing v5, and we want to release v5 in alpha or beta, then we will need Ship.js. There is nothing much to do for that. I updated `ship.config.js` like this:

```js
mergeStrategy: { toSameBranch: ['master'] },
// to
mergeStrategy: { toSameBranch: ['master', 'next'] },
```

Now if we create `next` branch from `master`, it will have Ship.js and this config. And if we run `yarn release:prepare`, it will run just the same. Since we do not have any Ship.js config which is specific to v4, the current config will work fine with `next`, too.

If we today create `next` branch, and add a `feat` commit, run `yarn release:prepare`, then Ship.js will think the next version is `4.3.0` (because the current version is `4.2.0`). That's okay, because Ship.js will ask you if the next version is `4.3.0`, we say "no", and we type `5.0.0-alpha.0` or `5.0.0-beta.0`. Then after that, Ship.js will automatically put that `alpha`, `beta` or whatever as a tag when publishing it to NPM.

## hotfix

When we had both `develop` and `master`, if we needed a hotfix, we should've checked out a new branch from `master`, add commits and publish from it. Now that we have only `master`, we can publish fixes from `master` whenever we need. So there is no particular process for hotfix.