### PR TITLE
fix(router): don't write an existing URL

### DIFF
--- a/src/lib/routers/__tests__/history.test.ts
+++ b/src/lib/routers/__tests__/history.test.ts
@@ -26,6 +26,32 @@ describe('life cycle', () => {
     expect(pushState).toHaveBeenCalledTimes(1);
   });
 
+  it('does not write if already externally updated to desired URL', async () => {
+    const pushState = jest.spyOn(window.history, 'pushState');
+    const router = historyRouter({
+      writeDelay: 0,
+    });
+
+    const fakeState = { identifier: 'fake state' };
+
+    router.write({ some: 'state one' });
+
+    // external update before timeout passes
+    window.history.pushState(
+      fakeState,
+      '',
+      'http://localhost/?some=state%20two'
+    );
+
+    // this write isn't needed anymore
+    router.write({ some: 'state two' });
+    await wait(0);
+
+    expect(pushState).toHaveBeenCalledTimes(1);
+    // proves that InstantSearch' write did not happen
+    expect(history.state).toBe(fakeState);
+  });
+
   it('does not write the same url title twice', async () => {
     const title = jest.spyOn(window.document, 'title', 'set');
     const pushState = jest.spyOn(window.history, 'pushState');

--- a/src/lib/routers/__tests__/history.test.ts
+++ b/src/lib/routers/__tests__/history.test.ts
@@ -1,0 +1,22 @@
+import historyRouter from '../history';
+
+const wait = (ms = 0) => new Promise(res => setTimeout(res, ms));
+
+describe('life cycle', () => {
+  it('does not write the same url twice', async () => {
+    const router = historyRouter({
+      writeDelay: 0,
+    });
+
+    const spy = jest.spyOn(window.history, 'pushState');
+
+    router.write({ some: 'state' });
+    await wait(0);
+    router.write({ some: 'state' });
+    await wait(0);
+    router.write({ some: 'state' });
+    await wait(0);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/routers/__tests__/history.test.ts
+++ b/src/lib/routers/__tests__/history.test.ts
@@ -24,6 +24,17 @@ describe('life cycle', () => {
     await wait(0);
 
     expect(pushState).toHaveBeenCalledTimes(1);
+    expect(pushState.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          Object {
+            "some": "state",
+          },
+          "",
+          "http://localhost/?some=state",
+        ],
+      ]
+    `);
   });
 
   it('does not write if already externally updated to desired URL', async () => {
@@ -48,6 +59,18 @@ describe('life cycle', () => {
     await wait(0);
 
     expect(pushState).toHaveBeenCalledTimes(1);
+    expect(pushState.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          Object {
+            "identifier": "fake state",
+          },
+          "",
+          "http://localhost/?some=state%20two",
+        ],
+      ]
+    `);
+
     // proves that InstantSearch' write did not happen
     expect(history.state).toBe(fakeState);
   });
@@ -74,6 +97,17 @@ describe('life cycle', () => {
     await wait(0);
 
     expect(pushState).toHaveBeenCalledTimes(1);
+    expect(pushState.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          Object {
+            "some": "state",
+          },
+          "My Site - state",
+          "http://localhost/?some=state",
+        ],
+      ]
+    `);
 
     expect(title).toHaveBeenCalledTimes(2);
     expect(window.document.title).toBe('My Site - state');
@@ -92,5 +126,16 @@ describe('life cycle', () => {
     await wait(0);
 
     expect(pushState).toHaveBeenCalledTimes(1);
+    expect(pushState.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          Object {
+            "some": "third",
+          },
+          "",
+          "http://localhost/?some=third",
+        ],
+      ]
+    `);
   });
 });

