### PR TITLE
fix(setUiState): display experimental warning

### DIFF
--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -518,6 +518,15 @@ See ${createDocumentationLink({
       );
     }
 
+    warning(
+      false,
+      `
+\`setUiState\` provides a powerful way to manage the UI state. This is considered experimental as the API might change in a next minor version.
+
+Feel free to give us feedback on GitHub: https://github.com/algolia/instantsearch.js/issues/new
+    `
+    );
+
     // We refresh the index UI state to update the local UI state that the
     // main index passes to the function form of `setUiState`.
     this.mainIndex.refreshUiState();

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -1491,6 +1491,10 @@ describe('use', () => {
 });
 
 describe('setUiState', () => {
+  beforeEach(() => {
+    warning.cache = {};
+  });
+
   test('throws if the instance has not started', () => {
     const searchClient = createSearchClient();
     const search = new InstantSearch({
@@ -1795,6 +1799,29 @@ search.addWidgets([
 If you're using custom widgets that do set these query parameters, we recommend using connectors instead.
 
 See https://www.algolia.com/doc/guides/building-search-ui/widgets/customize-an-existing-widget/js/#customize-the-complete-ui-of-the-widgets`);
+  });
+
+  it('warns about experimental API', () => {
+    const searchClient = createSearchClient();
+    const search = new InstantSearch({
+      indexName: 'indexName',
+      searchClient,
+    });
+
+    search.addWidgets([connectSearchBox(() => {})({})]);
+
+    search.start();
+
+    expect(() => {
+      search.setUiState({
+        indexName: {
+          query: 'Query',
+        },
+      });
+    })
+      .toWarnDev(`[InstantSearch.js]: \`setUiState\` provides a powerful way to manage the UI state. This is considered experimental as the API might change in a next minor version.
+
+Feel free to give us feedback on GitHub: https://github.com/algolia/instantsearch.js/issues/new`);
   });
 });
 


### PR DESCRIPTION
## Description

Before releasing the new set of APIs to control the UI state, we mark them as experimental to gather feedback and change their APIs in a next minor if needed.

The warning only happens in `setUiState` because `onStateChange` relies on `setUiState`.

## Related

- API documentation: algolia/doc#4352