### PR TITLE
fix(infiniteHits): work with controlled mode

### DIFF
--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -191,6 +191,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     const helper = algoliasearchHelper({} as SearchClient, '', {});
     helper.setPage(1);
     helper.search = jest.fn();
+    (helper as any).searchWithoutTriggeringOnStateChange = jest.fn();
     helper.emit = jest.fn();
 
     widget.init!(
@@ -227,7 +228,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     showPrevious();
     expect(helper.state.page).toBe(0);
     expect(helper.emit).not.toHaveBeenCalled();
-    expect(helper.search).toHaveBeenCalledTimes(1);
+    expect(helper.search).toHaveBeenCalledTimes(0);
+    expect(
+      (helper as any).searchWithoutTriggeringOnStateChange
+    ).toHaveBeenCalledTimes(1);
 
     // the results should be prepended if there is an decrement in page
     const previousHits = [

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -793,7 +793,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
   });
 
   describe('getWidgetState', () => {
-    test('returns the `uiState` empty without `showPrevious` option', () => {
+    test('returns the `uiState` with `page` when `showPrevious` not given', () => {
       const render = jest.fn();
       const makeWidget = connectInfiniteHits(render);
       const helper = algoliasearchHelper(createSearchClient(), 'indexName', {
@@ -809,10 +809,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
         }
       );
 
-      expect(actual).toEqual({});
+      expect(actual).toEqual({
+        page: 2,
+      });
     });
 
-    test('returns the `uiState` empty with `showPrevious` option on first page', () => {
+    test('returns the `uiState` with `page` when `showPrevious` given on first page', () => {
       const render = jest.fn();
       const makeWidget = connectInfiniteHits(render);
       const helper = algoliasearchHelper(createSearchClient(), 'indexName', {
@@ -830,7 +832,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
         }
       );
 
-      expect(actual).toEqual({});
+      expect(actual).toEqual({
+        page: 1,
+      });
     });
 
     test('returns the `uiState` containing `page` with `showPrevious` option', () => {

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -814,7 +814,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       });
     });
 
-    test('returns the `uiState` with `page` when `showPrevious` given on first page', () => {
+    test('returns the `uiState` without `page` on first page', () => {
       const render = jest.fn();
       const makeWidget = connectInfiniteHits(render);
       const helper = algoliasearchHelper(createSearchClient(), 'indexName', {
@@ -832,9 +832,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
         }
       );
 
-      expect(actual).toEqual({
-        page: 1,
-      });
+      expect(actual).toEqual({});
     });
 
     test('returns the `uiState` containing `page` with `showPrevious` option', () => {

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -303,11 +303,10 @@ const connectInfiniteHits: InfiniteHitsConnector = function connectInfiniteHits(
       },
 
       getWidgetState(uiState, { searchParameters }) {
-        const page = searchParameters.page || 0;
-
-        if (!hasShowPrevious || !page) {
-          return uiState;
-        }
+        const page = Math.max(
+          getLastReceivedPage(),
+          searchParameters.page || 0
+        );
 
         return {
           ...uiState,

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -304,6 +304,12 @@ const connectInfiniteHits: InfiniteHitsConnector = function connectInfiniteHits(
       getWidgetState(uiState, { searchParameters }) {
         const page = searchParameters.page || 0;
 
+        if (!page) {
+          // return without adding `page` to uiState
+          // because we don't want `page=1` in the URL
+          return uiState;
+        }
+
         return {
           ...uiState,
           // The page in the UI state is incremented by one

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -158,7 +158,7 @@ const connectInfiniteHits: InfiniteHitsConnector = function connectInfiniteHits(
           ...helper.state,
           page: getFirstReceivedPage() - 1,
         })
-        .search();
+        .searchWithoutTriggeringOnStateChange();
     };
     const getShowMore = (helper: Helper): (() => void) => () => {
       helper.setPage(getLastReceivedPage() + 1).search();

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -302,10 +302,7 @@ const connectInfiniteHits: InfiniteHitsConnector = function connectInfiniteHits(
       },
 
       getWidgetState(uiState, { searchParameters }) {
-        const page = Math.max(
-          getLastReceivedPage(),
-          searchParameters.page || 0
-        );
+        const page = searchParameters.page || 0;
 
         return {
           ...uiState,

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -137,6 +137,7 @@ const connectInfiniteHits: InfiniteHitsConnector = function connectInfiniteHits(
     const {
       escapeHTML = true,
       transformItems = (items: any[]) => items,
+      showPrevious: hasShowPrevious = false,
       cache = getInMemoryCache(),
     } = widgetParams || ({} as typeof widgetParams);
     let cachedHits: InfiniteHitsCachedHits | undefined = undefined;
@@ -304,7 +305,10 @@ const connectInfiniteHits: InfiniteHitsConnector = function connectInfiniteHits(
       getWidgetState(uiState, { searchParameters }) {
         const page = searchParameters.page || 0;
 
-        if (!page) {
+        if (
+          (hasShowPrevious && uiState.page && page <= uiState.page) ||
+          !page
+        ) {
           // return without adding `page` to uiState
           // because we don't want `page=1` in the URL
           return uiState;

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -137,7 +137,6 @@ const connectInfiniteHits: InfiniteHitsConnector = function connectInfiniteHits(
     const {
       escapeHTML = true,
       transformItems = (items: any[]) => items,
-      showPrevious: hasShowPrevious = false,
       cache = getInMemoryCache(),
     } = widgetParams || ({} as typeof widgetParams);
     let cachedHits: InfiniteHitsCachedHits | undefined = undefined;
@@ -305,10 +304,7 @@ const connectInfiniteHits: InfiniteHitsConnector = function connectInfiniteHits(
       getWidgetState(uiState, { searchParameters }) {
         const page = searchParameters.page || 0;
 
-        if (
-          (hasShowPrevious && uiState.page && page <= uiState.page) ||
-          !page
-        ) {
+        if (!page) {
           // return without adding `page` to uiState
           // because we don't want `page=1` in the URL
           return uiState;

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -137,7 +137,6 @@ const connectInfiniteHits: InfiniteHitsConnector = function connectInfiniteHits(
     const {
       escapeHTML = true,
       transformItems = (items: any[]) => items,
-      showPrevious: hasShowPrevious = false,
       cache = getInMemoryCache(),
     } = widgetParams || ({} as typeof widgetParams);
     let cachedHits: InfiniteHitsCachedHits | undefined = undefined;

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -365,6 +365,10 @@ const index = (props: IndexProps): Index => {
         return mainHelper.search();
       };
 
+      (helper as any).searchWithoutTriggeringOnStateChange = () => {
+        return mainHelper.search();
+      };
+
       // We use the same pattern for the `searchForFacetValues`.
       helper.searchForFacetValues = (
         facetName,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

## Summary

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

fixes https://github.com/algolia/instantsearch.js/issues/4409

This PR fixes some bugs around controlled mode.

## What didn't work before

### showPrevious + onStateChange
https://codesandbox.io/s/instantsearchjs-xr81o?file=/src/app.js
load some pages, refresh, and click "Show previous". It won't work correctly.

### onStateChange without pagination
https://codesandbox.io/s/instantsearchjs-x713i?file=/src/app.js
cannot load more page.


## Examples
- ✅ [showPrevious + onStateChange](https://codesandbox.io/s/instantsearchjs-pb4hc?file=/src/app.js)
- ✅ [showPrevious](https://codesandbox.io/s/instantsearchjs-ykjr9?file=/src/app.js)
- ✅ [onStateChange](https://codesandbox.io/s/instantsearchjs-737yh?file=/src/app.js)
- ✅ [normal](https://codesandbox.io/s/instantsearchjs-fhz1e)
- ✅ [onStateChange without pagination](https://codesandbox.io/s/instantsearchjs-yi2j1)

## Unresolved issue

With the example `showPrevious + onStateChange` and `showPrevious`,
- load some pages
- refresh
- click "show previous"
- then the `page` param in the url stays the same,
- but the pagination changes.

I've found out that this is not an issue from this PR, and exists in the stable version, too.
https://codesandbox.io/s/instantsearchjs-h20yo?file=/src/app.js