### PR TITLE
fix(rangeInput): clear input when refinement is cleared

### DIFF
--- a/src/components/RangeInput/RangeInput.js
+++ b/src/components/RangeInput/RangeInput.js
@@ -58,7 +58,7 @@ class RangeInput extends Component {
               min={min}
               max={max}
               step={step}
-              value={minValue}
+              value={minValue ?? ''}
               onInput={this.onInput('min')}
               placeholder={min}
               disabled={isDisabled}
@@ -81,7 +81,7 @@ class RangeInput extends Component {
               min={min}
               max={max}
               step={step}
-              value={maxValue}
+              value={maxValue ?? ''}
               onInput={this.onInput('max')}
               placeholder={max}
               disabled={isDisabled}

--- a/src/components/RangeInput/__tests__/__snapshots__/RangeInput-test.js.snap
+++ b/src/components/RangeInput/__tests__/__snapshots__/RangeInput-test.js.snap
@@ -20,6 +20,7 @@ exports[`RangeInput expect to render 1`] = `
         placeholder={0}
         step={1}
         type="number"
+        value=""
       />
     </label>
     <Template
@@ -52,6 +53,7 @@ exports[`RangeInput expect to render 1`] = `
         placeholder={500}
         step={1}
         type="number"
+        value=""
       />
     </label>
     <Template
@@ -98,6 +100,7 @@ exports[`RangeInput expect to render with disabled state 1`] = `
         placeholder={480}
         step={1}
         type="number"
+        value=""
       />
     </label>
     <Template
@@ -130,6 +133,7 @@ exports[`RangeInput expect to render with disabled state 1`] = `
         placeholder={20}
         step={1}
         type="number"
+        value=""
       />
     </label>
     <Template
@@ -256,6 +260,7 @@ exports[`RangeInput willReceiveProps expect to update the empty state from given
         placeholder={0}
         step={1}
         type="number"
+        value=""
       />
     </label>
     <Template
@@ -288,6 +293,7 @@ exports[`RangeInput willReceiveProps expect to update the empty state from given
         placeholder={500}
         step={1}
         type="number"
+        value=""
       />
     </label>
     <Template


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR fixes `RangeInput` component to correctly clear `<input>` when the state becomes nullish.

Once it's rendered, when either `state.min` or `state.max` becomes nullish (undefined or null, e.g. when "clearRefinements" is clicked), it doesn't remove the value, because `<input>` doesn't take nullish value. Instead, we need to pass an empty string.

**Result**

* [This example](https://codesandbox.io/s/instantsearchjs-0sdrc?file=/index.html) is built with the `v4.6.0`. If you refine, then clear it, the inputs won't be reset.

* [This example](https://codesandbox.io/s/instantsearchjs-y4xd1?file=/index.html) is built with the version in this pull-request. In this case, the inputs get reset correctly.

**Snapshots**

Some snapshots changed which I think will barely affect users. What do you think? Should I do something to avoid this snapshot changes?

**Test**

I failed to write tests for this. At component-level, `enzyme` actually behaved differently from the actual browser behavior. At widget-level, I copied [this](https://github.com/algolia/instantsearch.js/blob/0c7543790a10a3a736dbe5726ae1be3387d25bf3/src/widgets/range-input/__tests__/range-input-test.js#L312-L330) test but `container.innerHTML` was empty and couldn't figure out why.

Give me a piece of advice if you think this pull-request needs a test.