### PR TITLE
chore(fixes-yarn-lint-hangs): adds ecommerce example to eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,3 @@
-/dist
 /cjs
 /es
 /website

--- a/.eslintignore
+++ b/.eslintignore
@@ -6,6 +6,7 @@ node_modules/
 
 # TODO: don't ignore these examples once they're updated
 /examples/calendar-widget
-/examples/e-commerce
+/examples/e-commerce/.cache
+/examples/e-commerce/dist
 /examples/media
 /examples/tourism

--- a/.eslintignore
+++ b/.eslintignore
@@ -5,6 +5,7 @@
 node_modules/
 
 # TODO: don't ignore these examples once they're updated
+/examples/e-commerce
 /examples/calendar-widget
 /examples/media
 /examples/tourism

--- a/.eslintignore
+++ b/.eslintignore
@@ -5,7 +5,7 @@
 node_modules/
 
 # TODO: don't ignore these examples once they're updated
-/examples/e-commerce
 /examples/calendar-widget
+/examples/e-commerce
 /examples/media
 /examples/tourism

--- a/.eslintignore
+++ b/.eslintignore
@@ -2,11 +2,11 @@
 /cjs
 /es
 /website
+dist
+.cache
 node_modules/
 
 # TODO: don't ignore these examples once they're updated
 /examples/calendar-widget
-/examples/e-commerce/.cache
-/examples/e-commerce/dist
 /examples/media
 /examples/tourism


### PR DESCRIPTION
This pull request fixes the reason why `yarn lint` takes a year to lint the project. The reason is because it was trying to linting the ecommerce example.