### PR TITLE
fix(pagination): isLastPage when there's no pages

### DIFF
--- a/src/components/Pagination/Pagination.js
+++ b/src/components/Pagination/Pagination.js
@@ -48,7 +48,7 @@ class Pagination extends Component {
     return this.pageLink({
       ariaLabel: 'Previous',
       additionalClassName: this.props.cssClasses.previousPageItem,
-      isDisabled: this.props.nbHits === 0 || isFirstPage,
+      isDisabled: isFirstPage,
       label: this.props.templates.previous,
       pageNumber: currentPage - 1,
       createURL,
@@ -59,7 +59,7 @@ class Pagination extends Component {
     return this.pageLink({
       ariaLabel: 'Next',
       additionalClassName: this.props.cssClasses.nextPageItem,
-      isDisabled: this.props.nbHits === 0 || isLastPage,
+      isDisabled: isLastPage,
       label: this.props.templates.next,
       pageNumber: currentPage + 1,
       createURL,
@@ -70,7 +70,7 @@ class Pagination extends Component {
     return this.pageLink({
       ariaLabel: 'First',
       additionalClassName: this.props.cssClasses.firstPageItem,
-      isDisabled: this.props.nbHits === 0 || isFirstPage,
+      isDisabled: isFirstPage,
       label: this.props.templates.first,
       pageNumber: 0,
       createURL,
@@ -81,7 +81,7 @@ class Pagination extends Component {
     return this.pageLink({
       ariaLabel: 'Last',
       additionalClassName: this.props.cssClasses.lastPageItem,
-      isDisabled: this.props.nbHits === 0 || isLastPage,
+      isDisabled: isLastPage,
       label: this.props.templates.last,
       pageNumber: nbPages - 1,
       createURL,

--- a/src/components/Pagination/__tests__/Pagination-test.js
+++ b/src/components/Pagination/__tests__/Pagination-test.js
@@ -99,6 +99,11 @@ describe('Pagination', () => {
   });
 
   it('should have all buttons disabled if there are no results', () => {
+    const localPager = new Paginator({
+      currentPage: 0,
+      total: 0,
+      padding: 3,
+    });
     const wrapper = mount(
       <Pagination
         {...defaultProps}
@@ -109,7 +114,9 @@ describe('Pagination', () => {
         currentPage={0}
         nbHits={0}
         nbPages={0}
-        pages={[0]}
+        pages={localPager.pages()}
+        isFirstPage={localPager.isFirstPage()}
+        isLastPage={localPager.isLastPage()}
       />
     );
 

--- a/src/connectors/pagination/Paginator.js
+++ b/src/connectors/pagination/Paginator.js
@@ -48,7 +48,7 @@ class Paginator {
   }
 
   isLastPage() {
-    return this.currentPage === 0 || this.currentPage === this.total - 1;
+    return this.currentPage === this.total - 1 || this.total === 0;
   }
 
   isFirstPage() {

--- a/src/connectors/pagination/Paginator.js
+++ b/src/connectors/pagination/Paginator.js
@@ -48,7 +48,7 @@ class Paginator {
   }
 
   isLastPage() {
-    return this.currentPage === this.total - 1;
+    return this.currentPage === 0 || this.currentPage === this.total - 1;
   }
 
   isFirstPage() {

--- a/src/connectors/pagination/__tests__/Paginator-test.js
+++ b/src/connectors/pagination/__tests__/Paginator-test.js
@@ -155,3 +155,23 @@ describe('paginator: bug #668', () => {
     expect(pager.isLastPage()).toBe(false);
   });
 });
+
+describe('paginator: no results', () => {
+  const pager = new Paginator({
+    currentPage: 0,
+    total: 0,
+    padding: 3,
+  });
+
+  it('isFirstPage: true', () => {
+    expect(pager.isFirstPage()).toBe(true);
+  });
+
+  it('isLastPage: true', () => {
+    expect(pager.isLastPage()).toBe(true);
+  });
+
+  it('pages: just current page', () => {
+    expect(pager.pages()).toEqual([0]);
+  });
+});


### PR DESCRIPTION
fixes https://github.com/algolia/vue-instantsearch/issues/785

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This is discovered by @dotboris. When there are no pages, this.total === 0, so this.currentPage - 1 will be -1 instead of 0, and falsely indicate it's not the last page.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

isLastPage is true when there's no results.

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

