### PR TITLE
chore(ts-migration): exports missing types at top level

### DIFF
--- a/api-extractor.json
+++ b/api-extractor.json
@@ -28,12 +28,17 @@
 
       "ae-missing-release-tag": {
         "logLevel": "none"
+      },
+
+      "ae-internal-missing-underscore": {
+        "logLevel": "none"
       }
     },
 
+
     "tsdocMessageReporting": {
       "default": {
-        "logLevel": "warning"
+        "logLevel": "none"
       }
     }
   },

--- a/src/index.es.ts
+++ b/src/index.es.ts
@@ -41,4 +41,7 @@ import { connectSearchBox } from 'instantsearch.js/es/connectors'`
   },
 });
 
+export * from './types';
+export * from './middleware';
+
 export default instantsearch;

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -10,4 +10,4 @@ export type Middleware = ({
   instantSearchInstance: InstantSearch,
 }) => MiddlewareDefinition;
 
-export { createRouter, RouterProps } from './createRouter';
+export * from './createRouter';

--- a/src/types/algoliasearch.ts
+++ b/src/types/algoliasearch.ts
@@ -34,16 +34,25 @@ export type SearchClient = {
   addAlgoliaAgent?: DefaultSearchClient['addAlgoliaAgent'];
 };
 
+/**
+ * @internal
+ */
 export type MultiResponse<THit = any> = {
   results: Array<SearchResponse<THit>>;
 };
 
+/**
+ * @internal
+ */
 export type SearchResponse<
   THit
 > = DefaultSearchClient extends DummySearchClientV4
   ? SearchResponseV4<THit>
   : SearchResponseV3<THit>;
 
+/**
+ * @internal
+ */
 export type SearchForFacetValuesResponse = DefaultSearchClient extends DummySearchClientV4
   ? SearchForFacetValuesResponseV4
   : SearchForFacetValuesV3.Response;

--- a/src/types/instantsearch.ts
+++ b/src/types/instantsearch.ts
@@ -10,26 +10,26 @@ export type HelperChangeEvent = {
   state: SearchParameters;
 };
 
-type HitAttributeHighlightResult = {
+export type HitAttributeHighlightResult = {
   value: string;
   matchLevel: 'none' | 'partial' | 'full';
   matchedWords: string[];
   fullyHighlighted?: boolean;
 };
 
-type HitHighlightResult = {
+export type HitHighlightResult = {
   [attribute: string]:
     | HitAttributeHighlightResult
     | HitAttributeHighlightResult[]
     | HitHighlightResult;
 };
 
-type HitAttributeSnippetResult = Pick<
+export type HitAttributeSnippetResult = Pick<
   HitAttributeHighlightResult,
   'value' | 'matchLevel'
 >;
 
-type HitSnippetResult = {
+export type HitSnippetResult = {
   [attribute: string]:
     | HitAttributeSnippetResult
     | HitAttributeSnippetResult[]

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -7,6 +7,12 @@ import {
 } from 'algoliasearch-helper';
 import { InstantSearch } from './instantsearch';
 
+export {
+  Index,
+  IndexInitOptions,
+  IndexRenderOptions,
+} from '../widgets/index/index';
+
 export type InitOptions = {
   instantSearchInstance: InstantSearch;
   parent: Index | null;

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -33,12 +33,12 @@ type IndexProps = {
   indexId?: string;
 };
 
-type IndexInitOptions = Pick<
+export type IndexInitOptions = Pick<
   InitOptions,
   'instantSearchInstance' | 'parent' | 'uiState'
 >;
 
-type IndexRenderOptions = Pick<RenderOptions, 'instantSearchInstance'>;
+export type IndexRenderOptions = Pick<RenderOptions, 'instantSearchInstance'>;
 
 type LocalWidgetSearchParametersOptions = WidgetSearchParametersOptions & {
   initialSearchParameters: SearchParameters;


### PR DESCRIPTION
This pull request fixes most of the errors reported by API Extractor. They are related to the fact that some types weren't exported a top level making the API difficult to use. Here is an example that **was not** possible in typescript before this pull request:

```ts
const client: SearchClient = { ... }; // my own special search client that looks like algolia one.

const options: InstantSearchOptions = {
  indexName: 'instant_search',
  searchClient: client,
};

const search: InstantSearch = instantsearch(options);
```

**Warning**: I am still validating locally if we are not exporting things that we shouldn't. So this pull request is not ready to merge. Just wanted to know your opinion about this change.