### PR TITLE
chore(ts-migration): refactors connector types

### DIFF
--- a/src/connectors/autocomplete/connectAutocomplete.ts
+++ b/src/connectors/autocomplete/connectAutocomplete.ts
@@ -6,7 +6,7 @@ import {
   noop,
   warning,
 } from '../../lib/utils';
-import { Hits, InstantSearch, Connector } from '../../types';
+import { Hits, Connector } from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'autocomplete',

--- a/src/connectors/autocomplete/connectAutocomplete.ts
+++ b/src/connectors/autocomplete/connectAutocomplete.ts
@@ -54,7 +54,15 @@ export type AutocompleteRendererOptions = {
   refine: (query: string) => void;
 };
 
-export default (function connectAutocomplete(renderFn, unmountFn = noop) {
+export type AutocompleteConnector = Connector<
+  AutocompleteRendererOptions,
+  AutocompleteConnectorParams
+>;
+
+const connectAutocomplete: AutocompleteConnector = function connectAutocomplete(
+  renderFn,
+  unmountFn = noop
+) {
   checkRendering(renderFn, withUsage());
 
   return widgetParams => {
@@ -188,4 +196,6 @@ search.addWidgets([
       },
     };
   };
-} as Connector<AutocompleteRendererOptions, AutocompleteConnectorParams>);
+};
+
+export default connectAutocomplete;

--- a/src/connectors/autocomplete/connectAutocomplete.ts
+++ b/src/connectors/autocomplete/connectAutocomplete.ts
@@ -49,13 +49,6 @@ export type AutocompleteRendererOptions = {
   }>;
 
   /**
-   * The current instant search instance.
-   *
-   * @internal
-   */
-  instantSearchInstance: InstantSearch;
-
-  /**
    * Searches into the indices with the provided query.
    */
   refine: (query: string) => void;

