### PR TITLE
fix(range): fix range calculation when step is set

### DIFF
--- a/src/lib/utils/__tests__/range-test.ts
+++ b/src/lib/utils/__tests__/range-test.ts
@@ -13,20 +13,35 @@ describe('range', () => {
     expect(range({ end: 20, step: 5 })).toEqual([0, 5, 10, 15]);
   });
 
+  test('with start, end and step', () => {
+    expect(range({ start: 1300, end: 1350, step: 5 })).toEqual([
+      1300,
+      1305,
+      1310,
+      1315,
+      1320,
+      1325,
+      1330,
+      1335,
+      1340,
+      1345,
+    ]);
+  });
+
   test('rounds decimal array lengths', () => {
     // (5000 - 1) / 500 = 9.998 so we want the array length to be rounded to 10.
     expect(range({ start: 1, end: 5000, step: 500 })).toHaveLength(10);
     expect(range({ start: 1, end: 5000, step: 500 })).toEqual([
-      500,
-      1000,
-      1500,
-      2000,
-      2500,
-      3000,
-      3500,
-      4000,
-      4500,
-      5000,
+      1,
+      501,
+      1001,
+      1501,
+      2001,
+      2501,
+      3001,
+      3501,
+      4001,
+      4501,
     ]);
   });
 });

--- a/src/lib/utils/range.ts
+++ b/src/lib/utils/range.ts
@@ -16,7 +16,7 @@ function range({ start = 0, end, step = 1 }: RangeOptions): number[] {
   const arrayLength = Math.round((end - start) / limitStep);
 
   return [...Array(arrayLength)].map(
-    (_, current) => (start + current) * limitStep
+    (_, current) => start + current * limitStep
   );
 }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

The range was incorrectly calculated when a step was set and the start value was not 0. This was due to a small error in the range calculation (misplaced parenthesis).

For example with `{ start: 1300, end: 1350, step: 5 }` the calculation would have been `(1300 + 0) * 5` instead of `1300 + 0 * 5`, making the steps to start at `6500` instead of `1300`.

Helpscout ticket: https://secure.helpscout.net/conversation/1147259825/250436

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

The range is now correctly calculated. I added a new test to validate the fix and also updated the result for the `rounds decimal array lengths` one (the previous result seems incorrect, the new result with the fix seems more correct to me).

