### PR TITLE
Revert "chore: release v4.3.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,3 @@
-# [4.3.0](https://github.com/algolia/instantsearch.js/compare/v4.2.0...v4.3.0) (2020-02-25)
-
-This version fixes a case where refinements for a facet with a name that matches a substring of another facet could be cleared by mistake. The fix was addressed in the [helper of the library](https://github.com/algolia/algoliasearch-helper-js/pull/760).
-
-### Bug Fixes
-
-* **deps:** update dependency algoliasearch-helper to v3.1.1 ([#4335](https://github.com/algolia/instantsearch.js/issues/4335)) ([9bc66cf](https://github.com/algolia/instantsearch.js/commit/381cda05c9c51dc9d3245a6d926e3c919245b723))
-
-
-### Features
-
-* **highlight:** add cssClasses to snippet & highlight helper ([#4306](https://github.com/algolia/instantsearch.js/issues/4306)) ([ece0aa6](https://github.com/algolia/instantsearch.js/commit/ece0aa60f05c2c687a23f9219d62ace0d5b866f9))
-
-
-
 # [4.2.0](https://github.com/algolia/instantsearch.js/compare/v4.1.1...v4.2.0) (2020-01-23)
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ If this guide does not contain what you are looking for and thus prevents you fr
 - [Linting](#linting)
 - [Release](#release)
   - [Main version](#main-version)
-  - [Maintenance versions](#maintenance-versions)
+  - [Maintenance version](#maintenance-version)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instantsearch.js",
-  "version": "4.3.0",
+  "version": "4.2.0",
   "description": "InstantSearch.js is a JavaScript library for building performant and instant search experiences with Algolia.",
   "homepage": "https://community.algolia.com/instantsearch.js/",
   "keywords": [

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,1 +1,1 @@
-export default '4.3.0';
+export default '4.2.0';


### PR DESCRIPTION
Reverts algolia/instantsearch.js#4336 due to an error in the release process.