### PR TITLE
chore(ts-migration): migrates infinite hits contents

### DIFF
--- a/src/components/InfiniteHits/InfiniteHits.tsx
+++ b/src/components/InfiniteHits/InfiniteHits.tsx
@@ -27,7 +27,7 @@ type InfiniteHitsProps = {
   showMore: () => void;
   templateProps: {
     [key: string]: any;
-    templates: InfiniteHitsTemplates;
+    templates: Partial<InfiniteHitsTemplates>;
   };
   isFirstPage: boolean;
   isLastPage: boolean;

--- a/src/components/InfiniteHits/InfiniteHits.tsx
+++ b/src/components/InfiniteHits/InfiniteHits.tsx
@@ -27,7 +27,7 @@ type InfiniteHitsProps = {
   showMore: () => void;
   templateProps: {
     [key: string]: any;
-    templates: Partial<InfiniteHitsTemplates>;
+    templates: InfiniteHitsTemplates;
   };
   isFirstPage: boolean;
   isLastPage: boolean;

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -376,7 +376,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     const renderFn = jest.fn();
     const makeWidget = connectInfiniteHits(renderFn);
     const widget = makeWidget({
-      transformItems: items => items.map(() => ({ name: 'transformed' })),
+      transformItems: items => {
+        return items.map(item => ({ ...item, name: 'transformed' }));
+      },
     });
 
     const helper = algoliasearchHelper({} as SearchClient, '', {});
@@ -418,9 +420,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
 
     const transformedHits = [
       {
+        objectID: '1',
         name: 'transformed',
       },
       {
+        objectID: '2',
         name: 'transformed',
       },
     ];
@@ -435,14 +439,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     const makeWidget = connectInfiniteHits(renderFn);
     const widget = makeWidget({
       transformItems: items =>
-        items.map(item => ({
-          ...item,
-          _highlightResult: {
-            name: {
-              value: item._highlightResult.name.value.toUpperCase(),
-            },
-          },
-        })),
+        items.map(item => {
+          // @ts-ignore
+          item._highlightResult.name.value = item._highlightResult.name.value.toUpperCase();
+
+          return item;
+        }),
       escapeHTML: true,
     });
 

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -2,7 +2,7 @@ import algoliasearchHelper, {
   SearchResults,
   SearchParameters,
 } from 'algoliasearch-helper';
-import { SearchClient } from '../../../types';
+import { SearchClient, HitAttributeHighlightResult } from '../../../types';
 import { createInstantSearch } from '../../../../test/mock/createInstantSearch';
 import {
   createInitOptions,
@@ -440,8 +440,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     const widget = makeWidget({
       transformItems: items =>
         items.map(item => {
-          // @ts-ignore
-          item._highlightResult.name.value = item._highlightResult.name.value.toUpperCase();
+          const name = item._highlightResult!
+            .name as HitAttributeHighlightResult;
+
+          name.value = name.value.toUpperCase();
 
           return item;
         }),

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -3,7 +3,7 @@ import {
   AlgoliaSearchHelper as Helper,
   SearchParameters,
 } from 'algoliasearch-helper';
-import { Hits, Connector, TransformItems } from '../../types';
+import { Hits, Connector, TransformItems, AlgoliaHit } from '../../types';
 import {
   checkRendering,
   createDocumentationMessageGenerator,
@@ -32,9 +32,11 @@ export type InfiniteHitsConnectorParams = {
    * Receives the items, and is called before displaying them.
    * Useful for mapping over the items to transform, and remove or reorder them.
    */
-  transformItems?: TransformItems<{
-    __hitIndex: number;
-  }>;
+  transformItems?: TransformItems<
+    AlgoliaHit & {
+      __hitIndex: number;
+    }
+  >;
 };
 
 export type InfiniteHitsRendererOptions = {

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -3,7 +3,7 @@ import {
   AlgoliaSearchHelper as Helper,
   SearchParameters,
 } from 'algoliasearch-helper';
-import { Hits, Connector, TransformItems, AlgoliaHit } from '../../types';
+import { Hits, Connector, TransformItems, Hit } from '../../types';
 import {
   checkRendering,
   createDocumentationMessageGenerator,
@@ -32,11 +32,7 @@ export type InfiniteHitsConnectorParams = {
    * Receives the items, and is called before displaying them.
    * Useful for mapping over the items to transform, and remove or reorder them.
    */
-  transformItems?: TransformItems<
-    AlgoliaHit & {
-      __hitIndex: number;
-    }
-  >;
+  transformItems?: TransformItems<Hit>;
 };
 
 export type InfiniteHitsRendererOptions = {

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -3,7 +3,7 @@ import {
   AlgoliaSearchHelper as Helper,
   SearchParameters,
 } from 'algoliasearch-helper';
-import { Hits, Connector } from '../../types';
+import { Hits, Connector, TransformItems } from '../../types';
 import {
   checkRendering,
   createDocumentationMessageGenerator,
@@ -12,16 +12,54 @@ import {
   addQueryID,
   noop,
 } from '../../lib/utils';
-import { InfiniteHitsRendererWidgetParams } from '../../widgets/infinite-hits/infinite-hits';
 
-export type InfiniteHitsConnectorParams = Partial<
-  InfiniteHitsRendererWidgetParams
->;
+export type InfiniteHitsConnectorParamsItem = {
+  __hitIndex: number;
+};
+
+export type InfiniteHitsConnectorParams<
+  TInfiniteHitsConnectorParamsItem extends InfiniteHitsConnectorParamsItem = InfiniteHitsConnectorParamsItem
+> = {
+  /**
+   * Escapes HTML entities from hits string values.
+   *
+   * @default `true`
+   */
+  escapeHTML?: boolean;
+
+  /**
+   * Enable the button to load previous results.
+   *
+   * @default `false`
+   */
+  showPrevious?: boolean;
+
+  /**
+   * Receives the items, and is called before displaying them.
+   * Useful for mapping over the items to transform, and remove or reorder them.
+   */
+  transformItems?: TransformItems<TInfiniteHitsConnectorParamsItem>;
+};
 
 export type InfiniteHitsRendererOptions = {
+  /**
+   * Loads the previous results.
+   */
   showPrevious: () => void;
+
+  /**
+   * Loads the next page of hits.
+   */
   showMore: () => void;
+
+  /**
+   * Indicates whether the first page of hits has been reached.
+   */
   isFirstPage: boolean;
+
+  /**
+   * Indicates whether the last page of hits has been reached.
+   */
   isLastPage: boolean;
 };
 

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -13,13 +13,7 @@ import {
   noop,
 } from '../../lib/utils';
 
-export type InfiniteHitsConnectorParamsItem = {
-  __hitIndex: number;
-};
-
-export type InfiniteHitsConnectorParams<
-  TInfiniteHitsConnectorParamsItem extends InfiniteHitsConnectorParamsItem = InfiniteHitsConnectorParamsItem
-> = {
+export type InfiniteHitsConnectorParams = {
   /**
    * Escapes HTML entities from hits string values.
    *
@@ -38,7 +32,9 @@ export type InfiniteHitsConnectorParams<
    * Receives the items, and is called before displaying them.
    * Useful for mapping over the items to transform, and remove or reorder them.
    */
-  transformItems?: TransformItems<TInfiniteHitsConnectorParamsItem>;
+  transformItems?: TransformItems<{
+    __hitIndex: number;
+  }>;
 };
 
 export type InfiniteHitsRendererOptions = {

--- a/src/lib/insights/client.ts
+++ b/src/lib/insights/client.ts
@@ -101,9 +101,9 @@ const wrapInsightsClient = (
   aa(method, { ...inferredPayload, ...payload } as any);
 };
 
-export default function withInsights<TRenderOptions, TWidgetParams>(
-  connector: Connector<TRenderOptions, TWidgetParams>
-): Connector<TRenderOptions, TWidgetParams> {
+export default function withInsights<TRendererOptions, TConnectorParams>(
+  connector: Connector<TRendererOptions, TConnectorParams>
+): Connector<TRendererOptions, TConnectorParams> {
   const wrapRenderFn = renderFn => (renderOptions, isFirstRender) => {
     const { results, hits, instantSearchInstance } = renderOptions;
     if (results && hits && instantSearchInstance) {

--- a/src/types/instantsearch.ts
+++ b/src/types/instantsearch.ts
@@ -10,26 +10,26 @@ export type HelperChangeEvent = {
   state: SearchParameters;
 };
 
-type HitAttributeHighlightResult = {
+export type HitAttributeHighlightResult = {
   value: string;
   matchLevel: 'none' | 'partial' | 'full';
   matchedWords: string[];
   fullyHighlighted?: boolean;
 };
 
-type HitHighlightResult = {
+export type HitHighlightResult = {
   [attribute: string]:
     | HitAttributeHighlightResult
     | HitAttributeHighlightResult[]
     | HitHighlightResult;
 };
 
-type HitAttributeSnippetResult = Pick<
+export type HitAttributeSnippetResult = Pick<
   HitAttributeHighlightResult,
   'value' | 'matchLevel'
 >;
 
-type HitSnippetResult = {
+export type HitSnippetResult = {
   [attribute: string]:
     | HitAttributeSnippetResult
     | HitAttributeSnippetResult[]

--- a/src/widgets/infinite-hits/infinite-hits.tsx
+++ b/src/widgets/infinite-hits/infinite-hits.tsx
@@ -111,7 +111,7 @@ type InfiniteHitsWidgetParams = {
   templates?: InfiniteHitsTemplates;
 };
 
-type InfiniteHits = WidgetFactory<
+export type InfiniteHitsWidget = WidgetFactory<
   InfiniteHitsConnectorParams,
   InfiniteHitsWidgetParams
 >;
@@ -122,7 +122,7 @@ const renderer = ({
   renderState,
   templates,
   showPrevious: hasShowPrevious,
-}): Renderer<InfiniteHitsRendererOptions, InfiniteHitsRendererWidgetParams> => (
+}): Renderer<InfiniteHitsRendererOptions, InfiniteHitsWidgetParams> => (
   {
     hits,
     results,
@@ -161,7 +161,7 @@ const renderer = ({
   );
 };
 
-const infiniteHits: InfiniteHits = (
+const infiniteHits: InfiniteHitsWidget = (
   {
     container,
     escapeHTML,
@@ -208,7 +208,12 @@ const infiniteHits: InfiniteHits = (
     connectInfiniteHits
   )(specializedRenderer, () => render(null, containerNode));
 
-  return makeInfiniteHits({ escapeHTML, transformItems, showPrevious });
+  return makeInfiniteHits({
+    container: containerNode,
+    escapeHTML,
+    transformItems,
+    showPrevious,
+  });
 };
 
 export default infiniteHits;

--- a/src/widgets/infinite-hits/infinite-hits.tsx
+++ b/src/widgets/infinite-hits/infinite-hits.tsx
@@ -34,74 +34,64 @@ export type InfiniteHitsCSSClasses = {
   /**
    * The root element of the widget.
    */
-  root: string | string[];
+  root?: string | string[];
+
   /**
    * The root container without results.
    */
-  emptyRoot: string | string[];
+  emptyRoot?: string | string[];
+
   /**
    * The list of results.
    */
-  list: string | string[];
+  list?: string | string[];
+
   /**
    * The list item.
    */
-  item: string | string[];
+  item?: string | string[];
+
   /**
    * The “Show previous” button.
    */
-  loadPrevious: string | string[];
+  loadPrevious?: string | string[];
+
   /**
    * The disabled “Show previous” button.
    */
-  disabledLoadPrevious: string | string[];
+  disabledLoadPrevious?: string | string[];
+
   /**
    * The “Show more” button.
    */
-  loadMore: string | string[];
+  loadMore?: string | string[];
+
   /**
    * The disabled “Show more” button.
    */
-  disabledLoadMore: string | string[];
+  disabledLoadMore?: string | string[];
 };
 
 export type InfiniteHitsTemplates = {
   /**
    * The template to use when there are no results.
    */
-  empty: Template<{ results: SearchResults }>;
+  empty?: Template<{ results: SearchResults }>;
+
   /**
    * The template to use for the “Show previous” label.
    */
-  showPreviousText: Template;
+  showPreviousText?: Template;
+
   /**
    * The template to use for the “Show more” label.
    */
-  showMoreText: Template;
+  showMoreText?: Template;
+
   /**
    * The template to use for each result.
    */
-  item: Template<Hit>;
-};
-
-export type InfiniteHitsRendererWidgetParams = {
-  /**
-   * Escapes HTML entities from hits string values.
-   *
-   * @default `true`
-   */
-  escapeHTML?: boolean;
-  /**
-   * Enable the button to load previous results.
-   *
-   * @default `false`
-   */
-  showPrevious?: boolean;
-  /**
-   * Receives the items, and is called before displaying them.
-   * Useful for mapping over the items to transform, and remove or reorder them.
-   */
-  transformItems?: (items: any[]) => any[];
+  item?: Template<Hit>;
 };
 
 type InfiniteHitsWidgetParams = {
@@ -109,15 +99,17 @@ type InfiniteHitsWidgetParams = {
    * The CSS Selector or `HTMLElement` to insert the widget into.
    */
   container: string | HTMLElement;
+
   /**
    * The CSS classes to override.
    */
-  cssClasses?: Partial<InfiniteHitsCSSClasses>;
+  cssClasses?: InfiniteHitsCSSClasses;
+
   /**
    * The templates to use for the widget.
    */
-  templates?: Partial<InfiniteHitsTemplates>;
-} & InfiniteHitsRendererWidgetParams;
+  templates?: InfiniteHitsTemplates;
+};
 
 type InfiniteHits = WidgetFactory<
   InfiniteHitsConnectorParams,

--- a/src/widgets/infinite-hits/infinite-hits.tsx
+++ b/src/widgets/infinite-hits/infinite-hits.tsx
@@ -122,7 +122,10 @@ const renderer = ({
   renderState,
   templates,
   showPrevious: hasShowPrevious,
-}): Renderer<InfiniteHitsRendererOptions, InfiniteHitsWidgetParams> => (
+}): Renderer<
+  InfiniteHitsRendererOptions,
+  Partial<InfiniteHitsWidgetParams>
+> => (
   {
     hits,
     results,
@@ -204,12 +207,11 @@ const infiniteHits: InfiniteHitsWidget = (
     renderState: {},
   });
 
-  const makeInfiniteHits = withInsights(
+  const makeInfiniteHitsWidget = withInsights(
     connectInfiniteHits
   )(specializedRenderer, () => render(null, containerNode));
 
-  return makeInfiniteHits({
-    container: containerNode,
+  return makeInfiniteHitsWidget({
     escapeHTML,
     transformItems,
     showPrevious,

--- a/src/widgets/infinite-hits/infinite-hits.tsx
+++ b/src/widgets/infinite-hits/infinite-hits.tsx
@@ -94,7 +94,7 @@ export type InfiniteHitsTemplates = {
   item?: Template<Hit>;
 };
 
-type InfiniteHitsWidgetParams = {
+export type InfiniteHitsWidgetParams = {
   /**
    * The CSS Selector or `HTMLElement` to insert the widget into.
    */

--- a/src/widgets/infinite-hits/infinite-hits.tsx
+++ b/src/widgets/infinite-hits/infinite-hits.tsx
@@ -207,11 +207,11 @@ const infiniteHits: InfiniteHitsWidget = (
     renderState: {},
   });
 
-  const makeInfiniteHitsWidget = withInsights(
+  const makeInfiniteHits = withInsights(
     connectInfiniteHits
   )(specializedRenderer, () => render(null, containerNode));
 
-  return makeInfiniteHitsWidget({
+  return makeInfiniteHits({
     escapeHTML,
     transformItems,
     showPrevious,


### PR DESCRIPTION
This pull request migrates infinite hits contents.

I have a problem tho, I would like to pass a type to transform items:

```
    const widget = makeWidget({
      transformItems: <MYSPECIALTYPEHERE>(items) =>
        items.map(item => ({
          ...item,
          _highlightResult: {
            name: {
              value: item._highligh¨tResult.name.value.toUpperCase(),
            },
          },
        })),
      escapeHTML: true,
```

Going to try to solve this problem on top with @yannickcr 