### PR TITLE
WIP: pattern router

### DIFF
--- a/examples/media/index.html
+++ b/examples/media/index.html
@@ -15,7 +15,7 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css?family=Roboto"
     />
-    <link rel="stylesheet" href="main.css" />
+    <link rel="stylesheet" href="/main.css" />
   </head>
 
   <body>
@@ -24,8 +24,8 @@
         <a
           href="https://community.algolia.com/instantsearch.js/"
           class="is-logo"
-          ><img src="logo-is.png" width="40"/></a
-        ><a href="./" class="logo">You<i class="fa fa-youtube-play"></i></a>
+          ><img src="/logo-is.png" width="40"/></a
+        ><a href="/" class="logo">You<i class="fa fa-youtube-play"></i></a>
       </div>
       <div class="searchbox-container" id="searchbox"></div>
     </header>
@@ -57,7 +57,7 @@
 
     <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,Array.prototype.includes"></script>
     <script src="https://cdn.jsdelivr.net/npm/algoliasearch@4.0.0-beta.13/dist/algoliasearch-lite.umd.min.js"></script>
-    <script src="instantsearch.production.min.js"></script>
-    <script src="search.js"></script>
+    <script src="/instantsearch.production.min.js"></script>
+    <script src="/search.js"></script>
   </body>
 </html>