--- a/src/lib/routers/__tests__/history.test.ts
+++ b/src/lib/routers/__tests__/history.test.ts
@@ -3,20 +3,68 @@ import historyRouter from '../history';
 const wait = (ms = 0) => new Promise(res => setTimeout(res, ms));
 
 describe('life cycle', () => {
+  beforeEach(() => {
+    window.history.pushState(null, '-- divider --', 'http://localhost/');
+    jest.restoreAllMocks();
+  });
+
   it('does not write the same url twice', async () => {
+    const pushState = jest.spyOn(window.history, 'pushState');
     const router = historyRouter({
       writeDelay: 0,
     });
 
-    const spy = jest.spyOn(window.history, 'pushState');
-
-    router.write({ some: 'state' });
-    await wait(0);
-    router.write({ some: 'state' });
-    await wait(0);
     router.write({ some: 'state' });
     await wait(0);
 
-    expect(spy).toHaveBeenCalledTimes(1);
+    router.write({ some: 'state' });
+    await wait(0);
+
+    router.write({ some: 'state' });
+    await wait(0);
+
+    expect(pushState).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not write the same url title twice', async () => {
+    const title = jest.spyOn(window.document, 'title', 'set');
+    const pushState = jest.spyOn(window.history, 'pushState');
+
+    const router = historyRouter({
+      writeDelay: 0,
+      windowTitle: state => `My Site - ${state.some}`,
+    });
+
+    expect(title).toHaveBeenCalledTimes(1);
+    expect(window.document.title).toBe('My Site - undefined');
+
+    router.write({ some: 'state' });
+    await wait(0);
+
+    router.write({ some: 'state' });
+    await wait(0);
+
+    router.write({ some: 'state' });
+    await wait(0);
+
+    expect(pushState).toHaveBeenCalledTimes(1);
+
+    expect(title).toHaveBeenCalledTimes(2);
+    expect(window.document.title).toBe('My Site - state');
+  });
+
+  it('writes after timeout is done', async () => {
+    const pushState = jest.spyOn(window.history, 'pushState');
+
+    const router = historyRouter({
+      writeDelay: 0,
+    });
+
+    router.write({ some: 'state' });
+    router.write({ some: 'second' });
+    router.write({ some: 'third' });
+    await wait(0);
+
+    expect(pushState).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/routers/history.ts
+++ b/src/lib/routers/history.ts
@@ -26,6 +26,13 @@ type BrowserHistoryProps = {
   parseURL: ParseURL;
 };
 
+type BrowserHistoryArgs = {
+  windowTitle?: (routeState: RouteState) => string;
+  writeDelay?: number;
+  createURL?: CreateURL;
+  parseURL?: ParseURL;
+};
+
 const defaultCreateURL: CreateURL = ({ qsModule, routeState, location }) => {
   const { protocol, hostname, port = '', pathname, hash } = location;
   const queryString = qsModule.stringify(routeState);
@@ -96,7 +103,7 @@ class BrowserHistory implements Router {
       writeDelay = 400,
       createURL = defaultCreateURL,
       parseURL = defaultParseURL,
-    }: BrowserHistoryProps = {} as BrowserHistoryProps
+    }: BrowserHistoryArgs = {} as BrowserHistoryArgs
   ) {
     this.windowTitle = windowTitle;
     this.writeTimer = undefined;
@@ -128,9 +135,11 @@ class BrowserHistory implements Router {
     }
 
     this.writeTimer = window.setTimeout(() => {
-      setWindowTitle(title);
+      if (window.location.href !== url) {
+        setWindowTitle(title);
 
-      window.history.pushState(routeState, title || '', url);
+        window.history.pushState(routeState, title || '', url);
+      }
       this.writeTimer = undefined;
     }, this.writeDelay);
   }
@@ -192,6 +201,6 @@ class BrowserHistory implements Router {
   }
 }
 
-export default function(...args: BrowserHistoryProps[]): BrowserHistory {
-  return new BrowserHistory(...args);
+export default function(props?: BrowserHistoryArgs): BrowserHistory {
+  return new BrowserHistory(props);
 }

--- a/src/lib/routers/history.ts
+++ b/src/lib/routers/history.ts
@@ -19,13 +19,6 @@ type ParseURL = ({
   location: Location;
 }) => RouteState;
 
-type BrowserHistoryProps = {
-  windowTitle?: (routeState: RouteState) => string;
-  writeDelay: number;
-  createURL: CreateURL;
-  parseURL: ParseURL;
-};
-
 type BrowserHistoryArgs = {
   windowTitle?: (routeState: RouteState) => string;
   writeDelay?: number;
@@ -70,7 +63,7 @@ class BrowserHistory implements Router {
   /**
    * Transforms a UI state into a title for the page.
    */
-  private readonly windowTitle?: BrowserHistoryProps['windowTitle'];
+  private readonly windowTitle?: BrowserHistoryArgs['windowTitle'];
   /**
    * Time in milliseconds before performing a write in the history.
    * It prevents from adding too many entries in the history and
@@ -78,17 +71,17 @@ class BrowserHistory implements Router {
    *
    * @default 400
    */
-  private readonly writeDelay: BrowserHistoryProps['writeDelay'];
+  private readonly writeDelay: Required<BrowserHistoryArgs>['writeDelay'];
   /**
    * Creates a full URL based on the route state.
    * The storage adaptor maps all syncable keys to the query string of the URL.
    */
-  private readonly _createURL: BrowserHistoryProps['createURL'];
+  private readonly _createURL: Required<BrowserHistoryArgs>['createURL'];
   /**
    * Parses the URL into a route state.
    * It should be symetrical to `createURL`.
    */
-  private readonly parseURL: BrowserHistoryProps['parseURL'];
+  private readonly parseURL: Required<BrowserHistoryArgs>['parseURL'];
 
   private writeTimer?: number;
   private _onPopState?(event: PopStateEvent): void;


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

Every write puts a history entry, we never want to write the same as what's already written to the URL.

Demonstration of the bug being fixed in user land: https://codesandbox.io/s/vigilant-mayer-u3lyd?file=/src/app.js:2097-2279 (note that this searchFunction is very similar to the default one in Shopify)



The history router didn't have tests yet, so I added just one for this case, as not to lose time writing tests for existing cases.



<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

condition around pushing the URL, meaning it won't write if the URL is already the same. In theory a createURL could give a non-qualified URL, but that would make this condition a lot more complicated, so I'm ok with that caveat.

Also fixed the typescript of the class wrapper a bit