### PR TITLE
chore: update buildCommand for CodeSandbox CI

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,3 +1,4 @@
 {
-  "sandboxes": ["instantsearchjs-es-template-pcw1k"]
+  "sandboxes": ["instantsearchjs-es-template-pcw1k"],
+  "buildCommand": "build:es"
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR updates the CodeSandbox CI configuration.
It now runs `yarn run build`, but if it runs only `yarn run build:es` it can reduce the build time.

**Result**

Same, but faster.