### PR TITLE
fix: ensure lastResults object exists

### DIFF
--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -365,8 +365,8 @@ See: https://www.algolia.com/doc/guides/building-search-ui/widgets/create-your-o
           this._isSearchStalled = true;
           this._render(
             this.helper,
-            this.helper.lastResults,
-            this.helper.lastResults._state
+            this.helper && this.helper.lastResults,
+            this.helper.lastResults && this.helper.lastResults._state
           );
         }, this._stalledSearchDelay);
       }

--- a/src/lib/InstantSearch.js
+++ b/src/lib/InstantSearch.js
@@ -360,13 +360,17 @@ See: https://www.algolia.com/doc/guides/building-search-ui/widgets/create-your-o
     this.helper.search();
 
     this.helper.on('search', () => {
-      if (!this._isSearchStalled && !this._searchStalledTimer) {
+      if (
+        !this._isSearchStalled &&
+        !this._searchStalledTimer &&
+        this.helper.lastResults
+      ) {
         this._searchStalledTimer = setTimeout(() => {
           this._isSearchStalled = true;
           this._render(
             this.helper,
-            this.helper && this.helper.lastResults,
-            this.helper.lastResults && this.helper.lastResults._state
+            this.helper.lastResults,
+            this.helper.lastResults._state
           );
         }, this._stalledSearchDelay);
       }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This error was surfaced on mobile Safari. Ensure `lastResults` is an object before evaluating object property.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

This solves the error demonstrated in the included screenshot.

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

![Screen Shot 2020-05-19 at 4 33 45 PM](https://user-images.githubusercontent.com/11767079/82375668-ec109f80-99ee-11ea-9e48-ceb70b545ac8.jpg)