### PR TITLE
feat(helper): forward events from indices

### DIFF
--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -338,7 +338,7 @@ const index = (props: IndexProps): Index => {
         }
       });
 
-      derivedHelper.on('search', () => {
+      derivedHelper.on('search', event => {
         // The index does not manage the "staleness" of the search. This is the
         // responsibility of the main instance. It does not make sense to manage
         // it at the index level because it's either: all of them or none of them
@@ -515,9 +515,11 @@ If you're using custom widgets that do set these query parameters, we recommend 
 See https://www.algolia.com/doc/guides/building-search-ui/widgets/customize-an-existing-widget/js/#customize-the-complete-ui-of-the-widgets`
           );
         }
+
+        helper!.emit('search', event);
       });
 
-      derivedHelper.on('result', ({ results }) => {
+      derivedHelper.on('result', event => {
         // The index does not render the results it schedules a new render
         // to let all the other indices emit their own results. It allows us to
         // run the render process in one pass.
@@ -527,7 +529,11 @@ See https://www.algolia.com/doc/guides/building-search-ui/widgets/customize-an-e
         // which is exposed e.g. via instance.helper, doesn't search, and thus
         // does not have access to lastResults, which it used to in pre-federated
         // search behavior.
-        helper!.lastResults = results;
+        helper!.lastResults = event.results;
+
+        // similarly, there is no longer a "result" event on the main helper,
+        // so we will proxy this event
+        helper!.emit('result', event);
       });
 
       localWidgets.forEach(widget => {


### PR DESCRIPTION
This fixes a confusion when you want to listen to helper events (like change and result), but they aren't fired, since the root helper is not the actual one searching (the extra helper in the index is).

I'm making the PR so it can be found back in the future, but I don't think we should go for this now, since it encourages helper usage.

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

