### PR TITLE
fix(refinementList): prevent XSS via routing

### DIFF
--- a/src/components/RefinementList/RefinementList.js
+++ b/src/components/RefinementList/RefinementList.js
@@ -51,6 +51,7 @@ class RefinementList extends Component {
       url,
       attribute: this.props.attribute,
       cssClasses: this.props.cssClasses,
+      isFromSearch: this.props.isFromSearch,
     };
 
     let { value: key } = facetValue;

--- a/src/widgets/refinement-list/__tests__/__snapshots__/refinement-list-test.js.snap
+++ b/src/widgets/refinement-list/__tests__/__snapshots__/refinement-list-test.js.snap
@@ -59,7 +59,7 @@ Object {
          class=\\"{{cssClasses.checkbox}}\\"
          value=\\"{{value}}\\"
          {{#isRefined}}checked{{/isRefined}} />
-  <span class=\\"{{cssClasses.labelText}}\\">{{{highlighted}}}</span>
+  <span class=\\"{{cssClasses.labelText}}\\">{{#isFromSearch}}{{{highlighted}}}{{/isFromSearch}}{{^isFromSearch}}{{highlighted}}{{/isFromSearch}}</span>
   <span class=\\"{{cssClasses.count}}\\">{{#helpers.formatNumber}}{{count}}{{/helpers.formatNumber}}</span>
 </label>",
       "loadingIndicator": "

--- a/src/widgets/refinement-list/defaultTemplates.js
+++ b/src/widgets/refinement-list/defaultTemplates.js
@@ -4,7 +4,7 @@ export default {
          class="{{cssClasses.checkbox}}"
          value="{{value}}"
          {{#isRefined}}checked{{/isRefined}} />
-  <span class="{{cssClasses.labelText}}">{{{highlighted}}}</span>
+  <span class="{{cssClasses.labelText}}">{{#isFromSearch}}{{{highlighted}}}{{/isFromSearch}}{{^isFromSearch}}{{highlighted}}{{/isFromSearch}}</span>
   <span class="{{cssClasses.count}}">{{#helpers.formatNumber}}{{count}}{{/helpers.formatNumber}}</span>
 </label>`,
   showMoreText: `


### PR DESCRIPTION
There's a security issue with the [`refinementList`](https://www.algolia.com/doc/api-reference/widgets/refinement-list/js/) widget when relying on its default template and routing.

[Security issue demonstration →](https://instantsearchjs.netlify.com/examples/e-commerce/search/?brands=Samsung%22%3E%3Ciframe%2fonload%3dalert%28%22xss%22%29%3E)

## Why this is an issue

**Malicious users could inject some JavaScript code** via the URL to get specific information. This is [Cross-Site Scripting](https://en.wikipedia.org/wiki/Cross-site_scripting) (XSS) vulnerability.

## Why this happens

We use `{{{highlighted}}}` in the default [`item` template of the `refinementList` widget](https://github.com/algolia/instantsearch.js/blob/933d9ffb3c0a396a047eeb4b44733b17aa31d081/src/widgets/refinement-list/defaultTemplates.js#L7). The triple braces in [Hogan.js](https://twitter.github.io/hogan.js/) means that it doesn't escape the value, and uses the [`setInnerHTML`](https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML) method under the hood. Therefore, **HTML can be injected**. The issue comes from the fact that we allow users to select refinement list items from the URL, which means that it's not safe to use this method.

We use triple braces in the template because when SFFV (Searching For Facet Values), we highlight the matches with HTML tags. This specific case is not as dangerous because we don't synchronize the SFFV values in the URL.

## This solution

We can switch to using `{{highlighted}}` by default. This means that HTML won't be interpreted. When we detect that we're coming from a search (`props.isFromSearch` in the `RefinementList` component), we can safely rely on `{{{highlighted}}}` because SFFV are not synced with the URL.

We therefore conditionally use the "dangerous" value when it cannot come from the URL.

## Migration plan

This solution is the one that I think will be the less transparent for users. Very few (if not none) users must rely on facet values containing HTML and the triple brace Hogan syntax. If so, **this fix is more important than considering this as a breaking change to speed up the adoption of the next minor version**. We'll therefore be explicit about this security fix in the changelog if ever it breaks some apps, which again, is very unlikely.

## Other considerations

**Vue InstantSearch is vulnerable to the same attack.** [This happens](https://vue-instantsearch.netlify.com/examples/e-commerce/search/?brands=Samsung%2522%253E%253Ciframe%252Fonload%253Dalert%28%2522xss%2522%29%253E) because we rely on [`innerHTML` in the `ais-highlight`component](https://github.com/algolia/vue-instantsearch/blob/785c74fbf373a1a849d507e1a3c2a24e2c1cf8db/src/components/Highlight.vue#L4).

**We should be more careful with values generated from the URL.** This will also be true with values injected in the UI state more generally. We should think about rejecting values that cannot happen, since you're not supposed to be able to generate facet values via the URL. This is out of scope for now.

**We can delay the documentation for this new `isFromSearch` template property**. We shouldn't wait for the documentation update in the [`templates` section](https://www.algolia.com/doc/api-reference/widgets/refinement-list/js/#templates) before releasing a new version.