### PR TITLE
chore(ts-migration): migrates breadcrumb files content

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -32,10 +32,7 @@ export type BreadcrumbProps = {
   };
   createURL(value: string | undefined): string;
   refine(value: string | undefined): void;
-  /**
-   * @internal
-   */
-  canRefine?: boolean;
+  canRefine: boolean;
 };
 
 const Breadcrumb = ({

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -32,7 +32,7 @@ export type BreadcrumbProps = {
   };
   createURL(value: string | undefined): string;
   refine(value: string | undefined): void;
-  canRefine: boolean;
+  canRefine?: boolean;
 };
 
 const Breadcrumb = ({

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -32,6 +32,10 @@ export type BreadcrumbProps = {
   };
   createURL(value: string | undefined): string;
   refine(value: string | undefined): void;
+  /**
+   * @internal
+   */
+  canRefine?: boolean;
 };
 
 const Breadcrumb = ({

--- a/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.ts
+++ b/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.ts
@@ -3,9 +3,7 @@ import jsHelper, {
   SearchParameters,
 } from 'algoliasearch-helper';
 import { warning } from '../../../lib/utils';
-import connectBreadcrumb, {
-  BreadcrumbConnectorParams,
-} from '../connectBreadcrumb';
+import connectBreadcrumb from '../connectBreadcrumb';
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import { createSingleSearchResponse } from '../../../../test/mock/createAPIResponse';
 import {

--- a/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.ts
+++ b/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.ts
@@ -185,6 +185,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
             name: 'category',
             attributes: ['category', 'sub_category'],
             separator: ' > ',
+            // @TODO Add missing type to js helper
             // @ts-ignore
             rootPath: null,
           },

--- a/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.ts
+++ b/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.ts
@@ -149,8 +149,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
             name: 'country',
             attributes: ['country', 'sub_country'],
             separator: ' > ',
-            // @ts-ignore
-            rootPath: null,
           },
         ],
       });
@@ -168,7 +166,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
           name: 'country',
           attributes: ['country', 'sub_country'],
           separator: ' > ',
