### PR TITLE
chore(deps): update dependency instantsearch-e2e-tests to v1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "eslint-plugin-react": "7.18.0",
     "eslint-plugin-react-hooks": "2.3.0",
     "inquirer": "7.0.3",
-    "instantsearch-e2e-tests": "algolia/instantsearch-e2e-tests#1.2.4",
+    "instantsearch-e2e-tests": "algolia/instantsearch-e2e-tests#1.3.0",
     "jest": "25.1.0",
     "jest-diff": "25.1.0",
     "jest-environment-jsdom": "25.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8778,9 +8778,9 @@ insert-css@^2.0.0:
   resolved "https://registry.yarnpkg.com/insert-css/-/insert-css-2.0.0.tgz#eb5d1097b7542f4c79ea3060d3aee07d053880f4"
   integrity sha1-610Ql7dUL0x56jBg067gfQU4gPQ=
 
-instantsearch-e2e-tests@algolia/instantsearch-e2e-tests#1.2.4:
-  version "1.2.4"
-  resolved "https://codeload.github.com/algolia/instantsearch-e2e-tests/tar.gz/da70c1c4c0d1d0f3b6db2bbce1491e3103cf44fd"
+instantsearch-e2e-tests@algolia/instantsearch-e2e-tests#1.3.0:
+  version "1.3.0"
+  resolved "https://codeload.github.com/algolia/instantsearch-e2e-tests/tar.gz/df0f464f141d268e8c474035a6b0906b8b47d5a9"
   dependencies:
     dotenv "^8.0.0"
     ts-node "^8.3.0"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR updates the `instantsearch-e2e-tests` dependency to v1.3.0.

See the CHANGELOG: https://github.com/algolia/instantsearch-e2e-tests/blob/master/CHANGELOG.md#130-2020-04-17

