### PR TITLE
feat(core): introduce `getWidgetRenderState` (2/n)

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
   "bundlesize": [
     {
       "path": "./dist/instantsearch.production.min.js",
-      "maxSize": "64 kB"
+      "maxSize": "64.25 kB"
     },
     {
       "path": "./dist/instantsearch.development.js",

--- a/src/connectors/search-box/__tests__/connectSearchBox-test.js
+++ b/src/connectors/search-box/__tests__/connectSearchBox-test.js
@@ -3,6 +3,12 @@ import algoliasearchHelper, {
   SearchParameters,
 } from 'algoliasearch-helper';
 import connectSearchBox from '../connectSearchBox';
+import {
+  createInitOptions,
+  createRenderOptions,
+} from '../../../../test/mock/createWidget';
+import { InstantSearch } from '../../../types';
+import { createSearchClient } from '../../../../test/mock/createSearchClient';
 
 describe('connectSearchBox', () => {
   const getInitializedWidget = (config = {}) => {
@@ -16,11 +22,12 @@ describe('connectSearchBox', () => {
     const helper = algoliasearchHelper({}, '', initialConfig);
     helper.search = jest.fn();
 
-    widget.init({
-      helper,
-      state: helper.state,
-      createURL: () => '#',
-    });
+    widget.init(
+      createInitOptions({
+        helper,
+        state: helper.state,
+      })
+    );
 
     const { refine } = renderFn.mock.calls[0][0];
 
@@ -51,7 +58,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
           init: expect.any(Function),
           render: expect.any(Function),
           dispose: expect.any(Function),
-
+          getWidgetRenderState: expect.any(Function),
           getWidgetUiState: expect.any(Function),
           getWidgetSearchParameters: expect.any(Function),
         })
@@ -69,11 +76,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
     const helper = algoliasearchHelper({});
     helper.search = () => {};
 
-    widget.init({
-      helper,
-      state: helper.state,
-      createURL: () => '#',
-    });
+    widget.init(
+      createInitOptions({
+        helper,
+        state: helper.state,
+      })
+    );
 
     expect(renderFn).toHaveBeenCalledTimes(1);
     expect(renderFn).toHaveBeenLastCalledWith(
@@ -84,13 +92,13 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
       true
     );
 
-    widget.render({
-      results: new SearchResults(helper.state, [{}]),
-      state: helper.state,
-      helper,
-      createURL: () => '#',
-      searchMetadata: { isSearchStalled: false },
-    });
+    widget.render(
+      createRenderOptions({
+        results: new SearchResults(helper.state, [{}]),
+        state: helper.state,
+        helper,
+      })
+    );
 
     expect(renderFn).toHaveBeenCalledTimes(2);
     expect(renderFn).toHaveBeenLastCalledWith(
@@ -110,11 +118,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
     const helper = algoliasearchHelper({});
     helper.search = jest.fn();
 
-    widget.init({
-      helper,
-      state: helper.state,
-      createURL: () => '#',
-    });
+    widget.init(
+      createInitOptions({
+        helper,
+        state: helper.state,
+      })
+    );
 
     {
       const { refine, query } = renderFn.mock.calls[0][0];
@@ -125,13 +134,13 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
       expect(helper.search).toHaveBeenCalledTimes(1);
     }
 
-    widget.render({
-      results: new SearchResults(helper.state, [{}]),
-      state: helper.state,
-      helper,
-      createURL: () => '#',
-      searchMetadata: { isSearchStalled: false },
-    });
+    widget.render(
+      createRenderOptions({
+        results: new SearchResults(helper.state, [{}]),
+        state: helper.state,
+        helper,
+      })
+    );
 
     {
       const { refine, query } = renderFn.mock.calls[1][0];
@@ -153,11 +162,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
     });
     helper.search = jest.fn();
 
-    widget.init({
-      helper,
-      state: helper.state,
-      createURL: () => '#',
-    });
+    widget.init(
+      createInitOptions({
+        helper,
+        state: helper.state,
+      })
+    );
 
     {
       expect(helper.state.query).toBe('bup');
@@ -168,13 +178,13 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
       refine('bip'); // triggers a search
     }
 
-    widget.render({
-      results: new SearchResults(helper.state, [{}]),
-      state: helper.state,
-      helper,
-      createURL: () => '#',
-      searchMetadata: { isSearchStalled: false },
-    });
+    widget.render(
+      createRenderOptions({
+        results: new SearchResults(helper.state, [{}]),
+        state: helper.state,
+        helper,
+      })
+    );
 
     {
       expect(helper.state.query).toBe('bip');
@@ -200,11 +210,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
     const helper = algoliasearchHelper({});
     helper.search = jest.fn();
 
-    widget.init({
-      helper,
-      state: helper.state,
-      createURL: () => '#',
-    });
+    widget.init(
+      createInitOptions({
+        helper,
+        state: helper.state,
+      })
+    );
 
     {
       const { refine } = renderFn.mock.calls[0][0];
@@ -224,13 +235,13 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
 
     letSearchThrough = false;
 
-    widget.render({
-      results: new SearchResults(helper.state, [{}]),
-      state: helper.state,
-      helper,
-      createURL: () => '#',
-      searchMetadata: { isSearchStalled: false },
-    });
+    widget.render(
+      createRenderOptions({
+        results: new SearchResults(helper.state, [{}]),
+        state: helper.state,
+        helper,
+      })
+    );
 
     {
       const { refine } = renderFn.mock.calls[1][0];
@@ -248,42 +259,27 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
     }
   });
 
-  it('should always provide the same refine() and clear() function reference', () => {
-    const renderFn = jest.fn();
-    const makeWidget = connectSearchBox(renderFn);
-    const widget = makeWidget();
-
-    const helper = algoliasearchHelper({});
-    helper.search = () => {};
-
-    widget.init({
-      helper,
-      state: helper.state,
-      createURL: () => '#',
+  it('provides the same `refine` and `clear` function references', done => {
+    const initRenderState = {};
+    const createSearchBox = connectSearchBox(
+      ({ refine, clear }, isFirstRender) => {
+        if (isFirstRender) {
+          initRenderState.refine = refine;
+          initRenderState.clear = clear;
+        } else {
+          expect(refine).toBe(initRenderState.refine);
+          expect(clear).toBe(initRenderState.clear);
+          done();
+        }
+      }
+    );
+    const search = new InstantSearch({
+      searchClient: createSearchClient(),
+      indexName: 'indexName',
     });
 
-    widget.render({
-      results: new SearchResults(helper.state, [{}]),
-      state: helper.state,
-      helper,
-      createURL: () => '#',
-      searchMetadata: { isSearchStalled: false },
-    });
-
-    const firstRenderOptions = renderFn.mock.calls[0][0];
-
-    widget.render({
-      results: new SearchResults(helper.state, [{}]),
-      state: helper.state,
-      helper,
-      createURL: () => '#',
-      searchMetadata: { isSearchStalled: false },
-    });
-
-    const secondRenderOptions = renderFn.mock.calls[1][0];
-
-    expect(firstRenderOptions.clear).toBe(secondRenderOptions.clear);
-    expect(firstRenderOptions.refine).toBe(secondRenderOptions.refine);
+    search.addWidgets([createSearchBox()]);
+    search.start();
   });
 
   it('should clear on init as well', () => {
@@ -297,17 +293,107 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
 
     expect(helper.state.query).toBe('foobar');
 
-    widget.init({
-      helper,
-      state: helper.state,
-      createURL: () => '#',
-    });
+    widget.init(
+      createInitOptions({
+        helper,
+        state: helper.state,
+      })
+    );
 
     const { clear } = renderFn.mock.calls[0][0];
     clear();
 
     expect(helper.state.query).toBe('');
     expect(helper.search).toHaveBeenCalledTimes(1);
+  });
+
+  describe('getWidgetRenderState', () => {
+    test('returns the render state with default render options', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const queryHook = jest.fn();
+      const createSearchBox = connectSearchBox(renderFn, unmountFn);
+      const searchBox = createSearchBox({
+        queryHook,
+      });
+
+      const renderState1 = searchBox.getWidgetRenderState(
+        {},
+        createInitOptions()
+      );
+
+      expect(renderState1.searchBox).toEqual({
+        clear: expect.any(Function),
+        isSearchStalled: false,
+        query: '',
+        refine: undefined,
+        widgetParams: { queryHook },
+      });
+
+      searchBox.init(createInitOptions());
+
+      const renderState2 = searchBox.getWidgetRenderState(
+        {},
+        createRenderOptions()
+      );
+
+      expect(renderState2.searchBox).toEqual({
+        clear: renderState2.searchBox.clear,
+        isSearchStalled: false,
+        query: '',
+        refine: expect.any(Function),
+        widgetParams: {
+          queryHook,
+        },
+      });
+    });
+
+    test('returns the render state with a query', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const createSearchBox = connectSearchBox(renderFn, unmountFn);
+      const searchBox = createSearchBox();
+      const helper = algoliasearchHelper(createSearchClient(), 'indexName', {
+        query: 'query',
+      });
+
+      searchBox.init(createInitOptions());
+
+      const renderState = searchBox.getWidgetRenderState(
+        {},
+        createRenderOptions({ helper })
+      );
+
+      expect(renderState.searchBox).toEqual({
+        clear: expect.any(Function),
+        isSearchStalled: false,
+        query: 'query',
+        refine: expect.any(Function),
+        widgetParams: {},
+      });
+    });
+
+    test('returns the render state with stalled search', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const createSearchBox = connectSearchBox(renderFn, unmountFn);
+      const searchBox = createSearchBox();
+
+      searchBox.init(createInitOptions());
+
+      const renderState = searchBox.getWidgetRenderState(
+        {},
+        createRenderOptions({ searchMetadata: { isSearchStalled: true } })
+      );
+
+      expect(renderState.searchBox).toEqual({
+        clear: expect.any(Function),
+        isSearchStalled: true,
+        query: '',
+        refine: expect.any(Function),
+        widgetParams: {},
+      });
+    });
   });
 
   describe('dispose', () => {

--- a/src/connectors/search-box/connectSearchBox.js
+++ b/src/connectors/search-box/connectSearchBox.js
@@ -72,8 +72,7 @@ export default function connectSearchBox(renderFn, unmountFn = noop) {
 
     function clear(helper) {
       return function() {
-        helper.setQuery('');
-        helper.search();
+        helper.setQuery('').search();
       };
     }
 
@@ -86,7 +85,8 @@ export default function connectSearchBox(renderFn, unmountFn = noop) {
         this._clear();
       },
 
-      init({ helper, instantSearchInstance }) {
+      init(initOptions) {
+        const { helper, renderState, instantSearchInstance } = initOptions;
         this._cachedClear = this._cachedClear.bind(this);
         this._clear = clear(helper);
 
@@ -107,27 +107,21 @@ export default function connectSearchBox(renderFn, unmountFn = noop) {
 
         renderFn(
           {
-            query: helper.state.query || '',
-            refine: this._refine,
-            clear: this._cachedClear,
-            widgetParams,
+            ...this.getWidgetRenderState(renderState, initOptions).searchBox,
             instantSearchInstance,
           },
           true
         );
       },
 
-      render({ helper, instantSearchInstance, searchMetadata }) {
+      render(renderOptions) {
+        const { helper, renderState, instantSearchInstance } = renderOptions;
         this._clear = clear(helper);
 
         renderFn(
           {
-            query: helper.state.query || '',
-            refine: this._refine,
-            clear: this._cachedClear,
-            widgetParams,
+            ...this.getWidgetRenderState(renderState, renderOptions).searchBox,
             instantSearchInstance,
-            isSearchStalled: searchMetadata.isSearchStalled,
           },
           false
         );
@@ -137,6 +131,19 @@ export default function connectSearchBox(renderFn, unmountFn = noop) {
         unmountFn();
 
         return state.setQueryParameter('query', undefined);
+      },
+
+      getWidgetRenderState(renderState, { helper, searchMetadata }) {
+        return {
+          ...renderState,
+          searchBox: {
+            query: helper.state.query || '',
+            refine: this._refine,
+            clear: this._cachedClear,
+            widgetParams,
+            isSearchStalled: searchMetadata.isSearchStalled,
+          },
+        };
       },
 
       getWidgetUiState(uiState, { searchParameters }) {

--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -17,6 +17,7 @@ import {
   Widget,
   UiState,
   CreateURL,
+  RenderState,
 } from '../types';
 import hasDetectedInsightsClient from './utils/detect-insights-client';
 import { Middleware, MiddlewareDefinition } from '../middleware';
@@ -133,6 +134,7 @@ class InstantSearch extends EventEmitter {
   public mainIndex: Index;
   public started: boolean;
   public templatesConfig: object;
+  public renderState: RenderState = {};
   public _stalledSearchDelay: number;
   public _searchStalledTimer: any;
   public _isSearchStalled: boolean;

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -29,7 +29,6 @@ type SharedRenderOptions = {
 
 export type InitOptions = SharedRenderOptions & {
   uiState: UiState;
-  results: undefined;
 };
 
 export type RenderOptions = SharedRenderOptions & {

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -254,7 +254,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
             renderState: {},
             templatesConfig: instantSearchInstance.templatesConfig,
             createURL: expect.any(Function),
-            results: undefined,
             scopedResults: [],
             searchMetadata: {
               isSearchStalled: true,
@@ -312,7 +311,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
             renderState: {},
             templatesConfig: instantSearchInstance.templatesConfig,
             createURL: expect.any(Function),
-            results: undefined,
             scopedResults: [],
             searchMetadata: {
               isSearchStalled: true,
@@ -1017,7 +1015,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
           renderState: {},
           templatesConfig: instantSearchInstance.templatesConfig,
           createURL: expect.any(Function),
-          results: undefined,
           scopedResults: [],
           searchMetadata: {
             isSearchStalled: instantSearchInstance._isSearchStalled,
@@ -2070,7 +2067,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
           renderState: {},
           templatesConfig: instantSearchInstance.templatesConfig,
           createURL: expect.any(Function),
-          results: undefined,
           scopedResults: [],
           searchMetadata: {
             isSearchStalled: instantSearchInstance._isSearchStalled,

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -277,7 +277,6 @@ const index = (props: IndexProps): Index => {
                 renderState: localInstantSearchInstance!.renderState,
                 templatesConfig: localInstantSearchInstance!.templatesConfig,
                 createURL,
-                results: undefined,
                 scopedResults: [],
                 searchMetadata: {
                   isSearchStalled: localInstantSearchInstance!._isSearchStalled,
@@ -304,7 +303,6 @@ const index = (props: IndexProps): Index => {
               renderState: localInstantSearchInstance!.renderState,
               templatesConfig: localInstantSearchInstance!.templatesConfig,
               createURL,
-              results: undefined,
               scopedResults: [],
               searchMetadata: {
                 isSearchStalled: localInstantSearchInstance!._isSearchStalled,
@@ -482,7 +480,6 @@ const index = (props: IndexProps): Index => {
               renderState: instantSearchInstance.renderState,
               templatesConfig: instantSearchInstance.templatesConfig,
               createURL,
-              results: undefined,
               scopedResults: [],
               searchMetadata: {
                 isSearchStalled: instantSearchInstance._isSearchStalled,
@@ -514,7 +511,6 @@ const index = (props: IndexProps): Index => {
             templatesConfig: instantSearchInstance.templatesConfig,
             renderState: instantSearchInstance.renderState,
             createURL,
-            results: undefined,
             scopedResults: [],
             searchMetadata: {
               isSearchStalled: instantSearchInstance._isSearchStalled,

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -264,6 +264,9 @@ const index = (props: IndexProps): Index => {
           _uiState: localUiState,
         });
 
+        // We compute the render state before calling `init` in a separate loop
+        // to construct the whole render state object that is then passed to
+        // `init`.
         widgets.forEach(widget => {
           if (widget.getWidgetRenderState) {
             const widgetRenderState = widget.getWidgetRenderState(
@@ -467,6 +470,9 @@ const index = (props: IndexProps): Index => {
         helper!.lastResults = results;
       });
 
+      // We compute the render state before calling `render` in a separate loop
+      // to construct the whole render state object that is then passed to
+      // `render`.
       localWidgets.forEach(widget => {
         if (widget.getWidgetRenderState) {
           const widgetRenderState = widget.getWidgetRenderState(

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -264,7 +264,7 @@ const index = (props: IndexProps): Index => {
           _uiState: localUiState,
         });
 
-        localWidgets.forEach(widget => {
+        widgets.forEach(widget => {
           if (widget.getWidgetRenderState) {
             const widgetRenderState = widget.getWidgetRenderState(
               localInstantSearchInstance!.renderState[this.getIndexId()] || {},

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -13,7 +13,7 @@ import {
   Widget,
   InitOptions,
   RenderOptions,
-  WidgetStateOptions,
+  WidgetUiStateOptions,
   WidgetSearchParametersOptions,
   ScopedResult,
   SearchClient,
@@ -105,7 +105,7 @@ function privateHelperSetState(
 
 function getLocalWidgetsState(
   widgets: Widget[],
-  widgetStateOptions: WidgetStateOptions,
+  widgetStateOptions: WidgetUiStateOptions,
   initialUiState: IndexUiState = {}
 ): IndexUiState {
   return widgets
@@ -264,16 +264,51 @@ const index = (props: IndexProps): Index => {
           _uiState: localUiState,
         });
 
+        localWidgets.forEach(widget => {
+          if (widget.getWidgetRenderState) {
+            const widgetRenderState = widget.getWidgetRenderState(
+              localInstantSearchInstance!.renderState[this.getIndexId()] || {},
+              {
+                uiState: localInstantSearchInstance!._initialUiState,
+                helper: this.getHelper()!,
+                parent: this,
+                instantSearchInstance: localInstantSearchInstance!,
+                state: helper!.state,
+                renderState: localInstantSearchInstance!.renderState,
+                templatesConfig: localInstantSearchInstance!.templatesConfig,
+                createURL,
+                results: undefined,
+                scopedResults: [],
+                searchMetadata: {
+                  isSearchStalled: localInstantSearchInstance!._isSearchStalled,
+                },
+              }
+            );
+
+            storeRenderState({
+              widgetRenderState,
+              instantSearchInstance: localInstantSearchInstance!,
+              parent: this,
+            });
+          }
+        });
+
         widgets.forEach(widget => {
-          if (localInstantSearchInstance && widget.init) {
+          if (widget.init) {
             widget.init({
               helper: helper!,
               parent: this,
-              uiState: localInstantSearchInstance._initialUiState,
-              instantSearchInstance: localInstantSearchInstance,
+              uiState: localInstantSearchInstance!._initialUiState,
+              instantSearchInstance: localInstantSearchInstance!,
               state: helper!.state,
-              templatesConfig: localInstantSearchInstance.templatesConfig,
+              renderState: localInstantSearchInstance!.renderState,
+              templatesConfig: localInstantSearchInstance!.templatesConfig,
               createURL,
+              results: undefined,
+              scopedResults: [],
+              searchMetadata: {
+                isSearchStalled: localInstantSearchInstance!._isSearchStalled,
+              },
             });
           }
         });
@@ -435,6 +470,35 @@ const index = (props: IndexProps): Index => {
       });
 
       localWidgets.forEach(widget => {
+        if (widget.getWidgetRenderState) {
+          const widgetRenderState = widget.getWidgetRenderState(
+            instantSearchInstance.renderState[this.getIndexId()] || {},
+            {
+              uiState,
+              helper: this.getHelper()!,
+              parent: this,
+              instantSearchInstance,
+              state: helper!.state,
+              renderState: instantSearchInstance.renderState,
+              templatesConfig: instantSearchInstance.templatesConfig,
+              createURL,
+              results: undefined,
+              scopedResults: [],
+              searchMetadata: {
+                isSearchStalled: instantSearchInstance._isSearchStalled,
+              },
+            }
+          );
+
+          storeRenderState({
+            widgetRenderState,
+            instantSearchInstance,
+            parent: this,
+          });
+        }
+      });
+
+      localWidgets.forEach(widget => {
         warning(
           !widget.getWidgetState,
           'The `getWidgetState` method is renamed `getWidgetUiState` and will no longer exist under that name in InstantSearch.js 5.x. Please use `getWidgetUiState` instead.'
@@ -448,7 +512,13 @@ const index = (props: IndexProps): Index => {
             instantSearchInstance,
             state: helper!.state,
             templatesConfig: instantSearchInstance.templatesConfig,
+            renderState: instantSearchInstance.renderState,
             createURL,
+            results: undefined,
+            scopedResults: [],
+            searchMetadata: {
+              isSearchStalled: instantSearchInstance._isSearchStalled,
+            },
           });
         }
       });
@@ -483,6 +553,38 @@ const index = (props: IndexProps): Index => {
     },
 
     render({ instantSearchInstance }: IndexRenderOptions) {
+      if (!this.getResults()) {
+        return;
+      }
+
+      localWidgets.forEach(widget => {
+        if (widget.getWidgetRenderState) {
+          const widgetRenderState = widget.getWidgetRenderState(
+            instantSearchInstance.renderState[this.getIndexId()] || {},
+            {
+              helper: this.getHelper()!,
+              parent: this,
+              instantSearchInstance,
+              results: this.getResults()!,
+              scopedResults: resolveScopedResultsFromIndex(this),
+              state: this.getResults()!._state,
+              renderState: instantSearchInstance.renderState,
+              templatesConfig: instantSearchInstance.templatesConfig,
+              createURL,
+              searchMetadata: {
+                isSearchStalled: instantSearchInstance._isSearchStalled,
+              },
+            }
+          );
+
+          storeRenderState({
+            widgetRenderState,
+            instantSearchInstance,
+            parent: this,
+          });
+        }
+      });
+
       localWidgets.forEach(widget => {
         // At this point, all the variables used below are set. Both `helper`
         // and `derivedHelper` have been created at the `init` step. The attribute
@@ -491,13 +593,15 @@ const index = (props: IndexProps): Index => {
         // be delayed. The render is triggered for the complete tree but some parts do
         // not have results yet.
 
-        if (widget.render && derivedHelper!.lastResults) {
+        if (widget.render) {
           widget.render({
             helper: helper!,
+            parent: this,
             instantSearchInstance,
-            results: derivedHelper!.lastResults,
+            results: this.getResults()!,
             scopedResults: resolveScopedResultsFromIndex(this),
-            state: derivedHelper!.lastResults._state,
+            state: this.getResults()!._state,
+            renderState: instantSearchInstance.renderState,
             templatesConfig: instantSearchInstance.templatesConfig,
             createURL,
             searchMetadata: {
@@ -569,3 +673,21 @@ const index = (props: IndexProps): Index => {
 };
 
 export default index;
+
+function storeRenderState({
+  widgetRenderState,
+  instantSearchInstance,
+  parent,
+}) {
+  const parentIndexName = parent
+    ? parent.getIndexId()
+    : instantSearchInstance.mainIndex.getIndexId();
+
+  instantSearchInstance.renderState = {
+    ...instantSearchInstance.renderState,
+    [parentIndexName]: {
+      ...instantSearchInstance.renderState[parentIndexName],
+      ...widgetRenderState,
+    },
+  };
+}

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -479,7 +479,7 @@ const index = (props: IndexProps): Index => {
             instantSearchInstance.renderState[this.getIndexId()] || {},
             {
               uiState,
-              helper: this.getHelper()!,
+              helper: helper!,
               parent: this,
               instantSearchInstance,
               state: helper!.state,
@@ -514,8 +514,8 @@ const index = (props: IndexProps): Index => {
             parent: this,
             instantSearchInstance,
             state: helper!.state,
-            templatesConfig: instantSearchInstance.templatesConfig,
             renderState: instantSearchInstance.renderState,
+            templatesConfig: instantSearchInstance.templatesConfig,
             createURL,
             scopedResults: [],
             searchMetadata: {

--- a/src/widgets/search-box/__tests__/search-box-test.js
+++ b/src/widgets/search-box/__tests__/search-box-test.js
@@ -1,5 +1,9 @@
 import { render } from 'preact';
 import searchBox from '../search-box';
+import {
+  createInitOptions,
+  createRenderOptions,
+} from '../../../../test/mock/createWidget';
 
 jest.mock('preact', () => {
   const module = require.requireActual('preact');
@@ -42,7 +46,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
     test('renders during init()', () => {
       const widget = searchBox({ container: document.createElement('div') });
 
-      widget.init({ helper });
+      widget.init(createInitOptions({ helper }));
 
       const [firstRender] = render.mock.calls;
 
@@ -54,8 +58,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
       const container = document.createElement('div');
       const widget = searchBox({ container });
 
-      widget.init({ helper });
-      widget.render({ helper, searchMetadata: { isSearchStalled: false } });
+      widget.init(createInitOptions({ helper }));
+      widget.render(createRenderOptions({ helper }));
 
       const [firstRender, secondRender] = render.mock.calls;
 
@@ -71,7 +75,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
         container: document.createElement('div'),
       });
 
-      widget.init({ helper });
+      widget.init(createInitOptions({ helper }));
 
       const [firstRender] = render.mock.calls;
 
@@ -81,8 +85,13 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
     test('sets isSearchStalled', () => {
       const widget = searchBox({ container: document.createElement('div') });
 
-      widget.init({ helper });
-      widget.render({ helper, searchMetadata: { isSearchStalled: true } });
+      widget.init(createInitOptions({ helper }));
+      widget.render(
+        createRenderOptions({
+          helper,
+          searchMetadata: { isSearchStalled: true },
+        })
+      );
 
       const [, secondRender] = render.mock.calls;
 

--- a/test/mock/createInstantSearch.ts
+++ b/test/mock/createInstantSearch.ts
@@ -29,6 +29,7 @@ export const createInstantSearch = (
     templatesConfig: {},
     insightsClient: null,
     middleware: [],
+    renderState: {},
     scheduleStalledRender: defer(jest.fn()),
     scheduleSearch: defer(jest.fn()),
     scheduleRender: defer(jest.fn()),

--- a/test/mock/createWidget.ts
+++ b/test/mock/createWidget.ts
@@ -20,7 +20,13 @@ export const createInitOptions = (
     templatesConfig: instantSearchInstance.templatesConfig,
     helper: instantSearchInstance.helper!,
     state: instantSearchInstance.helper!.state,
+    renderState: instantSearchInstance.renderState,
+    results: undefined,
+    scopedResults: [],
     createURL: jest.fn(() => '#'),
+    searchMetadata: {
+      isSearchStalled: false,
+    },
     ...rest,
   };
 };
@@ -38,9 +44,11 @@ export const createRenderOptions = (
 
   return {
     instantSearchInstance,
+    parent: instantSearchInstance.mainIndex,
     templatesConfig: instantSearchInstance.templatesConfig,
     helper,
     state: helper.state,
+    renderState: instantSearchInstance.renderState,
     results,
     scopedResults: [
       {

--- a/test/mock/createWidget.ts
+++ b/test/mock/createWidget.ts
@@ -21,7 +21,6 @@ export const createInitOptions = (
     helper: instantSearchInstance.helper!,
     state: instantSearchInstance.helper!.state,
     renderState: instantSearchInstance.renderState,
-    results: undefined,
     scopedResults: [],
     createURL: jest.fn(() => '#'),
     searchMetadata: {


### PR DESCRIPTION
> This is part 2 of the series "[Render State](https://github.com/algolia/instantsearch-rfcs/pull/38)".

## Related

- algolia/instantsearch-rfcs#38
- algolia/instantsearch.js#4454

## Description

This introduces the widget lifecycle hook `getWidgetRenderState` and implements it for `connectSearchBox`.

The `getWidgetRenderState` method allows to accumulate and store the global render state of the widgets tree. This render state has a similar structure to the UI state but stores the render params.

## Motivation

When you mount a widget in the InstantSearch tree, you may want to use its render params (e.g., `refine` function) in another widget to create richer and more interactive interfaces.

In InstantSearch.js, it requires using the JavaScript helper, which means that you get out of the InstantSearch API. In React InstantSearch, you can hack around it to [use a React context and provide the render params to other components](https://github.com/algolia/unified-instantsearch-ecommerce/blob/8a5adffd651e8b0df6101bfef817a0a7decaeda4/src/components/SearchBox/ConnectedSearchBox.js#L11-L13). Still, this is a workaround that goes against React's paradigm.

**This PR aims at providing an InstantSearch API layer that provides the render state to all widgets.**

## Usage

### In an InstantSearch widget

The render state is available in the render params.

```tsx
const customPagination = connectPagination(
  ({ renderState, widgetParams }, isFirstRender) => {
    if (isFirstRender) {
      const button = document.createElement('button');
      button.textContent = 'Trigger search';
      button.addEventListener('click', () => {
        // Control the search box from the pagination widget
        renderState.instant_search.searchBox.refine('samsung');
      });
      widgetParams.container.appendChild(button);
    }
  }
);
```

### In a component outside of InstantSearch

The render state is available on the InstantSearch instance on `search.renderState` so that developers can interact with the search state from outside of InstantSearch widgets. This avoids nesting multiple widgets to use their render params. Using widgets also have the cons of relying on the network and the search results to be back before rendering (because we wait for results before rendering). This results in a UI flash, even if you don't want to display only search data coming from the network; this goes against the progressive enhancement paradigm.

A pattern that can emerge is to mount virtual widgets to make their render state available on the instance, then use the render state params in another website's element.

```tsx
function App({ search }) {
  function filterSamsungProducts() {
    search.renderState.instant_search.refinementList.brand.refine('Samsung');
  }

  return (
    <div>
      <button onClick={filterSamsungProducts}>Check Samsung products</button>
    </div>
  );
}
```

_The JSX syntax is used for convenience_.

### With React InstantSearch

> This PR doesn't deal with React InstantSearch because it's not based on InstantSearch.js, but this section explains how we can expose this Render State API in React as a next step.

The render state could be exposed using a React Context provider:

```tsx
function App() {
  return (
    <InstantSearch.RenderStateProvider>
      {(renderState) => (
        /* ... */
      )}
    </InstantSearch.RenderStateProvider>
  );
}
```

And using React hooks:

```tsx
function Search() {
  const renderState = useRenderState();

  return (
    /* ... */
  );
}
```

### With Vue InstantSearch

This is an example of a `renderState` mixin that exposes the API to Vue InstantSearch.

```html
<template>
  <ais-refinement-list>
    <template slot-scope="{ refine, items }">
      <button
        @click="
          refine(items[0].value);
          setQuery('');
        "
      >
        Refine first element and reset query
      </button>
    </template>
  </ais-refinement-list>
</template>

<script>
  export default {
    mixins: [renderState],
    methods: {
      setQuery(query) {
        return this.renderState.instant_search.searchBox.refine(query);
      },
    },
  };
</script>
```

## Detailed design

The render state has a similar structure to the UI state but stores the render params.

> **Note:** the render state is exclusively stored "per widget", as opposed to the UI state that delegates concepts like the search query to a `query` key, instead of a `searchBox` key.

### Storage

The render state is stored on the InstantSearch instance as an object.

```tsx
type RenderState = {
  [indexName: string]: {
    searchBox: {
      query: string;
      refine(query: string): void;
      // ...
    };
    // ...
  };
};

const renderState: RenderState = {
  instant_search: {
    searchBox: {
      query: 'iphone',
      refine: ƒ(query),
      // ...
    },
  },
};
```

### API addition

Each widget can now implement a new method called `getWidgetRenderState(indexRenderState, renderOptions): IndexRenderState`.

**Example**

```ts
const widget = {
  // ...
  getWidgetRenderState(renderState, { helper, searchMetadata }) {
    return {
      ...renderState,
      searchBox: {
        query: helper.state.query || '',
        refine: this._refine,
        clear: this._cachedClear,
        widgetParams,
        isSearchStalled: searchMetadata.isSearchStalled,
      },
    };
  },
};
```

Having an API for the render state (previously called render params) results in a few benefits:

- No direct behavioral change in how InstantSearch and its widgets work because the API is an addition
- Fewer inconsistencies between `init` and `render` returned render params (they would both use `getWidgetRenderState`)

Storing the render state on the InstantSearch instance unlocks APIs that we wanted to implement:

- **Access `widgetParams` from the InstantSearch instance.** This can be useful to track which widget options are used. (E.g., `renderState.instant_search.searchBox.widgetParams`)
- **Provide information to hide widgets with `panel`.** We now have the `getWidgetRenderState` API that can be used to compute a `canRefine` value, instead of finding the information with the JavaScript helper.

## How we teach this

- Create a new section about the render state in the documentation

## Next steps

- Implement the `getWidgetRenderState` method in all widgets