-          rootPath: null,
         },
         {
           name: 'category',

--- a/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.ts
+++ b/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.ts
@@ -3,12 +3,21 @@ import jsHelper, {
   SearchParameters,
 } from 'algoliasearch-helper';
 import { warning } from '../../../lib/utils';
-import connectBreadcrumb from '../connectBreadcrumb';
+import connectBreadcrumb, {
+  BreadcrumbConnectorParams,
+} from '../connectBreadcrumb';
+import { createSearchClient } from '../../../../test/mock/createSearchClient';
+import { createSingleSearchResponse } from '../../../../test/mock/createAPIResponse';
+import {
+  createInitOptions,
+  createRenderOptions,
+} from '../../../../test/mock/createWidget';
 
 describe('connectBreadcrumb', () => {
   describe('Usage', () => {
     it('throws without render function', () => {
       expect(() => {
+        // @ts-ignore
         connectBreadcrumb()({});
       }).toThrowErrorMatchingInlineSnapshot(`
 "The render function is not valid (received type Undefined).
@@ -20,6 +29,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
     it('throws with undefined `attributes`', () => {
       expect(() => {
         connectBreadcrumb(() => {})({
+          // @ts-ignore
           attributes: undefined,
         });
       }).toThrowErrorMatchingInlineSnapshot(`
@@ -67,12 +77,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
     it('returns the `SearchParameters` with default value', () => {
       const render = () => {};
       const makeWidget = connectBreadcrumb(render);
-      const helper = jsHelper({}, '');
+      const helper = jsHelper(createSearchClient(), '');
       const widget = makeWidget({
         attributes: ['category', 'sub_category'],
       });
 
-      const actual = widget.getWidgetSearchParameters(helper.state, {
+      const actual = widget.getWidgetSearchParameters!(helper.state, {
         uiState: {},
       });
 
@@ -89,13 +99,13 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
     it('returns the `SearchParameters` with default a custom `separator`', () => {
       const render = () => {};
       const makeWidget = connectBreadcrumb(render);
-      const helper = jsHelper({}, '');
+      const helper = jsHelper(createSearchClient(), '');
       const widget = makeWidget({
         attributes: ['category', 'sub_category'],
         separator: ' / ',
       });
 
-      const actual = widget.getWidgetSearchParameters(helper.state, {
+      const actual = widget.getWidgetSearchParameters!(helper.state, {
         uiState: {},
       });
 
@@ -112,13 +122,13 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
     it('returns the `SearchParameters` with default a custom `rootPath`', () => {
       const render = () => {};
       const makeWidget = connectBreadcrumb(render);
-      const helper = jsHelper({}, '');
+      const helper = jsHelper(createSearchClient(), '');
       const widget = makeWidget({
         attributes: ['category', 'sub_category'],
         rootPath: 'TopLevel > SubLevel',
       });
 
-      const actual = widget.getWidgetSearchParameters(helper.state, {
+      const actual = widget.getWidgetSearchParameters!(helper.state, {
         uiState: {},
       });
 
@@ -135,12 +145,13 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
     it('returns the `SearchParameters` with another `hierarchicalFacets` already defined', () => {
       const render = () => {};
       const makeWidget = connectBreadcrumb(render);
-      const helper = jsHelper({}, '', {
+      const helper = jsHelper(createSearchClient(), '', {
         hierarchicalFacets: [
           {
             name: 'country',
             attributes: ['country', 'sub_country'],
             separator: ' > ',
+            // @ts-ignore
             rootPath: null,
           },
         ],
@@ -150,7 +161,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
         attributes: ['category', 'sub_category'],
       });
 
-      const actual = widget.getWidgetSearchParameters(helper.state, {
+      const actual = widget.getWidgetSearchParameters!(helper.state, {
         uiState: {},
       });
 
@@ -173,12 +184,13 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
     it('returns the `SearchParameters` with the same `hierarchicalFacets` already defined', () => {
       const render = () => {};
       const makeWidget = connectBreadcrumb(render);
-      const helper = jsHelper({}, '', {
+      const helper = jsHelper(createSearchClient(), '', {
         hierarchicalFacets: [
           {
             name: 'category',
             attributes: ['category', 'sub_category'],
             separator: ' > ',
+            // @ts-ignore
             rootPath: null,
           },
         ],
@@ -188,7 +200,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
         attributes: ['category', 'sub_category'],
       });
 
-      const actual = widget.getWidgetSearchParameters(helper.state, {
+      const actual = widget.getWidgetSearchParameters!(helper.state, {
         uiState: {},
       });
 
@@ -205,12 +217,13 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
     it('warns with the same `hierarchicalFacets` already defined with different `attributes`', () => {
       const render = () => {};
       const makeWidget = connectBreadcrumb(render);
-      const helper = jsHelper({}, '', {
+      const helper = jsHelper(createSearchClient(), '', {
         hierarchicalFacets: [
           {
             name: 'category',
             attributes: ['category', 'sub_category', 'sub_sub_category'],
             separator: ' > ',
+            // @ts-ignore
             rootPath: null,
           },
         ],
@@ -221,7 +234,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
       });
 
       expect(() =>
-        widget.getWidgetSearchParameters(helper.state, {
+        widget.getWidgetSearchParameters!(helper.state, {
           uiState: {},
         })
       ).toWarnDev();
@@ -230,12 +243,13 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
     it('warns with the same `hierarchicalFacets` already defined with different `separator`', () => {
       const render = () => {};
       const makeWidget = connectBreadcrumb(render);
-      const helper = jsHelper({}, '', {
+      const helper = jsHelper(createSearchClient(), '', {
         hierarchicalFacets: [
           {
             name: 'category',
             attributes: ['category', 'sub_category'],
             separator: ' > ',
+            // @ts-ignore
             rootPath: null,
           },
         ],
@@ -247,7 +261,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
       });
 
       expect(() =>
-        widget.getWidgetSearchParameters(helper.state, {
+        widget.getWidgetSearchParameters!(helper.state, {
           uiState: {},
         })
       ).toWarnDev();
@@ -256,12 +270,13 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
     it('warns with the same `hierarchicalFacets` already defined with different `rootPath`', () => {
       const render = () => {};
       const makeWidget = connectBreadcrumb(render);
-      const helper = jsHelper({}, '', {
+      const helper = jsHelper(createSearchClient(), '', {
         hierarchicalFacets: [
           {
             name: 'category',
             attributes: ['category', 'sub_category'],
             separator: ' > ',
+            // @ts-ignore
             rootPath: 'TopLevel > SubLevel',
           },
         ],
@@ -273,7 +288,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
       });
 
       expect(() =>
-        widget.getWidgetSearchParameters(helper.state, {
+        widget.getWidgetSearchParameters!(helper.state, {
           uiState: {},
         })
       ).toWarnDev();
@@ -285,7 +300,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
     const makeWidget = connectBreadcrumb(rendering);
     const widget = makeWidget({ attributes: ['category', 'sub_category'] });
 
-    const config = widget.getWidgetSearchParameters(new SearchParameters({}), {
+    const config = widget.getWidgetSearchParameters!(new SearchParameters({}), {
       uiState: {},
     });
     expect(config).toEqual(
@@ -294,6 +309,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
           {
             attributes: ['category', 'sub_category'],
             name: 'category',
+            // @ts-ignore
             rootPath: null,
             separator: ' > ',
           },
@@ -304,14 +320,16 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
     // Verify that the widget has not been rendered yet at this point
     expect(rendering.mock.calls).toHaveLength(0);
 
-    const helper = jsHelper({}, '', config);
+    const helper = jsHelper(createSearchClient(), '', config);
     helper.search = jest.fn();
 
-    widget.init({
-      helper,
-      state: helper.state,
-      createURL: () => '#',
-    });
+    widget.init!(
+      createInitOptions({
+        helper,
+        state: helper.state,
+        createURL: () => '#',
+      })
+    );
 
     // Verify that rendering has been called upon init with isFirstRendering = true
     expect(rendering.mock.calls).toHaveLength(1);
@@ -320,35 +338,34 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
     });
     expect(rendering.mock.calls[0][1]).toBe(true);
 
-    const instantSearchInstance = { templatesConfig: undefined };
-    widget.render({
-      results: new SearchResults(helper.state, [
-        {
-          hits: [],
-          facets: {
-            category: {
-              Decoration: 880,
+    widget.render!(
+      createRenderOptions({
+        results: new SearchResults(helper.state, [
+          createSingleSearchResponse({
+            hits: [],
+            facets: {
+              category: {
+                Decoration: 880,
+              },
+              subCategory: {
+                'Decoration > Candle holders & candles': 193,
+                'Decoration > Frames & pictures': 173,
+              },
             },
-            subCategory: {
-              'Decoration > Candle holders & candles': 193,
-              'Decoration > Frames & pictures': 173,
+          }),
+          createSingleSearchResponse({
+            facets: {
+              category: {
+                Decoration: 880,
+                Outdoor: 47,
+              },
             },
-          },
-        },
-        {
-          facets: {
-            category: {
-              Decoration: 880,
-              Outdoor: 47,
-            },
-          },
-        },
-      ]),
-      state: helper.state,
-      helper,
-      createURL: () => '#',
-      instantSearchInstance,
-    });
+          }),
+        ]),
+        state: helper.state,
+        helper,
+      })
+    );
 
     // Verify that rendering has been called upon render with isFirstRendering = false
     expect(rendering.mock.calls).toHaveLength(2);
@@ -363,48 +380,52 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
     const makeWidget = connectBreadcrumb(rendering);
     const widget = makeWidget({ attributes: ['category', 'sub_category'] });
 
-    const config = widget.getWidgetSearchParameters(new SearchParameters());
-    const helper = jsHelper({}, '', config);
+    const config = widget.getWidgetSearchParameters!(new SearchParameters(), {
+      uiState: {},
+    });
+    const helper = jsHelper(createSearchClient(), '', config);
     helper.search = jest.fn();
 
     helper.toggleRefinement('category', 'Decoration');
 
-    widget.init({
-      helper,
-      state: helper.state,
-      createURL: () => '#',
-    });
+    widget.init!(
+      createInitOptions({
+        helper,
+        state: helper.state,
+      })
+    );
 
     const firstRenderingOptions = rendering.mock.calls[0][0];
     expect(firstRenderingOptions.items).toEqual([]);
 
-    widget.render({
-      results: new SearchResults(helper.state, [
-        {
-          hits: [],
-          facets: {
-            category: {
-              Decoration: 880,
+    widget.render!(
+      createRenderOptions({
+        results: new SearchResults(helper.state, [
+          createSingleSearchResponse({
+            hits: [],
+            facets: {
+              category: {
+                Decoration: 880,
+              },
+              subCategory: {
+                'Decoration > Candle holders & candles': 193,
+                'Decoration > Frames & pictures': 173,
+              },
             },
-            subCategory: {
-              'Decoration > Candle holders & candles': 193,
-              'Decoration > Frames & pictures': 173,
+          }),
+          createSingleSearchResponse({
+            facets: {
+              category: {
+                Decoration: 880,
+                Outdoor: 47,
+              },
             },
-          },
-        },
-        {
-          facets: {
-            category: {
-              Decoration: 880,
-              Outdoor: 47,
-            },
-          },
-        },
-      ]),
-      state: helper.state,
-      helper,
-      createURL: () => '#',
-    });
+          }),
+        ]),
+        state: helper.state,
+        helper,
+      })
+    );
 
     const secondRenderingOptions = rendering.mock.calls[1][0];
     expect(secondRenderingOptions.items).toEqual([
@@ -419,39 +440,41 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
       attributes: ['category', 'sub_category'],
     });
 
-    const config = widget.getWidgetSearchParameters(new SearchParameters({}), {
+    const config = widget.getWidgetSearchParameters!(new SearchParameters({}), {
       uiState: {},
     });
-    const helper = jsHelper({}, '', config);
+    const helper = jsHelper(createSearchClient(), '', config);
 
     helper.search = jest.fn();
 
     helper.toggleRefinement('category', 'Decoration');
 
-    widget.init({
-      helper,
-      state: helper.state,
-      createURL: () => '#',
-    });
+    widget.init!(
+      createInitOptions({
+        helper,
+        state: helper.state,
+      })
+    );
 
     const firstRenderingOptions = rendering.mock.calls[0][0];
     expect(firstRenderingOptions.items).toEqual([]);
 
-    widget.render({
-      results: new SearchResults(helper.state, [
-        {
-          hits: [],
-          facets: {},
-        },
-        {
-          hits: [],
-          facets: {},
-        },
-      ]),
-      state: helper.state,
-      helper,
-      createURL: () => '#',
-    });
+    widget.render!(
+      createRenderOptions({
+        results: new SearchResults(helper.state, [
+          createSingleSearchResponse({
+            hits: [],
+            facets: {},
+          }),
+          createSingleSearchResponse({
+            hits: [],
+            facets: {},
+          }),
+        ]),
+        state: helper.state,
+        helper,
+      })
+    );
 
     const secondRenderingOptions = rendering.mock.calls[1][0];
     expect(secondRenderingOptions.items).toEqual([]);
@@ -466,48 +489,52 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
         items.map(item => ({ ...item, label: 'transformed' })),
     });
 
-    const config = widget.getWidgetSearchParameters(new SearchParameters());
-    const helper = jsHelper({}, '', config);
+    const config = widget.getWidgetSearchParameters!(new SearchParameters(), {
+      uiState: {},
+    });
+    const helper = jsHelper(createSearchClient(), '', config);
     helper.search = jest.fn();
 
     helper.toggleRefinement('category', 'Decoration');
 
-    widget.init({
-      helper,
-      state: helper.state,
-      createURL: () => '#',
-    });
+    widget.init!(
+      createInitOptions({
+        helper,
+        state: helper.state,
+      })
+    );
 
     const firstRenderingOptions = rendering.mock.calls[0][0];
     expect(firstRenderingOptions.items).toEqual([]);
 
-    widget.render({
-      results: new SearchResults(helper.state, [
-        {
-          hits: [],
-          facets: {
-            category: {
-              Decoration: 880,
+    widget.render!(
+      createRenderOptions({
+        results: new SearchResults(helper.state, [
+          createSingleSearchResponse({
+            hits: [],
+            facets: {
+              category: {
+                Decoration: 880,
+              },
+              subCategory: {
+                'Decoration > Candle holders & candles': 193,
+                'Decoration > Frames & pictures': 173,
+              },
             },
-            subCategory: {
-              'Decoration > Candle holders & candles': 193,
-              'Decoration > Frames & pictures': 173,
+          }),
+          createSingleSearchResponse({
+            facets: {
+              category: {
+                Decoration: 880,
+                Outdoor: 47,
+              },
             },
-          },
-        },
-        {
-          facets: {
-            category: {
-              Decoration: 880,
-              Outdoor: 47,
-            },
-          },
-        },
-      ]),
-      state: helper.state,
-      helper,
-      createURL: () => '#',
-    });
+          }),
+        ]),
+        state: helper.state,
+        helper,
+      })
+    );
 
     const secondRenderingOptions = rendering.mock.calls[1][0];
     expect(secondRenderingOptions.items).toEqual([
@@ -520,46 +547,52 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
     const makeWidget = connectBreadcrumb(rendering);
     const widget = makeWidget({ attributes: ['category', 'sub_category'] });
 
-    const config = widget.getWidgetSearchParameters(new SearchParameters());
-    const helper = jsHelper({}, '', config);
+    const config = widget.getWidgetSearchParameters!(new SearchParameters(), {
+      uiState: {},
+    });
+    const helper = jsHelper(createSearchClient(), '', config);
     helper.search = jest.fn();
 
-    widget.init({
-      helper,
-      state: helper.state,
-      createURL: state => state,
-    });
+    widget.init!(
+      createInitOptions({
+        helper,
+        state: helper.state,
+        createURL: state => (state as unknown) as string,
+      })
+    );
 
     const firstRenderingOptions = rendering.mock.calls[0][0];
     expect(firstRenderingOptions.items).toEqual([]);
 
-    widget.render({
-      results: new SearchResults(helper.state, [
-        {
-          hits: [],
-          facets: {
-            category: {
-              Decoration: 880,
+    widget.render!(
+      createRenderOptions({
+        results: new SearchResults(helper.state, [
+          createSingleSearchResponse({
+            hits: [],
+            facets: {
+              category: {
+                Decoration: 880,
+              },
+              subCategory: {
+                'Decoration > Candle holders & candles': 193,
+                'Decoration > Frames & pictures': 173,
+              },
             },
-            subCategory: {
-              'Decoration > Candle holders & candles': 193,
-              'Decoration > Frames & pictures': 173,
+          }),
+          createSingleSearchResponse({
+            facets: {
+              category: {
+                Decoration: 880,
+                Outdoor: 47,
+              },
             },
-          },
-        },
-        {
-          facets: {
-            category: {
-              Decoration: 880,
-              Outdoor: 47,
-            },
-          },
-        },
-      ]),
-      state: helper.state,
-      helper,
-      createURL: state => state,
-    });
+          }),
+        ]),
+        state: helper.state,
+        helper,
+        createURL: state => (state as unknown) as string,
+      })
+    );
     const createURL = rendering.mock.calls[1][0].createURL;
     expect(helper.state.hierarchicalFacetsRefinements).toEqual({});
     const stateForURL = createURL('Decoration > Candle holders & candles');
@@ -579,15 +612,19 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
       ],
     });
 
-    const config = widget.getWidgetSearchParameters(new SearchParameters());
-    const helper = jsHelper({}, '', config);
+    const config = widget.getWidgetSearchParameters!(new SearchParameters(), {
+      uiState: {},
+    });
+    const helper = jsHelper(createSearchClient(), '', config);
     helper.search = jest.fn();
 
-    widget.init({
-      helper,
-      state: helper.state,
-      createURL: state => state,
-    });
+    widget.init!(
+      createInitOptions({
+        helper,
+        state: helper.state,
+        createURL: state => (state as unknown) as string,
+      })
+    );
 
     const firstRenderingOptions = rendering.mock.calls[0][0];
     expect(firstRenderingOptions.items).toEqual([]);
@@ -596,130 +633,132 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
       'hierarchicalCategories.lvl0',
       'Cameras & Camcorders > Digital Cameras > Digital SLR Cameras'
     );
-    widget.render({
-      results: new SearchResults(helper.state, [
-        {
-          hits: [],
-          page: 0,
-          nbPages: 57,
-          index: 'instant_search',
-          processingTimeMS: 1,
-          nbHits: 170,
-          query: '',
-          hitsPerPage: 3,
-          params:
-            'query=&hitsPerPage=3&page=0&facets=%5B%22hierarchicalCategories.lvl0%22%2C%22hierarchicalCategories.lvl1%22%2C%22hierarchicalCategories.lvl2%22%5D&tagFilters=&facetFilters=%5B%5B%22hierarchicalCategories.lvl1%3ACameras%20%26%20Camcorders%20%3E%20Digital%20Cameras%22%5D%5D',
-          exhaustiveFacetsCount: true,
-          exhaustiveNbHits: true,
-          facets: {
-            'hierarchicalCategories.lvl1': {
-              'Cameras & Camcorders > Digital Cameras': 170,
+    widget.render!(
+      createRenderOptions({
+        results: new SearchResults(helper.state, [
+          createSingleSearchResponse({
+            hits: [],
+            page: 0,
+            nbPages: 57,
+            index: 'instant_search',
+            processingTimeMS: 1,
+            nbHits: 170,
+            query: '',
+            hitsPerPage: 3,
+            params:
+              'query=&hitsPerPage=3&page=0&facets=%5B%22hierarchicalCategories.lvl0%22%2C%22hierarchicalCategories.lvl1%22%2C%22hierarchicalCategories.lvl2%22%5D&tagFilters=&facetFilters=%5B%5B%22hierarchicalCategories.lvl1%3ACameras%20%26%20Camcorders%20%3E%20Digital%20Cameras%22%5D%5D',
+            exhaustiveFacetsCount: true,
+            exhaustiveNbHits: true,
+            facets: {
+              'hierarchicalCategories.lvl1': {
+                'Cameras & Camcorders > Digital Cameras': 170,
+              },
+              'hierarchicalCategories.lvl2': {
+                'Cameras & Camcorders > Digital Cameras > Digital SLR Cameras': 44,
+                'Cameras & Camcorders > Digital Cameras > Mirrorless Cameras': 29,
+                'Cameras & Camcorders > Digital Cameras > Point & Shoot Cameras': 84,
+              },
+              'hierarchicalCategories.lvl0': {
+                'Cameras & Camcorders': 170,
+              },
             },
-            'hierarchicalCategories.lvl2': {
-              'Cameras & Camcorders > Digital Cameras > Digital SLR Cameras': 44,
-              'Cameras & Camcorders > Digital Cameras > Mirrorless Cameras': 29,
-              'Cameras & Camcorders > Digital Cameras > Point & Shoot Cameras': 84,
+          }),
+          createSingleSearchResponse({
+            exhaustiveFacetsCount: true,
+            params:
+              'query=&hitsPerPage=1&page=0&attributesToRetrieve=%5B%5D&attributesToHighlight=%5B%5D&attributesToSnippet=%5B%5D&tagFilters=&facets=%5B%22hierarchicalCategories.lvl0%22%2C%22hierarchicalCategories.lvl1%22%5D&facetFilters=%5B%5B%22hierarchicalCategories.lvl0%3ACameras%20%26%20Camcorders%22%5D%5D',
+            facets: {
+              'hierarchicalCategories.lvl0': {
+                'Cameras & Camcorders': 1369,
+              },
+              'hierarchicalCategories.lvl1': {
+                'Cameras & Camcorders > Camcorders': 50,
+                'Cameras & Camcorders > Memory Cards': 113,
+                'Cameras & Camcorders > Trail Cameras': 5,
+                'Cameras & Camcorders > Microscopes': 5,
+                'Cameras & Camcorders > Spotting Scopes': 5,
+                'Cameras & Camcorders > Telescopes': 15,
+                'Cameras & Camcorders > Monoculars': 5,
+                'Cameras & Camcorders > Digital Cameras': 170,
+                'Cameras & Camcorders > P&S Adapters & Chargers': 1,
+                'Cameras & Camcorders > Binoculars': 20,
+                'Cameras & Camcorders > Camcorder Accessories': 173,
+                'Cameras & Camcorders > Digital Camera Accessories': 804,
+              },
             },
-            'hierarchicalCategories.lvl0': {
-              'Cameras & Camcorders': 170,
+            exhaustiveNbHits: true,
+            hitsPerPage: 1,
+            index: 'instant_search',
+            processingTimeMS: 1,
+            nbPages: 1000,
+            nbHits: 1369,
+            query: '',
+            page: 0,
+            hits: [],
+          }),
+          createSingleSearchResponse({
+            params:
+              'query=&hitsPerPage=1&page=0&attributesToRetrieve=%5B%5D&attributesToHighlight=%5B%5D&attributesToSnippet=%5B%5D&tagFilters=&facets=%5B%22hierarchicalCategories.lvl0%22%5D',
+            exhaustiveFacetsCount: true,
+            exhaustiveNbHits: true,
+            facets: {
+              'hierarchicalCategories.lvl0': {
+                Audio: 1570,
+                'Computers & Tablets': 3563,
+                'Movies & Music': 18,
+                Paper: 65,
+                'MP Pending': 3,
+                'Cameras & Camcorders': 1369,
+                'Cell Phones': 3291,
+                Appliances: 4306,
+                'Custom Parts': 2,
+                'Health, Fitness & Beauty': 923,
+                'Video Games': 505,
+                'Office & School Supplies': 617,
+                'Entertainment Gift Cards': 46,
+                'Musical Instruments': 312,
+                'MP Exclusives': 1,
+                'Toys, Games & Drones': 285,
+                'Name Brands': 101,
+                'Batteries & Power': 7,
+                'Star Wars': 1,
+                'Geek Squad': 2,
+                'DC Comics': 1,
+                'Scanners, Faxes & Copiers': 46,
+                'Furniture & Decor': 91,
+                'Household Essentials': 148,
+                'Car Electronics & GPS': 1208,
+                'Magnolia Home Theater': 33,
+                Housewares: 255,
+                'Smart Home': 405,
+                'Beverage & Wine Coolers': 1,
+                'TV & Home Theater': 1201,
+                'Avengers: Age of Ultron': 1,
+                Exclusives: 1,
+                'Gift Ideas': 2,
+                'Carfi Instore Only': 4,
+                'Office Electronics': 328,
+                'Office Furniture & Storage': 152,
+                'Wearable Technology': 271,
+                'In-Store Only': 2,
+                'Telephones & Communication': 194,
+              },
             },
-          },
-        },
-        {
-          exhaustiveFacetsCount: true,
-          params:
-            'query=&hitsPerPage=1&page=0&attributesToRetrieve=%5B%5D&attributesToHighlight=%5B%5D&attributesToSnippet=%5B%5D&tagFilters=&facets=%5B%22hierarchicalCategories.lvl0%22%2C%22hierarchicalCategories.lvl1%22%5D&facetFilters=%5B%5B%22hierarchicalCategories.lvl0%3ACameras%20%26%20Camcorders%22%5D%5D',
-          facets: {
-            'hierarchicalCategories.lvl0': {
-              'Cameras & Camcorders': 1369,
-            },
-            'hierarchicalCategories.lvl1': {
-              'Cameras & Camcorders > Camcorders': 50,
-              'Cameras & Camcorders > Memory Cards': 113,
-              'Cameras & Camcorders > Trail Cameras': 5,
-              'Cameras & Camcorders > Microscopes': 5,
-              'Cameras & Camcorders > Spotting Scopes': 5,
-              'Cameras & Camcorders > Telescopes': 15,
-              'Cameras & Camcorders > Monoculars': 5,
-              'Cameras & Camcorders > Digital Cameras': 170,
-              'Cameras & Camcorders > P&S Adapters & Chargers': 1,
-              'Cameras & Camcorders > Binoculars': 20,
-              'Cameras & Camcorders > Camcorder Accessories': 173,
-              'Cameras & Camcorders > Digital Camera Accessories': 804,
-            },
-          },
-          exhaustiveNbHits: true,
-          hitsPerPage: 1,
-          index: 'instant_search',
-          processingTimeMS: 1,
-          nbPages: 1000,
-          nbHits: 1369,
-          query: '',
-          page: 0,
-          hits: [],
-        },
-        {
-          params:
-            'query=&hitsPerPage=1&page=0&attributesToRetrieve=%5B%5D&attributesToHighlight=%5B%5D&attributesToSnippet=%5B%5D&tagFilters=&facets=%5B%22hierarchicalCategories.lvl0%22%5D',
-          exhaustiveFacetsCount: true,
-          exhaustiveNbHits: true,
-          facets: {
-            'hierarchicalCategories.lvl0': {
-              Audio: 1570,
-              'Computers & Tablets': 3563,
-              'Movies & Music': 18,
-              Paper: 65,
-              'MP Pending': 3,
-              'Cameras & Camcorders': 1369,
-              'Cell Phones': 3291,
-              Appliances: 4306,
-              'Custom Parts': 2,
-              'Health, Fitness & Beauty': 923,
-              'Video Games': 505,
-              'Office & School Supplies': 617,
-              'Entertainment Gift Cards': 46,
-              'Musical Instruments': 312,
-              'MP Exclusives': 1,
-              'Toys, Games & Drones': 285,
-              'Name Brands': 101,
-              'Batteries & Power': 7,
-              'Star Wars': 1,
-              'Geek Squad': 2,
-              'DC Comics': 1,
-              'Scanners, Faxes & Copiers': 46,
-              'Furniture & Decor': 91,
-              'Household Essentials': 148,
-              'Car Electronics & GPS': 1208,
-              'Magnolia Home Theater': 33,
-              Housewares: 255,
-              'Smart Home': 405,
-              'Beverage & Wine Coolers': 1,
-              'TV & Home Theater': 1201,
-              'Avengers: Age of Ultron': 1,
-              Exclusives: 1,
-              'Gift Ideas': 2,
-              'Carfi Instore Only': 4,
-              'Office Electronics': 328,
-              'Office Furniture & Storage': 152,
-              'Wearable Technology': 271,
-              'In-Store Only': 2,
-              'Telephones & Communication': 194,
-            },
-          },
-          hitsPerPage: 1,
-          nbPages: 1000,
-          processingTimeMS: 1,
-          index: 'instant_search',
-          query: '',
-          nbHits: 21469,
-          hits: [],
-          page: 0,
-        },
-      ]),
-      state: helper.state,
-      helper,
-      createURL: state => state,
-    });
+            hitsPerPage: 1,
+            nbPages: 1000,
+            processingTimeMS: 1,
+            index: 'instant_search',
+            query: '',
+            nbHits: 21469,
+            hits: [],
+            page: 0,
+          }),
+        ]),
+        state: helper.state,
+        helper,
+        createURL: state => (state as unknown) as string,
+      })
+    );
     const { createURL, items } = rendering.mock.calls[1][0];
     const secondItemValue = items[1].value;
 
@@ -739,48 +778,52 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
     const makeWidget = connectBreadcrumb(rendering);
     const widget = makeWidget({ attributes: ['category', 'sub_category'] });
 
-    const config = widget.getWidgetSearchParameters(new SearchParameters());
-    const helper = jsHelper({}, '', config);
+    const config = widget.getWidgetSearchParameters!(new SearchParameters(), {
+      uiState: {},
+    });
+    const helper = jsHelper(createSearchClient(), '', config);
     helper.search = jest.fn();
 
-    widget.init({
-      helper,
-      state: helper.state,
-      createURL: () => '#',
-    });
+    widget.init!(
+      createInitOptions({
+        helper,
+        state: helper.state,
+      })
+    );
 
     const firstRenderingOptions = rendering.mock.calls[0][0];
     expect(firstRenderingOptions.items).toEqual([]);
 
     helper.toggleRefinement('category', 'Decoration');
 
-    widget.render({
-      results: new SearchResults(helper.state, [
-        {
-          hits: [],
-          facets: {
-            category: {
-              Decoration: 880,
+    widget.render!(
+      createRenderOptions({
+        results: new SearchResults(helper.state, [
+          createSingleSearchResponse({
+            hits: [],
+            facets: {
+              category: {
+                Decoration: 880,
+              },
+              subCategory: {
+                'Decoration > Candle holders & candles': 193,
+                'Decoration > Frames & pictures': 173,
+              },
             },
-            subCategory: {
-              'Decoration > Candle holders & candles': 193,
-              'Decoration > Frames & pictures': 173,
+          }),
+          createSingleSearchResponse({
+            facets: {
+              category: {
+                Decoration: 880,
+                Outdoor: 47,
+              },
             },
-          },
-        },
-        {
-          facets: {
-            category: {
-              Decoration: 880,
-              Outdoor: 47,
-            },
-          },
-        },
-      ]),
-      state: helper.state,
-      helper,
-      createURL: () => '#',
-    });
+          }),
+        ]),
+        state: helper.state,
+        helper,
+      })
+    );
     const refine = rendering.mock.calls[1][0].refine;
     expect(helper.getHierarchicalFacetBreadcrumb('category')).toEqual([
       'Decoration',
@@ -791,14 +834,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
 
   describe('dispose', () => {
     it('does not throw without the unmount function', () => {
-      const helper = jsHelper({}, '');
+      const helper = jsHelper(createSearchClient(), '');
 
       const renderFn = () => {};
       const makeWidget = connectBreadcrumb(renderFn);
       const widget = makeWidget({ attributes: ['category'] });
 
       expect(() =>
-        widget.dispose({ helper, state: helper.state })
+        widget.dispose!({ helper, state: helper.state })
       ).not.toThrow();
     });
 
@@ -807,20 +850,21 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
       const makeWidget = connectBreadcrumb(renderFn);
       const widget = makeWidget({ attributes: ['category'] });
 
-      const helper = jsHelper({}, '', {
+      const helper = jsHelper(createSearchClient(), '', {
         hierarchicalFacetsRefinements: {
           category: ['boxes'],
         },
       });
       helper.search = jest.fn();
 
-      widget.init({
-        helper,
-        state: helper.state,
-        createURL: () => '#',
-      });
+      widget.init!(
+        createInitOptions({
+          helper,
+          state: helper.state,
+        })
+      );
 
-      const newState = widget.dispose({ helper, state: helper.state });
+      const newState = widget.dispose!({ helper, state: helper.state });
 
       expect(newState).toBeUndefined();
     });

--- a/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.ts
+++ b/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.ts
@@ -552,7 +552,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
       createInitOptions({
         helper,
         state: helper.state,
-        createURL: state => (state as unknown) as string,
+        createURL: state => JSON.stringify(state),
       })
     );
 
@@ -585,12 +585,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
         ]),
         state: helper.state,
         helper,
-        createURL: state => (state as unknown) as string,
+        createURL: state => JSON.stringify(state),
       })
     );
     const createURL = rendering.mock.calls[1][0].createURL;
     expect(helper.state.hierarchicalFacetsRefinements).toEqual({});
-    const stateForURL = createURL('Decoration > Candle holders & candles');
+    const stateForURL = JSON.parse(
+      createURL('Decoration > Candle holders & candles')
+    );
     expect(stateForURL.hierarchicalFacetsRefinements).toEqual({
       category: ['Decoration > Candle holders & candles'],
     });
@@ -617,7 +619,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
       createInitOptions({
         helper,
         state: helper.state,
-        createURL: state => (state as unknown) as string,
+        createURL: state => JSON.stringify(state),
       })
     );
 
@@ -751,18 +753,18 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
         ]),
         state: helper.state,
         helper,
-        createURL: state => (state as unknown) as string,
+        createURL: state => JSON.stringify(state),
       })
     );
     const { createURL, items } = rendering.mock.calls[1][0];
     const secondItemValue = items[1].value;
 
-    const stateForURL = createURL(secondItemValue);
+    const stateForURL = JSON.parse(createURL(secondItemValue));
 
     expect(stateForURL.hierarchicalFacetsRefinements).toEqual({
       'hierarchicalCategories.lvl0': ['Cameras & Camcorders > Digital Cameras'],
     });
-    const stateForHome = createURL(null);
+    const stateForHome = JSON.parse(createURL(null));
     expect(stateForHome.hierarchicalFacetsRefinements).toEqual({
       'hierarchicalCategories.lvl0': [],
     });

--- a/src/connectors/breadcrumb/connectBreadcrumb.ts
+++ b/src/connectors/breadcrumb/connectBreadcrumb.ts
@@ -66,7 +66,7 @@ export type BreadcrumbRendererOptions = {
   refine: (value: BreadcrumbConnectorParamsItem['value']) => void;
 
   /**
-   * @internal
+   * True if refinement can be applied.
    */
   canRefine: boolean;
 };

--- a/src/connectors/breadcrumb/connectBreadcrumb.ts
+++ b/src/connectors/breadcrumb/connectBreadcrumb.ts
@@ -5,54 +5,97 @@ import {
   isEqual,
   noop,
 } from '../../lib/utils';
+import { SearchResults } from 'algoliasearch-helper';
+import { Connector, TransformItems, CreateURL } from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'breadcrumb',
   connector: true,
 });
 
-/**
- * @typedef {Object} BreadcrumbItem
- * @property {string} label Label of the category or subcategory.
- * @property {string} value Value of breadcrumb item.
- */
+export type BreadcrumbConnectorParamsItem = {
+  /**
+   * Label of the category or subcategory.
+   */
+  label: string;
 
-/**
- * @typedef {Object} CustomBreadcrumbWidgetOptions
- * @property {string[]} attributes Attributes to use to generate the hierarchy of the breadcrumb.
- * @property {string} [rootPath = null] Prefix path to use if the first level is not the root level.
- * @property {function(object[]):object[]} [transformItems] Function to transform the items passed to the templates.
- *
- * You can also use a sort function that behaves like the standard Javascript [compareFunction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#Syntax).
- */
+  /**
+   * Value of breadcrumb item.
+   */
+  value: string;
+};
 
-/**
- * @typedef {Object} BreadcrumbRenderingOptions
- * @property {function(item.value): string} createURL Creates an url for the next state for a clicked item. The special value `null` is used for the `Home` (or root) item of the breadcrumb and will return an empty array.
- * @property {BreadcrumbItem[]} items Values to be rendered.
- * @property {function(item.value)} refine Sets the path of the hierarchical filter and triggers a new search.
- * @property {Object} widgetParams All original `CustomBreadcrumbWidgetOptions` forwarded to the `renderFn`.
- */
+export type BreadcrumbConnectorParams = {
+  /**
+   * Attributes to use to generate the hierarchy of the breadcrumb.
+   */
+  attributes: string[];
 
-/**
- * **Breadcrumb** connector provides the logic to build a custom widget
- * that will give the user the ability to see the current path in a hierarchical facet.
- *
- * This is commonly used in websites that have a large amount of content organized in a hierarchical manner (usually e-commerce websites).
- * @type {Connector}
- * @param {function(BreadcrumbRenderingOptions, boolean)} renderFn Rendering function for the custom **Breadcrumb* widget.
- * @param {function} unmountFn Unmount function called when the widget is disposed.
- * @return {function(CustomBreadcrumbWidgetOptions)} Re-usable widget factory for a custom **Breadcrumb** widget.
- */
-export default function connectBreadcrumb(renderFn, unmountFn = noop) {
+  /**
+   * Prefix path to use if the first level is not the root level.
+   */
+  rootPath?: string;
+
+  /**
+   * Function to transform the items passed to the templates.
+   */
+  transformItems?: TransformItems<BreadcrumbConnectorParamsItem>;
+
+  /**
+   * The level separator used in the records.
+   *
+   * @default '>'
+   */
+  separator?: string;
+};
+
+export type BreadcrumbRendererOptions = {
+  /**
+   * Creates the URL for a single item name in the list.
+   */
+  createURL: CreateURL<BreadcrumbConnectorParamsItem['value']>;
+
+  /**
+   * Array of objects defining the different values and labels.
+   */
+  items: BreadcrumbConnectorParamsItem[];
+
+  /**
+   * Sets the path of the hierarchical filter and triggers a new search.
+   */
+  refine: (value: BreadcrumbConnectorParamsItem['value']) => void;
+
+  /**
+   * @internal
+   */
+  canRefine: boolean;
+};
+
+export type BreadcrumbConnector = Connector<
+  BreadcrumbRendererOptions,
+  BreadcrumbConnectorParams
+>;
+
+const connectBreadcrumb: BreadcrumbConnector = function connectBreadcrumb(
+  renderFn,
+  unmountFn = noop
+) {
   checkRendering(renderFn, withUsage());
-  return (widgetParams = {}) => {
+
+  type ConnectorState = {
+    refine: BreadcrumbRendererOptions['refine'];
+    createURL: BreadcrumbRendererOptions['createURL'];
+  };
+
+  const connectorState = {} as ConnectorState;
+
+  return widgetParams => {
     const {
       attributes,
       separator = ' > ',
       rootPath = null,
       transformItems = items => items,
-    } = widgetParams;
+    } = widgetParams || ({} as typeof widgetParams);
 
     if (!attributes || !Array.isArray(attributes) || attributes.length === 0) {
       throw new Error(
@@ -66,14 +109,14 @@ export default function connectBreadcrumb(renderFn, unmountFn = noop) {
       $$type: 'ais.breadcrumb',
 
       init({ createURL, helper, instantSearchInstance }) {
-        this._createURL = facetValue => {
+        connectorState.createURL = facetValue => {
           if (!facetValue) {
             const breadcrumb = helper.getHierarchicalFacetBreadcrumb(
               hierarchicalFacetName
             );
             if (breadcrumb.length > 0) {
               return createURL(
-                helper.state.toggleRefinement(
+                helper.state.toggleFacetRefinement(
                   hierarchicalFacetName,
                   breadcrumb[0]
                 )
@@ -81,11 +124,14 @@ export default function connectBreadcrumb(renderFn, unmountFn = noop) {
             }
           }
           return createURL(
-            helper.state.toggleRefinement(hierarchicalFacetName, facetValue)
+            helper.state.toggleFacetRefinement(
+              hierarchicalFacetName,
+              facetValue
+            )
           );
         };
 
-        this._refine = function(facetValue) {
+        connectorState.refine = facetValue => {
           if (!facetValue) {
             const breadcrumb = helper.getHierarchicalFacetBreadcrumb(
               hierarchicalFacetName
@@ -102,11 +148,11 @@ export default function connectBreadcrumb(renderFn, unmountFn = noop) {
 
         renderFn(
           {
-            createURL: this._createURL,
+            createURL: connectorState.createURL,
             canRefine: false,
             instantSearchInstance,
             items: [],
-            refine: this._refine,
+            refine: connectorState.refine,
             widgetParams,
           },
           true
@@ -116,17 +162,20 @@ export default function connectBreadcrumb(renderFn, unmountFn = noop) {
       render({ instantSearchInstance, results, state }) {
         const [{ name: facetName }] = state.hierarchicalFacets;
 
-        const facetValues = results.getFacetValues(facetName);
+        const facetValues = results.getFacetValues(
+          facetName,
+          {}
+        ) as SearchResults.HierarchicalFacet;
         const data = Array.isArray(facetValues.data) ? facetValues.data : [];
         const items = transformItems(shiftItemsValues(prepareItems(data)));
 
         renderFn(
           {
             canRefine: items.length > 0,
-            createURL: this._createURL,
+            createURL: connectorState.createURL,
             instantSearchInstance,
             items,
-            refine: this._refine,
+            refine: connectorState.refine,
             widgetParams,
           },
           false
@@ -162,7 +211,7 @@ export default function connectBreadcrumb(renderFn, unmountFn = noop) {
       },
     };
   };
-}
+};
 
 function prepareItems(data) {
   return data.reduce((result, currentItem) => {
@@ -185,3 +234,5 @@ function shiftItemsValues(array) {
     value: idx + 1 === array.length ? null : array[idx + 1].value,
   }));
 }
+
+export default connectBreadcrumb;

--- a/src/connectors/current-refinements/connectCurrentRefinements.ts
+++ b/src/connectors/current-refinements/connectCurrentRefinements.ts
@@ -15,7 +15,7 @@ import {
   FacetRefinement,
   NumericRefinement,
 } from '../../lib/utils/getRefinements';
-import { Connector } from '../../types';
+import { Connector, TransformItems } from '../../types';
 
 export type ConnectorRefinement = {
   attribute: string;
@@ -71,12 +71,11 @@ export type CurrentRefinementsConnectorParams = {
    * @default `['query']`
    */
   excludedAttributes?: string[];
+
   /**
-   * Receives the items, and is called before displaying them.
-   * Should return a new array with the same shape as the original array.
-   * Useful for mapping over the items to transform, and remove or reorder them.
+   * Function to transform the items passed to the templates.
    */
-  transformItems?: (items: Item[]) => any;
+  transformItems?: TransformItems<Item>;
 };
 
 export type CurrentRefinementsRendererOptions = {

--- a/src/connectors/hits-per-page/connectHitsPerPage.ts
+++ b/src/connectors/hits-per-page/connectHitsPerPage.ts
@@ -6,7 +6,7 @@ import {
 } from '../../lib/utils';
 
 import { SearchParameters } from 'algoliasearch-helper';
-import { Connector } from '../../types';
+import { Connector, TransformItems, CreateURL } from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'hits-per-page',
@@ -58,9 +58,7 @@ export type HitsPerPageConnectorParams = {
   /**
    * Function to transform the items passed to the templates.
    */
-  transformItems?: <TItem extends HitsPerPageConnectorParamsItem>(
-    objects: TItem[]
-  ) => TItem[];
+  transformItems?: TransformItems<HitsPerPageConnectorParamsItem>;
 };
 
 export type HitsPerPageRendererOptions = {
@@ -74,7 +72,7 @@ export type HitsPerPageRendererOptions = {
    *
    * @internal
    */
-  createURL: (value: HitsPerPageConnectorParamsItem['value']) => string;
+  createURL: CreateURL<HitsPerPageConnectorParamsItem['value']>;
 
   /**
    * Sets the number of hits per page and triggers a search.

--- a/src/connectors/numeric-menu/connectNumericMenu.ts
+++ b/src/connectors/numeric-menu/connectNumericMenu.ts
@@ -4,7 +4,7 @@ import {
   isFiniteNumber,
   noop,
 } from '../../lib/utils';
-import { Connector } from '../../types';
+import { Connector, CreateURL } from '../../types';
 import { SearchParameters } from 'algoliasearch-helper';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -72,7 +72,7 @@ export type NumericMenuRendererOptions = {
   /**
    * Creates URLs for the next state, the string is the name of the selected option
    */
-  createURL: (value: Item['value']) => string;
+  createURL: CreateURL<Item['value']>;
   /**
    * `true` if the last search contains no result
    */

--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -16,6 +16,7 @@ import {
   SearchClient,
   Widget,
   UiState,
+  CreateURL,
 } from '../types';
 import hasDetectedInsightsClient from './utils/detect-insights-client';
 import { Middleware, MiddlewareDefinition } from '../middleware';
@@ -136,7 +137,7 @@ class InstantSearch extends EventEmitter {
   public _searchStalledTimer: any;
   public _isSearchStalled: boolean;
   public _initialUiState: UiState;
-  public _createURL: (nextState: UiState) => string;
+  public _createURL: CreateURL<UiState>;
   public _searchFunction?: InstantSearchOptions['searchFunction'];
   public _mainHelperSearch?: AlgoliaSearchHelper['search'];
   public middleware: MiddlewareDefinition[] = [];

--- a/src/types/connector.ts
+++ b/src/types/connector.ts
@@ -75,7 +75,7 @@ export type Connector<TRendererOptions, TConnectorParams> = <TWidgetParams>(
 /**
  * Transforms the given items.
  */
-export type TransformItems<TItem> = (objects: TItem[]) => TItem[];
+export type TransformItems<TItem> = (items: TItem[]) => TItem[];
 
 /**
  * Creates the URL for the given value.

--- a/src/types/connector.ts
+++ b/src/types/connector.ts
@@ -71,3 +71,13 @@ export type Connector<TRendererOptions, TConnectorParams> = <TWidgetParams>(
    */
   unmountFn?: Unmounter
 ) => WidgetFactory<TConnectorParams, TWidgetParams>;
+
+/**
+ * Transforms the given items.
+ */
+export type TransformItems<TItem> = (objects: TItem[]) => TItem[];
+
+/**
+ * Creates the URL for the given value.
+ */
+export type CreateURL<TValue> = (value: TValue) => string;

--- a/src/widgets/breadcrumb/__tests__/__snapshots__/breadcrumb-test.ts.snap
+++ b/src/widgets/breadcrumb/__tests__/__snapshots__/breadcrumb-test.ts.snap
@@ -31,7 +31,7 @@ Object {
       "home": "Home",
       "separator": ">",
     },
-    "templatesConfig": undefined,
+    "templatesConfig": Object {},
     "useCustomCompileOptions": Object {
       "home": false,
       "separator": false,

--- a/src/widgets/breadcrumb/__tests__/breadcrumb-test.ts
+++ b/src/widgets/breadcrumb/__tests__/breadcrumb-test.ts
@@ -1,5 +1,12 @@
-import { render } from 'preact';
+import { render as preactRender } from 'preact';
 import breadcrumb from '../breadcrumb';
+import { castToJestMock } from '../../../../test/utils/castToJestMock';
+import {
+  createRenderOptions,
+  createInitOptions,
+} from '../../../../test/mock/createWidget';
+
+const render = castToJestMock(preactRender);
 
 jest.mock('preact', () => {
   const module = require.requireActual('preact');
@@ -24,6 +31,7 @@ describe('breadcrumb()', () => {
     it('throws without `container`', () => {
       expect(() => {
         breadcrumb({
+          // @ts-ignore
           container: undefined,
         });
       }).toThrowErrorMatchingInlineSnapshot(`
@@ -99,15 +107,17 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
         transformItems: items =>
           items.map(item => ({ ...item, transformed: true })),
       });
-      widget.init({
-        helper,
-        instantSearchInstance: {},
-      });
-      widget.render({
-        results,
-        state,
-        instantSearchInstance: {},
-      });
+      widget.init!(
+        createInitOptions({
+          helper,
+        })
+      );
+      widget.render!(
+        createRenderOptions({
+          results,
+          state,
+        })
+      );
 
       const [firstRender] = render.mock.calls;
 

--- a/src/widgets/breadcrumb/breadcrumb.tsx
+++ b/src/widgets/breadcrumb/breadcrumb.tsx
@@ -3,7 +3,9 @@
 import { h, render } from 'preact';
 import cx from 'classnames';
 import Breadcrumb from '../../components/Breadcrumb/Breadcrumb';
-import connectBreadcrumb from '../../connectors/breadcrumb/connectBreadcrumb';
+import connectBreadcrumb, {
+  BreadcrumbConnectorParams,
+} from '../../connectors/breadcrumb/connectBreadcrumb';
 import defaultTemplates from './defaultTemplates';
 import {
   getContainerNode,
@@ -11,6 +13,7 @@ import {
   createDocumentationMessageGenerator,
 } from '../../lib/utils';
 import { component } from '../../lib/suit';
+import { WidgetFactory } from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({ name: 'breadcrumb' });
 const suit = component('Breadcrumb');
@@ -42,97 +45,88 @@ const renderer = ({ containerNode, cssClasses, renderState, templates }) => (
   );
 };
 
-/**
- * @typedef {Object} BreadcrumbCSSClasses
- * @property {string|string[]} [root] CSS class to add to the root element of the widget.
- * @property {string|string[]} [noRefinementRoot] CSS class to add to the root element of the widget if there are no refinements.
- * @property {string|string[]} [list] CSS class to add to the list element.
- * @property {string|string[]} [item] CSS class to add to the items of the list. The items contains the link and the separator.
- * @property {string|string[]} [selectedItem] CSS class to add to the selected item in the list: the last one or the home if there are no refinements.
- * @property {string|string[]} [separator] CSS class to add to the separator.
- * @property {string|string[]} [link] CSS class to add to the links in the items.
- */
+export type BreadcrumbCSSClasses = {
+  /**
+   * CSS class to add to the root element of the widget.
+   */
+  root?: string | string[];
 
-/**
- * @typedef {Object} BreadcrumbTemplates
- * @property {string|function(object):string} [home = 'Home'] Label of the breadcrumb's first element.
- * @property {string|function(object):string} [separator = '>'] Symbol used to separate the elements of the breadcrumb.
- */
+  /**
+   * CSS class to add to the root element of the widget if there are no refinements.
+   */
+  noRefinementRoot?: string | string[];
 
-/**
- * @typedef {Object} BreadcrumbWidgetOptions
- * @property {string|HTMLElement} container CSS Selector or HTMLElement to insert the widget.
- * @property {string[]} attributes Array of attributes to use to generate the breadcrumb.
- * @property {string} [separator = ' > '] The level separator used in the records.
- * @property {string} [rootPath = null] Prefix path to use if the first level is not the root level.
- * @property {BreadcrumbTemplates} [templates] Templates to use for the widget.
- * @property {function(object[]):object[]} [transformItems] Function to transform the items passed to the templates.
- * @property {BreadcrumbCSSClasses} [cssClasses] CSS classes to add to the wrapping elements.
- */
+  /**
+   * CSS class to add to the list element.
+   */
+  list?: string | string[];
 
-/**
- * The breadcrumb widget is a secondary navigation scheme that allows the user to see where the current page is in relation to the facet's hierarchy.
- *
- * It reduces the number of actions a user needs to take in order to get to a higher-level page and improve the discoverability of the app or website's sections and pages.
- * It is commonly used for websites with a large amount of data organized into categories with subcategories.
- *
- * All attributes (lvl0, lvl1 in this case) must be declared as [attributes for faceting](https://www.algolia.com/doc/guides/searching/faceting/#declaring-attributes-for-faceting) in your
- * Algolia settings.
- *
- * @requirements
- * Your objects must be formatted in a specific way to be
- * able to display a breadcrumb. Here's an example:
- *
- * ```javascript
- * {
- *   "objectID": "123",
- *   "name": "orange",
- *   "categories": {
- *     "lvl0": "fruits",
- *     "lvl1": "fruits > citrus"
- *   }
- * }
- * ```
- *
- * Each level must be specified entirely.
- * It's also possible to have multiple values per level, for instance:
- *
- * ```javascript
- * {
- *   "objectID": "123",
- *   "name": "orange",
- *   "categories": {
- *     "lvl0": ["fruits", "vitamins"],
- *     "lvl1": ["fruits > citrus", "vitamins > C"]
- *   }
- * }
- * ```
- * @type {WidgetFactory}
- * @devNovel Breadcrumb
- * @category navigation
- * @param {BreadcrumbWidgetOptions} $0 The Breadcrumb widget options.
- * @return {Widget} A new Breadcrumb widget instance.
- * @example
- * search.addWidgets([
- *   instantsearch.widgets.breadcrumb({
- *     container: '#breadcrumb',
- *     attributes: ['hierarchicalCategories.lvl0', 'hierarchicalCategories.lvl1', 'hierarchicalCategories.lvl2'],
- *     templates: { home: 'Home Page' },
- *     separator: ' / ',
- *     rootPath: 'Cameras & Camcorders > Digital Cameras',
- *   })
- * ]);
- */
+  /**
+   * CSS class to add to the items of the list. The items contains the link and the separator.
+   */
+  item?: string | string[];
 
-export default function breadcrumb({
-  container,
-  attributes,
-  separator,
-  rootPath = null,
-  transformItems,
-  templates = defaultTemplates,
-  cssClasses: userCssClasses = {},
-} = {}) {
+  /**
+   * CSS class to add to the selected item in the list: the last one or the home if there are no refinements.
+   */
+  selectedItem?: string | string[];
+
+  /**
+   * CSS class to add to the separator.
+   */
+  separator?: string | string[];
+
+  /**
+   * CSS class to add to the links in the items.
+   */
+  link?: string | string[];
+};
+
+export type BreadcrumbTemplates = {
+  /**
+   * Label of the breadcrumb's first element.
+   */
+  home?: string | ((value: any) => string);
+
+  /**
+   * Symbol used to separate the elements of the breadcrumb.
+   */
+  separator?: string | ((value: any) => string);
+};
+
+export type BreadcrumbWidgetOptions = {
+  /**
+   * CSS Selector or HTMLElement to insert the widget.
+   */
+  container: string | HTMLElement;
+
+  /**
+   * Templates to use for the widget.
+   */
+  templates?: BreadcrumbTemplates;
+
+  /**
+   * CSS classes to add to the wrapping elements.
+   */
+  cssClasses?: BreadcrumbCSSClasses;
+};
+
+export type BreadcrumbWidget = WidgetFactory<
+  BreadcrumbConnectorParams,
+  BreadcrumbWidgetOptions
+>;
+
+const breadcrumb: BreadcrumbWidget = function breadcrumb(widgetOptions) {
+  const {
+    container,
+    attributes,
+    separator,
+    rootPath,
+    transformItems,
+    templates = defaultTemplates,
+    cssClasses: userCssClasses = {},
+  } = widgetOptions || ({} as typeof widgetOptions);
+
   if (!container) {
     throw new Error(withUsage('The `container` option is required.'));
   }
@@ -170,4 +164,6 @@ export default function breadcrumb({
   );
 
   return makeBreadcrumb({ attributes, separator, rootPath, transformItems });
-}
+};
+
+export default breadcrumb;

--- a/src/widgets/breadcrumb/breadcrumb.tsx
+++ b/src/widgets/breadcrumb/breadcrumb.tsx
@@ -13,7 +13,7 @@ import {
   createDocumentationMessageGenerator,
 } from '../../lib/utils';
 import { component } from '../../lib/suit';
-import { WidgetFactory } from '../../types';
+import { WidgetFactory, Template } from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({ name: 'breadcrumb' });
 const suit = component('Breadcrumb');
@@ -86,12 +86,12 @@ export type BreadcrumbTemplates = {
   /**
    * Label of the breadcrumb's first element.
    */
-  home?: string | ((value: any) => string);
+  home?: Template;
 
   /**
    * Symbol used to separate the elements of the breadcrumb.
    */
-  separator?: string | ((value: any) => string);
+  separator?: Template;
 };
 
 export type BreadcrumbWidgetOptions = {

--- a/src/widgets/hits-per-page/hits-per-page.tsx
+++ b/src/widgets/hits-per-page/hits-per-page.tsx
@@ -78,6 +78,8 @@ export type HitsPerPageWidget = WidgetFactory<
 
 const hitsPerPage: HitsPerPageWidget = function hitsPerPage(widgetOptions) {
   const { container, items, cssClasses: userCssClasses = {}, transformItems } =
+    widgetOptions || ({} as typeof widgetOptions);
+
   if (!container) {
     throw new Error(withUsage('The `container` option is required.'));
   }

--- a/src/widgets/hits-per-page/hits-per-page.tsx
+++ b/src/widgets/hits-per-page/hits-per-page.tsx
@@ -76,14 +76,8 @@ export type HitsPerPageWidget = WidgetFactory<
   HitsPerPageWidgetOptions
 >;
 
-export default (function hitsPerPage(
-  {
-    container,
-    items,
-    cssClasses: userCssClasses = {},
-    transformItems,
-  } = {} as HitsPerPageConnectorParams & HitsPerPageWidgetOptions
-) {
+const hitsPerPage: HitsPerPageWidget = function hitsPerPage(widgetOptions) {
+  const { container, items, cssClasses: userCssClasses = {}, transformItems } =
   if (!container) {
     throw new Error(withUsage('The `container` option is required.'));
   }
@@ -106,4 +100,6 @@ export default (function hitsPerPage(
   );
 
   return makeHitsPerPage({ items, transformItems });
-} as HitsPerPageWidget);
+};
+
+export default hitsPerPage;

--- a/stories/breadcrumb.stories.js
+++ b/stories/breadcrumb.stories.js
@@ -2,6 +2,7 @@ import { storiesOf } from '@storybook/html';
 import { withHits, withLifecycle } from '../.storybook/decorators';
 import { connectHierarchicalMenu } from '../src/connectors';
 import { noop } from '../src/lib/utils';
+import { breadcrumb } from '../src/widgets';
 
 const virtualHierarchicalMenu = (args = {}) =>
   connectHierarchicalMenu(
@@ -20,14 +21,14 @@ storiesOf('Metadata|Breadcrumb', module)
   .add(
     'default',
     withHits(
-      ({ search, container, instantsearch }) => {
-        const breadcrumb = document.createElement('div');
-        container.appendChild(breadcrumb);
+      ({ search, container }) => {
+        const breadcrumbDiv = document.createElement('div');
+        container.appendChild(breadcrumbDiv);
 
         search.addWidgets([
           virtualHierarchicalMenu(),
 
-          instantsearch.widgets.breadcrumb({
+          breadcrumb({
             container: breadcrumb,
             attributes: [
               'hierarchicalCategories.lvl0',
@@ -53,14 +54,14 @@ storiesOf('Metadata|Breadcrumb', module)
   .add(
     'with custom separators',
     withHits(
-      ({ search, container, instantsearch }) => {
-        const breadcrumb = document.createElement('div');
-        container.appendChild(breadcrumb);
+      ({ search, container }) => {
+        const breadcrumbDiv = document.createElement('div');
+        container.appendChild(breadcrumbDiv);
 
         search.addWidgets([
           virtualHierarchicalMenu(),
 
-          instantsearch.widgets.breadcrumb({
+          breadcrumb({
             container: breadcrumb,
             attributes: [
               'hierarchicalCategories.lvl0',
@@ -89,14 +90,14 @@ storiesOf('Metadata|Breadcrumb', module)
   .add(
     'with custom home label',
     withHits(
-      ({ search, container, instantsearch }) => {
-        const breadcrumb = document.createElement('div');
-        container.appendChild(breadcrumb);
+      ({ search, container }) => {
+        const breadcrumbDiv = document.createElement('div');
+        container.appendChild(breadcrumbDiv);
 
         search.addWidgets([
           virtualHierarchicalMenu(),
 
-          instantsearch.widgets.breadcrumb({
+          breadcrumb({
             container: breadcrumb,
             attributes: [
               'hierarchicalCategories.lvl0',
@@ -126,14 +127,14 @@ storiesOf('Metadata|Breadcrumb', module)
     'with root path',
     withHits(
       ({ search, container, instantsearch }) => {
-        const breadcrumb = document.createElement('div');
+        const breadcrumbDiv = document.createElement('div');
         const hierarchicalMenu = document.createElement('div');
 
-        container.appendChild(breadcrumb);
+        container.appendChild(breadcrumbDiv);
         container.appendChild(hierarchicalMenu);
 
         search.addWidgets([
-          instantsearch.widgets.breadcrumb({
+          breadcrumb({
             container: breadcrumb,
             attributes: [
               'hierarchicalCategories.lvl0',
@@ -171,13 +172,13 @@ storiesOf('Metadata|Breadcrumb', module)
     'with hierarchical menu',
     withHits(
       ({ search, container, instantsearch }) => {
-        const breadcrumb = document.createElement('div');
-        container.appendChild(breadcrumb);
+        const breadcrumbDiv = document.createElement('div');
+        container.appendChild(breadcrumbDiv);
         const hierarchicalMenu = document.createElement('div');
         container.appendChild(hierarchicalMenu);
 
         search.addWidgets([
-          instantsearch.widgets.breadcrumb({
+          breadcrumb({
             container: breadcrumb,
             attributes: [
               'hierarchicalCategories.lvl0',
@@ -212,14 +213,14 @@ storiesOf('Metadata|Breadcrumb', module)
   .add(
     'with transformed items',
     withHits(
-      ({ search, container, instantsearch }) => {
-        const breadcrumb = document.createElement('div');
-        container.appendChild(breadcrumb);
+      ({ search, container }) => {
+        const breadcrumbDiv = document.createElement('div');
+        container.appendChild(breadcrumbDiv);
 
         search.addWidgets([
           virtualHierarchicalMenu(),
 
-          instantsearch.widgets.breadcrumb({
+          breadcrumb({
             container: breadcrumb,
             attributes: [
               'hierarchicalCategories.lvl0',
@@ -250,11 +251,11 @@ storiesOf('Metadata|Breadcrumb', module)
   .add(
     'with add/remove',
     withHits(
-      ({ search, container, instantsearch }) => {
+      ({ search, container }) => {
         search.addWidgets([virtualHierarchicalMenu()]);
 
         withLifecycle(search, container, node =>
-          instantsearch.widgets.breadcrumb({
+          breadcrumb({
             container: node,
             attributes: [
               'hierarchicalCategories.lvl0',


### PR DESCRIPTION
This pull request migrates breadcrumb ( connectors and widget ) to typescript. Please take in consideration my comments on the pull request.

Internally it also adds new types to make refactor easy: TransformItems, and CreateURL.