### PR TITLE
chore: validate conditions before release

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "scriptjs": "2.5.9",
     "semver": "6.3.0",
     "shelljs": "0.8.3",
-    "shipjs": "0.14.2",
+    "shipjs": "0.15.0",
     "typescript": "3.7.5",
     "webpack": "4.41.5"
   },

--- a/scripts/rollup/config.js
+++ b/scripts/rollup/config.js
@@ -5,7 +5,7 @@ import replace from 'rollup-plugin-replace';
 import { uglify } from 'rollup-plugin-uglify';
 import filesize from 'rollup-plugin-filesize';
 
-if (process.env.SHIPJS === 'true' && !process.env.VERSION) {
+if (process.env.NODE_ENV === 'production' && !process.env.VERSION) {
   throw new Error(
     'You need to specify an environment variable `VERSION` to run the build process.'
   );

--- a/scripts/rollup/config.js
+++ b/scripts/rollup/config.js
@@ -6,16 +6,13 @@ import { uglify } from 'rollup-plugin-uglify';
 import filesize from 'rollup-plugin-filesize';
 import semver from 'semver';
 
-if (process.env.NODE_ENV === 'production') {
-  if (!process.env.VERSION) {
-    throw new Error(
-      'You need to specify an environment variable `VERSION` to run the build process.'
-    );
-  }
-
-  if (!semver.valid(process.env.VERSION)) {
-    throw new Error(`${process.env.VERSION} is not a valid semver.`);
-  }
+if (
+  process.env.NODE_ENV === 'production' &&
+  !semver.valid(process.env.VERSION)
+) {
+  throw new Error(
+    `You need to specify a valid semver environment variable 'VERSION' to run the build process (received: '${process.env.VERSION}').`
+  );
 }
 
 const version =

--- a/scripts/rollup/config.js
+++ b/scripts/rollup/config.js
@@ -5,6 +5,12 @@ import replace from 'rollup-plugin-replace';
 import { uglify } from 'rollup-plugin-uglify';
 import filesize from 'rollup-plugin-filesize';
 
+if (process.env.SHIPJS === 'true' && !process.env.VERSION) {
+  throw new Error(
+    'You need to specify an environment variable `VERSION` to run the build process.'
+  );
+}
+
 const version =
   process.env.VERSION || `UNRELEASED (${new Date().toUTCString()})`;
 const algolia = '© Algolia, Inc. and contributors; MIT License';

--- a/scripts/rollup/config.js
+++ b/scripts/rollup/config.js
@@ -4,11 +4,18 @@ import babel from 'rollup-plugin-babel';
 import replace from 'rollup-plugin-replace';
 import { uglify } from 'rollup-plugin-uglify';
 import filesize from 'rollup-plugin-filesize';
+import semver from 'semver';
 
-if (process.env.NODE_ENV === 'production' && !process.env.VERSION) {
-  throw new Error(
-    'You need to specify an environment variable `VERSION` to run the build process.'
-  );
+if (process.env.NODE_ENV === 'production') {
+  if (!process.env.VERSION) {
+    throw new Error(
+      'You need to specify an environment variable `VERSION` to run the build process.'
+    );
+  }
+
+  if (!semver.valid(process.env.VERSION)) {
+    throw new Error(`${process.env.VERSION} is not a valid semver.`);
+  }
 }
 
 const version =

--- a/scripts/rollup/config.js
+++ b/scripts/rollup/config.js
@@ -11,7 +11,7 @@ if (
   !semver.valid(process.env.VERSION)
 ) {
   throw new Error(
-    `You need to specify a valid semver environment variable 'VERSION' to run the build process (received: '${process.env.VERSION}').`
+    `You need to specify a valid semver environment variable 'VERSION' to run the build process (received: JSON.stringify(${process.env.VERSION})).`
   );
 }
 

--- a/scripts/rollup/config.js
+++ b/scripts/rollup/config.js
@@ -11,7 +11,7 @@ if (
   !semver.valid(process.env.VERSION)
 ) {
   throw new Error(
-    `You need to specify a valid semver environment variable 'VERSION' to run the build process (received: JSON.stringify(${process.env.VERSION})).`
+    `You need to specify a valid semver environment variable 'VERSION' to run the build process (received: ${JSON.stringify(process.env.VERSION)}).`
   );
 }
 

--- a/ship.config.js
+++ b/ship.config.js
@@ -4,6 +4,13 @@ const path = require('path');
 
 module.exports = {
   mergeStrategy: { toSameBranch: ['master', 'next'] },
+  shouldPrepare: ({ releaseType, commitNumbersPerType }) => {
+    const { fix = 0 } = commitNumbersPerType;
+    if (releaseType === 'patch' && fix === 0) {
+      return false;
+    }
+    return true;
+  },
   versionUpdated: ({ version, dir }) => {
     fs.writeFileSync(
       path.resolve(dir, 'src', 'lib', 'version.ts'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3628,10 +3628,10 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
-arg@4.1.2:
-  version "4.1.2"
-  resolved "https://registry.npmjs.org/arg/-/arg-4.1.2.tgz#e70c90579e02c63d80e3ad4e31d8bfdb8bd50064"
-  integrity sha512-+ytCkGcBtHZ3V2r2Z06AncYO8jz46UEamcspGoU8lHcEbpn6J77QK0vdWvChsclg/tM5XIJC5tnjmPp7Eq6Obg==
+arg@4.1.3:
+  version "4.1.3"
+  resolved "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 arg@^4.1.0:
   version "4.1.1"
@@ -13727,10 +13727,10 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-shipjs-lib@0.14.2:
-  version "0.14.2"
-  resolved "https://registry.npmjs.org/shipjs-lib/-/shipjs-lib-0.14.2.tgz#fd0ffa371212e16b82595a46ecffceb12857aa04"
-  integrity sha512-lQjFRDk9o+0QCZdjC/00na849HLvX/heJQDdumEK1pkZJhh7S5Ws90egFjIBiMe56mD/XZ2tbnNkycFCAbnU2w==
+shipjs-lib@0.15.0:
+  version "0.15.0"
+  resolved "https://registry.npmjs.org/shipjs-lib/-/shipjs-lib-0.15.0.tgz#82d613632e3dab0e2075c576b1b027b8dc1e981a"
+  integrity sha512-d2rFWj21s8MIOm/fYMka4jm3rspKw8duY3oRUTudSG/8IHCWX8w1seuh2xLekMWK8ym4q0zcBM9xkMmvRacbZQ==
   dependencies:
     deepmerge "^4.2.2"
     dotenv "^8.1.0"
@@ -13738,16 +13738,16 @@ shipjs-lib@0.14.2:
     semver "6.3.0"
     shelljs "0.8.3"
 
-shipjs@0.14.2:
-  version "0.14.2"
-  resolved "https://registry.npmjs.org/shipjs/-/shipjs-0.14.2.tgz#be87e0b4235b2967bf0479bc93f011b21ae79ada"
-  integrity sha512-w1SEiGylSjxh3tRR2GRf8kUjrZfEJjj6WkA9RHGI+QIYKpHYIkFyoW4cJ7nJuKTQEg0nT4JHyJaQQ/6mw9HqsA==
+shipjs@0.15.0:
+  version "0.15.0"
+  resolved "https://registry.npmjs.org/shipjs/-/shipjs-0.15.0.tgz#6a4e060944b19b06252286072a19e73ced04e9e3"
+  integrity sha512-iAtPwwYCBU5H99n30cH5Gt/cHNoOjQ4Oyq+BI5lp/02bB+6D4qL4hLqpy2/+RXFmntsXrQWCTdbzU5JOXetA5g==
   dependencies:
     "@babel/runtime" "^7.6.3"
     "@octokit/rest" "^16.35.0"
     "@slack/webhook" "^5.0.1"
     add-stream "^1.0.0"
-    arg "4.1.2"
+    arg "4.1.3"
     chalk "3.0.0"
     change-case "4.1.1"
     conventional-changelog "^3.1.15"
@@ -13762,7 +13762,7 @@ shipjs@0.14.2:
     prettier "^1.18.2"
     serialize-javascript "^2.1.0"
     shell-quote "^1.7.2"
-    shipjs-lib "0.14.2"
+    shipjs-lib "0.15.0"
     temp-write "4.0.0"
     tempfile "^3.0.0"
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR actually does two things but they're small enough, so I put it in a same PR and both of them depends on the new update of Ship.js@0.15.0.

## 1. Missing `VERSION`

When SHIPJS=true and VERSION is undefined, rollup will throw an exception to prevent having a `UNRELEASE` comment in released bundle.

https://unpkg.com/instantsearch.js@4.2.0/dist/instantsearch.production.min.js

## 2. Skipping preparation when there's nothing important

When it's a patch release and if there are only chores but no fixes, then `yarn release:prepare` will skip and won't create a PR. What do you think of this behavior? With rules like this, we can later automate `yarn release:prepare`.