--- a/examples/media/search.js
+++ b/examples/media/search.js
@@ -3,7 +3,46 @@
 var search = instantsearch({
   indexName: 'movies',
   searchClient: algoliasearch('latency', '6be0576ff61c053d5f9a3225e2a90f76'),
-  routing: true,
+  routing: {
+    router: instantsearch.routers.pattern({
+      // Notes:
+      // has to start with /
+      // stateMapping to a flat object is required for any key in the path
+      // never put two optional values adjacent
+      //   - ambiguous when first value is empty
+      // value can not be empty string, but can be undefined
+      //   - make sure you filter out empty strings in stateToRoute
+      // unlisted parameters go to query string.
+      pattern: '/genre/:genre*/rating/:rating?',
+    }),
+    stateMapping: {
+      stateToRoute({ movies: indexUiState = {} } = {}) {
+        const {
+          query,
+          refinementList: { genre } = {},
+          ratingMenu: { rating } = {},
+        } = indexUiState;
+        return {
+          query,
+          genre,
+          rating,
+        };
+      },
+      routeToState({ query, genre, rating } = {}) {
+        return {
+          movies: {
+            query,
+            refinementList: {
+              genre,
+            },
+            ratingMenu: {
+              rating,
+            },
+          },
+        };
+      },
+    },
+  },
 });
 
 search.addWidgets([

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "classnames": "^2.2.5",
     "events": "^1.1.0",
     "hogan.js": "^3.0.2",
+    "path-to-regexp": "6.1.0",
     "preact": "^10.0.0",
     "prop-types": "^15.5.10",
     "qs": "^6.5.1"

--- a/src/lib/routers/index.ts
+++ b/src/lib/routers/index.ts
@@ -1,1 +1,3 @@
 export { default as history } from './history';
+// TODO: I'd like to call this patternRouter, but that's inconsistent with the history router
+export { default as pattern } from './pattern';

--- a/src/lib/routers/pattern.ts
+++ b/src/lib/routers/pattern.ts
@@ -22,9 +22,10 @@ export default function patternRouter<TRouteState extends object = UiState>({
     decode: decodeURIComponent,
   });
   const pathParameters = parse(pattern)
-    .filter(token => typeof token === 'object')
-    // TODO: why do I need to guard twice here? TS complained
-    .map(token => (typeof token === 'object' ? token.name : ''));
+    .filter(
+      <TKey>(token: TKey | string): token is TKey => typeof token !== 'string'
+    )
+    .map(token => token.name);
 
   let onPopState: (event: PopStateEvent) => void | undefined;
   let writeTimer: number | undefined;

--- a/src/lib/routers/pattern.ts
+++ b/src/lib/routers/pattern.ts
@@ -1,0 +1,127 @@
+import { match, compile, parse } from 'path-to-regexp';
+import qs from 'qs';
+import { Router, UiState } from '../../types';
+
+const setWindowTitle = (title?: string): void => {
+  if (title) {
+    window.document.title = title;
+  }
+};
+
+export default function patternRouter<TRouteState extends object = UiState>({
+  pattern,
+  windowTitle,
+  writeDelay = 400,
+}: {
+  pattern: string;
+  windowTitle?: (routeState: TRouteState) => string;
+  writeDelay?: number;
+}) {
+  const toPath = compile<TRouteState>(pattern, { encode: encodeURIComponent });
+  const urlToParts = match<TRouteState>(pattern, {
+    decode: decodeURIComponent,
+  });
+  const pathParameters = parse(pattern)
+    .filter(token => typeof token === 'object')
+    // TODO: why do I need to guard twice here? TS complained
+    .map(token => (typeof token === 'object' ? token.name : ''));
+
+  let onPopState: (event: PopStateEvent) => void | undefined;
+  let writeTimer: number | undefined;
+
+  function parseURL(url: URL) {
+    const res = urlToParts(url.pathname);
+
+    if (res === false) {
+      return {} as TRouteState;
+    }
+
+    const queryParams = qs.parse(url.search, {
+      arrayLimit: 99,
+      ignoreQueryPrefix: true,
+    }) as TRouteState;
+
+    return Object.assign({}, res.params, queryParams);
+  }
+
+  const router: Router<TRouteState> = {
+    createURL(state) {
+      // TODO: decide whether URL is needed here, or just location methods are fine?
+      const url = new URL(window.location.href);
+
+      url.pathname = toPath(state);
+
+      // TODO: do this without needing polyfills
+      const queryState = Object.fromEntries(
+        Object.entries(state).filter(
+          ([key]) => pathParameters.indexOf(key) === -1
+        )
+      );
+
+      url.search = qs.stringify(queryState, { addQueryPrefix: true });
+
+      return url.toString();
+    },
+
+    write(routeState) {
+      const url = router.createURL(routeState);
+
+      const title = windowTitle && windowTitle(routeState);
+
+      if (writeTimer) {
+        window.clearTimeout(writeTimer);
+      }
+
+      writeTimer = window.setTimeout(() => {
+        setWindowTitle(title);
+
+        window.history.pushState(routeState, title || '', url);
+        writeTimer = undefined;
+      }, writeDelay);
+    },
+
+    read() {
+      return parseURL(new URL(window.location.href));
+    },
+
+    onUpdate(callback) {
+      onPopState = event => {
+        if (writeTimer) {
+          window.clearTimeout(writeTimer);
+          writeTimer = undefined;
+        }
+
+        const routeState = event.state;
+
+        // At initial load, the state is read from the URL without update.
+        // Therefore the state object is not available.
+        // In this case, we fallback and read the URL.
+        if (!routeState) {
+          callback(this.read());
+        } else {
+          callback(routeState);
+        }
+      };
+
+      window.addEventListener('popstate', onPopState);
+    },
+
+    dispose() {
+      if (onPopState) {
+        window.removeEventListener('popstate', onPopState);
+      }
+
+      if (writeTimer) {
+        window.clearTimeout(writeTimer);
+      }
+
+      this.write({} as TRouteState);
+    },
+  };
+
+  const title = windowTitle && windowTitle(router.read());
+
+  setWindowTitle(title);
+
+  return router;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11841,6 +11841,11 @@ path-to-regexp@0.1.7:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
+path-to-regexp@6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.1.0.tgz#0b18f88b7a0ce0bfae6a25990c909ab86f512427"
+  integrity sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==
+
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"


### PR DESCRIPTION
This is a proof of concept of a new router, its advantage is that it's way more readable than a classic SEO history router. I will write an RFC on this once there's a first batch of rough feedback.

The example usage is in the media example, so that

Things to think about:

- how do we deal with this dependency?
- is this something we want to offer
- technically: clean up the "omit" part for which params go to query string
- do people want more control over e.g. hash parameters?
- do we need a polyfill of URL in the docs, or do we rewrite it to not need it?
- naming?  we can't both call the parameter "pattern", as well as the router
- does this become an option in historyRouter instead of a separate router?

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

