### PR TITLE
chore(ts-migration): improves build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,3 +207,24 @@ yarn run release:prepare
 
 The script will ask you a question about the next version. If it's wrong, you can say "No" and specify the version (e.g. "7.0.0-beta.0"). Then, it will open a pull request for that release. When the pull request is merged, CircleCI will publish it to npm with a `--tag beta` argument.
 
+#### Experimental TypeScript version
+
+An experimental version containing the TypeScript declaration files is available on the npm tag `experimental-typescript`.
+
+Since some of these declaration files are generated from the JSDoc comments, they can contain some typing errors. This version will stay experimental until we are confident enough in the generated declarations to put them in a stable release.
+
+To generate the experimental TypeScript version for a particular (stable) release, run:
+
+```sh
+./scripts/release/build-experimental-typescript.js
+```
+
+To publish it manually, run:
+
+```
+npm publish --tag experimental-typescript
+# or
+yarn publish --no-git-tag-version --non-interactive --tag experimental-typescript
+```
+
+_Note that this build will be automatically published along with the current stable version by Ship.js._

--- a/api-extractor.json
+++ b/api-extractor.json
@@ -41,7 +41,7 @@
       }
     }
   },
-  "mainEntryPointFilePath": ".temp/index.d.ts",
+  "mainEntryPointFilePath": "scripts/build/.temp/index.d.ts",
   "dtsRollup": {
     "enabled": false
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "start": "yarn run dev",
     "dev": "yarn run storybook",
-    "build": "yarn run build:cjs && yarn run build:es && yarn run build:umd && yarn run build:types",
+    "build": "yarn run build:cjs && yarn run build:es && yarn run build:umd",
     "build:umd": "rm -rf dist && BABEL_ENV=umd rollup --config scripts/rollup/config.js",
     "build:cjs": "rm -rf cjs && BABEL_ENV=cjs babel src --extensions '.js,.ts,.tsx' --out-dir cjs/ --ignore 'src/index.es.ts','**/__tests__','**/__mocks__' --quiet",
     "build:es": "rm -rf es && BABEL_ENV=es babel src --extensions '.js,.ts,.tsx' --out-dir es/ --ignore 'src/index.es.ts','**/__tests__','**/__mocks__' --quiet && BABEL_ENV=es babel src/index.es.ts --out-file es/index.js --quiet",

--- a/scripts/build/types.js
+++ b/scripts/build/types.js
@@ -40,7 +40,7 @@ fs.writeFileSync(
 );
 
 const extractorConfig = ExtractorConfig.loadFileAndPrepare(
-  path.resolve(path.join(__dirname, 'api-extractor.json'))
+  path.resolve(path.join(__dirname, '../../', 'api-extractor.json'))
 );
 
 const result = Extractor.invoke(extractorConfig, {

--- a/scripts/release/build-experimental-typescript.js
+++ b/scripts/release/build-experimental-typescript.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+/* eslint-disable import/no-commonjs */
+
+const fs = require('fs');
+const path = require('path');
+const shell = require('shelljs');
+
+const packageJsonPath = path.resolve('package.json');
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath).toString());
+const { version: currentVersion } = packageJson;
+const newVersion = `${currentVersion}-experimental-typescript.0`;
+packageJson.version = newVersion;
+packageJson.types = 'es/index.d.ts';
+fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+
+fs.writeFileSync(
+  path.resolve('src', 'lib', 'version.ts'),
+  `export default '${newVersion}';\n`
+);
+
+shell.exec(`NODE_ENV=production VERSION=${newVersion} yarn build`);
+shell.exec('yarn build:types');


### PR DESCRIPTION
This pull request is the last one of my mission. And it just reverts some work optimistic work done at the beginning that I thought we could deliver 100% this quarter. 

Some important notes:

- I have re-tested all 45% connectors/widgets migrated in this mission using a real instant-search project in typescript with the snippets from the docs.
- API Extractor shows tons of warnings while validating types as they are tons of missing exports, I guess we are going to address them once we have 100% connectors/widgets migrated.
- Running `tsc` with a project that requires `4.4.1-experimental-typescript.0` still shows 5 errors ( 7 prior to this mission ). Would be cool to address that soon.