### PR TITLE
fix(pagination): isLastPage when there's no pages

### DIFF
--- a/src/connectors/pagination/Paginator.js
+++ b/src/connectors/pagination/Paginator.js
@@ -48,7 +48,7 @@ class Paginator {
   }
 
   isLastPage() {
-    return this.currentPage === this.total - 1;
+    return this.currentPage === this.total - 1 || this.total === 0;
   }
 
   isFirstPage() {

--- a/src/connectors/pagination/__tests__/Paginator-test.js
+++ b/src/connectors/pagination/__tests__/Paginator-test.js
@@ -155,3 +155,23 @@ describe('paginator: bug #668', () => {
     expect(pager.isLastPage()).toBe(false);
   });
 });
+
+describe('paginator: no results', () => {
+  const pager = new Paginator({
+    currentPage: 0,
+    total: 0,
+    padding: 3,
+  });
+
+  it('isFirstPage: true', () => {
+    expect(pager.isFirstPage()).toBe(true);
+  });
+
+  it('isLastPage: true', () => {
+    expect(pager.isLastPage()).toBe(true);
+  });
+
+  it('pages: just current page', () => {
+    expect(pager.pages()).toEqual([0]);
+  });
+});


### PR DESCRIPTION
fixes https://github.com/algolia/vue-instantsearch/issues/785

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This is discovered by @dotboris. When there are no pages, this.total === 0, so this.currentPage - 1 will be -1 instead of 0, and falsely indicate it's not the last page.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

isLastPage is true when there's no results.

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

same as https://github.com/algolia/instantsearch.js/pull/4422, but for **v3** (Vue InstantSearch is using that before our next major version)