--- a/src/connectors/configure-related-items/__tests__/connectConfigureRelatedItems-test.ts
+++ b/src/connectors/configure-related-items/__tests__/connectConfigureRelatedItems-test.ts
@@ -2,6 +2,7 @@ import connectConfigureRelatedItems from '../connectConfigureRelatedItems';
 import instantsearch from '../../../lib/main';
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import { AlgoliaHit } from '../../../types';
+import { noop } from '../../../lib/utils';
 
 const hit: AlgoliaHit = {
   objectID: '1',
@@ -37,7 +38,7 @@ const hit: AlgoliaHit = {
 describe('connectConfigureRelatedItems', () => {
   describe('usage', () => {
     test('throws without hit option', () => {
-      const configureRelatedItems = connectConfigureRelatedItems();
+      const configureRelatedItems = connectConfigureRelatedItems(noop);
 
       expect(() => {
         // @ts-ignore missing options
@@ -50,7 +51,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure-r
     });
 
     test('throws without matchingPatterns option', () => {
-      const configureRelatedItems = connectConfigureRelatedItems();
+      const configureRelatedItems = connectConfigureRelatedItems(noop);
 
       expect(() => {
         // @ts-ignore missing options
@@ -65,7 +66,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure-r
     });
 
     test('does not throw on correct usage', () => {
-      const configureRelatedItems = connectConfigureRelatedItems();
+      const configureRelatedItems = connectConfigureRelatedItems(noop);
 
       expect(() => {
         configureRelatedItems({
@@ -76,7 +77,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure-r
     });
 
     test('is a widget', () => {
-      const configureRelatedItems = connectConfigureRelatedItems();
+      const configureRelatedItems = connectConfigureRelatedItems(noop);
       const widget = configureRelatedItems({
         hit,
         matchingPatterns: {},
@@ -102,7 +103,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure-r
         indexName: 'indexName',
         searchClient,
       });
-      const configureRelatedItems = connectConfigureRelatedItems();
+      const configureRelatedItems = connectConfigureRelatedItems(noop);
 
       search.addWidgets([
         configureRelatedItems({
@@ -142,7 +143,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure-r
         indexName: 'indexName',
         searchClient,
       });
-      const configureRelatedItems = connectConfigureRelatedItems();
+      const configureRelatedItems = connectConfigureRelatedItems(noop);
 
       search.addWidgets([
         configureRelatedItems({
@@ -201,7 +202,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure-r
         indexName: 'indexName',
         searchClient,
       });
-      const configureRelatedItems = connectConfigureRelatedItems();
+      const configureRelatedItems = connectConfigureRelatedItems(noop);
 
       expect(() => {
         search.addWidgets([

--- a/src/connectors/configure-related-items/connectConfigureRelatedItems.ts
+++ b/src/connectors/configure-related-items/connectConfigureRelatedItems.ts
@@ -54,7 +54,16 @@ function createOptionalFilter({
   return `${attributeName}:${attributeValue}<score=${attributeScore || 1}>`;
 }
 
-export default (function connectConfigureRelatedItems(renderFn, unmountFn) {
+type ConfigureRelatedItemsConnector = Connector<
+  ConfigureRendererOptions,
+  ConfigureRelatedItemsConnectorParams
+>;
+
+export default (function connectConfigureRelatedItems<
+  TWidgetParams extends {
+    searchParameters: algoliasearchHelper.PlainSearchParameters;
+  }
+>(renderFn, unmountFn) {
   return widgetParams => {
     const { hit, matchingPatterns, transformSearchParameters = x => x } =
       widgetParams || ({} as typeof widgetParams);
@@ -130,11 +139,11 @@ See https://www.algolia.com/doc/api-reference/api-parameters/optionalFilters/
       ),
     };
 
-    const makeConfigure = connectConfigure(renderFn, unmountFn);
+    const makeConfigure = connectConfigure<TWidgetParams>(renderFn, unmountFn);
 
     return {
-      ...makeConfigure({ searchParameters } as any),
+      ...makeConfigure({ searchParameters } as TWidgetParams),
       $$type: 'ais.configureRelatedItems',
     };
   };
-} as Connector<ConfigureRendererOptions, ConfigureRelatedItemsConnectorParams>);
+} as ConfigureRelatedItemsConnector);

--- a/src/connectors/configure-related-items/connectConfigureRelatedItems.ts
+++ b/src/connectors/configure-related-items/connectConfigureRelatedItems.ts
@@ -2,15 +2,14 @@ import algoliasearchHelper, {
   SearchParameters,
   PlainSearchParameters,
 } from 'algoliasearch-helper';
-import { Unmounter, WidgetFactory, AlgoliaHit } from '../../types';
+import { AlgoliaHit, Connector } from '../../types';
 import {
   createDocumentationMessageGenerator,
   getObjectType,
   warning,
 } from '../../lib/utils';
 import connectConfigure, {
-  ConfigureRenderer,
-  ConfigureConnectorParams,
+  ConfigureRendererOptions,
 } from '../configure/connectConfigure';
 
 export type MatchingPatterns = {
@@ -42,17 +41,6 @@ export type ConfigureRelatedItemsConnectorParams = {
   ): PlainSearchParameters;
 };
 
-export type ConfigureRelatedItemsWidgetFactory<
-  TConfigureRelatedItemsWidgetParams
-> = WidgetFactory<
-  ConfigureRelatedItemsConnectorParams & TConfigureRelatedItemsWidgetParams
->;
-
-type ConfigureRelatedItemsConnector = <TConfigureRelatedItemsWidgetParams>(
-  render?: ConfigureRenderer<ConfigureConnectorParams>,
-  unmount?: Unmounter
-) => ConfigureRelatedItemsWidgetFactory<TConfigureRelatedItemsWidgetParams>;
-
 const withUsage = createDocumentationMessageGenerator({
   name: 'configure-related-items',
   connector: true,
@@ -66,10 +54,7 @@ function createOptionalFilter({
   return `${attributeName}:${attributeValue}<score=${attributeScore || 1}>`;
 }
 
-const connectConfigureRelatedItems: ConfigureRelatedItemsConnector = (
-  renderFn,
-  unmountFn
-) => {
+export default (function connectConfigureRelatedItems(renderFn, unmountFn) {
   return widgetParams => {
     const { hit, matchingPatterns, transformSearchParameters = x => x } =
       widgetParams || ({} as typeof widgetParams);
@@ -148,11 +133,8 @@ See https://www.algolia.com/doc/api-reference/api-parameters/optionalFilters/
     const makeConfigure = connectConfigure(renderFn, unmountFn);
 
     return {
-      ...makeConfigure({ searchParameters }),
-
+      ...makeConfigure({ searchParameters } as any),
       $$type: 'ais.configureRelatedItems',
     };
   };
-};
-
-export default connectConfigureRelatedItems;
+} as Connector<ConfigureRendererOptions, ConfigureRelatedItemsConnectorParams>);

--- a/src/connectors/configure-related-items/connectConfigureRelatedItems.ts
+++ b/src/connectors/configure-related-items/connectConfigureRelatedItems.ts
@@ -141,6 +141,8 @@ See https://www.algolia.com/doc/api-reference/api-parameters/optionalFilters/
     const makeConfigure = connectConfigure(renderFn, unmountFn);
 
     return {
+      // required, since widget parameters differ between these connectors
+      // and we don't want to have the parameters of configure here
       ...makeConfigure({ searchParameters } as any),
       $$type: 'ais.configureRelatedItems',
     };

--- a/src/connectors/configure-related-items/connectConfigureRelatedItems.ts
+++ b/src/connectors/configure-related-items/connectConfigureRelatedItems.ts
@@ -54,16 +54,15 @@ function createOptionalFilter({
   return `${attributeName}:${attributeValue}<score=${attributeScore || 1}>`;
 }
 
-type ConfigureRelatedItemsConnector = Connector<
+export type ConfigureRelatedItemsConnector = Connector<
   ConfigureRendererOptions,
   ConfigureRelatedItemsConnectorParams
 >;
 
-export default (function connectConfigureRelatedItems<
-  TWidgetParams extends {
-    searchParameters: algoliasearchHelper.PlainSearchParameters;
-  }
->(renderFn, unmountFn) {
+const connectConfigureRelatedItems: ConfigureRelatedItemsConnector = function connectConfigureRelatedItems(
+  renderFn,
+  unmountFn
+) {
   return widgetParams => {
     const { hit, matchingPatterns, transformSearchParameters = x => x } =
       widgetParams || ({} as typeof widgetParams);
@@ -139,11 +138,13 @@ See https://www.algolia.com/doc/api-reference/api-parameters/optionalFilters/
       ),
     };
 
-    const makeConfigure = connectConfigure<TWidgetParams>(renderFn, unmountFn);
+    const makeConfigure = connectConfigure(renderFn, unmountFn);
 
     return {
-      ...makeConfigure({ searchParameters } as TWidgetParams),
+      ...makeConfigure({ searchParameters } as any),
       $$type: 'ais.configureRelatedItems',
     };
   };
-} as ConfigureRelatedItemsConnector);
+};
+
+export default connectConfigureRelatedItems;

--- a/src/connectors/configure/__tests__/connectConfigure-test.ts
+++ b/src/connectors/configure/__tests__/connectConfigure-test.ts
@@ -9,6 +9,7 @@ import {
   createInitOptions,
   createDisposeOptions,
 } from '../../../../test/mock/createWidget';
+import { noop } from '../../../lib/utils';
 
 describe('connectConfigure', () => {
   let helper: AlgoliaSearchHelper;
@@ -80,7 +81,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
   });
 
   it('should apply searchParameters', () => {
-    const makeWidget = connectConfigure();
+    const makeWidget = connectConfigure(noop);
     const widget = makeWidget({
       searchParameters: {
         analytics: true,
@@ -99,7 +100,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
   });
 
   it('should apply searchParameters with a higher priority', () => {
-    const makeWidget = connectConfigure();
+    const makeWidget = connectConfigure(noop);
     const widget = makeWidget({
       searchParameters: {
         analytics: true,
@@ -195,7 +196,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
   });
 
   it('should dispose only the state set by configure', () => {
-    const makeWidget = connectConfigure();
+    const makeWidget = connectConfigure(noop);
     const widget = makeWidget({
       searchParameters: {
         analytics: true,
@@ -241,7 +242,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
 
   describe('getWidgetState', () => {
     it('adds default parameters', () => {
-      const makeWidget = connectConfigure();
+      const makeWidget = connectConfigure(noop);
       const widget = makeWidget({
         searchParameters: {
           analytics: true,
@@ -298,7 +299,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
     });
 
     it('merges with existing configuration', () => {
-      const makeWidget = connectConfigure();
+      const makeWidget = connectConfigure(noop);
       const widget = makeWidget({
         searchParameters: {
           analytics: true,
@@ -316,7 +317,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
     });
 
     it('overwrites existing configuration', () => {
-      const makeWidget = connectConfigure();
+      const makeWidget = connectConfigure(noop);
       const widget = makeWidget({
         searchParameters: {
           analytics: true,
@@ -336,7 +337,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
 
   describe('getWidgetSearchParameters', () => {
     it('returns parameters set by default', () => {
-      const makeWidget = connectConfigure();
+      const makeWidget = connectConfigure(noop);
       const widget = makeWidget({
         searchParameters: {
           analytics: true,
@@ -351,7 +352,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
     });
 
     it('returns parameters set by uiState', () => {
-      const makeWidget = connectConfigure();
+      const makeWidget = connectConfigure(noop);
       const widget = makeWidget({ searchParameters: {} });
 
       const sp = widget.getWidgetSearchParameters!(new SearchParameters(), {
@@ -366,7 +367,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
     });
 
     it('overrides parameters set by uiState', () => {
-      const makeWidget = connectConfigure();
+      const makeWidget = connectConfigure(noop);
       const widget = makeWidget({
         searchParameters: {
           analytics: true,
@@ -385,7 +386,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
     });
 
     it('merges parameters set by uiState', () => {
-      const makeWidget = connectConfigure();
+      const makeWidget = connectConfigure(noop);
       const widget = makeWidget({
         searchParameters: {
           analyticsTags: ['best-website-in-the-world'],
@@ -409,7 +410,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
     });
 
     it('merges with the previous parameters', () => {
-      const makeWidget = connectConfigure();
+      const makeWidget = connectConfigure(noop);
       const widget = makeWidget({
         searchParameters: {
           disjunctiveFacets: ['brand'],

--- a/src/connectors/configure/connectConfigure.ts
+++ b/src/connectors/configure/connectConfigure.ts
@@ -54,7 +54,15 @@ function getInitialSearchParameters(
   );
 }
 
-export default (function connectConfigure(renderFn = noop, unmountFn = noop) {
+export type ConfigureConnector = Connector<
+  ConfigureRendererOptions,
+  ConfigureConnectorParams
+>;
+
+const connectConfigure: ConfigureConnector = function connectConfigure(
+  renderFn = noop,
+  unmountFn = noop
+) {
   return widgetParams => {
     if (!widgetParams || !isPlainObject(widgetParams.searchParameters)) {
       throw new Error(
@@ -142,4 +150,6 @@ export default (function connectConfigure(renderFn = noop, unmountFn = noop) {
       },
     };
   };
-} as Connector<ConfigureRendererOptions, ConfigureConnectorParams>);
+};
+
+export default connectConfigure;

--- a/src/connectors/configure/connectConfigure.ts
+++ b/src/connectors/configure/connectConfigure.ts
@@ -3,12 +3,7 @@ import algoliasearchHelper, {
   PlainSearchParameters,
   AlgoliaSearchHelper,
 } from 'algoliasearch-helper';
-import {
-  Renderer,
-  RendererOptions,
-  Unmounter,
-  WidgetFactory,
-} from '../../types';
+import { Connector } from '../../types';
 import {
   createDocumentationMessageGenerator,
   isPlainObject,
@@ -16,6 +11,9 @@ import {
   noop,
 } from '../../lib/utils';
 
+/**
+ * Refine the given search parameters.
+ */
 type Refine = (searchParameters: PlainSearchParameters) => void;
 
 export type ConfigureConnectorParams = {
@@ -26,22 +24,12 @@ export type ConfigureConnectorParams = {
   searchParameters: PlainSearchParameters;
 };
 
-export type ConfigureRendererOptions<TConfigureWidgetParams> = {
+export type ConfigureRendererOptions = {
+  /**
+   * Refine the given search parameters.
+   */
   refine: Refine;
-} & RendererOptions<TConfigureWidgetParams>;
-
-export type ConfigureRenderer<TConfigureWidgetParams> = Renderer<
-  ConfigureRendererOptions<ConfigureConnectorParams & TConfigureWidgetParams>
->;
-
-export type ConfigureWidgetFactory<TConfigureWidgetParams> = WidgetFactory<
-  ConfigureConnectorParams & TConfigureWidgetParams
->;
-
-export type ConfigureConnector = <TConfigureWidgetParams>(
-  render?: ConfigureRenderer<TConfigureWidgetParams>,
-  unmount?: Unmounter
-) => ConfigureWidgetFactory<TConfigureWidgetParams>;
+};
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'configure',
@@ -66,10 +54,7 @@ function getInitialSearchParameters(
   );
 }
 
-const connectConfigure: ConfigureConnector = (
-  renderFn = noop,
-  unmountFn = noop
-) => {
+export default (function connectConfigure(renderFn = noop, unmountFn = noop) {
   return widgetParams => {
     if (!widgetParams || !isPlainObject(widgetParams.searchParameters)) {
       throw new Error(
@@ -157,6 +142,4 @@ const connectConfigure: ConfigureConnector = (
       },
     };
   };
-};
-
-export default connectConfigure;
+} as Connector<ConfigureRendererOptions, ConfigureConnectorParams>);

--- a/src/connectors/current-refinements/__tests__/connectCurrentRefinements-test.ts
+++ b/src/connectors/current-refinements/__tests__/connectCurrentRefinements-test.ts
@@ -32,10 +32,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
       const render = jest.fn();
       const unmount = jest.fn();
 
-      const customCurrentRefinements = connectCurrentRefinements(
+      const customCurrentRefinements = connectCurrentRefinements<{}>(
         render,
         unmount
       );
+
       const widget = customCurrentRefinements({});
 
       expect(widget).toEqual(

--- a/src/connectors/current-refinements/connectCurrentRefinements.ts
+++ b/src/connectors/current-refinements/connectCurrentRefinements.ts
@@ -90,7 +90,15 @@ const withUsage = createDocumentationMessageGenerator({
   connector: true,
 });
 
-export default (function connectCurrentRefinements(renderFn, unmountFn = noop) {
+export type CurrentRefinementsConnector = Connector<
+  CurrentRefinementsRendererOptions,
+  CurrentRefinementsConnectorParams
+>;
+
+const connectCurrentRefinements: CurrentRefinementsConnector = function connectCurrentRefinements(
+  renderFn,
+  unmountFn = noop
+) {
   checkRendering(renderFn, withUsage());
 
   return widgetParams => {
@@ -169,10 +177,7 @@ export default (function connectCurrentRefinements(renderFn, unmountFn = noop) {
       },
     };
   };
-} as Connector<
-  CurrentRefinementsRendererOptions,
-  CurrentRefinementsConnectorParams
->);
+};
 
 function getItems({
   results,
@@ -312,3 +317,5 @@ function normalizeRefinement(refinement: Refinement): ConnectorRefinement {
 
   return normalizedRefinement;
 }
+
+export default connectCurrentRefinements;

--- a/src/connectors/current-refinements/connectCurrentRefinements.ts
+++ b/src/connectors/current-refinements/connectCurrentRefinements.ts
@@ -15,12 +15,7 @@ import {
   FacetRefinement,
   NumericRefinement,
 } from '../../lib/utils/getRefinements';
-import {
-  Unmounter,
-  WidgetFactory,
-  Renderer,
-  RendererOptions,
-} from '../../types';
+import { Connector } from '../../types';
 
 export type ConnectorRefinement = {
   attribute: string;
@@ -61,7 +56,7 @@ export type ItemRefinement = {
   exhaustive?: boolean;
 };
 
-type CurrentRefinementsConnectorParams = {
+export type CurrentRefinementsConnectorParams = {
   /**
    * The attributes to include in the widget (all by default).
    * Cannot be used with `excludedAttributes`.
@@ -84,42 +79,18 @@ type CurrentRefinementsConnectorParams = {
   transformItems?: (items: Item[]) => any;
 };
 
-export type CurrentRefinementsRendererOptions<
-  TCurrentRefinementsWidgetParams
-> = {
+export type CurrentRefinementsRendererOptions = {
   items: Item[];
   refine(refinement: ItemRefinement): void;
   createURL(state: ItemRefinement): string;
-} & RendererOptions<TCurrentRefinementsWidgetParams>;
-
-export type CurrentRefinementsRenderer<
-  TCurrentRefinementsWidgetParams
-> = Renderer<
-  CurrentRefinementsRendererOptions<
-    CurrentRefinementsConnectorParams & TCurrentRefinementsWidgetParams
-  >
->;
-
-export type CurrentRefinementsWidgetFactory<
-  TCurrentRefinementsWidgetParams
-> = WidgetFactory<
-  CurrentRefinementsConnectorParams & TCurrentRefinementsWidgetParams
->;
-
-export type CurrentRefinementsConnector = <TCurrentRefinementsWidgetParams>(
-  render: CurrentRefinementsRenderer<TCurrentRefinementsWidgetParams>,
-  unmount?: Unmounter
-) => CurrentRefinementsWidgetFactory<TCurrentRefinementsWidgetParams>;
+};
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'current-refinements',
   connector: true,
 });
 
-const connectCurrentRefinements: CurrentRefinementsConnector = (
-  renderFn,
-  unmountFn = noop
-) => {
+export default (function connectCurrentRefinements(renderFn, unmountFn = noop) {
   checkRendering(renderFn, withUsage());
 
   return widgetParams => {
@@ -198,7 +169,10 @@ const connectCurrentRefinements: CurrentRefinementsConnector = (
       },
     };
   };
-};
+} as Connector<
+  CurrentRefinementsRendererOptions,
+  CurrentRefinementsConnectorParams
+>);
 
 function getItems({
   results,
@@ -338,5 +312,3 @@ function normalizeRefinement(refinement: Refinement): ConnectorRefinement {
 
   return normalizedRefinement;
 }
-
-export default connectCurrentRefinements;

--- a/src/connectors/hits-per-page/connectHitsPerPage.ts
+++ b/src/connectors/hits-per-page/connectHitsPerPage.ts
@@ -4,9 +4,9 @@ import {
   createDocumentationMessageGenerator,
   noop,
 } from '../../lib/utils';
-import { Connector } from '../../types';
 
 import { SearchParameters } from 'algoliasearch-helper';
+import { Connector } from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'hits-per-page',
@@ -70,17 +70,12 @@ export type HitsPerPageRendererOptions = {
   hasNoResults: boolean;
 };
 
-export type HitsPerPageConnector = Connector<
-  HitsPerPageRendererOptions,
-  HitsPerPageConnectorParams
->;
-
 export default (function connectHitsPerPage(renderFn, unmountFn = noop) {
   checkRendering(renderFn, withUsage());
 
   return widgetParams => {
     const { items: userItems, transformItems = items => items } =
-      widgetParams || ({} as Parameters<ReturnType<HitsPerPageConnector>>[0]);
+      widgetParams || ({} as typeof widgetParams);
     let items = userItems;
 
     if (!Array.isArray(items)) {
@@ -225,4 +220,4 @@ You may want to add another entry to the \`items\` option with this value.`
       },
     };
   };
-} as HitsPerPageConnector);
+} as Connector<HitsPerPageRendererOptions, HitsPerPageConnectorParams>);

--- a/src/connectors/hits-per-page/connectHitsPerPage.ts
+++ b/src/connectors/hits-per-page/connectHitsPerPage.ts
@@ -87,7 +87,15 @@ export type HitsPerPageRendererOptions = {
   hasNoResults: boolean;
 };
 
-export default (function connectHitsPerPage(renderFn, unmountFn = noop) {
+export type HitsPerPageConnector = Connector<
+  HitsPerPageRendererOptions,
+  HitsPerPageConnectorParams
+>;
+
+const connectHitsPerPage: HitsPerPageConnector = function connectHitsPerPage(
+  renderFn,
+  unmountFn = noop
+) {
   checkRendering(renderFn, withUsage());
 
   return widgetParams => {
@@ -237,4 +245,6 @@ You may want to add another entry to the \`items\` option with this value.`
       },
     };
   };
-} as Connector<HitsPerPageRendererOptions, HitsPerPageConnectorParams>);
+};
+
+export default connectHitsPerPage;

--- a/src/connectors/hits-per-page/connectHitsPerPage.ts
+++ b/src/connectors/hits-per-page/connectHitsPerPage.ts
@@ -13,6 +13,23 @@ const withUsage = createDocumentationMessageGenerator({
   connector: true,
 });
 
+export type HitsPerPageRendererOptionsItem = {
+  /**
+   * Label to display in the option.
+   */
+  label: string;
+
+  /**
+   * Number of hits to display per page.
+   */
+  value: number;
+
+  /**
+   * Indicates if it's the current refined value.
+   */
+  isRefined: boolean;
+};
+
 export type HitsPerPageConnectorParamsItem = {
   /**
    * Label to display in the option.
@@ -50,7 +67,7 @@ export type HitsPerPageRendererOptions = {
   /**
    * Array of objects defining the different values and labels.
    */
-  items: Array<HitsPerPageConnectorParamsItem & { isRefined: boolean }>;
+  items: HitsPerPageRendererOptionsItem[];
 
   /**
    * Creates the URL for a single item name in the list.

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -30,7 +30,15 @@ const withUsage = createDocumentationMessageGenerator({
   connector: true,
 });
 
-export default (function connectInfiniteHits(renderFn, unmountFn = noop) {
+export type InfiniteHitsConnector = Connector<
+  InfiniteHitsRendererOptions,
+  InfiniteHitsConnectorParams
+>;
+
+const connectInfiniteHits: InfiniteHitsConnector = function connectInfiniteHits(
+  renderFn,
+  unmountFn = noop
+) {
   checkRendering(renderFn, withUsage());
 
   return widgetParams => {
@@ -230,4 +238,6 @@ export default (function connectInfiniteHits(renderFn, unmountFn = noop) {
       },
     };
   };
-} as Connector<InfiniteHitsRendererOptions, InfiniteHitsConnectorParams>);
+};
+
+export default connectInfiniteHits;

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -3,13 +3,7 @@ import {
   AlgoliaSearchHelper as Helper,
   SearchParameters,
 } from 'algoliasearch-helper';
-import {
-  Renderer,
-  RendererOptions,
-  WidgetFactory,
-  Hits,
-  Unmounter,
-} from '../../types';
+import { Hits, Connector } from '../../types';
 import {
   checkRendering,
   createDocumentationMessageGenerator,
@@ -24,37 +18,19 @@ export type InfiniteHitsConnectorParams = Partial<
   InfiniteHitsRendererWidgetParams
 >;
 
-export type InfiniteHitsRendererOptions<TInfiniteHitsWidgetParams> = {
+export type InfiniteHitsRendererOptions = {
   showPrevious: () => void;
   showMore: () => void;
   isFirstPage: boolean;
   isLastPage: boolean;
-} & RendererOptions<TInfiniteHitsWidgetParams>;
-
-export type InfiniteHitsRenderer<TInfiniteHitsWidgetParams> = Renderer<
-  InfiniteHitsRendererOptions<
-    InfiniteHitsConnectorParams & TInfiniteHitsWidgetParams
-  >
->;
-
-export type InfiniteHitsWidgetFactory<
-  TInfiniteHitsWidgetParams
-> = WidgetFactory<InfiniteHitsConnectorParams & TInfiniteHitsWidgetParams>;
-
-export type InfiniteHitsConnector = <TInfiniteHitsWidgetParams>(
-  render: InfiniteHitsRenderer<TInfiniteHitsWidgetParams>,
-  unmount?: Unmounter
-) => InfiniteHitsWidgetFactory<TInfiniteHitsWidgetParams>;
+};
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'infinite-hits',
   connector: true,
 });
 
-const connectInfiniteHits: InfiniteHitsConnector = (
-  renderFn,
-  unmountFn = noop
-) => {
+export default (function connectInfiniteHits(renderFn, unmountFn = noop) {
   checkRendering(renderFn, withUsage());
 
   return widgetParams => {
@@ -254,6 +230,4 @@ const connectInfiniteHits: InfiniteHitsConnector = (
       },
     };
   };
-};
-
-export default connectInfiniteHits;
+} as Connector<InfiniteHitsRendererOptions, InfiniteHitsConnectorParams>);

--- a/src/connectors/numeric-menu/connectNumericMenu.ts
+++ b/src/connectors/numeric-menu/connectNumericMenu.ts
@@ -4,7 +4,7 @@ import {
   isFiniteNumber,
   noop,
 } from '../../lib/utils';
-import { RendererOptions, Renderer, WidgetFactory } from '../../types';
+import { Connector } from '../../types';
 import { SearchParameters } from 'algoliasearch-helper';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -64,7 +64,7 @@ export type NumericMenuConnectorParams = {
 
 type Refine = (facetValue: string) => void;
 
-export type NumericMenuRendererOptions<TNumericMenuWidgetParams> = {
+export type NumericMenuRendererOptions = {
   /**
    * The list of available choices
    */
@@ -81,27 +81,9 @@ export type NumericMenuRendererOptions<TNumericMenuWidgetParams> = {
    * Sets the selected value and trigger a new search
    */
   refine: Refine;
-} & RendererOptions<TNumericMenuWidgetParams>;
+};
 
-export type NumericMenuRenderer<TNumericMenuWidgetParams> = Renderer<
-  NumericMenuRendererOptions<
-    NumericMenuConnectorParams & TNumericMenuWidgetParams
-  >
->;
-
-export type NumericMenuWidgetFactory<TNumericMenuWidgetParams> = WidgetFactory<
-  NumericMenuConnectorParams & TNumericMenuWidgetParams
->;
-
-type NumericMenuConnector = <TNumericMenuWidgetParams>(
-  render: NumericMenuRenderer<TNumericMenuWidgetParams>,
-  unmount?: () => void
-) => NumericMenuWidgetFactory<TNumericMenuWidgetParams>;
-
-const connectNumericMenu: NumericMenuConnector = (
-  renderFn,
-  unmountFn = noop
-) => {
+export default (function connectNumericMenu(renderFn, unmountFn = noop) {
   checkRendering(renderFn, withUsage());
 
   return widgetParams => {
@@ -248,7 +230,7 @@ const connectNumericMenu: NumericMenuConnector = (
       },
     };
   };
-};
+} as Connector<NumericMenuRendererOptions, NumericMenuConnectorParams>);
 
 function isRefined(state: SearchParameters, attribute: string, option: Option) {
   // @TODO: same as another spot, why is this mixing arrays & elements?
@@ -373,5 +355,3 @@ function hasNumericRefinement(
     currentRefinements[operator]!.includes(value)
   );
 }
-
-export default connectNumericMenu;

--- a/src/connectors/numeric-menu/connectNumericMenu.ts
+++ b/src/connectors/numeric-menu/connectNumericMenu.ts
@@ -83,7 +83,15 @@ export type NumericMenuRendererOptions = {
   refine: Refine;
 };
 
-export default (function connectNumericMenu(renderFn, unmountFn = noop) {
+export type NumericMenuConnector = Connector<
+  NumericMenuRendererOptions,
+  NumericMenuConnectorParams
+>;
+
+const connectNumericMenu: NumericMenuConnector = function connectNumericMenu(
+  renderFn,
+  unmountFn = noop
+) {
   checkRendering(renderFn, withUsage());
 
   return widgetParams => {
@@ -230,7 +238,7 @@ export default (function connectNumericMenu(renderFn, unmountFn = noop) {
       },
     };
   };
-} as Connector<NumericMenuRendererOptions, NumericMenuConnectorParams>);
+};
 
 function isRefined(state: SearchParameters, attribute: string, option: Option) {
   // @TODO: same as another spot, why is this mixing arrays & elements?
@@ -355,3 +363,5 @@ function hasNumericRefinement(
     currentRefinements[operator]!.includes(value)
   );
 }
+
+export default connectNumericMenu;

--- a/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
+++ b/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
@@ -10,14 +10,16 @@ import {
   createRenderOptions,
 } from '../../../../test/mock/createWidget';
 import { createSingleSearchResponse } from '../../../../test/mock/createAPIResponse';
+import { WidgetFactory } from '../../../types';
 import connectQueryRules, {
-  QueryRulesWidgetFactory,
+  QueryRulesConnectorParams,
+  QueryRulesRendererOptions,
 } from '../connectQueryRules';
 
 describe('connectQueryRules', () => {
   let renderFn = jest.fn();
   let unmountFn = jest.fn();
-  let makeWidget: QueryRulesWidgetFactory<{}>;
+  let makeWidget: WidgetFactory<QueryRulesConnectorParams, {}>;
 
   const createFakeHelper = (state = {}): Helper => {
     const client = createSearchClient();
@@ -57,9 +59,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
       expect(() => {
         makeWidget({
           // @ts-ignore
-          trackedFilters: {
-            brand: ['Samsung'],
-          },
+          trackedFilters: { brand: ['Samsung'] },
         });
       }).toThrowErrorMatchingInlineSnapshot(`
 "'The \\"brand\\" filter value in the \`trackedFilters\` option expects a function.
@@ -200,8 +200,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
     test('does not throw without the unmount function', () => {
       const helper = createFakeHelper();
       const rendering = () => {};
-      const createWidget = connectQueryRules(rendering);
-      const widget = createWidget({});
+      const createWidget = connectQueryRules<QueryRulesRendererOptions>(
+        rendering
+      );
+      const widget = createWidget({
+        items: [] as any[],
+      });
 
       widget.init!(
         createInitOptions({

--- a/src/connectors/query-rules/connectQueryRules.ts
+++ b/src/connectors/query-rules/connectQueryRules.ts
@@ -148,7 +148,15 @@ Consider using \`transformRuleContexts\` to minimize the number of rules sent to
   }
 }
 
-export default (function connectQueryRules(render, unmount = noop) {
+export type QueryRulesConnector = Connector<
+  QueryRulesRendererOptions,
+  QueryRulesConnectorParams
+>;
+
+const connectQueryRules: QueryRulesConnector = function connectQueryRules(
+  render,
+  unmount = noop
+) {
   checkRendering(render, withUsage());
 
   return widgetParams => {
@@ -241,4 +249,6 @@ export default (function connectQueryRules(render, unmount = noop) {
       },
     };
   };
-} as Connector<QueryRulesRendererOptions, QueryRulesConnectorParams>);
+};
+
+export default connectQueryRules;

--- a/src/connectors/query-rules/connectQueryRules.ts
+++ b/src/connectors/query-rules/connectQueryRules.ts
@@ -3,12 +3,7 @@ import {
   SearchParameters,
   SearchResults,
 } from 'algoliasearch-helper';
-import {
-  Renderer,
-  RendererOptions,
-  WidgetFactory,
-  HelperChangeEvent,
-} from '../../types';
+import { HelperChangeEvent, Connector } from '../../types';
 import {
   checkRendering,
   createDocumentationMessageGenerator,
@@ -38,22 +33,9 @@ export type QueryRulesConnectorParams = {
   transformItems?: ParamTransformItems;
 };
 
-export type QueryRulesRendererOptions<TQueryRulesWidgetParams> = {
+export type QueryRulesRendererOptions = {
   items: any[];
-} & RendererOptions<TQueryRulesWidgetParams>;
-
-export type QueryRulesRenderer<TQueryRulesWidgetParams> = Renderer<
-  QueryRulesRendererOptions<QueryRulesConnectorParams & TQueryRulesWidgetParams>
->;
-
-export type QueryRulesWidgetFactory<TQueryRulesWidgetParams> = WidgetFactory<
-  QueryRulesConnectorParams & TQueryRulesWidgetParams
->;
-
-export type QueryRulesConnector = <TQueryRulesWidgetParams>(
-  render: QueryRulesRenderer<TQueryRulesWidgetParams>,
-  unmount?: () => void
-) => QueryRulesWidgetFactory<TQueryRulesWidgetParams>;
+};
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'query-rules',
@@ -166,7 +148,7 @@ Consider using \`transformRuleContexts\` to minimize the number of rules sent to
   }
 }
 
-const connectQueryRules: QueryRulesConnector = (render, unmount = noop) => {
+export default (function connectQueryRules(render, unmount = noop) {
   checkRendering(render, withUsage());
 
   return widgetParams => {
@@ -259,6 +241,4 @@ const connectQueryRules: QueryRulesConnector = (render, unmount = noop) => {
       },
     };
   };
-};
-
-export default connectQueryRules;
+} as Connector<QueryRulesRendererOptions, QueryRulesConnectorParams>);

--- a/src/connectors/voice-search/connectVoiceSearch.ts
+++ b/src/connectors/voice-search/connectVoiceSearch.ts
@@ -30,7 +30,15 @@ export type VoiceSearchRendererOptions = {
   voiceListeningState: VoiceListeningState;
 };
 
-export default (function connectVoiceSearch(renderFn, unmountFn = noop) {
+export type VoiceSearchConnector = Connector<
+  VoiceSearchRendererOptions,
+  VoiceSearchConnectorParams
+>;
+
+const connectVoiceSearch: VoiceSearchConnector = function connectVoiceSearch(
+  renderFn,
+  unmountFn = noop
+) {
   checkRendering(renderFn, withUsage());
 
   return widgetParams => {
@@ -163,4 +171,6 @@ export default (function connectVoiceSearch(renderFn, unmountFn = noop) {
       },
     };
   };
-} as Connector<VoiceSearchRendererOptions, VoiceSearchConnectorParams>);
+};
+
+export default connectVoiceSearch;

--- a/src/connectors/voice-search/connectVoiceSearch.ts
+++ b/src/connectors/voice-search/connectVoiceSearch.ts
@@ -4,7 +4,7 @@ import {
   createDocumentationMessageGenerator,
   noop,
 } from '../../lib/utils';
-import { Renderer, RendererOptions, WidgetFactory } from '../../types';
+import { Connector } from '../../types';
 import createVoiceSearchHelper, {
   VoiceListeningState,
   ToggleListening,
@@ -16,39 +16,21 @@ const withUsage = createDocumentationMessageGenerator({
 });
 
 export type VoiceSearchConnectorParams = {
-  searchAsYouSpeak: boolean;
+  searchAsYouSpeak?: boolean;
   language?: string;
   additionalQueryParameters?: (params: {
     query: string;
   }) => PlainSearchParameters | void;
 };
 
-export type VoiceSearchRendererOptions<TVoiceSearchWidgetParams> = {
+export type VoiceSearchRendererOptions = {
   isBrowserSupported: boolean;
   isListening: boolean;
   toggleListening: ToggleListening;
   voiceListeningState: VoiceListeningState;
-} & RendererOptions<TVoiceSearchWidgetParams>;
+};
 
-export type VoiceSearchRenderer<TVoiceSearchWidgetParams> = Renderer<
-  VoiceSearchRendererOptions<
-    VoiceSearchConnectorParams & TVoiceSearchWidgetParams
-  >
->;
-
-export type VoiceSearchWidgetFactory<TVoiceSearchWidgetParams> = WidgetFactory<
-  VoiceSearchConnectorParams & TVoiceSearchWidgetParams
->;
-
-export type VoiceSearchConnector = <TVoiceSearchWidgetParams>(
-  renderFn: VoiceSearchRenderer<TVoiceSearchWidgetParams>,
-  unmountFn?: () => void
-) => VoiceSearchWidgetFactory<TVoiceSearchWidgetParams>;
-
-const connectVoiceSearch: VoiceSearchConnector = (
-  renderFn,
-  unmountFn = noop
-) => {
+export default (function connectVoiceSearch(renderFn, unmountFn = noop) {
   checkRendering(renderFn, withUsage());
 
   return widgetParams => {
@@ -181,6 +163,4 @@ const connectVoiceSearch: VoiceSearchConnector = (
       },
     };
   };
-};
-
-export default connectVoiceSearch;
+} as Connector<VoiceSearchRendererOptions, VoiceSearchConnectorParams>);

--- a/src/lib/__tests__/insights-client-test.ts
+++ b/src/lib/__tests__/insights-client-test.ts
@@ -1,9 +1,10 @@
 import { withInsights, inferInsightsPayload } from '../insights';
 import { Widget, WidgetFactory } from '../../types';
 
-const connectHits = (renderFn: any, unmountFn: any): WidgetFactory<unknown> => (
-  widgetParams = {}
-): Widget => ({
+const connectHits = (
+  renderFn: any,
+  unmountFn: any
+): WidgetFactory<unknown, unknown> => (widgetParams = {}): Widget => ({
   init() {},
   render({ results, instantSearchInstance }) {
     const hits = results.hits;

--- a/src/lib/insights/client.ts
+++ b/src/lib/insights/client.ts
@@ -6,10 +6,7 @@ import {
   InsightsClientMethod,
   InsightsClientPayload,
   InsightsClientWrapper,
-  Renderer,
-  RendererOptions,
-  Unmounter,
-  WidgetFactory,
+  Connector,
 } from '../../types';
 
 const getSelectedHits = (hits: Hits, selectedObjectIDs: string[]): Hits => {
@@ -104,20 +101,10 @@ const wrapInsightsClient = (
   aa(method, { ...inferredPayload, ...payload } as any);
 };
 
-type Connector<TWidgetParams> = (
-  renderFn: Renderer<any>,
-  unmountFn: Unmounter
-) => WidgetFactory<TWidgetParams>;
-
-export default function withInsights(
-  connector: Connector<any>
-): Connector<unknown> {
-  const wrapRenderFn = (
-    renderFn: Renderer<RendererOptions<unknown>>
-  ): Renderer<RendererOptions<unknown>> => (
-    renderOptions: RendererOptions,
-    isFirstRender: boolean
-  ) => {
+export default function withInsights<TRenderOptions, TWidgetParams>(
+  connector: Connector<TRenderOptions, TWidgetParams>
+): Connector<TRenderOptions, TWidgetParams> {
+  const wrapRenderFn = renderFn => (renderOptions, isFirstRender) => {
     const { results, hits, instantSearchInstance } = renderOptions;
     if (results && hits && instantSearchInstance) {
       const insights = wrapInsightsClient(
@@ -130,6 +117,5 @@ export default function withInsights(
     return renderFn(renderOptions, isFirstRender);
   };
 
-  return (renderFn: Renderer<RendererOptions<unknown>>, unmountFn: Unmounter) =>
-    connector(wrapRenderFn(renderFn), unmountFn);
+  return (renderFn, unmountFn) => connector(wrapRenderFn(renderFn), unmountFn);
 }

--- a/src/lib/utils/checkRendering.ts
+++ b/src/lib/utils/checkRendering.ts
@@ -1,7 +1,10 @@
 import { Renderer } from '../../types/connector';
 import getObjectType from './getObjectType';
 
-function checkRendering(rendering: Renderer, usage: string): void {
+function checkRendering<TRenderOptions, TWidgetParams>(
+  rendering: Renderer<TRenderOptions, TWidgetParams>,
+  usage: string
+): void {
   if (rendering === undefined || typeof rendering !== 'function') {
     throw new Error(`The render function is not valid (received type ${getObjectType(
       rendering

--- a/src/types/connector.ts
+++ b/src/types/connector.ts
@@ -1,22 +1,73 @@
 import { SearchResults } from 'algoliasearch-helper';
 import { Hits, InstantSearch } from './instantsearch';
 import { InsightsClient } from './insights';
+import { WidgetFactory } from './widget';
 
-export type RendererOptions<TWidgetParams = unknown> = {
+/**
+ * The base renderer options. All render functions receive
+ * the options below plus the specific options per connector.
+ */
+export type RendererOptions<TWidgetParams> = {
   /**
-   * Original parameters for this widget.
-   * Useful for giving back the render parameters to the renderer.
+   * The original widget params. Useful as you may
+   * need them while using the render function.
    */
   widgetParams: TWidgetParams;
+
+  /**
+   * The current instant search instance.
+   */
   instantSearchInstance: InstantSearch;
+
+  /**
+   * The original search results.
+   */
   results?: SearchResults;
+
+  /**
+   * The mutable list of hits. The may change depending
+   * of the given transform items function.
+   */
   hits?: Hits;
+
+  /**
+   * The current insights client, if any.
+   */
   insights?: InsightsClient;
 };
 
-export type Renderer<TRenderOptions extends RendererOptions = any> = (
-  renderOptions: TRenderOptions,
+/**
+ * The render function.
+ */
+export type Renderer<TRenderOptions, TWidgetParams> = (
+  /**
+   * The base render options plus the specific options of the widget.
+   */
+  renderOptions: TRenderOptions & RendererOptions<TWidgetParams>,
+
+  /**
+   * If is the first run.
+   */
   isFirstRender: boolean
 ) => void;
 
+/**
+ * The called function when unmounting a widget.
+ */
 export type Unmounter = () => void;
+
+/**
+ * The connector handles the business logic and exposes
+ * a simplified API to the rendering function.
+ */
+export type Connector<TRendererOptions, TConnectorParams> = <TWidgetParams>(
+  /**
+   * The render function.
+   */
+  renderFn: Renderer<TRendererOptions, TWidgetParams>,
+
+  /**
+   * The called function when unmounting a widget.
+   */
+  unmountFn: Unmounter
+) => WidgetFactory<TConnectorParams & TWidgetParams>;

--- a/src/types/connector.ts
+++ b/src/types/connector.ts
@@ -69,5 +69,5 @@ export type Connector<TRendererOptions, TConnectorParams> = <TWidgetParams>(
   /**
    * The called function when unmounting a widget.
    */
-  unmountFn: Unmounter
-) => WidgetFactory<TConnectorParams & TWidgetParams>;
+  unmountFn?: Unmounter
+) => WidgetFactory<TConnectorParams, TWidgetParams>;

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -192,8 +192,14 @@ export type Widget = {
   ): SearchParameters;
 };
 
-export type WidgetFactory<TWidgetParams> = (
-  widgetParams: TWidgetParams
+/**
+ * The function that creates a new widget.
+ */
+export type WidgetFactory<TConnectorParams, TWidgetParams> = (
+  /**
+   * The params of the widget.
+   */
+  widgetParams: TConnectorParams & TWidgetParams
 ) => Widget;
 
 export type Template<TTemplateData = void> =

--- a/src/widgets/configure-related-items/configure-related-items.ts
+++ b/src/widgets/configure-related-items/configure-related-items.ts
@@ -1,11 +1,8 @@
-import connectConfigureRelatedItems, {
-  ConfigureRelatedItemsWidgetFactory,
-} from '../../connectors/configure-related-items/connectConfigureRelatedItems';
+import { noop } from '../../lib/utils';
+import connectConfigureRelatedItems from '../../connectors/configure-related-items/connectConfigureRelatedItems';
 
-type ConfigureRelatedItems = ConfigureRelatedItemsWidgetFactory<{}>;
-
-const configureRelatedItems: ConfigureRelatedItems = widgetParams => {
-  const makeWidget = connectConfigureRelatedItems();
+const configureRelatedItems = widgetParams => {
+  const makeWidget = connectConfigureRelatedItems(noop);
 
   return makeWidget(widgetParams);
 };

--- a/src/widgets/configure/configure.ts
+++ b/src/widgets/configure/configure.ts
@@ -1,6 +1,7 @@
 import { PlainSearchParameters } from 'algoliasearch-helper';
 import connectConfigure from '../../connectors/configure/connectConfigure';
 import { WidgetFactory } from '../../types';
+import { noop } from '../../lib/utils';
 
 /**
  * A list of [search parameters](https://www.algolia.com/doc/api-reference/search-api-parameters/)
@@ -8,12 +9,12 @@ import { WidgetFactory } from '../../types';
  */
 type ConfigureWidgetParams = PlainSearchParameters;
 
-type Configure = WidgetFactory<ConfigureWidgetParams>;
+type Configure = WidgetFactory<{}, ConfigureWidgetParams>;
 
 const configure: Configure = (widgetParams: ConfigureWidgetParams) => {
   // This is a renderless widget that falls back to the connector's
   // noop render and unmount functions.
-  const makeWidget = connectConfigure();
+  const makeWidget = connectConfigure(noop);
 
   return makeWidget({ searchParameters: widgetParams });
 };

--- a/src/widgets/current-refinements/current-refinements.tsx
+++ b/src/widgets/current-refinements/current-refinements.tsx
@@ -4,15 +4,16 @@ import { h, render } from 'preact';
 import cx from 'classnames';
 import CurrentRefinements from '../../components/CurrentRefinements/CurrentRefinements';
 import connectCurrentRefinements, {
-  CurrentRefinementsRenderer,
   Item,
+  CurrentRefinementsConnectorParams,
+  CurrentRefinementsRendererOptions,
 } from '../../connectors/current-refinements/connectCurrentRefinements';
 import {
   getContainerNode,
   createDocumentationMessageGenerator,
 } from '../../lib/utils';
 import { component } from '../../lib/suit';
-import { WidgetFactory } from '../../types';
+import { WidgetFactory, Renderer } from '../../types';
 
 type CurrentRefinementsCSSClasses = {
   root: string | string[];
@@ -62,16 +63,24 @@ export type CurrentRefinementsWidgetParams = {
 type CurrentRefinementsRendererWidgetParams = {
   container: HTMLElement;
   cssClasses: CurrentRefinementsComponentCSSClasses;
-} & CurrentRefinementsWidgetParams;
+};
 
-type CurrentRefinements = WidgetFactory<CurrentRefinementsWidgetParams>;
+type CurrentRefinements = WidgetFactory<
+  CurrentRefinementsConnectorParams,
+  CurrentRefinementsWidgetParams
+>;
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'current-refinements',
 });
 const suit = component('CurrentRefinements');
 
-const renderer: CurrentRefinementsRenderer<CurrentRefinementsRendererWidgetParams> = (
+type CurrentRefinementsRenderer = Renderer<
+  CurrentRefinementsRendererOptions,
+  CurrentRefinementsRendererWidgetParams
+>;
+
+const renderer: CurrentRefinementsRenderer = (
   { items, widgetParams },
   isFirstRender
 ) => {
@@ -112,9 +121,9 @@ const currentRefinements: CurrentRefinements = ({
     delete: cx(suit({ descendantName: 'delete' }), userCssClasses.delete),
   };
 
-  const makeWidget = connectCurrentRefinements(renderer, () =>
-    render(null, containerNode)
-  );
+  const makeWidget = connectCurrentRefinements<
+    CurrentRefinementsRendererWidgetParams
+  >(renderer, () => render(null, containerNode));
 
   return makeWidget({
     container: containerNode,

--- a/src/widgets/hits-per-page/hits-per-page.tsx
+++ b/src/widgets/hits-per-page/hits-per-page.tsx
@@ -5,7 +5,6 @@ import cx from 'classnames';
 import Selector from '../../components/Selector/Selector';
 import connectHitsPerPage, {
   HitsPerPageConnectorParams,
-  HitsPerPageRenderer,
   HitsPerPageRendererOptions,
 } from '../../connectors/hits-per-page/connectHitsPerPage';
 import {
@@ -24,7 +23,7 @@ const suit = component('HitsPerPage');
 const renderer = ({ containerNode, cssClasses }) => (
   { items, refine }: HitsPerPageRendererOptions,
   isFirstRendering
-): HitsPerPageRenderer<HitsPerPageWidgetOptions> | void => {
+) => {
   if (isFirstRendering) return;
 
   const { value: currentValue } =
@@ -60,8 +59,6 @@ export type HitsPerPageCSSClasses = {
   option?: string | string[];
 };
 
-export type HitsPerPageItems = HitsPerPageConnectorParams['items'];
-
 export type HitsPerPageWidgetOptions = {
   /**
    * CSS Selector or HTMLElement to insert the widget.
@@ -72,17 +69,20 @@ export type HitsPerPageWidgetOptions = {
    * CSS classes to be added.
    */
   cssClasses?: HitsPerPageCSSClasses;
-} & HitsPerPageConnectorParams;
+};
 
-export type HitsPerPageWidget = WidgetFactory<HitsPerPageWidgetOptions>;
+export type HitsPerPageWidget = WidgetFactory<
+  HitsPerPageConnectorParams,
+  HitsPerPageWidgetOptions
+>;
 
-const hitsPerPage: HitsPerPageWidget = function hitsPerPage(
+export default (function hitsPerPage(
   {
     container,
     items,
     cssClasses: userCssClasses = {},
     transformItems,
-  } = {} as HitsPerPageWidgetOptions
+  } = {} as HitsPerPageConnectorParams & HitsPerPageWidgetOptions
 ) {
   if (!container) {
     throw new Error(withUsage('The `container` option is required.'));
@@ -106,6 +106,4 @@ const hitsPerPage: HitsPerPageWidget = function hitsPerPage(
   );
 
   return makeHitsPerPage({ items, transformItems });
-};
-
-export default hitsPerPage;
+} as HitsPerPageWidget);

--- a/src/widgets/infinite-hits/infinite-hits.tsx
+++ b/src/widgets/infinite-hits/infinite-hits.tsx
@@ -5,7 +5,8 @@ import cx from 'classnames';
 import { SearchResults } from 'algoliasearch-helper';
 import InfiniteHits from '../../components/InfiniteHits/InfiniteHits';
 import connectInfiniteHits, {
-  InfiniteHitsRenderer,
+  InfiniteHitsConnectorParams,
+  InfiniteHitsRendererOptions,
 } from '../../connectors/infinite-hits/connectInfiniteHits';
 import {
   prepareTemplateProps,
@@ -19,6 +20,7 @@ import {
   Template,
   Hit,
   InsightsClientWrapper,
+  Renderer,
 } from '../../types';
 import defaultTemplates from './defaultTemplates';
 
@@ -117,7 +119,10 @@ type InfiniteHitsWidgetParams = {
   templates?: Partial<InfiniteHitsTemplates>;
 } & InfiniteHitsRendererWidgetParams;
 
-type InfiniteHits = WidgetFactory<InfiniteHitsWidgetParams>;
+type InfiniteHits = WidgetFactory<
+  InfiniteHitsConnectorParams,
+  InfiniteHitsWidgetParams
+>;
 
 const renderer = ({
   cssClasses,
@@ -125,7 +130,7 @@ const renderer = ({
   renderState,
   templates,
   showPrevious: hasShowPrevious,
-}): InfiniteHitsRenderer<Required<InfiniteHitsRendererWidgetParams>> => (
+}): Renderer<InfiniteHitsRendererOptions, InfiniteHitsRendererWidgetParams> => (
   {
     hits,
     results,

--- a/src/widgets/panel/panel.tsx
+++ b/src/widgets/panel/panel.tsx
@@ -103,7 +103,7 @@ type NestedWidgetOptions = {
 type PanelWidget = (
   params?: PanelWidgetParams
 ) => (
-  widgetFactory: WidgetFactory<NestedWidgetOptions>
+  widgetFactory: WidgetFactory<{}, NestedWidgetOptions>
 ) => (widgetOptions: NestedWidgetOptions) => Widget;
 
 /**
@@ -162,7 +162,7 @@ const panel: PanelWidget = (widgetParams = {} as PanelWidgetParams) => {
     footer: cx(suit({ descendantName: 'footer' }), userCssClasses.footer),
   };
 
-  return (widgetFactory: WidgetFactory<NestedWidgetOptions>) => (
+  return (widgetFactory: WidgetFactory<{}, NestedWidgetOptions>) => (
     widgetOptions = {} as NestedWidgetOptions
   ): Widget => {
     const { container } = widgetOptions;

--- a/src/widgets/places/places.ts
+++ b/src/widgets/places/places.ts
@@ -31,7 +31,7 @@ type PlacesWidgetState = {
  * This widget sets the geolocation value for the search based on the selected
  * result in the Algolia Places autocomplete.
  */
-const placesWidget: WidgetFactory<PlacesWidgetOptions> = (
+const placesWidget: WidgetFactory<{}, PlacesWidgetOptions> = (
   widgetOptions: PlacesWidgetOptions
 ) => {
   const {

--- a/src/widgets/query-rule-context/query-rule-context.tsx
+++ b/src/widgets/query-rule-context/query-rule-context.tsx
@@ -3,6 +3,7 @@ import { createDocumentationMessageGenerator, noop } from '../../lib/utils';
 import connectQueryRules, {
   ParamTrackedFilters,
   ParamTransformRuleContexts,
+  QueryRulesConnectorParams,
 } from '../../connectors/query-rules/connectQueryRules';
 
 type QueryRuleContextWidgetParams = {
@@ -10,7 +11,10 @@ type QueryRuleContextWidgetParams = {
   transformRuleContexts?: ParamTransformRuleContexts;
 };
 
-type QueryRuleContext = WidgetFactory<QueryRuleContextWidgetParams>;
+type QueryRuleContext = WidgetFactory<
+  QueryRulesConnectorParams,
+  QueryRuleContextWidgetParams
+>;
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'query-rule-context',

--- a/src/widgets/query-rule-custom-data/query-rule-custom-data.tsx
+++ b/src/widgets/query-rule-custom-data/query-rule-custom-data.tsx
@@ -7,9 +7,10 @@ import {
   createDocumentationMessageGenerator,
 } from '../../lib/utils';
 import { component } from '../../lib/suit';
-import { WidgetFactory } from '../../types';
+import { WidgetFactory, Renderer } from '../../types';
 import connectQueryRules, {
-  QueryRulesRenderer,
+  QueryRulesConnectorParams,
+  QueryRulesRendererOptions,
 } from '../../connectors/query-rules/connectQueryRules';
 import CustomData from '../../components/QueryRuleCustomData/QueryRuleCustomData';
 
@@ -34,7 +35,10 @@ type QueryRuleCustomDataRendererWidgetParams = {
   templates: QueryRuleCustomDataTemplates;
 } & QueryRuleCustomDataWidgetParams;
 
-type QueryRuleCustomData = WidgetFactory<QueryRuleCustomDataWidgetParams>;
+type QueryRuleCustomDataWidget = WidgetFactory<
+  QueryRulesConnectorParams,
+  QueryRuleCustomDataWidgetParams
+>;
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'query-rule-custom-data',
@@ -42,10 +46,10 @@ const withUsage = createDocumentationMessageGenerator({
 
 const suit = component('QueryRuleCustomData');
 
-const renderer: QueryRulesRenderer<QueryRuleCustomDataRendererWidgetParams> = ({
-  items,
-  widgetParams,
-}) => {
+const renderer: Renderer<
+  QueryRulesRendererOptions,
+  QueryRuleCustomDataRendererWidgetParams
+> = ({ items, widgetParams }) => {
   const { container, cssClasses, templates } = widgetParams;
 
   render(
@@ -54,7 +58,7 @@ const renderer: QueryRulesRenderer<QueryRuleCustomDataRendererWidgetParams> = ({
   );
 };
 
-const queryRuleCustomData: QueryRuleCustomData = (
+const queryRuleCustomData: QueryRuleCustomDataWidget = (
   {
     container,
     cssClasses: userCssClasses = {} as QueryRuleCustomDataCSSClasses,

--- a/src/widgets/voice-search/voice-search.tsx
+++ b/src/widgets/voice-search/voice-search.tsx
@@ -9,13 +9,14 @@ import {
 } from '../../lib/utils';
 import { component } from '../../lib/suit';
 import connectVoiceSearch, {
-  VoiceSearchRenderer,
+  VoiceSearchConnectorParams,
+  VoiceSearchRendererOptions,
 } from '../../connectors/voice-search/connectVoiceSearch';
 import VoiceSearch, {
   VoiceSearchComponentCSSClasses,
 } from '../../components/VoiceSearch/VoiceSearch';
 import defaultTemplates from './defaultTemplates';
-import { WidgetFactory, Template } from '../../types';
+import { WidgetFactory, Template, Renderer } from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({ name: 'voice-search' });
 const suit = component('VoiceSearch');
@@ -57,9 +58,15 @@ type VoiceSearchRendererWidgetParams = {
   templates: VoiceSearchTemplates;
 } & VoiceSearchWidgetParams;
 
-type VoiceSearch = WidgetFactory<VoiceSearchWidgetParams>;
+type VoiceSearch = WidgetFactory<
+  VoiceSearchConnectorParams,
+  VoiceSearchWidgetParams
+>;
 
-const renderer: VoiceSearchRenderer<VoiceSearchRendererWidgetParams> = ({
+const renderer: Renderer<
+  VoiceSearchRendererOptions,
+  VoiceSearchRendererWidgetParams
+> = ({
   isBrowserSupported,
   isListening,
   toggleListening,


### PR DESCRIPTION
This pull request reduces a little bit the number of types needed while migrating a connector to typescript. In addition, it also makes a the minimum amount of work to have widgets in this new type system.

<img width="127" alt="Screenshot 2020-03-23 at 14 53 53" src="https://user-images.githubusercontent.com/5457236/77323820-2541d180-6d16-11ea-80c4-bd641e6122d0.png">

Note that some new lines are comments to uncommented types before.
