### PR TITLE
fix(rangeInput): fix a bug that floating number cannot be typed

### DIFF
--- a/src/components/RangeInput/RangeInput.js
+++ b/src/components/RangeInput/RangeInput.js
@@ -24,14 +24,17 @@ class RangeInput extends Component {
 
   onInput = name => event => {
     this.setState({
-      [name]: Number(event.currentTarget.value),
+      [name]: event.currentTarget.value,
     });
   };
 
   onSubmit = event => {
     event.preventDefault();
 
-    this.props.refine([this.state.min, this.state.max]);
+    this.props.refine([
+      this.state.min && Number(this.state.min),
+      this.state.max && Number(this.state.max),
+    ]);
   };
 
   render() {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

## Summary

This PR fixes a regression which disabled floating numbers in rangeInput widget.

**Before this PR**
```js
  onInput = name => event => {
    this.setState({
      [name]: Number(event.currentTarget.value),
    });
  };
```

When user wants to type "10.34", that callback will be fired with the following `event.currentTarget.value` values:

- `1`
- `10`
- `10.`
- `10.3`
- `10.34`

When it had "10.", `Number("10.")` returns `10` which makes the input value back to `10`. So people never can get to "10.3".

So I removed `Number()` function there (which was the case before the regression). And I used `Number()` when refining.

* [The working example from this branch](https://codesandbox.io/s/instantsearchjs-0d34s?file=/src/app.js:382-470)
* [The failing example from master(v4.5.0)](https://codesandbox.io/s/instantsearchjs-zg1ri?file=/src/app.js)

**Result**

User should be able to type floating numbers.