### PR TITLE
fix(dev): don't show a warning for connectRange

### DIFF
--- a/src/lib/utils/checkIndexUiState.ts
+++ b/src/lib/utils/checkIndexUiState.ts
@@ -8,7 +8,7 @@ import { Widget, IndexUiState } from '../../types';
 function getWidgetNames(connectorName: string): string[] {
   switch (connectorName) {
     case 'range':
-      return ['rangeInput', 'rangeSlider'];
+      return [];
 
     case 'menu':
       return ['menu', 'menuSelect'];

--- a/src/lib/utils/checkIndexUiState.ts
+++ b/src/lib/utils/checkIndexUiState.ts
@@ -56,7 +56,7 @@ const stateToWidgetsMap: StateToWidgets = {
   },
   range: {
     connectors: ['connectRange'],
-    widgets: ['ais.rangeInput', 'ais.rangeSlider'],
+    widgets: ['ais.rangeInput', 'ais.rangeSlider', 'ais.range'],
   },
   toggle: {
     connectors: ['connectToggleRefinement'],


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

If a custom connectRange widget is used, the uiState for that widget would always show as "incorrect" and show the dev warning; while it wasn't needed

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

fixes #4437 

**Result**

https://github.com/algolia/instantsearch.js/blob/master/src/widgets/range-input/range-input.js#L170 e.g. edits the $$type (see #4227), but that means that the base type was no longer accepted, which is fixed here

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

cc @yonguelink
