### PR TITLE
chore(deps): bump algoliasearch-helper from 3.1.1 to 3.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   ],
   "dependencies": {
     "@types/googlemaps": "^3.39.6",
-    "algoliasearch-helper": "^3.1.1",
+    "algoliasearch-helper": "^3.2.0",
     "classnames": "^2.2.5",
     "events": "^1.1.0",
     "hogan.js": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   ],
   "dependencies": {
     "@types/googlemaps": "^3.39.6",
-    "algoliasearch-helper": "^3.2.0",
+    "algoliasearch-helper": "^3.2.1",
     "classnames": "^2.2.5",
     "events": "^1.1.0",
     "hogan.js": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3604,10 +3604,10 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-algoliasearch-helper@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.2.0.tgz#79e6a5dcf36dae226001fd0ffeca8ff42e072bd0"
-  integrity sha512-L2VoqjI0mGHNqWXt57389aINNAlBMyg4jABD7+FVAbGVpkh27sCqsJXmh6k0NWxhXNu6VW//uzCA3j3JJ3eB5A==
+algoliasearch-helper@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.2.1.tgz#8082b4bd9d0966318926b9bafd63d46e6460e02e"
+  integrity sha512-qf/1HVsx24JQUxMz5djeBPDc4Zmnf23VrC2FT8PrZEclcBmZqD9ZGv7mhOVUr8pTo1hWU6knl7KM+WnorzIxag==
   dependencies:
     events "^1.1.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3604,10 +3604,10 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-algoliasearch-helper@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.1.1.tgz#4cdfbaed6670d82626ac1fae001ccbf53192f497"
-  integrity sha512-Jkqlp8jezQRixf7sbQ2zFXHpdaT41g9sHBqT6pztv5nfDmg94K+pwesAy6UbxRY78IL54LIaV1FLttMtT+IzzA==
+algoliasearch-helper@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.2.0.tgz#79e6a5dcf36dae226001fd0ffeca8ff42e072bd0"
+  integrity sha512-L2VoqjI0mGHNqWXt57389aINNAlBMyg4jABD7+FVAbGVpkh27sCqsJXmh6k0NWxhXNu6VW//uzCA3j3JJ3eB5A==
   dependencies:
     events "^1.1.1"
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR updates the version of `algoliasearch-helper` from 3.1.1 to 3.2.1.

There is not much of difference between `^3.1.1` and `^3.2.1`, but when I tried to test something specific from 3.2.0, CodeSandbox wrongly resolved 3.1.1, probably because of the yarn.lock file inside InstantSearch.js.