### PR TITLE
chore(deps): update dependency algoliasearch-helper to v3.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "scripts/transforms"
   ],
   "dependencies": {
-    "algoliasearch-helper": "^3.1.0",
+    "algoliasearch-helper": "^3.1.1",
     "classnames": "^2.2.5",
     "events": "^1.1.0",
     "hogan.js": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3408,10 +3408,10 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-algoliasearch-helper@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.1.0.tgz#f8725bd6f0d1f515955d720ccd617a3af4ac695f"
-  integrity sha512-d48U2GIsGJr/fVV+W7Z1Ud6GWLSblKQgA71M254YNtxvniKFsbI0Z6hQZ/8yodfGWHjJ4dETeb7ihGKQaXihUw==
+algoliasearch-helper@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.1.1.tgz#4cdfbaed6670d82626ac1fae001ccbf53192f497"
+  integrity sha512-Jkqlp8jezQRixf7sbQ2zFXHpdaT41g9sHBqT6pztv5nfDmg94K+pwesAy6UbxRY78IL54LIaV1FLttMtT+IzzA==
   dependencies:
     events "^1.1.1"
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR updates `algoliasearch-helper` to v3.1.1. This is required for us to build and distribute the UMD package with the latest `algoliasearch-helper` version.

**Result**

This update fixes a case where refinements for a facets with a name that matches a substring of another one could be cleared by mistakes. For more information see the original PR in `algoliasearch-helper` https://github.com/algolia/algoliasearch-helper-js/pull/760
