### PR TITLE
chore(github): update template chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Bug Report
+    url: https://github.com/algolia/instantsearch.js/issues/new?template=Bug_report.md
+    about: Report a bug using GitHub issues.
+  - name: Feature Request
+    url: https://github.com/algolia/instantsearch.js/discussions/new
+    about: Request a feature to add to InstantSearch.
+  - name: Ask a Question
+    url: https://github.com/algolia/instantsearch.js/discussions/new
+    about: Ask questions and discuss with other community members.


### PR DESCRIPTION
## Description

This leverages the [GitHub Template Chooser](https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser) to direct people to the right platform based on their intentions.

- Bug report → GitHub Issue with the Bug Report template
- Feature Request → GitHub discussion to better leverage threads and the Discussions feature
- Question → GitHub discussion to better leverage threads and the Discussions feature

## Preview

When opening an issue, you would have this screen:

![image](https://user-images.githubusercontent.com/6137112/80691332-632dd480-8ad0-11ea-8d01-14ef571bb6fa.png)