### PR TITLE
chore(ts-migration): improves validating of types with api extractor

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,6 +4,7 @@
 dist
 .cache
 node_modules/
+.temp/
 
 # TODO: don't ignore these examples once they're updated
 /examples/calendar-widget

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,10 +1,10 @@
 /cjs
 /es
+/scripts/build/.temp
 /website
 dist
 .cache
 node_modules/
-.temp/
 
 # TODO: don't ignore these examples once they're updated
 /examples/calendar-widget

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ yarn-error.log
 /dist
 /cjs
 /es
-/.temp
+/scripts/build/.temp
 
 # Generated files
 /docs

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ yarn-error.log
 /dist
 /cjs
 /es
+/.temp
 
 # Generated files
 /docs

--- a/api-extractor.json
+++ b/api-extractor.json
@@ -26,6 +26,10 @@
         "addToApiReportFile": true
       },
 
+      "ae-internal-missing-underscore": {
+        "logLevel": "none"
+      },
+
       "ae-missing-release-tag": {
         "logLevel": "none"
       }
@@ -33,7 +37,7 @@
 
     "tsdocMessageReporting": {
       "default": {
-        "logLevel": "warning"
+        "logLevel": "none"
       }
     }
   },

--- a/api-extractor.json
+++ b/api-extractor.json
@@ -41,7 +41,7 @@
       }
     }
   },
-  "mainEntryPointFilePath": "./global.d.ts",
+  "mainEntryPointFilePath": "./.temp/index.d.ts",
   "dtsRollup": {
     "enabled": false
   }

--- a/scripts/build/api-extractor.json
+++ b/scripts/build/api-extractor.json
@@ -41,7 +41,7 @@
       }
     }
   },
-  "mainEntryPointFilePath": "./.temp/index.d.ts",
+  "mainEntryPointFilePath": ".temp/index.d.ts",
   "dtsRollup": {
     "enabled": false
   }

--- a/scripts/build/types.js
+++ b/scripts/build/types.js
@@ -20,7 +20,8 @@ const publicExports = [
   // 'components' -> does not contains index.d.ts yet
   'connectors',
   // 'lib', -> Api extrator "import * as ___ from ___;" is not supported yet for local files
-  'middleware',
+  // 'middleware',
+  'helpers',
   'types',
   'widgets', //  -> It does not compile as WidgetFactory is not imported in all files
 ];

--- a/scripts/build/types.js
+++ b/scripts/build/types.js
@@ -30,23 +30,16 @@ const publicExports = [
   'widgets', //  -> It does not compile as WidgetFactory is not imported in all files
 ];
 
-const tempSingleFileApiContentRelativePath = '.temp/index.d.ts';
-const tempSingleFileApiContent = publicExports
-  .map(publicExport => `../es/${publicExport}`)
-  .map(exportedFile => {
-    return `export * from '${exportedFile}';`;
-  })
-  .join('\r\n');
-
 fs.writeFileSync(
-  tempSingleFileApiContentRelativePath,
-  tempSingleFileApiContent
+  '.temp/index.d.ts',
+  publicExports
+    .map(publicExport => `../es/${publicExport}`)
+    .map(exportedFile => {
+      return `export * from '${exportedFile}';`;
+    })
+    .join('\r\n')
 );
-extractorConfig.mainEntryPointFilePath = `${pkgDir}/${tempSingleFileApiContentRelativePath}`;
 
