### PR TITLE
feat(core): introduce `getWidgetUiState` lifecycle hook (1/n)

### DIFF
--- a/src/connectors/autocomplete/__tests__/connectAutocomplete-test.ts
+++ b/src/connectors/autocomplete/__tests__/connectAutocomplete-test.ts
@@ -429,11 +429,11 @@ search.addWidgets([
     });
   });
 
-  describe('getWidgetState', () => {
+  describe('getWidgetUiState', () => {
     test('should give back the object unmodified if the default value is selected', () => {
       const [widget, helper] = getInitializedWidget();
       const uiStateBefore = {};
-      const uiStateAfter = widget.getWidgetState(uiStateBefore, {
+      const uiStateAfter = widget.getWidgetUiState(uiStateBefore, {
         searchParameters: helper.state,
         helper,
       });
@@ -444,7 +444,7 @@ search.addWidgets([
       const [widget, helper, refine] = getInitializedWidget();
       refine('some query');
       const uiStateBefore = {};
-      const uiStateAfter = widget.getWidgetState(uiStateBefore, {
+      const uiStateAfter = widget.getWidgetUiState(uiStateBefore, {
         searchParameters: helper.state,
         helper,
       });
@@ -456,14 +456,14 @@ search.addWidgets([
     test('should give back the same instance if the value is already in the uiState', () => {
       const [widget, helper, refine] = getInitializedWidget();
       refine('query');
-      const uiStateBefore = widget.getWidgetState(
+      const uiStateBefore = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
           helper,
         }
       );
-      const uiStateAfter = widget.getWidgetState(uiStateBefore, {
+      const uiStateAfter = widget.getWidgetUiState(uiStateBefore, {
         searchParameters: helper.state,
         helper,
       });

--- a/src/connectors/autocomplete/connectAutocomplete.ts
+++ b/src/connectors/autocomplete/connectAutocomplete.ts
@@ -147,7 +147,7 @@ search.addWidgets([
         );
       },
 
-      getWidgetState(uiState, { searchParameters }) {
+      getWidgetUiState(uiState, { searchParameters }) {
         const query = searchParameters.query || '';
 
         if (query === '' || (uiState && uiState.query === query)) {

--- a/src/connectors/configure-related-items/__tests__/connectConfigureRelatedItems-test.ts
+++ b/src/connectors/configure-related-items/__tests__/connectConfigureRelatedItems-test.ts
@@ -90,7 +90,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure-r
           render: expect.any(Function),
           dispose: expect.any(Function),
           getWidgetSearchParameters: expect.any(Function),
-          getWidgetState: expect.any(Function),
+          getWidgetUiState: expect.any(Function),
         })
       );
     });

--- a/src/connectors/configure/__tests__/connectConfigure-test.ts
+++ b/src/connectors/configure/__tests__/connectConfigure-test.ts
@@ -240,7 +240,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
     );
   });
 
-  describe('getWidgetState', () => {
+  describe('getWidgetUiState', () => {
     it('adds default parameters', () => {
       const makeWidget = connectConfigure(noop);
       const widget = makeWidget({
@@ -250,7 +250,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
       });
 
       expect(
-        widget.getWidgetState!({}, { helper, searchParameters: helper.state })
+        widget.getWidgetUiState!({}, { helper, searchParameters: helper.state })
       ).toEqual({
         configure: { analytics: true },
       });
@@ -271,7 +271,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
       refine({ analytics: false });
 
       expect(
-        widget.getWidgetState!({}, { helper, searchParameters: helper.state })
+        widget.getWidgetUiState!({}, { helper, searchParameters: helper.state })
       ).toEqual({
         configure: { analytics: false },
       });
@@ -292,7 +292,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
       refine({ query: 'unsafe toys' });
 
       expect(
-        widget.getWidgetState!({}, { helper, searchParameters: helper.state })
+        widget.getWidgetUiState!({}, { helper, searchParameters: helper.state })
       ).toEqual({
         configure: { query: 'unsafe toys' },
       });
@@ -307,7 +307,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
       });
 
       expect(
-        widget.getWidgetState!(
+        widget.getWidgetUiState!(
           { configure: { queryType: 'prefixAll' } },
           { helper, searchParameters: helper.state }
         )
@@ -325,7 +325,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
       });
 
       expect(
-        widget.getWidgetState!(
+        widget.getWidgetUiState!(
           { configure: { analytics: false } },
           { helper, searchParameters: helper.state }
         )

--- a/src/connectors/configure/connectConfigure.ts
+++ b/src/connectors/configure/connectConfigure.ts
@@ -139,7 +139,7 @@ const connectConfigure: ConfigureConnector = function connectConfigure(
         );
       },
 
-      getWidgetState(uiState) {
+      getWidgetUiState(uiState) {
         return {
           ...uiState,
           configure: {

--- a/src/connectors/geo-search/__tests__/connectGeoSearch-test.js
+++ b/src/connectors/geo-search/__tests__/connectGeoSearch-test.js
@@ -59,7 +59,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
       init: expect.any(Function),
       render: expect.any(Function),
       dispose: expect.any(Function),
-      getWidgetState: expect.any(Function),
+      getWidgetUiState: expect.any(Function),
       getWidgetSearchParameters: expect.any(Function),
     });
   });
@@ -1153,12 +1153,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
     });
   });
 
-  describe('getWidgetState', () => {
+  describe('getWidgetUiState', () => {
     it('expect to return the uiState unmodified if no boundingBox is selected', () => {
       const [widget, helper] = getInitializedWidget();
 
       const uiStateBefore = {};
-      const uiStateAfter = widget.getWidgetState(uiStateBefore, {
+      const uiStateAfter = widget.getWidgetUiState(uiStateBefore, {
         searchParameters: helper.state,
         helper,
       });
@@ -1175,7 +1175,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
       });
 
       const uiStateBefore = {};
-      const uiStateAfter = widget.getWidgetState(uiStateBefore, {
+      const uiStateAfter = widget.getWidgetUiState(uiStateBefore, {
         searchParameters: helper.state,
         helper,
       });
@@ -1195,7 +1195,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
         southWest: { lat: 12, lng: 14 },
       });
 
-      const uiStateBefore = widget.getWidgetState(
+      const uiStateBefore = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -1203,7 +1203,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
         }
       );
 
-      const uiStateAfter = widget.getWidgetState(uiStateBefore, {
+      const uiStateAfter = widget.getWidgetUiState(uiStateBefore, {
         searchParameters: helper.state,
         helper,
       });

--- a/src/connectors/geo-search/connectGeoSearch.js
+++ b/src/connectors/geo-search/connectGeoSearch.js
@@ -268,7 +268,7 @@ const connectGeoSearch = (renderFn, unmountFn = noop) => {
         return state.setQueryParameter('insideBoundingBox', undefined);
       },
 
-      getWidgetState(uiState, { searchParameters }) {
+      getWidgetUiState(uiState, { searchParameters }) {
         const boundingBox = searchParameters.insideBoundingBox;
 
         if (

--- a/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.js
+++ b/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.js
@@ -61,7 +61,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
           render: expect.any(Function),
           dispose: expect.any(Function),
 
-          getWidgetState: expect.any(Function),
+          getWidgetUiState: expect.any(Function),
           getWidgetSearchParameters: expect.any(Function),
         })
       );
@@ -425,7 +425,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
     });
   });
 
-  describe('getWidgetState', () => {
+  describe('getWidgetUiState', () => {
     test('returns the `uiState` empty', () => {
       const render = () => {};
       const makeWidget = connectHierarchicalMenu(render);
@@ -434,7 +434,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
         attributes: ['categoriesLvl0', 'categoriesLvl1'],
       });
 
-      const actual = widget.getWidgetState(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -466,7 +466,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
         attributes: ['categoriesLvl0', 'categoriesLvl1'],
       });
 
-      const actual = widget.getWidgetState(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -502,7 +502,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
         attributes: ['categoriesLvl0', 'categoriesLvl1'],
       });
 
-      const actual = widget.getWidgetState(
+      const actual = widget.getWidgetUiState(
         {
           hierarchicalMenu: {
             countryLvl0: ['TopLevelCountry', 'SubLevelCountry'],

--- a/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
+++ b/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
@@ -218,7 +218,7 @@ export default function connectHierarchicalMenu(renderFn, unmountFn = noop) {
           .setQueryParameter('maxValuesPerFacet', undefined);
       },
 
-      getWidgetState(uiState, { searchParameters }) {
+      getWidgetUiState(uiState, { searchParameters }) {
         const path = searchParameters.getHierarchicalFacetBreadcrumb(
           hierarchicalFacetName
         );

--- a/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.ts
+++ b/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.ts
@@ -97,7 +97,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
           render: expect.any(Function),
           dispose: expect.any(Function),
 
-          getWidgetState: expect.any(Function),
+          getWidgetUiState: expect.any(Function),
           getWidgetSearchParameters: expect.any(Function),
         })
       );
@@ -657,7 +657,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
     });
   });
 
-  describe('getWidgetState', () => {
+  describe('getWidgetUiState', () => {
     test('returns the `uiState` empty', () => {
       const render = jest.fn();
       const makeWidget = connectHitsPerPage(render);
@@ -670,7 +670,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
         ],
       });
 
-      const actual = widget.getWidgetState!(
+      const actual = widget.getWidgetUiState!(
         {},
         {
           searchParameters: helper.state,
@@ -696,7 +696,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
         ],
       });
 
-      const actual = widget.getWidgetState!(
+      const actual = widget.getWidgetUiState!(
         {},
         {
           searchParameters: helper.state,
@@ -721,7 +721,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
         ],
       });
 
-      const actual = widget.getWidgetState!(
+      const actual = widget.getWidgetUiState!(
         {},
         {
           searchParameters: helper.state,

--- a/src/connectors/hits-per-page/connectHitsPerPage.ts
+++ b/src/connectors/hits-per-page/connectHitsPerPage.ts
@@ -223,7 +223,7 @@ You may want to add another entry to the \`items\` option with this value.`
         return state.setQueryParameter('hitsPerPage', undefined);
       },
 
-      getWidgetState(uiState, { searchParameters }) {
+      getWidgetUiState(uiState, { searchParameters }) {
         const hitsPerPage = searchParameters.hitsPerPage;
 
         if (hitsPerPage === undefined || hitsPerPage === defaultItem.value) {

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -46,7 +46,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
         render: expect.any(Function),
         dispose: expect.any(Function),
 
-        getWidgetState: expect.any(Function),
+        getWidgetUiState: expect.any(Function),
         getWidgetSearchParameters: expect.any(Function),
       })
     );
@@ -792,7 +792,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     });
   });
 
-  describe('getWidgetState', () => {
+  describe('getWidgetUiState', () => {
     test('returns the `uiState` with `page` when `showPrevious` not given', () => {
       const render = jest.fn();
       const makeWidget = connectInfiniteHits(render);
@@ -801,7 +801,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       });
       const widget = makeWidget({});
 
-      const actual = widget.getWidgetState!(
+      const actual = widget.getWidgetUiState!(
         {},
         {
           searchParameters: helper.state,
@@ -824,7 +824,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
         showPrevious: true,
       });
 
-      const actual = widget.getWidgetState!(
+      const actual = widget.getWidgetUiState!(
         {},
         {
           searchParameters: helper.state,
@@ -845,7 +845,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
         showPrevious: true,
       });
 
-      const actual = widget.getWidgetState!(
+      const actual = widget.getWidgetUiState!(
         {},
         {
           searchParameters: helper.state,
@@ -868,7 +868,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
         showPrevious: true,
       });
 
-      const actual = widget.getWidgetState!(
+      const actual = widget.getWidgetUiState!(
         {},
         {
           searchParameters: helper.state,

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -301,7 +301,7 @@ const connectInfiniteHits: InfiniteHitsConnector = function connectInfiniteHits(
         );
       },
 
-      getWidgetState(uiState, { searchParameters }) {
+      getWidgetUiState(uiState, { searchParameters }) {
         const page = searchParameters.page || 0;
 
         if (!page) {

--- a/src/connectors/menu/__tests__/connectMenu-test.js
+++ b/src/connectors/menu/__tests__/connectMenu-test.js
@@ -70,7 +70,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
         render: expect.any(Function),
         dispose: expect.any(Function),
 
-        getWidgetState: expect.any(Function),
+        getWidgetUiState: expect.any(Function),
         getWidgetSearchParameters: expect.any(Function),
       })
     );
@@ -641,14 +641,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
     });
   });
 
-  describe('getWidgetState', () => {
+  describe('getWidgetUiState', () => {
     test('returns the `uiState` empty', () => {
       const helper = jsHelper({}, '');
       const widget = makeWidget({
         attribute: 'brand',
       });
 
-      const actual = widget.getWidgetState(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -675,7 +675,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
         attribute: 'brand',
       });
 
-      const actual = widget.getWidgetState(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -706,7 +706,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
         attribute: 'brand',
       });
 
-      const actual = widget.getWidgetState(
+      const actual = widget.getWidgetUiState(
         {
           menu: {
             categories: 'Phone',

--- a/src/connectors/menu/connectMenu.js
+++ b/src/connectors/menu/connectMenu.js
@@ -218,7 +218,7 @@ export default function connectMenu(renderFn, unmountFn = noop) {
           .setQueryParameter('maxValuesPerFacet', undefined);
       },
 
-      getWidgetState(uiState, { searchParameters }) {
+      getWidgetUiState(uiState, { searchParameters }) {
         const [value] = searchParameters.getHierarchicalFacetBreadcrumb(
           attribute
         );

--- a/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.ts
+++ b/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.ts
@@ -106,7 +106,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
           init: expect.any(Function),
           render: expect.any(Function),
           dispose: expect.any(Function),
-          getWidgetState: expect.any(Function),
+          getWidgetUiState: expect.any(Function),
           getWidgetSearchParameters: expect.any(Function),
         })
       );
@@ -737,11 +737,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
     ).not.toThrow();
   });
 
-  describe('getWidgetState', () => {
+  describe('getWidgetUiState', () => {
     test('returns the `uiState` empty', () => {
       const [widget, helper] = getInitializedWidget();
 
-      const actual = widget.getWidgetState(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -757,7 +757,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
 
       helper.addNumericRefinement('numerics', '=', 20);
 
-      const actual = widget.getWidgetState(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -777,7 +777,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
 
       helper.addNumericRefinement('numerics', '>=', 10);
 
-      const actual = widget.getWidgetState(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -797,7 +797,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
 
       helper.addNumericRefinement('numerics', '<=', 20);
 
-      const actual = widget.getWidgetState(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -818,7 +818,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
       helper.addNumericRefinement('numerics', '>=', 10);
       helper.addNumericRefinement('numerics', '<=', 20);
 
-      const actual = widget.getWidgetState(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -839,7 +839,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
       helper.addNumericRefinement('numerics', '>=', 10);
       helper.addNumericRefinement('numerics', '<=', 20);
 
-      const actual = widget.getWidgetState(
+      const actual = widget.getWidgetUiState(
         {
           numericMenu: {
             numerics2: '27:36',

--- a/src/connectors/numeric-menu/connectNumericMenu.ts
+++ b/src/connectors/numeric-menu/connectNumericMenu.ts
@@ -171,7 +171,7 @@ const connectNumericMenu: NumericMenuConnector = function connectNumericMenu(
         return state.clearRefinements(attribute);
       },
 
-      getWidgetState(uiState, { searchParameters }) {
+      getWidgetUiState(uiState, { searchParameters }) {
         const values = searchParameters.getNumericRefinements(attribute);
 
         const equal = values['='] && values['='][0];

--- a/src/connectors/pagination/__tests__/connectPagination-test.js
+++ b/src/connectors/pagination/__tests__/connectPagination-test.js
@@ -50,7 +50,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/pagination/
           render: expect.any(Function),
           dispose: expect.any(Function),
 
-          getWidgetState: expect.any(Function),
+          getWidgetUiState: expect.any(Function),
           getWidgetSearchParameters: expect.any(Function),
         })
       );
@@ -332,11 +332,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/pagination/
     });
   });
 
-  describe('getWidgetState', () => {
+  describe('getWidgetUiState', () => {
     test('returns the `uiState` empty', () => {
       const [widget, helper] = getInitializedWidget();
 
-      const actual = widget.getWidgetState(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -352,7 +352,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/pagination/
 
       helper.setQueryParameter('page', 4);
 
-      const actual = widget.getWidgetState(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,

--- a/src/connectors/pagination/connectPagination.js
+++ b/src/connectors/pagination/connectPagination.js
@@ -160,7 +160,7 @@ export default function connectPagination(renderFn, unmountFn = noop) {
         return state.setQueryParameter('page', undefined);
       },
 
-      getWidgetState(uiState, { searchParameters }) {
+      getWidgetUiState(uiState, { searchParameters }) {
         const page = searchParameters.page || 0;
 
         if (!page) {

--- a/src/connectors/range/__tests__/connectRange-test.js
+++ b/src/connectors/range/__tests__/connectRange-test.js
@@ -50,7 +50,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
           render: expect.any(Function),
           dispose: expect.any(Function),
 
-          getWidgetState: expect.any(Function),
+          getWidgetUiState: expect.any(Function),
           getWidgetSearchParameters: expect.any(Function),
         })
       );
@@ -937,7 +937,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
   });
 });
 
-describe('getWidgetState', () => {
+describe('getWidgetUiState', () => {
   test('returns the `uiState` empty', () => {
     const render = jest.fn();
     const makeWidget = connectRange(render);
@@ -946,7 +946,7 @@ describe('getWidgetState', () => {
       attribute: 'price',
     });
 
-    const actual = widget.getWidgetState(
+    const actual = widget.getWidgetUiState(
       {},
       {
         searchParameters: helper.state,
@@ -972,7 +972,7 @@ describe('getWidgetState', () => {
       attribute: 'price',
     });
 
-    const actual = widget.getWidgetState(
+    const actual = widget.getWidgetUiState(
       {},
       {
         searchParameters: helper.state,
@@ -997,7 +997,7 @@ describe('getWidgetState', () => {
       attribute: 'price',
     });
 
-    const actual = widget.getWidgetState(
+    const actual = widget.getWidgetUiState(
       {},
       {
         searchParameters: helper.state,
@@ -1026,7 +1026,7 @@ describe('getWidgetState', () => {
       attribute: 'price',
     });
 
-    const actual = widget.getWidgetState(
+    const actual = widget.getWidgetUiState(
       {},
       {
         searchParameters: helper.state,
@@ -1056,7 +1056,7 @@ describe('getWidgetState', () => {
       attribute: 'price',
     });
 
-    const actual = widget.getWidgetState(
+    const actual = widget.getWidgetUiState(
       {},
       {
         searchParameters: helper.state,
@@ -1086,7 +1086,7 @@ describe('getWidgetState', () => {
       attribute: 'price',
     });
 
-    const actual = widget.getWidgetState(
+    const actual = widget.getWidgetUiState(
       {},
       {
         searchParameters: helper.state,
@@ -1116,7 +1116,7 @@ describe('getWidgetState', () => {
       attribute: 'price',
     });
 
-    const actual = widget.getWidgetState(
+    const actual = widget.getWidgetUiState(
       {},
       {
         searchParameters: helper.state,
@@ -1146,7 +1146,7 @@ describe('getWidgetState', () => {
       attribute: 'price',
     });
 
-    const actual = widget.getWidgetState(
+    const actual = widget.getWidgetUiState(
       {
         range: {
           age: '16:',

--- a/src/connectors/range/connectRange.js
+++ b/src/connectors/range/connectRange.js
@@ -258,7 +258,7 @@ export default function connectRange(renderFn, unmountFn = noop) {
         return stateWithoutDisjunctive;
       },
 
-      getWidgetState(uiState, { searchParameters }) {
+      getWidgetUiState(uiState, { searchParameters }) {
         const {
           '>=': min = [],
           '<=': max = [],

--- a/src/connectors/rating-menu/__tests__/connectRatingMenu-test.js
+++ b/src/connectors/rating-menu/__tests__/connectRatingMenu-test.js
@@ -67,7 +67,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
           init: expect.any(Function),
           render: expect.any(Function),
           dispose: expect.any(Function),
-          getWidgetState: expect.any(Function),
+          getWidgetUiState: expect.any(Function),
           getWidgetSearchParameters: expect.any(Function),
         })
       );
@@ -335,7 +335,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
     });
   });
 
-  describe('getWidgetState', () => {
+  describe('getWidgetUiState', () => {
     test('returns the `uiState` empty', () => {
       const render = () => {};
       const makeWidget = connectRatingMenu(render);
@@ -344,7 +344,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
         attribute: 'grade',
       });
 
-      const actual = widget.getWidgetState(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -369,7 +369,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
         attribute: 'grade',
       });
 
-      const actual = widget.getWidgetState(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -398,7 +398,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
         attribute: 'grade',
       });
 
-      const actual = widget.getWidgetState(
+      const actual = widget.getWidgetUiState(
         {
           ratingMenu: {
             rating: 4,

--- a/src/connectors/rating-menu/connectRatingMenu.js
+++ b/src/connectors/rating-menu/connectRatingMenu.js
@@ -180,7 +180,7 @@ export default function connectRatingMenu(renderFn, unmountFn = noop) {
         return state.removeDisjunctiveFacet(attribute);
       },
 
-      getWidgetState(uiState, { searchParameters }) {
+      getWidgetUiState(uiState, { searchParameters }) {
         const value = this._getRefinedStar(searchParameters);
 
         if (typeof value !== 'number') {

--- a/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
+++ b/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
@@ -98,7 +98,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
         render: expect.any(Function),
         dispose: expect.any(Function),
 
-        getWidgetState: expect.any(Function),
+        getWidgetUiState: expect.any(Function),
         getWidgetSearchParameters: expect.any(Function),
       })
     );
@@ -2014,7 +2014,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
     });
   });
 
-  describe('getWidgetState', () => {
+  describe('getWidgetUiState', () => {
     test('returns the `uiState` empty', () => {
       const render = () => {};
       const makeWidget = connectRefinementList(render);
@@ -2023,7 +2023,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
         attribute: 'brand',
       });
 
-      const actual = widget.getWidgetState(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -2047,7 +2047,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
         attribute: 'brand',
       });
 
-      const actual = widget.getWidgetState(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -2075,7 +2075,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
         attribute: 'brand',
       });
 
-      const actual = widget.getWidgetState(
+      const actual = widget.getWidgetUiState(
         {
           refinementList: {
             categories: ['Phone', 'Tablet'],

--- a/src/connectors/refinement-list/connectRefinementList.js
+++ b/src/connectors/refinement-list/connectRefinementList.js
@@ -382,7 +382,7 @@ export default function connectRefinementList(renderFn, unmountFn = noop) {
         return withoutMaxValuesPerFacet.removeDisjunctiveFacet(attribute);
       },
 
-      getWidgetState(uiState, { searchParameters }) {
+      getWidgetUiState(uiState, { searchParameters }) {
         const values =
           operator === 'or'
             ? searchParameters.getDisjunctiveRefinements(attribute)

--- a/src/connectors/search-box/__tests__/connectSearchBox-test.js
+++ b/src/connectors/search-box/__tests__/connectSearchBox-test.js
@@ -52,7 +52,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
           render: expect.any(Function),
           dispose: expect.any(Function),
 
-          getWidgetState: expect.any(Function),
+          getWidgetUiState: expect.any(Function),
           getWidgetSearchParameters: expect.any(Function),
         })
       );
@@ -355,11 +355,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
     });
   });
 
-  describe('getWidgetState', () => {
+  describe('getWidgetUiState', () => {
     test('should give back the object unmodified if the default value is selected', () => {
       const [widget, helper] = getInitializedWidget();
       const uiStateBefore = {};
-      const uiStateAfter = widget.getWidgetState(uiStateBefore, {
+      const uiStateAfter = widget.getWidgetUiState(uiStateBefore, {
         searchParameters: helper.state,
         helper,
       });
@@ -370,7 +370,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
       const [widget, helper, refine] = getInitializedWidget();
       refine('some query');
       const uiStateBefore = {};
-      const uiStateAfter = widget.getWidgetState(uiStateBefore, {
+      const uiStateAfter = widget.getWidgetUiState(uiStateBefore, {
         searchParameters: helper.state,
         helper,
       });
@@ -382,14 +382,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
     test('should give back the same instance if the value is alreay in the uiState', () => {
       const [widget, helper, refine] = getInitializedWidget();
       refine('query');
-      const uiStateBefore = widget.getWidgetState(
+      const uiStateBefore = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
           helper,
         }
       );
-      const uiStateAfter = widget.getWidgetState(uiStateBefore, {
+      const uiStateAfter = widget.getWidgetUiState(uiStateBefore, {
         searchParameters: helper.state,
         helper,
       });

--- a/src/connectors/search-box/connectSearchBox.js
+++ b/src/connectors/search-box/connectSearchBox.js
@@ -139,7 +139,7 @@ export default function connectSearchBox(renderFn, unmountFn = noop) {
         return state.setQueryParameter('query', undefined);
       },
 
-      getWidgetState(uiState, { searchParameters }) {
+      getWidgetUiState(uiState, { searchParameters }) {
         const query = searchParameters.query || '';
 
         if (query === '' || (uiState && uiState.query === query)) {

--- a/src/connectors/sort-by/__tests__/connectSortBy-test.js
+++ b/src/connectors/sort-by/__tests__/connectSortBy-test.js
@@ -57,7 +57,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
           init: expect.any(Function),
           render: expect.any(Function),
           dispose: expect.any(Function),
-          getWidgetState: expect.any(Function),
+          getWidgetUiState: expect.any(Function),
           getWidgetSearchParameters: expect.any(Function),
         })
       );
@@ -358,12 +358,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
       return [widget, helper, refine];
     };
 
-    describe('getWidgetState', () => {
+    describe('getWidgetUiState', () => {
       test('should return the same `uiState` when the default value is selected', () => {
         const [widget, helper] = getInitializedWidget();
 
         const uiStateBefore = {};
-        const uiStateAfter = widget.getWidgetState(uiStateBefore, {
+        const uiStateAfter = widget.getWidgetUiState(uiStateBefore, {
           searchParameters: helper.state,
           helper,
         });
@@ -377,7 +377,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
         refine('priceASC');
 
         const uiStateBefore = {};
-        const uiStateAfter = widget.getWidgetState(uiStateBefore, {
+        const uiStateAfter = widget.getWidgetUiState(uiStateBefore, {
           searchParameters: helper.state,
           helper,
         });
@@ -392,14 +392,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
 
         refine('priceASC');
 
-        const uiStateBefore = widget.getWidgetState(
+        const uiStateBefore = widget.getWidgetUiState(
           {},
           {
             searchParameters: helper.state,
             helper,
           }
         );
-        const uiStateAfter = widget.getWidgetState(uiStateBefore, {
+        const uiStateAfter = widget.getWidgetUiState(uiStateBefore, {
           searchParameters: helper.state,
           helper,
         });
@@ -438,7 +438,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
           })
         );
 
-        const actual = widget.getWidgetState(
+        const actual = widget.getWidgetUiState(
           {},
           {
             searchParameters: helper.state,
@@ -484,7 +484,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
           })
         );
 
-        const actual = widget.getWidgetState(
+        const actual = widget.getWidgetUiState(
           {},
           {
             searchParameters: helper.state,

--- a/src/connectors/sort-by/connectSortBy.js
+++ b/src/connectors/sort-by/connectSortBy.js
@@ -153,7 +153,7 @@ export default function connectSortBy(renderFn, unmountFn = noop) {
         return state.setIndex(this.initialIndex);
       },
 
-      getWidgetState(uiState, { searchParameters }) {
+      getWidgetUiState(uiState, { searchParameters }) {
         const currentIndex = searchParameters.index;
         const isInitialIndex = currentIndex === this.initialIndex;
 

--- a/src/connectors/toggle-refinement/__tests__/connectToggleRefinement-test.js
+++ b/src/connectors/toggle-refinement/__tests__/connectToggleRefinement-test.js
@@ -39,7 +39,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
           init: expect.any(Function),
           render: expect.any(Function),
           dispose: expect.any(Function),
-          getWidgetState: expect.any(Function),
+          getWidgetUiState: expect.any(Function),
           getWidgetSearchParameters: expect.any(Function),
         })
       );
@@ -812,7 +812,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
     });
   });
 
-  describe('getWidgetState', () => {
+  describe('getWidgetUiState', () => {
     test('returns the `uiState` empty', () => {
       const render = jest.fn();
       const makeWidget = connectToggleRefinement(render);
@@ -821,7 +821,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
         attribute: 'free_shipping',
       });
 
-      const actual = widget.getWidgetState(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -844,7 +844,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
         attribute: 'freeShipping',
       });
 
-      const actual = widget.getWidgetState(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -871,7 +871,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
         attribute: 'freeShipping',
       });
 
-      const actual = widget.getWidgetState(
+      const actual = widget.getWidgetUiState(
         {
           toggle: {
             discount: true,

--- a/src/connectors/toggle-refinement/connectToggleRefinement.js
+++ b/src/connectors/toggle-refinement/connectToggleRefinement.js
@@ -279,7 +279,7 @@ export default function connectToggleRefinement(renderFn, unmountFn = noop) {
         return state.removeDisjunctiveFacet(attribute);
       },
 
-      getWidgetState(uiState, { searchParameters }) {
+      getWidgetUiState(uiState, { searchParameters }) {
         const isRefined =
           on &&
           on.every(v =>

--- a/src/connectors/voice-search/__tests__/connectVoiceSearch-test.js
+++ b/src/connectors/voice-search/__tests__/connectVoiceSearch-test.js
@@ -63,7 +63,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/voice-searc
           render: expect.any(Function),
           dispose: expect.any(Function),
 
-          getWidgetState: expect.any(Function),
+          getWidgetUiState: expect.any(Function),
           getWidgetSearchParameters: expect.any(Function),
         })
       );
@@ -225,11 +225,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/voice-searc
     });
   });
 
-  describe('getWidgetState', () => {
+  describe('getWidgetUiState', () => {
     test('returns the `uiState` empty', () => {
       const { widget, helper } = getInitializedWidget();
 
-      const actual = widget.getWidgetState(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -244,7 +244,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/voice-searc
 
       helper.setQueryParameter('query', 'Apple');
 
-      const actual = widget.getWidgetState(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,

--- a/src/connectors/voice-search/connectVoiceSearch.ts
+++ b/src/connectors/voice-search/connectVoiceSearch.ts
@@ -166,7 +166,7 @@ const connectVoiceSearch: VoiceSearchConnector = function connectVoiceSearch(
         return newState.setQueryParameter('query', undefined);
       },
 
-      getWidgetState(uiState, { searchParameters }) {
+      getWidgetUiState(uiState, { searchParameters }) {
         const query = searchParameters.query || '';
 
         if (!query) {

--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -529,7 +529,7 @@ Feel free to give us feedback on GitHub: https://github.com/algolia/instantsearc
     this.mainIndex.refreshUiState();
     const nextUiState =
       typeof uiState === 'function'
-        ? uiState(this.mainIndex.getWidgetState({}))
+        ? uiState(this.mainIndex.getWidgetUiState({}))
         : uiState;
 
     const setIndexHelperState = (indexWidget: Index) => {
@@ -559,7 +559,7 @@ Feel free to give us feedback on GitHub: https://github.com/algolia/instantsearc
   };
 
   public onInternalStateChange = () => {
-    const nextUiState = this.mainIndex.getWidgetState({});
+    const nextUiState = this.mainIndex.getWidgetUiState({});
 
     this.middleware.forEach(m => {
       m.onStateChange({

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -579,7 +579,7 @@ describe('start', () => {
 
     search.start();
 
-    expect(search.mainIndex.getWidgetState()).toEqual({
+    expect(search.mainIndex.getWidgetUiState()).toEqual({
       indexName: {
         refinementList: {
           brand: ['Apple'],
@@ -612,7 +612,7 @@ describe('start', () => {
 
     search.start();
 
-    expect(search.mainIndex.getWidgetState()).toEqual({
+    expect(search.mainIndex.getWidgetUiState()).toEqual({
       indexName: {
         hierarchicalMenu: {
           'hierarchicalCategories.lvl0': ['Cell Phones'],

--- a/src/lib/__tests__/RoutingManager-test.ts
+++ b/src/lib/__tests__/RoutingManager-test.ts
@@ -84,7 +84,7 @@ const createFakeSearchBox = (): Widget =>
     getWidgetSearchParameters(searchParameters, { uiState }) {
       return searchParameters.setQuery(uiState.query || '');
     },
-    getWidgetState(uiState, { searchParameters }) {
+    getWidgetUiState(uiState, { searchParameters }) {
       return {
         ...uiState,
         query: searchParameters.query,
@@ -100,7 +100,7 @@ const createFakeHitsPerPage = (): Widget =>
     getWidgetSearchParameters(parameters) {
       return parameters;
     },
-    getWidgetState(uiState) {
+    getWidgetUiState(uiState) {
       return uiState;
     },
   });
@@ -123,7 +123,7 @@ describe('RoutingManager', () => {
 
       const widget = {
         render: jest.fn(),
-        getWidgetState: jest.fn((uiState, { searchParameters }) => ({
+        getWidgetUiState: jest.fn((uiState, { searchParameters }) => ({
           ...uiState,
           q: searchParameters.query,
         })),
@@ -242,7 +242,7 @@ describe('RoutingManager', () => {
 
       search.addWidgets([
         createWidget({
-          getWidgetState(uiState, { searchParameters }) {
+          getWidgetUiState(uiState, { searchParameters }) {
             return {
               ...uiState,
               query: searchParameters.query,

--- a/src/middleware/createRouter.ts
+++ b/src/middleware/createRouter.ts
@@ -36,7 +36,7 @@ export const createRouter: RoutingManager = (props = {}) => {
           ...acc,
           [indexId]: nextState[indexId],
         }),
-        instantSearchInstance.mainIndex.getWidgetState({})
+        instantSearchInstance.mainIndex.getWidgetUiState({})
       );
 
       const route = stateMapping.stateToRoute(uiState);

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -175,6 +175,18 @@ export type Widget = {
    * @param uiState current state
    * @param widgetStateOptions extra information to calculate uiState
    */
+  getWidgetUiState?(
+    uiState: IndexUiState,
+    widgetStateOptions: WidgetStateOptions
+  ): IndexUiState;
+  /**
+   * This function is required for a widget to be taken in account for routing.
+   * It will derive a uiState for this widget based on the existing uiState and
+   * the search parameters applied.
+   * @deprecated Use `getWidgetUiState` instead.
+   * @param uiState current state
+   * @param widgetStateOptions extra information to calculate uiState
+   */
   getWidgetState?(
     uiState: IndexUiState,
     widgetStateOptions: WidgetStateOptions

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -13,6 +13,7 @@ import {
 import { runAllMicroTasks } from '../../../../test/utils/runAllMicroTasks';
 import { Widget } from '../../../types';
 import index from '../index';
+import { warning } from '../../../lib/utils';
 
 describe('index', () => {
   const createSearchBox = (args: Partial<Widget> = {}): Widget =>
@@ -20,7 +21,7 @@ describe('index', () => {
       dispose: jest.fn(({ state }) => {
         return state.setQueryParameter('query', undefined);
       }),
-      getWidgetState: jest.fn((uiState, { searchParameters }) => {
+      getWidgetUiState: jest.fn((uiState, { searchParameters }) => {
         if (!searchParameters.query) {
           return uiState;
         }
@@ -41,7 +42,7 @@ describe('index', () => {
       dispose: jest.fn(({ state }) => {
         return state.setQueryParameter('page', undefined);
       }),
-      getWidgetState: jest.fn((uiState, { searchParameters }) => {
+      getWidgetUiState: jest.fn((uiState, { searchParameters }) => {
         if (!searchParameters.page) {
           return uiState;
         }
@@ -73,7 +74,7 @@ describe('index', () => {
           )
         );
       }),
-      getWidgetState(uiState) {
+      getWidgetUiState(uiState) {
         return {
           ...uiState,
           configure: {
@@ -309,7 +310,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
 
         inner.addWidgets(innerWidgets);
 
-        expect(inner.getWidgetState({})).toEqual({
+        expect(inner.getWidgetUiState({})).toEqual({
           two: {
             query: 'inner',
           },
@@ -1184,7 +1185,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
           .setQueryParameter('query', 'Apple iPhone XS Red')
           .setQueryParameter('page', 4);
 
-        expect(level0.getWidgetState({})).toEqual({
+        expect(level0.getWidgetUiState({})).toEqual({
           level0IndexName: {
             query: 'Apple',
             page: 1,
@@ -1209,7 +1210,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
           .setQuery('Hey')
           .search();
 
-        expect(level0.getWidgetState({})).toEqual({
+        expect(level0.getWidgetUiState({})).toEqual({
           level0IndexName: {
             query: 'Hey',
           },
@@ -1489,7 +1490,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
           .setQueryParameter('query', 'Apple')
           .setQueryParameter('page', 5);
 
-        expect(instance.getWidgetState({})).toEqual({
+        expect(instance.getWidgetUiState({})).toEqual({
           indexId: {
             query: 'Apple',
             page: 5,
@@ -1530,7 +1531,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
           })
         );
 
-        expect(topLevelInstance.getWidgetState({})).toEqual({
+        expect(topLevelInstance.getWidgetUiState({})).toEqual({
           topLevelIndexName: {
             configure: {
               hitsPerPage: 5,
@@ -1573,7 +1574,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
           .setQueryParameter('query', 'Apple')
           .setQueryParameter('page', 5);
 
-        expect(instance.getWidgetState({})).toEqual({
+        expect(instance.getWidgetUiState({})).toEqual({
           indexName: {
             query: 'Apple',
             page: 5,
@@ -1621,7 +1622,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
           })
         );
 
-        expect(instance.getWidgetState({})).toEqual({
+        expect(instance.getWidgetUiState({})).toEqual({
           indexName: {},
         });
 
@@ -1635,7 +1636,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
         const level1 = index({ indexName: 'level1IndexName' });
         const widgets = [createSearchBox(), createPagination()];
 
-        jest.spyOn(level1, 'getWidgetState');
+        jest.spyOn(level1, 'getWidgetUiState');
 
         level0.addWidgets([...widgets, level1]);
 
@@ -1648,10 +1649,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
           .setQueryParameter('page', 5);
 
         widgets.forEach(widget => {
-          expect(widget.getWidgetState).toHaveBeenCalledTimes(2); // 2 changes
+          expect(widget.getWidgetUiState).toHaveBeenCalledTimes(2); // 2 changes
         });
 
-        expect(level1.getWidgetState).toHaveBeenCalledTimes(0);
+        expect(level1.getWidgetUiState).toHaveBeenCalledTimes(0);
       });
 
       it('updates the local `uiState` when they differ on first render', () => {
@@ -1669,7 +1670,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
           })
         );
 
-        expect(instance.getWidgetState({})).toEqual({
+        expect(instance.getWidgetUiState({})).toEqual({
           indexName: {},
         });
 
@@ -1688,7 +1689,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
         expect(
           instantSearchInstance.onInternalStateChange
         ).toHaveBeenCalledTimes(1);
-        expect(instance.getWidgetState({})).toEqual({
+        expect(instance.getWidgetUiState({})).toEqual({
           indexName: {
             query: 'Apple iPhone',
           },
@@ -1709,7 +1710,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
         expect(
           instantSearchInstance.onInternalStateChange
         ).toHaveBeenCalledTimes(2);
-        expect(instance.getWidgetState({})).toEqual({
+        expect(instance.getWidgetUiState({})).toEqual({
           indexName: {
             query: 'Apple iPhone XS',
           },
@@ -1735,7 +1736,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
           })
         );
 
-        expect(subLevelInstance.getWidgetState({})).toEqual({
+        expect(subLevelInstance.getWidgetUiState({})).toEqual({
           subLevelIndexName: {},
         });
 
@@ -1762,7 +1763,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
         expect(
           instantSearchInstance.onInternalStateChange
         ).not.toHaveBeenCalled();
-        expect(subLevelInstance.getWidgetState({})).toEqual({
+        expect(subLevelInstance.getWidgetUiState({})).toEqual({
           subLevelIndexName: {},
         });
       });
@@ -1803,7 +1804,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
           .setQueryParameter('query', 'Apple iPhone 5S')
           .setQueryParameter('page', 9);
 
-        expect(level0.getWidgetState({})).toEqual({
+        expect(level0.getWidgetUiState({})).toEqual({
           level0IndexName: {
             query: 'Apple',
             page: 5,
@@ -1819,7 +1820,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
           level3IndexName: {},
         });
 
-        expect(level1.getWidgetState({})).toEqual({
+        expect(level1.getWidgetUiState({})).toEqual({
           level1IndexName: {
             query: 'Apple iPhone',
             page: 7,
@@ -1831,7 +1832,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
           level3IndexName: {},
         });
 
-        expect(level2.getWidgetState({})).toEqual({
+        expect(level2.getWidgetUiState({})).toEqual({
           level2IndexName: {
             query: 'Apple iPhone 5S',
             page: 9,
@@ -1839,7 +1840,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
           level3IndexName: {},
         });
 
-        expect(level3.getWidgetState({})).toEqual({
+        expect(level3.getWidgetUiState({})).toEqual({
           level3IndexName: {},
         });
       });
@@ -1882,7 +1883,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
 
       expect(level0.getHelper()!.state.query).toBe('something');
 
-      expect(instantSearchInstance.mainIndex.getWidgetState({})).toEqual({
+      expect(instantSearchInstance.mainIndex.getWidgetUiState({})).toEqual({
         indexName: {},
         level0IndexName: {
           configure: {
@@ -2224,14 +2225,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
       // Simulate a state change
       helper.setQueryParameter('query', 'Apple iPhone');
 
-      expect(searchBox.getWidgetState).toHaveBeenCalledTimes(1);
+      expect(searchBox.getWidgetUiState).toHaveBeenCalledTimes(1);
 
       instance.dispose(createDisposeOptions());
 
       // Simulate a state change
       helper.setQueryParameter('query', 'Apple iPhone 5S');
 
-      expect(searchBox.getWidgetState).toHaveBeenCalledTimes(1);
+      expect(searchBox.getWidgetUiState).toHaveBeenCalledTimes(1);
     });
 
     it('removes the internal Helper', () => {
@@ -2294,6 +2295,70 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
       instance.dispose(createDisposeOptions());
 
       expect(mainHelper.derivedHelpers).toHaveLength(0);
+    });
+  });
+
+  describe('getWidgetState', () => {
+    test('warns when index has this method', () => {
+      warning.cache = {};
+
+      const instance = index({ indexName: 'indexName' });
+
+      expect(() => {
+        instance.getWidgetState({});
+      }).toWarnDev(
+        '[InstantSearch.js]: The `getWidgetState` method is renamed `getWidgetUiState` and will no longer exist under that name in InstantSearch.js 5.x. Please use `getWidgetUiState` instead.'
+      );
+    });
+
+    test('warns when widget has this method', () => {
+      warning.cache = {};
+
+      const createDeprecatedSearchBox = (args: Partial<Widget> = {}): Widget =>
+        createWidget({
+          dispose: jest.fn(({ state }) => {
+            return state.setQueryParameter('query', undefined);
+          }),
+          getWidgetState: jest.fn((uiState, { searchParameters }) => {
+            if (!searchParameters.query) {
+              return uiState;
+            }
+
+            return {
+              ...uiState,
+              query: searchParameters.query,
+            };
+          }),
+          getWidgetSearchParameters: jest.fn(
+            (searchParameters, { uiState }) => {
+              return searchParameters.setQueryParameter(
+                'query',
+                uiState.query || ''
+              );
+            }
+          ),
+          ...args,
+        });
+
+      const instance = index({ indexName: 'indexName' });
+      const searchClient = createSearchClient();
+      const mainHelper = algoliasearchHelper(searchClient, '', {});
+      const instantSearchInstance = createInstantSearch({
+        mainHelper,
+      });
+
+      instance.addWidgets([createDeprecatedSearchBox()]);
+
+      expect(() => {
+        instance.init(
+          createInitOptions({
+            instantSearchInstance,
+            parent: null,
+          })
+        );
+      }).toWarnDev(
+        '[InstantSearch.js]: The `getWidgetState` method is renamed `getWidgetUiState` and will no longer exist under that name in InstantSearch.js 5.x. Please use `getWidgetUiState` instead.'
+      );
     });
   });
 });

--- a/src/widgets/places/__tests__/places-test.ts
+++ b/src/widgets/places/__tests__/places-test.ts
@@ -373,7 +373,7 @@ describe('places', () => {
       });
     });
 
-    describe('getWidgetState', () => {
+    describe('getWidgetUiState', () => {
       test('returns the default state empty', () => {
         const searchClient = createSearchClient();
         const helper = createFakeHelper(searchClient);
@@ -382,7 +382,7 @@ describe('places', () => {
         });
 
         const previousUiState = {};
-        const nextUiState = widget.getWidgetState!(previousUiState, {
+        const nextUiState = widget.getWidgetUiState!(previousUiState, {
           helper,
           searchParameters: helper.state,
         });
@@ -399,7 +399,7 @@ describe('places', () => {
         });
 
         const previousUiState = {};
-        const nextUiState = widget.getWidgetState!(previousUiState, {
+        const nextUiState = widget.getWidgetUiState!(previousUiState, {
           helper,
           searchParameters: helper.state,
         });
@@ -434,7 +434,7 @@ describe('places', () => {
         });
 
         const previousUiState = {};
-        const nextUiState = widget.getWidgetState!(previousUiState, {
+        const nextUiState = widget.getWidgetUiState!(previousUiState, {
           helper,
           searchParameters: helper.state,
         });
@@ -466,7 +466,7 @@ describe('places', () => {
         clearEventListener();
 
         const previousUiState = {};
-        const nextUiState = widget.getWidgetState!(previousUiState, {
+        const nextUiState = widget.getWidgetUiState!(previousUiState, {
           helper,
           searchParameters: helper.state,
         });
@@ -494,7 +494,7 @@ describe('places', () => {
         clearEventListener();
 
         const previousUiState = {};
-        const nextUiState = widget.getWidgetState!(previousUiState, {
+        const nextUiState = widget.getWidgetUiState!(previousUiState, {
           helper,
           searchParameters: helper.state,
         });

--- a/src/widgets/places/places.ts
+++ b/src/widgets/places/places.ts
@@ -94,7 +94,7 @@ const placesWidget: WidgetFactory<{}, PlacesWidgetOptions> = (
       });
     },
 
-    getWidgetState(uiState, { searchParameters }) {
+    getWidgetUiState(uiState, { searchParameters }) {
       const position =
         searchParameters.aroundLatLng || defaultPosition.join(',');
       const hasPositionSet = position !== defaultPosition.join(',');


### PR DESCRIPTION
> This is part 1 of the series "[Render State](https://github.com/algolia/instantsearch-rfcs/pull/38)".

## Description

This deprecates `getWidgetState` to `getWidgetUiState` to make the upcoming `getWidgetRenderState` less confusing.

`getWidgetState` still works a previously, but displays a warning. We'll stop supporting this naming from InstantSearch.js v5.

## Related

- algolia/instantsearch-rfcs#38