### PR TITLE
chore(vscode): exclude cjs, dist, es from file explorer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "search.exclude": {
+    "cjs/**": true,
+    "dist/**": true,
+    "es/**": true
+  }
+}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR excludes cjs, dist, es folders from file explorer in VSCode.

![image](https://user-images.githubusercontent.com/499898/80081758-a7125e00-8553-11ea-8f1b-391375a2ad8f.png)

We haven't put any editor-specific config in the repository, but I'm opening this PR to see what you think of it.
