### PR TITLE
chore(favours-types): replaces interfaces by types

### DIFF
--- a/examples/e-commerce/src/routing.ts
+++ b/examples/e-commerce/src/routing.ts
@@ -7,7 +7,7 @@ import {
   getFallbackRatingsRoutingValue,
 } from './widgets';
 
-interface RouteState {
+type RouteState = {
   query?: string;
   page?: string;
   brands?: string[];
@@ -17,9 +17,9 @@ interface RouteState {
   free_shipping?: string;
   sortBy?: string;
   hitsPerPage?: string;
-}
+};
 
-interface UiState {
+type UiState = {
   query?: string;
   page?: string;
   hierarchicalMenu?: {
@@ -39,7 +39,7 @@ interface UiState {
   };
   sortBy?: string;
   hitsPerPage?: number;
-}
+};
 
 const routeStateDefaultValues = {
   query: '',

--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -15,7 +15,7 @@ type PanelComponentCSSClasses = Omit<
   'collapseIcon'
 >;
 
-interface PanelProps {
+type PanelProps = {
   hidden: boolean;
   collapsible: boolean;
   isCollapsed: boolean;
@@ -23,7 +23,7 @@ interface PanelProps {
   cssClasses: PanelComponentCSSClasses;
   templates: PanelTemplates;
   bodyElement: HTMLElement;
-}
+};
 
 function Panel(props: PanelProps) {
   const [isCollapsed, setIsCollapsed] = useState<boolean>(props.isCollapsed);

--- a/src/connectors/autocomplete/connectAutocomplete.ts
+++ b/src/connectors/autocomplete/connectAutocomplete.ts
@@ -20,28 +20,27 @@ const withUsage = createDocumentationMessageGenerator({
   connector: true,
 });
 
-interface AutocompleteIndex {
+type AutocompleteIndex = {
   indexName: string;
   hits: Hits;
   results: SearchResults;
-}
+};
 
-interface AutocompleteConnectorParams {
+type AutocompleteConnectorParams = {
   /**
    * Escapes HTML entities from hits string values.
    *
    * @default `true`
    */
   escapeHTML?: boolean;
-}
+};
 
-export interface AutocompleteRendererOptions<TAutocompleteWidgetParams>
-  extends RendererOptions<TAutocompleteWidgetParams> {
+export type AutocompleteRendererOptions<TAutocompleteWidgetParams> = {
   currentRefinement: string;
   indices: AutocompleteIndex[];
   instantSearchInstance: InstantSearch;
   refine: (query: string) => void;
-}
+} & RendererOptions<TAutocompleteWidgetParams>;
 
 export type AutocompleteRenderer<TAutocompleteWidgetParams> = Renderer<
   AutocompleteRendererOptions<

--- a/src/connectors/configure-related-items/connectConfigureRelatedItems.ts
+++ b/src/connectors/configure-related-items/connectConfigureRelatedItems.ts
@@ -24,7 +24,7 @@ export type MatchingPatterns = {
   };
 };
 
-export interface ConfigureRelatedItemsConnectorParams {
+export type ConfigureRelatedItemsConnectorParams = {
   /**
    * The reference hit to extract the filters from.
    */
@@ -40,7 +40,7 @@ export interface ConfigureRelatedItemsConnectorParams {
   transformSearchParameters?(
     searchParameters: SearchParameters
   ): PlainSearchParameters;
-}
+};
 
 export type ConfigureRelatedItemsWidgetFactory<
   TConfigureRelatedItemsWidgetParams

--- a/src/connectors/configure/connectConfigure.ts
+++ b/src/connectors/configure/connectConfigure.ts
@@ -18,18 +18,17 @@ import {
 
 type Refine = (searchParameters: PlainSearchParameters) => void;
 
-export interface ConfigureConnectorParams {
+export type ConfigureConnectorParams = {
   /**
    * A list of [search parameters](https://www.algolia.com/doc/api-reference/search-api-parameters/)
    * to enable when the widget mounts.
    */
   searchParameters: PlainSearchParameters;
-}
+};
 
-export interface ConfigureRendererOptions<TConfigureWidgetParams>
-  extends RendererOptions<TConfigureWidgetParams> {
+export type ConfigureRendererOptions<TConfigureWidgetParams> = {
   refine: Refine;
-}
+} & RendererOptions<TConfigureWidgetParams>;
 
 export type ConfigureRenderer<TConfigureWidgetParams> = Renderer<
   ConfigureRendererOptions<ConfigureConnectorParams & TConfigureWidgetParams>

--- a/src/connectors/current-refinements/connectCurrentRefinements.ts
+++ b/src/connectors/current-refinements/connectCurrentRefinements.ts
@@ -32,9 +32,9 @@ export type ConnectorRefinement = {
   exhaustive?: boolean;
 };
 
-interface ConnectorNumericRefinement extends ConnectorRefinement {
+type ConnectorNumericRefinement = {
   value: number;
-}
+} & ConnectorRefinement;
 
 export type Item = {
   indexName: string;
@@ -61,7 +61,7 @@ export type ItemRefinement = {
   exhaustive?: boolean;
 };
 
-interface CurrentRefinementsConnectorParams {
+type CurrentRefinementsConnectorParams = {
   /**
    * The attributes to include in the widget (all by default).
    * Cannot be used with `excludedAttributes`.
@@ -82,15 +82,15 @@ interface CurrentRefinementsConnectorParams {
    * Useful for mapping over the items to transform, and remove or reorder them.
    */
   transformItems?: (items: Item[]) => any;
-}
+};
 
-export interface CurrentRefinementsRendererOptions<
+export type CurrentRefinementsRendererOptions<
   TCurrentRefinementsWidgetParams
-> extends RendererOptions<TCurrentRefinementsWidgetParams> {
+> = {
   items: Item[];
   refine(refinement: ItemRefinement): void;
   createURL(state: ItemRefinement): string;
-}
+} & RendererOptions<TCurrentRefinementsWidgetParams>;
 
 export type CurrentRefinementsRenderer<
   TCurrentRefinementsWidgetParams

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -24,13 +24,12 @@ export type InfiniteHitsConnectorParams = Partial<
   InfiniteHitsRendererWidgetParams
 >;
 
-export interface InfiniteHitsRendererOptions<TInfiniteHitsWidgetParams>
-  extends RendererOptions<TInfiniteHitsWidgetParams> {
+export type InfiniteHitsRendererOptions<TInfiniteHitsWidgetParams> = {
   showPrevious: () => void;
   showMore: () => void;
   isFirstPage: boolean;
   isLastPage: boolean;
-}
+} & RendererOptions<TInfiniteHitsWidgetParams>;
 
 export type InfiniteHitsRenderer<TInfiniteHitsWidgetParams> = Renderer<
   InfiniteHitsRendererOptions<

--- a/src/connectors/numeric-menu/connectNumericMenu.ts
+++ b/src/connectors/numeric-menu/connectNumericMenu.ts
@@ -64,8 +64,7 @@ export type NumericMenuConnectorParams = {
 
 type Refine = (facetValue: string) => void;
 
-export interface NumericMenuRendererOptions<TNumericMenuWidgetParams>
-  extends RendererOptions<TNumericMenuWidgetParams> {
+export type NumericMenuRendererOptions<TNumericMenuWidgetParams> = {
   /**
    * The list of available choices
    */
@@ -82,7 +81,7 @@ export interface NumericMenuRendererOptions<TNumericMenuWidgetParams>
    * Sets the selected value and trigger a new search
    */
   refine: Refine;
-}
+} & RendererOptions<TNumericMenuWidgetParams>;
 
 export type NumericMenuRenderer<TNumericMenuWidgetParams> = Renderer<
   NumericMenuRendererOptions<

--- a/src/connectors/query-rules/connectQueryRules.ts
+++ b/src/connectors/query-rules/connectQueryRules.ts
@@ -38,10 +38,9 @@ export type QueryRulesConnectorParams = {
   transformItems?: ParamTransformItems;
 };
 
-export interface QueryRulesRendererOptions<TQueryRulesWidgetParams>
-  extends RendererOptions<TQueryRulesWidgetParams> {
+export type QueryRulesRendererOptions<TQueryRulesWidgetParams> = {
   items: any[];
-}
+} & RendererOptions<TQueryRulesWidgetParams>;
 
 export type QueryRulesRenderer<TQueryRulesWidgetParams> = Renderer<
   QueryRulesRendererOptions<QueryRulesConnectorParams & TQueryRulesWidgetParams>

--- a/src/connectors/voice-search/connectVoiceSearch.ts
+++ b/src/connectors/voice-search/connectVoiceSearch.ts
@@ -23,13 +23,12 @@ export type VoiceSearchConnectorParams = {
   }) => PlainSearchParameters | void;
 };
 
-export interface VoiceSearchRendererOptions<TVoiceSearchWidgetParams>
-  extends RendererOptions<TVoiceSearchWidgetParams> {
+export type VoiceSearchRendererOptions<TVoiceSearchWidgetParams> = {
   isBrowserSupported: boolean;
   isListening: boolean;
   toggleListening: ToggleListening;
   voiceListeningState: VoiceListeningState;
-}
+} & RendererOptions<TVoiceSearchWidgetParams>;
 
 export type VoiceSearchRenderer<TVoiceSearchWidgetParams> = Renderer<
   VoiceSearchRendererOptions<

--- a/src/lib/createHelpers.ts
+++ b/src/lib/createHelpers.ts
@@ -9,12 +9,12 @@ import { Hit, InsightsClientMethod, InsightsClientPayload } from '../types';
 
 type HoganRenderer = (value: any) => string;
 
-interface HoganHelpers {
+type HoganHelpers = {
   formatNumber: (value: number, render: HoganRenderer) => string;
   highlight: (options: string, render: HoganRenderer) => string;
   snippet: (options: string, render: HoganRenderer) => string;
   insights: (options: string, render: HoganRenderer) => string;
-}
+};
 
 export default function hoganHelpers({
   numberLocale,

--- a/src/lib/suit.ts
+++ b/src/lib/suit.ts
@@ -1,9 +1,9 @@
 const NAMESPACE = 'ais';
 
-interface SuitOptions {
+type SuitOptions = {
   descendantName?: string;
   modifierName?: string;
-}
+};
 
 type SuitSelector = (names?: SuitOptions) => string;
 

--- a/src/lib/utils/getRefinements.ts
+++ b/src/lib/utils/getRefinements.ts
@@ -2,7 +2,7 @@ import { SearchParameters, SearchResults } from 'algoliasearch-helper';
 import find from './find';
 import unescapeRefinement from './unescapeRefinement';
 
-export interface FacetRefinement {
+export type FacetRefinement = {
   type:
     | 'facet'
     | 'exclude'
@@ -15,24 +15,23 @@ export interface FacetRefinement {
   name: string;
   count?: number;
   exhaustive?: boolean;
-}
+};
 
-export interface QueryRefinement
-  extends Pick<FacetRefinement, 'type' | 'attribute' | 'name'> {
+export type QueryRefinement = {
   type: 'query';
   query: string;
-}
+} & Pick<FacetRefinement, 'type' | 'attribute' | 'name'>;
 
-export interface NumericRefinement extends FacetRefinement {
+export type NumericRefinement = {
   type: 'numeric';
   numericValue: number;
   operator: '<' | '<=' | '=' | '!=' | '>=' | '>';
-}
+} & FacetRefinement;
 
-export interface FacetExcludeRefinement extends FacetRefinement {
+export type FacetExcludeRefinement = {
   type: 'exclude';
   exclude: boolean;
-}
+} & FacetRefinement;
 
 export type Refinement =
   | FacetRefinement

--- a/src/middleware/createRouter.ts
+++ b/src/middleware/createRouter.ts
@@ -16,10 +16,10 @@ const walk = (current: Index, callback: (index: Index) => void) => {
     });
 };
 
-export interface RouterProps<TRouteState = UiState> {
+export type RouterProps<TRouteState = UiState> = {
   router?: Router<TRouteState>;
   stateMapping?: StateMapping<TRouteState>;
-}
+};
 
 export type RoutingManager<TRouteState = UiState> = (
   props?: RouterProps<TRouteState>

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -1,10 +1,10 @@
 import { UiState } from '../types';
 
-export interface MiddlewareDefinition {
+export type MiddlewareDefinition = {
   onStateChange(options: { state: UiState }): void;
   subscribe(): void;
   unsubscribe(): void;
-}
+};
 
 export type Middleware = ({
   instantSearchInstance: InstantSearch,

--- a/src/types/algoliasearch.ts
+++ b/src/types/algoliasearch.ts
@@ -28,9 +28,9 @@ export type Client = ReturnType<
   ? SearchClientV4
   : SearchClientV3;
 
-export interface MultiResponse<THit = any> {
+export type MultiResponse<THit = any> = {
   results: Array<SearchResponse<THit>>;
-}
+};
 
 export type SearchResponse<THit> = Client extends DummySearchClientV4
   ? SearchResponseV4<THit>

--- a/src/types/instantsearch.ts
+++ b/src/types/instantsearch.ts
@@ -37,7 +37,7 @@ type HitSnippetResult = {
     | HitSnippetResult;
 };
 
-export interface AlgoliaHit {
+export type AlgoliaHit = {
   [attribute: string]: any;
   objectID: string;
   _highlightResult?: HitHighlightResult;
@@ -60,12 +60,12 @@ export interface AlgoliaHit {
     };
   };
   _distinctSeqID?: number;
-}
+};
 
-export interface Hit extends AlgoliaHit {
+export type Hit = {
   __position: number;
   __queryID?: string;
-}
+} & AlgoliaHit;
 
 export type Hits = Hit[];
 
@@ -93,7 +93,7 @@ export type Refinement = FacetRefinement | NumericRefinement;
  * The router is the part that saves and reads the object from the storage.
  * Usually this is the URL.
  */
-export interface Router<TRouteState = UiState> {
+export type Router<TRouteState = UiState> = {
   /**
    * onUpdate Sets an event listener that is triggered when the storage is updated.
    * The function should accept a callback to trigger when the update happens.
@@ -124,7 +124,7 @@ export interface Router<TRouteState = UiState> {
    * Called when InstantSearch is disposed. Used to remove subscriptions.
    */
   dispose(): void;
-}
+};
 
 /**
  * The state mapping is a way to customize the structure before sending it to the router.

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -7,7 +7,7 @@ import {
 } from 'algoliasearch-helper';
 import { InstantSearch } from './instantsearch';
 
-export interface InitOptions {
+export type InitOptions = {
   instantSearchInstance: InstantSearch;
   parent: Index | null;
   uiState: UiState;
@@ -15,15 +15,15 @@ export interface InitOptions {
   helper: Helper;
   templatesConfig: object;
   createURL(state: SearchParameters): string;
-}
+};
 
-export interface ScopedResult {
+export type ScopedResult = {
   indexId: string;
   results: SearchResults;
   helper: Helper;
-}
+};
 
-export interface RenderOptions {
+export type RenderOptions = {
   instantSearchInstance: InstantSearch;
   templatesConfig: object;
   results: SearchResults;
@@ -34,21 +34,21 @@ export interface RenderOptions {
     isSearchStalled: boolean;
   };
   createURL(state: SearchParameters): string;
-}
+};
 
-export interface DisposeOptions {
+export type DisposeOptions = {
   helper: Helper;
   state: SearchParameters;
-}
+};
 
-export interface WidgetStateOptions {
+export type WidgetStateOptions = {
   searchParameters: SearchParameters;
   helper: Helper;
-}
+};
 
-export interface WidgetSearchParametersOptions {
+export type WidgetSearchParametersOptions = {
   uiState: IndexUiState;
-}
+};
 
 export type IndexUiState = {
   query?: string;
@@ -123,7 +123,7 @@ export type UiState = {
  * Widgets are the building blocks of InstantSearch.js. Any valid widget must
  * have at least a `render` or a `init` function.
  */
-export interface Widget {
+export type Widget = {
   $$type?:
     | 'ais.autocomplete'
     | 'ais.breadcrumb'
@@ -190,7 +190,7 @@ export interface Widget {
     state: SearchParameters,
     widgetSearchParametersOptions: WidgetSearchParametersOptions
   ): SearchParameters;
-}
+};
 
 export type WidgetFactory<TWidgetParams> = (
   widgetParams: TWidgetParams

--- a/src/widgets/current-refinements/current-refinements.tsx
+++ b/src/widgets/current-refinements/current-refinements.tsx
@@ -59,11 +59,10 @@ export type CurrentRefinementsWidgetParams = {
   transformItems?: (items: Item[]) => any;
 };
 
-interface CurrentRefinementsRendererWidgetParams
-  extends CurrentRefinementsWidgetParams {
+type CurrentRefinementsRendererWidgetParams = {
   container: HTMLElement;
   cssClasses: CurrentRefinementsComponentCSSClasses;
-}
+} & CurrentRefinementsWidgetParams;
 
 type CurrentRefinements = WidgetFactory<CurrentRefinementsWidgetParams>;
 

--- a/src/widgets/infinite-hits/infinite-hits.tsx
+++ b/src/widgets/infinite-hits/infinite-hits.tsx
@@ -102,7 +102,7 @@ export type InfiniteHitsRendererWidgetParams = {
   transformItems?: (items: any[]) => any[];
 };
 
-interface InfiniteHitsWidgetParams extends InfiniteHitsRendererWidgetParams {
+type InfiniteHitsWidgetParams = {
   /**
    * The CSS Selector or `HTMLElement` to insert the widget into.
    */
@@ -115,7 +115,7 @@ interface InfiniteHitsWidgetParams extends InfiniteHitsRendererWidgetParams {
    * The templates to use for the widget.
    */
   templates?: Partial<InfiniteHitsTemplates>;
-}
+} & InfiniteHitsRendererWidgetParams;
 
 type InfiniteHits = WidgetFactory<InfiniteHitsWidgetParams>;
 

--- a/src/widgets/panel/panel.tsx
+++ b/src/widgets/panel/panel.tsx
@@ -12,7 +12,7 @@ import { component } from '../../lib/suit';
 import Panel from '../../components/Panel/Panel';
 import { WidgetFactory, Template, RenderOptions, Widget } from '../../types';
 
-export interface PanelCSSClasses {
+export type PanelCSSClasses = {
   /**
    * CSS classes to add to the root element of the widget.
    */
@@ -49,9 +49,9 @@ export interface PanelCSSClasses {
    * CSS classes to add to the footer.
    */
   footer: string | string[];
-}
+};
 
-export interface PanelTemplates {
+export type PanelTemplates = {
   /**
    * Template to use for the header.
    */
@@ -64,14 +64,14 @@ export interface PanelTemplates {
    * Template to use for collapse button.
    */
   collapseButtonText: Template<{ collapsed: boolean }>;
-}
+};
 
-interface PanelWidgetParams {
+type PanelWidgetParams = {
   hidden?(options: RenderOptions): boolean;
   collapsed?(options: RenderOptions): boolean;
   templates?: Partial<PanelTemplates>;
   cssClasses?: Partial<PanelCSSClasses>;
-}
+};
 
 const withUsage = createDocumentationMessageGenerator({ name: 'panel' });
 const suit = component('Panel');

--- a/src/widgets/places/places.ts
+++ b/src/widgets/places/places.ts
@@ -6,7 +6,7 @@ import {
 } from 'places.js';
 import { WidgetFactory } from '../../types';
 
-interface PlacesWidgetOptions extends StaticOptions {
+type PlacesWidgetOptions = {
   /**
    * The Algolia Places reference to use.
    *
@@ -19,13 +19,13 @@ interface PlacesWidgetOptions extends StaticOptions {
    * The default position when the input is empty.
    */
   defaultPosition?: string[];
-}
+} & StaticOptions;
 
-interface PlacesWidgetState {
+type PlacesWidgetState = {
   query: string;
   initialLatLngViaIP: boolean | undefined;
   isInitialLatLngViaIPSet: boolean;
-}
+};
 
 /**
  * This widget sets the geolocation value for the search based on the selected

--- a/src/widgets/query-rule-custom-data/query-rule-custom-data.tsx
+++ b/src/widgets/query-rule-custom-data/query-rule-custom-data.tsx
@@ -28,12 +28,11 @@ type QueryRuleCustomDataWidgetParams = {
   transformItems?: (items: any[]) => any;
 };
 
-interface QueryRuleCustomDataRendererWidgetParams
-  extends QueryRuleCustomDataWidgetParams {
+type QueryRuleCustomDataRendererWidgetParams = {
   container: HTMLElement;
   cssClasses: QueryRuleCustomDataCSSClasses;
   templates: QueryRuleCustomDataTemplates;
-}
+} & QueryRuleCustomDataWidgetParams;
 
 type QueryRuleCustomData = WidgetFactory<QueryRuleCustomDataWidgetParams>;
 

--- a/src/widgets/voice-search/__tests__/voice-search-test.ts
+++ b/src/widgets/voice-search/__tests__/voice-search-test.ts
@@ -24,12 +24,12 @@ jest.mock('preact', () => {
   return module;
 });
 
-interface DefaultSetupWrapper {
+type DefaultSetupWrapper = {
   container: HTMLDivElement;
   widget: Widget;
   widgetInit: (helper: Helper) => void;
   widgetRender: (helper: Helper) => void;
-}
+};
 
 function defaultSetup(opts = {}): DefaultSetupWrapper {
   const container = document.createElement('div');

--- a/src/widgets/voice-search/voice-search.tsx
+++ b/src/widgets/voice-search/voice-search.tsx
@@ -51,11 +51,11 @@ type VoiceSearchWidgetParams = {
   }) => PlainSearchParameters | void;
 };
 
-interface VoiceSearchRendererWidgetParams extends VoiceSearchWidgetParams {
+type VoiceSearchRendererWidgetParams = {
   container: HTMLElement;
   cssClasses: VoiceSearchComponentCSSClasses;
   templates: VoiceSearchTemplates;
-}
+} & VoiceSearchWidgetParams;
 
 type VoiceSearch = WidgetFactory<VoiceSearchWidgetParams>;
 


### PR DESCRIPTION
This pull request replaces `interfaces` by `types` on the IS type system. The main reason is to be consistent across all the code base.