-console.log(
-  `Validating type definitions of: ${extractorConfig.mainEntryPointFilePath}`
-);
 const result = Extractor.invoke(extractorConfig, {
   localBuild: true,
   showVerboseMessages: true,

--- a/scripts/build/types.js
+++ b/scripts/build/types.js
@@ -17,7 +17,7 @@ const { Extractor, ExtractorConfig } = require('@microsoft/api-extractor');
 
 const publicExports = [
   '',
-  // 'components' -> does not conns index.d.ts yet
+  // 'components' -> does not contains index.d.ts yet
   'connectors',
   // 'lib', -> Api extrator "import * as ___ from ___;" is not supported yet for local files
   'middleware',

--- a/scripts/build/types.js
+++ b/scripts/build/types.js
@@ -10,15 +10,10 @@ shell.exec(
   `tsc -p tsconfig.declaration.json --outDir es/; mv es/index.es.d.ts es/index.d.ts`
 );
 
-const pkgDir = path.resolve('');
-
 console.log();
 console.log(`Validating definitions...`);
 
 const { Extractor, ExtractorConfig } = require('@microsoft/api-extractor');
-
-const extractorConfigPath = path.resolve(pkgDir, `api-extractor.json`);
-const extractorConfig = ExtractorConfig.loadFileAndPrepare(extractorConfigPath);
 
 const publicExports = [
   '',
@@ -30,14 +25,21 @@ const publicExports = [
   'widgets', //  -> It does not compile as WidgetFactory is not imported in all files
 ];
 
+shell.cd(__dirname);
+shell.mkdir('-p', '.temp');
+
 fs.writeFileSync(
   '.temp/index.d.ts',
   publicExports
-    .map(publicExport => `../es/${publicExport}`)
+    .map(publicExport => `../../../es/${publicExport}`)
     .map(exportedFile => {
       return `export * from '${exportedFile}';`;
     })
     .join('\r\n')
+);
+
+const extractorConfig = ExtractorConfig.loadFileAndPrepare(
+  path.resolve(path.join(__dirname, 'api-extractor.json'))
 );
 
 const result = Extractor.invoke(extractorConfig, {

--- a/scripts/build/types.js
+++ b/scripts/build/types.js
@@ -2,6 +2,7 @@
 
 /* eslint-disable import/no-commonjs, no-console */
 
+const fs = require('fs');
 const path = require('path');
 const shell = require('shelljs');
 
@@ -20,33 +21,42 @@ const extractorConfigPath = path.resolve(pkgDir, `api-extractor.json`);
 const extractorConfig = ExtractorConfig.loadFileAndPrepare(extractorConfigPath);
 
 const publicExports = [
-  'index.d.ts',
-  // 'components/index.d.ts' -> does not contains index.d.ts yet
-  'connectors/index.d.ts',
-  // 'lib/main.d.ts', -> Api extrator "import * as ___ from ___;" is not supported yet for local files
-  'middleware/index.d.ts',
-  'types/index.d.ts',
-  'widgets/index.d.ts', //  -> It does not compile as WidgetFactory is not imported in all files
+  '',
+  // 'components' -> does not conns index.d.ts yet
+  'connectors',
+  // 'lib', -> Api extrator "import * as ___ from ___;" is not supported yet for local files
+  'middleware',
+  'types',
+  'widgets', //  -> It does not compile as WidgetFactory is not imported in all files
 ];
 
-const validateExport = publicExport => {
-  extractorConfig.mainEntryPointFilePath = `${pkgDir}/es/${publicExport}`;
-  console.log(
-    `Validating type definitions of: ${extractorConfig.mainEntryPointFilePath}`
+const tempSingleFileApiContentRelativePath = '.temp/index.d.ts';
+const tempSingleFileApiContent = publicExports
+  .map(publicExport => `../es/${publicExport}`)
+  .map(exportedFile => {
+    return `export * from '${exportedFile}';`;
+  })
+  .join('\r\n');
+
+fs.writeFileSync(
+  tempSingleFileApiContentRelativePath,
+  tempSingleFileApiContent
+);
+extractorConfig.mainEntryPointFilePath = `${pkgDir}/${tempSingleFileApiContentRelativePath}`;
+
+console.log(
+  `Validating type definitions of: ${extractorConfig.mainEntryPointFilePath}`
+);
+const result = Extractor.invoke(extractorConfig, {
+  localBuild: true,
+  showVerboseMessages: true,
+});
+
+if (!result.succeeded) {
+  console.error(
+    `API Extractor completed with ${result.errorCount} errors` +
+      ` and ${result.warningCount} warnings`
   );
-  const result = Extractor.invoke(extractorConfig, {
-    localBuild: true,
-    showVerboseMessages: true,
-  });
 
-  if (!result.succeeded) {
-    console.error(
-      `API Extractor completed with ${result.errorCount} errors` +
-        ` and ${result.warningCount} warnings`
-    );
-
-    process.exitCode = 1;
-  }
-};
-
-publicExports.forEach(validateExport);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
This pull request improves the current api extrator implementation, creating a temporary single public file API with:

```
export * from '../es/';
export * from '../es/connectors';
export * from '../es/middleware';
export * from '../es/types';
export * from '../es/widgets';
```

Previously, since we were validating file by file, the file `connectors/index.d.ts` was complaining that  'types' folder contains types that are not exported at `connectors/index.d.ts` ( the root level for api extrator ).

With this change, we are creating a temporary single file public api, and api extrator will no longer report those false positives.

@Haroenv We can't avoid the temporary folder in this case, as node don't have rights to write on the root system.