### PR TITLE
chore(ts-migration): renders explicit the client type

### DIFF
--- a/src/connectors/autocomplete/__tests__/connectAutocomplete-test.ts
+++ b/src/connectors/autocomplete/__tests__/connectAutocomplete-test.ts
@@ -11,7 +11,7 @@ import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import { createSingleSearchResponse } from '../../../../test/mock/createAPIResponse';
 import connectAutocomplete from '../connectAutocomplete';
 import { TAG_PLACEHOLDER } from '../../../lib/escape-highlight';
-import { Client } from '../../../types';
+import { SearchClient } from '../../../types';
 
 describe('connectAutocomplete', () => {
   const getInitializedWidget = (config = {}) => {
@@ -22,7 +22,7 @@ describe('connectAutocomplete', () => {
     });
 
     const initialConfig = {};
-    const helper = algoliasearchHelper({} as Client, '', initialConfig);
+    const helper = algoliasearchHelper({} as SearchClient, '', initialConfig);
     helper.search = jest.fn();
 
     widget.init!(

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -2,7 +2,7 @@ import algoliasearchHelper, {
   SearchResults,
   SearchParameters,
 } from 'algoliasearch-helper';
-import { Client } from '../../../types';
+import { SearchClient } from '../../../types';
 import { createInstantSearch } from '../../../../test/mock/createInstantSearch';
 import {
   createInitOptions,
@@ -62,7 +62,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
 
     expect(renderFn).toHaveBeenCalledTimes(0);
 
-    const helper = algoliasearchHelper({} as Client, '', {});
+    const helper = algoliasearchHelper({} as SearchClient, '', {});
     helper.search = jest.fn();
 
     widget.init!(
@@ -124,7 +124,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     const makeWidget = connectInfiniteHits(renderFn);
     const widget = makeWidget({});
 
-    const helper = algoliasearchHelper({} as Client, '', {});
+    const helper = algoliasearchHelper({} as SearchClient, '', {});
     helper.search = jest.fn();
 
     widget.init!(
@@ -188,7 +188,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     const makeWidget = connectInfiniteHits(renderFn);
     const widget = makeWidget({});
 
-    const helper = algoliasearchHelper({} as Client, '', {});
+    const helper = algoliasearchHelper({} as SearchClient, '', {});
     helper.setPage(1);
     helper.search = jest.fn();
     helper.emit = jest.fn();
@@ -256,7 +256,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     const makeWidget = connectInfiniteHits(renderFn);
     const widget = makeWidget({});
 
-    const helper = algoliasearchHelper({} as Client, '', {});
+    const helper = algoliasearchHelper({} as SearchClient, '', {});
     helper.search = jest.fn();
 
     widget.init!(
@@ -319,7 +319,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     const makeWidget = connectInfiniteHits(renderFn);
     const widget = makeWidget({ escapeHTML: true });
 
-    const helper = algoliasearchHelper({} as Client, '', {});
+    const helper = algoliasearchHelper({} as SearchClient, '', {});
     helper.search = jest.fn();
 
     widget.init!(
@@ -379,7 +379,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       transformItems: items => items.map(() => ({ name: 'transformed' })),
     });
 
-    const helper = algoliasearchHelper({} as Client, '', {});
+    const helper = algoliasearchHelper({} as SearchClient, '', {});
     helper.search = jest.fn();
 
     widget.init!(
@@ -446,7 +446,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       escapeHTML: true,
     });
 
-    const helper = algoliasearchHelper({} as Client, '', {});
+    const helper = algoliasearchHelper({} as SearchClient, '', {});
     helper.search = jest.fn();
 
     widget.init!(
@@ -523,7 +523,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     const makeWidget = connectInfiniteHits(renderFn);
     const widget = makeWidget({});
 
-    const helper = algoliasearchHelper({} as Client, '', {});
+    const helper = algoliasearchHelper({} as SearchClient, '', {});
     helper.search = jest.fn();
 
     widget.init!(
@@ -581,7 +581,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     const makeWidget = connectInfiniteHits(renderFn);
     const widget = makeWidget({});
 
-    const helper = algoliasearchHelper({} as Client, '', {});
+    const helper = algoliasearchHelper({} as SearchClient, '', {});
     helper.search = jest.fn();
 
     widget.init!(
@@ -657,7 +657,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     const makeWidget = connectInfiniteHits(rendering);
     const widget = makeWidget({});
 
-    const helper = algoliasearchHelper({} as Client, '', {});
+    const helper = algoliasearchHelper({} as SearchClient, '', {});
     helper.search = jest.fn();
 
     createInitOptions();
@@ -688,7 +688,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
 
   describe('dispose', () => {
     it('calls the unmount function', () => {
-      const helper = algoliasearchHelper({} as Client, '', {});
+      const helper = algoliasearchHelper({} as SearchClient, '', {});
 
       const renderFn = (): void => {};
       const unmountFn = jest.fn();
@@ -703,7 +703,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     });
 
     it('does not throw without the unmount function', () => {
-      const helper = algoliasearchHelper({} as Client, '', {});
+      const helper = algoliasearchHelper({} as SearchClient, '', {});
 
       const renderFn = (): void => {};
       const makeWidget = connectInfiniteHits(renderFn);
@@ -715,7 +715,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     });
 
     it('removes the TAG_PLACEHOLDER from the `SearchParameters`', () => {
-      const helper = algoliasearchHelper({} as Client, '', {
+      const helper = algoliasearchHelper({} as SearchClient, '', {
         ...TAG_PLACEHOLDER,
       });
 
@@ -741,7 +741,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     });
 
     it('does not remove the TAG_PLACEHOLDER from the `SearchParameters` with `escapeHTML` disabled', () => {
-      const helper = algoliasearchHelper({} as Client, '', {
+      const helper = algoliasearchHelper({} as SearchClient, '', {
         highlightPreTag: '<mark>',
         highlightPostTag: '</mark>',
       });
@@ -765,7 +765,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     });
 
     it('removes the `page` from the `SearchParameters`', () => {
-      const helper = algoliasearchHelper({} as Client, '', {
+      const helper = algoliasearchHelper({} as SearchClient, '', {
         page: 5,
       });
 

--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -16,7 +16,6 @@ import {
   SearchClient,
   Widget,
   UiState,
-  Client as AlgoliaSearchClient,
 } from '../types';
 import hasDetectedInsightsClient from './utils/detect-insights-client';
 import { Middleware, MiddlewareDefinition } from '../middleware';
@@ -66,7 +65,7 @@ export type InstantSearchOptions<TRouteState = UiState> = {
    * });
    * ```
    */
-  searchClient: SearchClient | AlgoliaSearchClient;
+  searchClient: SearchClient;
 
   /**
    * The locale used to display numbers. This will be passed
@@ -173,13 +172,8 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
       );
     }
 
-    if (
-      typeof (searchClient as AlgoliaSearchClient).addAlgoliaAgent ===
-      'function'
-    ) {
-      (searchClient as AlgoliaSearchClient).addAlgoliaAgent(
-        `instantsearch.js (${version})`
-      );
+    if (typeof searchClient.addAlgoliaAgent === 'function') {
+      searchClient.addAlgoliaAgent(`instantsearch.js (${version})`);
     }
 
     warning(
@@ -397,7 +391,7 @@ See ${createDocumentationLink({
       // to not throw errors
       const fakeClient = ({
         search: () => new Promise(noop),
-      } as any) as AlgoliaSearchClient;
+      } as any) as SearchClient;
 
       this._mainHelperSearch = mainHelper.search.bind(mainHelper);
       mainHelper.search = () => {

--- a/src/lib/utils/__tests__/clearRefinements-test.ts
+++ b/src/lib/utils/__tests__/clearRefinements-test.ts
@@ -1,9 +1,9 @@
 import clearRefinements from '../clearRefinements';
 import algoliasearchHelper, { SearchParameters } from 'algoliasearch-helper';
-import { Client } from '../../../types';
+import { SearchClient } from '../../../types';
 
 const initHelperWithRefinements = () => {
-  const helper = algoliasearchHelper({} as Client, 'index', {
+  const helper = algoliasearchHelper({} as SearchClient, 'index', {
     facets: ['conjFacet'],
     disjunctiveFacets: ['disjFacet'],
   });
@@ -21,7 +21,7 @@ describe('clearRefinements', () => {
   test('with hierarchical refinements', () => {
     expect(
       clearRefinements({
-        helper: algoliasearchHelper({} as Client, '', {
+        helper: algoliasearchHelper({} as SearchClient, '', {
           hierarchicalFacets: [
             { name: 'attr', attributes: ['attr'], separator: '>' },
           ],
@@ -46,7 +46,7 @@ describe('clearRefinements', () => {
   test('with empty hierarchical refinements', () => {
     expect(
       clearRefinements({
-        helper: algoliasearchHelper({} as Client, '', {
+        helper: algoliasearchHelper({} as SearchClient, '', {
           hierarchicalFacets: [
             { name: 'attr', attributes: ['attr'], separator: '>' },
           ],
@@ -71,7 +71,7 @@ describe('clearRefinements', () => {
   test('with disjunctive refinements', () => {
     expect(
       clearRefinements({
-        helper: algoliasearchHelper({} as Client, '', {
+        helper: algoliasearchHelper({} as SearchClient, '', {
           disjunctiveFacets: ['attr'],
           disjunctiveFacetsRefinements: {
             attr: ['text'],
@@ -92,7 +92,7 @@ describe('clearRefinements', () => {
   test('with empty disjunctive refinements', () => {
     expect(
       clearRefinements({
-        helper: algoliasearchHelper({} as Client, '', {
+        helper: algoliasearchHelper({} as SearchClient, '', {
           disjunctiveFacets: ['attr'],
           disjunctiveFacetsRefinements: {
             attr: [],
@@ -115,7 +115,7 @@ describe('clearRefinements', () => {
   test('with conjunctive refinements', () => {
     expect(
       clearRefinements({
-        helper: algoliasearchHelper({} as Client, '', {
+        helper: algoliasearchHelper({} as SearchClient, '', {
           facets: ['attr'],
           facetsRefinements: {
             attr: ['text'],
@@ -138,7 +138,7 @@ describe('clearRefinements', () => {
   test('with empty conjunctive refinements', () => {
     expect(
       clearRefinements({
-        helper: algoliasearchHelper({} as Client, '', {
+        helper: algoliasearchHelper({} as SearchClient, '', {
           facets: ['attr'],
           facetsRefinements: {
             attr: [],
@@ -161,7 +161,7 @@ describe('clearRefinements', () => {
   test('with numeric refinements', () => {
     expect(
       clearRefinements({
-        helper: algoliasearchHelper({} as Client, '', {
+        helper: algoliasearchHelper({} as SearchClient, '', {
           disjunctiveFacets: ['attr'],
           numericRefinements: {
             attr: {
@@ -188,7 +188,7 @@ describe('clearRefinements', () => {
   test('with empty numeric refinements', () => {
     expect(
       clearRefinements({
-        helper: algoliasearchHelper({} as Client, '', {
+        helper: algoliasearchHelper({} as SearchClient, '', {
           disjunctiveFacets: ['attr'],
           numericRefinements: {
             attr: {
@@ -215,7 +215,7 @@ describe('clearRefinements', () => {
   test('with multiple numeric refinements', () => {
     expect(
       clearRefinements({
-        helper: algoliasearchHelper({} as Client, '', {
+        helper: algoliasearchHelper({} as SearchClient, '', {
           disjunctiveFacets: ['attr'],
           numericRefinements: {
             attr: {

--- a/src/types/algoliasearch.ts
+++ b/src/types/algoliasearch.ts
@@ -22,20 +22,28 @@ type DummySearchClientV4 = {
   readonly addAlgoliaAgent: (segment: string, version?: string) => void;
 };
 
-export type Client = ReturnType<
+type DefaultSearchClient = ReturnType<
   typeof algoliasearch
 > extends DummySearchClientV4
   ? SearchClientV4
   : SearchClientV3;
 
+export type SearchClient = {
+  search: DefaultSearchClient['search'];
+  searchForFacetValues: DefaultSearchClient['searchForFacetValues'];
+  addAlgoliaAgent?: DefaultSearchClient['addAlgoliaAgent'];
+};
+
 export type MultiResponse<THit = any> = {
   results: Array<SearchResponse<THit>>;
 };
 
-export type SearchResponse<THit> = Client extends DummySearchClientV4
+export type SearchResponse<
+  THit
+> = DefaultSearchClient extends DummySearchClientV4
   ? SearchResponseV4<THit>
   : SearchResponseV3<THit>;
 
-export type SearchForFacetValuesResponse = Client extends DummySearchClientV4
+export type SearchForFacetValuesResponse = DefaultSearchClient extends DummySearchClientV4
   ? SearchForFacetValuesResponseV4
   : SearchForFacetValuesV3.Response;

--- a/src/types/instantsearch.ts
+++ b/src/types/instantsearch.ts
@@ -1,5 +1,4 @@
 import { SearchParameters } from 'algoliasearch-helper';
-import { Client as AlgoliaSearchClient } from './algoliasearch';
 import { UiState } from './widget';
 export {
   default as InstantSearch,
@@ -152,8 +151,3 @@ export type StateMapping<TRouteState = UiState> = {
 export type RouteState = {
   [stateKey: string]: any;
 };
-
-export type SearchClient = Pick<
-  AlgoliaSearchClient,
-  'search' | 'searchForFacetValues'
->;

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -15,7 +15,7 @@ import {
   WidgetStateOptions,
   WidgetSearchParametersOptions,
   ScopedResult,
-  Client,
+  SearchClient,
 } from '../../types';
 import {
   checkIndexUiState,
@@ -304,7 +304,11 @@ const index = (props: IndexProps): Index => {
       // This Helper is only used for state management we do not care about the
       // `searchClient`. Only the "main" Helper created at the `InstantSearch`
       // level is aware of the client.
-      helper = algoliasearchHelper({} as Client, parameters.index, parameters);
+      helper = algoliasearchHelper(
+        {} as SearchClient,
+        parameters.index,
+        parameters
+      );
 
       // We forward the call to `search` to the "main" instance of the Helper
       // which is responsible for managing the queries (it's the only one that is

--- a/src/widgets/infinite-hits/__tests__/infinite-hits-test.ts
+++ b/src/widgets/infinite-hits/__tests__/infinite-hits-test.ts
@@ -1,6 +1,6 @@
 import { render as preactRender } from 'preact';
 import algoliasearchHelper from 'algoliasearch-helper';
-import { Client } from '../../../types';
+import { SearchClient } from '../../../types';
 import infiniteHits from '../infinite-hits';
 import { castToJestMock } from '../../../../test/utils/castToJestMock';
 
@@ -36,7 +36,7 @@ describe('infiniteHits()', () => {
   beforeEach(() => {
     render.mockClear();
 
-    helper = algoliasearchHelper({} as Client, '', {});
+    helper = algoliasearchHelper({} as SearchClient, '', {});
     helper.search = jest.fn();
 
     container = document.createElement('div');


### PR DESCRIPTION
This pull request makes explicit the client type used along instantsearch. Also improves a little bit the type itself, saying that the `addAlgoliaAgent` is optional. 