### PR TITLE
docs(examples): fix undefined pagination in e-commerce demo

### DIFF
--- a/examples/e-commerce/src/routing.ts
+++ b/examples/e-commerce/src/routing.ts
@@ -194,7 +194,7 @@ const getStateMapping = ({ indexName }) => ({
     const indexUiState = uiState[indexName];
     return {
       query: indexUiState.query,
-      page: String(indexUiState.page),
+      page: indexUiState.page,
       brands: indexUiState.refinementList && indexUiState.refinementList.brand,
       category:
         indexUiState.hierarchicalMenu &&


### PR DESCRIPTION
In #4408, we updated the e-commerce example and casted the type of the `page` URL parameter to `string`, which when `undefined`, became `"undefined"`.

This causes a bug that you can reproduce with these steps:

- Go to https://deploy-preview-4408--instantsearchjs.netlify.app/examples/e-commerce/
- Select a brand
- Notice `?page=undefined` in the URL

You can try the above steps in this PR deployment, which works as expected.