### PR TITLE
chore(ts-migration): fixes configure widget types

### DIFF
--- a/src/widgets/configure/configure.ts
+++ b/src/widgets/configure/configure.ts
@@ -7,11 +7,11 @@ import { noop } from '../../lib/utils';
  * A list of [search parameters](https://www.algolia.com/doc/api-reference/search-api-parameters/)
  * to enable when the widget mounts.
  */
-type ConfigureWidgetParams = PlainSearchParameters;
+export type ConfigureWidgetOptions = PlainSearchParameters;
 
-type Configure = WidgetFactory<{}, ConfigureWidgetParams>;
+export type ConfigureWidget = WidgetFactory<{}, ConfigureWidgetOptions>;
 
-const configure: Configure = (widgetParams: ConfigureWidgetParams) => {
+const configure: ConfigureWidget = widgetParams => {
   // This is a renderless widget that falls back to the connector's
   // noop render and unmount functions.
   const makeWidget = connectConfigure(noop);


### PR DESCRIPTION
This pull request fixes the types on the configure widget, they aren't exported and the name was incorrect.