### PR TITLE
chore(tsconfig): ignores build folder that contains type definitions

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,5 +19,5 @@
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true
   },
-  "exclude": ["examples"]
+  "exclude": ["examples", "es"]
 }


### PR DESCRIPTION
This pull request makes the command `yarn type-check` ignore the build folder that contains the type definitions.