### PR TITLE
chore(ts-migration): creates refine generic type

### DIFF
--- a/src/components/MenuSelect/MenuSelect.tsx
+++ b/src/components/MenuSelect/MenuSelect.tsx
@@ -4,6 +4,7 @@ import { h } from 'preact';
 import cx from 'classnames';
 import { find } from '../../lib/utils';
 import Template from '../Template/Template';
+import { Refine } from '../../types';
 
 type MenuSelectTemplates = {
   defaultOption: string;
@@ -37,7 +38,7 @@ type Props = {
     option: string;
   };
   items: MenuItem[];
-  refine: (value: MenuItem['value']) => void;
+  refine: Refine<MenuItem['value']>;
   templateProps: {
     templates: MenuSelectTemplates;
   };

--- a/src/connectors/autocomplete/connectAutocomplete.ts
+++ b/src/connectors/autocomplete/connectAutocomplete.ts
@@ -6,7 +6,7 @@ import {
   noop,
   warning,
 } from '../../lib/utils';
-import { Hits, Connector } from '../../types';
+import { Hits, Connector, Refine } from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'autocomplete',
@@ -51,7 +51,7 @@ export type AutocompleteRendererOptions = {
   /**
    * Searches into the indices with the provided query.
    */
-  refine: (query: string) => void;
+  refine: Refine<string>;
 };
 
 export type AutocompleteConnector = Connector<
@@ -94,7 +94,7 @@ search.addWidgets([
     );
 
     type ConnectorState = {
-      refine?: (query: string) => void;
+      refine?: Refine<string>;
     };
 
     const connectorState: ConnectorState = {};

--- a/src/connectors/breadcrumb/connectBreadcrumb.ts
+++ b/src/connectors/breadcrumb/connectBreadcrumb.ts
@@ -6,7 +6,7 @@ import {
   noop,
 } from '../../lib/utils';
 import { SearchResults } from 'algoliasearch-helper';
-import { Connector, TransformItems, CreateURL } from '../../types';
+import { Connector, TransformItems, CreateURL, Refine } from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'breadcrumb',
@@ -63,7 +63,7 @@ export type BreadcrumbRendererOptions = {
   /**
    * Sets the path of the hierarchical filter and triggers a new search.
    */
-  refine: (value: BreadcrumbConnectorParamsItem['value']) => void;
+  refine: Refine<BreadcrumbConnectorParamsItem['value']>;
 
   /**
    * True if refinement can be applied.

--- a/src/connectors/configure/connectConfigure.ts
+++ b/src/connectors/configure/connectConfigure.ts
@@ -3,18 +3,13 @@ import algoliasearchHelper, {
   PlainSearchParameters,
   AlgoliaSearchHelper,
 } from 'algoliasearch-helper';
-import { Connector } from '../../types';
+import { Connector, Refine } from '../../types';
 import {
   createDocumentationMessageGenerator,
   isPlainObject,
   mergeSearchParameters,
   noop,
 } from '../../lib/utils';
-
-/**
- * Refine the given search parameters.
- */
-type Refine = (searchParameters: PlainSearchParameters) => void;
 
 export type ConfigureConnectorParams = {
   /**
@@ -28,7 +23,7 @@ export type ConfigureRendererOptions = {
   /**
    * Refine the given search parameters.
    */
-  refine: Refine;
+  refine: Refine<PlainSearchParameters>;
 };
 
 const withUsage = createDocumentationMessageGenerator({
@@ -71,12 +66,14 @@ const connectConfigure: ConfigureConnector = function connectConfigure(
     }
 
     type ConnectorState = {
-      refine?: Refine;
+      refine?: Refine<PlainSearchParameters>;
     };
 
     const connectorState: ConnectorState = {};
 
-    function refine(helper: AlgoliaSearchHelper): Refine {
+    function refine(
+      helper: AlgoliaSearchHelper
+    ): Refine<PlainSearchParameters> {
       return (searchParameters: PlainSearchParameters) => {
         // Merge new `searchParameters` with the ones set from other widgets
         const actualState = getInitialSearchParameters(

--- a/src/connectors/hits-per-page/connectHitsPerPage.ts
+++ b/src/connectors/hits-per-page/connectHitsPerPage.ts
@@ -6,7 +6,7 @@ import {
 } from '../../lib/utils';
 
 import { SearchParameters } from 'algoliasearch-helper';
-import { Connector, TransformItems, CreateURL } from '../../types';
+import { Connector, TransformItems, CreateURL, Refine } from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'hits-per-page',

--- a/src/connectors/hits-per-page/connectHitsPerPage.ts
+++ b/src/connectors/hits-per-page/connectHitsPerPage.ts
@@ -77,7 +77,7 @@ export type HitsPerPageRendererOptions = {
   /**
    * Sets the number of hits per page and triggers a search.
    */
-  refine: (value: number) => void;
+  refine: Refine<number>;
 
   /**
    * Indicates whether or not the search has results.

--- a/src/connectors/numeric-menu/connectNumericMenu.ts
+++ b/src/connectors/numeric-menu/connectNumericMenu.ts
@@ -62,8 +62,6 @@ export type NumericMenuConnectorParams = {
   transformItems?: ParamTransformItems;
 };
 
-type Refine = (facetValue: string) => void;
-
 export type NumericMenuRendererOptions = {
   /**
    * The list of available choices
@@ -80,7 +78,7 @@ export type NumericMenuRendererOptions = {
   /**
    * Sets the selected value and trigger a new search
    */
-  refine: Refine;
+  refine: Refine<string>;
 };
 
 export type NumericMenuConnector = Connector<
@@ -112,7 +110,7 @@ const connectNumericMenu: NumericMenuConnector = function connectNumericMenu(
     }
 
     type ConnectorState = {
-      refine?: Refine;
+      refine?: Refine<string>;
       createURL?: (state: SearchParameters) => (facetValue: string) => string;
     };
 

--- a/src/connectors/numeric-menu/connectNumericMenu.ts
+++ b/src/connectors/numeric-menu/connectNumericMenu.ts
@@ -4,7 +4,7 @@ import {
   isFiniteNumber,
   noop,
 } from '../../lib/utils';
-import { Connector, CreateURL } from '../../types';
+import { Connector, CreateURL, Refine } from '../../types';
 import { SearchParameters } from 'algoliasearch-helper';
 
 const withUsage = createDocumentationMessageGenerator({

--- a/src/types/connector.ts
+++ b/src/types/connector.ts
@@ -81,3 +81,8 @@ export type TransformItems<TItem> = (items: TItem[]) => TItem[];
  * Creates the URL for the given value.
  */
 export type CreateURL<TValue> = (value: TValue) => string;
+
+/**
+ * Trigers a search with the given value.
+ */
+export type Refine<TValue> = (value: TValue) => void;


### PR DESCRIPTION
This pull request makes the refine type easier to reuse.