### PR TITLE
fix(deps): move @types/googlemaps to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "scripts/transforms"
   ],
   "dependencies": {
-    "@types/googlemaps": "^3.39.6",
     "algoliasearch-helper": "^3.1.1",
     "classnames": "^2.2.5",
     "events": "^1.1.0",
@@ -79,6 +78,7 @@
     "@testing-library/preact": "1.0.2",
     "@types/classnames": "^2.2.7",
     "@types/enzyme": "^3.1.15",
+    "@types/googlemaps": "^3.39.6",
     "@types/jest": "^24.0.0",
     "@types/jest-diff": "^20.0.1",
     "@types/qs": "^6.5.3",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

In https://github.com/algolia/instantsearch.js/pull/4408 `@types/googlemaps` was added as a dependency while it should have been added as a devDependency.