### PR TITLE
fix(connectToggleRefinement): fix onFacetValue/offFacetValue on render when using arrays for on/off

### DIFF
--- a/src/connectors/toggle-refinement/connectToggleRefinement.js
+++ b/src/connectors/toggle-refinement/connectToggleRefinement.js
@@ -209,30 +209,41 @@ export default function connectToggleRefinement(renderFn, unmountFn = noop) {
         const isRefined =
           on &&
           on.every(v => helper.state.isDisjunctiveFacetRefined(attribute, v));
-        const offValue = off === undefined ? false : off;
+        const offValue = toArray(off === undefined ? false : off);
         const allFacetValues = results.getFacetValues(attribute) || [];
 
-        const onData = find(
-          allFacetValues,
-          ({ name }) => name === unescapeRefinement(on)
-        );
+        const onData =
+          on &&
+          on
+            .map(v =>
+              find(allFacetValues, ({ name }) => name === unescapeRefinement(v))
+            )
+            .filter(v => v !== undefined);
         const onFacetValue = {
-          isRefined: onData !== undefined ? onData.isRefined : false,
-          count: onData === undefined ? null : onData.count,
+          isRefined: onData.length > 0 ? onData.every(v => v.isRefined) : false,
+          count:
+            onData.length === 0
+              ? null
+              : onData.reduce((acc, v) => acc + v.count, 0),
         };
 
         const offData = hasAnOffValue
-          ? find(
-              allFacetValues,
-              ({ name }) => name === unescapeRefinement(offValue)
-            )
-          : undefined;
+          ? offValue
+              .map(v =>
+                find(
+                  allFacetValues,
+                  ({ name }) => name === unescapeRefinement(v)
+                )
+              )
+              .filter(v => v !== undefined)
+          : [];
         const offFacetValue = {
-          isRefined: offData !== undefined ? offData.isRefined : false,
+          isRefined:
+            offData.length > 0 ? offData.every(v => v.isRefined) : false,
           count:
-            offData === undefined
+            offData.length === 0
               ? allFacetValues.reduce((total, { count }) => total + count, 0)
-              : offData.count,
+              : offData.reduce((acc, v) => acc + v.count, 0),
         };
 
         // what will we show by default,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

I was working on #4445 and I found a bug introduced by myself in #4420. :neutral_face: 

The bug is in `render` method, where `onFacetValue` and `offFacetValue` could be wrong when using arrays for `on` or `off`.

I've added a failing test: 
![Capture d’écran de 2020-07-18 23-55-57](https://user-images.githubusercontent.com/2103975/87862640-8f7c2300-c952-11ea-97c6-d19d66fad81c.png)


**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

`render` method now handle `onFacetValue` and `offFacetValue` correctly when using arrays for `on` and `off` options.

Thanks!