### PR TITLE
feat(autocomplete): implement `getWidgetRenderState`

### DIFF
--- a/src/connectors/autocomplete/__tests__/connectAutocomplete-test.ts
+++ b/src/connectors/autocomplete/__tests__/connectAutocomplete-test.ts
@@ -429,6 +429,65 @@ search.addWidgets([
     });
   });
 
+  describe('getWidgetRenderState', () => {
+    test('returns the render state', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const createAutocomplete = connectAutocomplete(renderFn, unmountFn);
+      const autocomplete = createAutocomplete({});
+
+      const renderState1 = autocomplete.getWidgetRenderState!(
+        {},
+        createInitOptions()
+      );
+
+      expect(renderState1.autocomplete).toEqual({
+        currentRefinement: '',
+        indices: [],
+        refine: undefined,
+        widgetParams: {},
+      });
+
+      autocomplete.init!(createInitOptions());
+
+      const renderState2 = autocomplete.getWidgetRenderState!(
+        {},
+        createRenderOptions()
+      );
+
+      expect(renderState2.autocomplete).toEqual({
+        currentRefinement: '',
+        indices: expect.any(Array),
+        refine: expect.any(Function),
+        widgetParams: {},
+      });
+    });
+
+    test('returns the render state with a query', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const createAutocomplete = connectAutocomplete(renderFn, unmountFn);
+      const autocomplete = createAutocomplete({});
+      const helper = algoliasearchHelper(createSearchClient(), 'indexName', {
+        query: 'query',
+      });
+
+      autocomplete.init!(createInitOptions());
+
+      const renderState = autocomplete.getWidgetRenderState!(
+        {},
+        createRenderOptions({ helper })
+      );
+
+      expect(renderState.autocomplete).toEqual({
+        currentRefinement: 'query',
+        indices: expect.any(Array),
+        refine: expect.any(Function),
+        widgetParams: {},
+      });
+    });
+  });
+
   describe('getWidgetUiState', () => {
     test('should give back the object unmodified if the default value is selected', () => {
       const [widget, helper] = getInitializedWidget();

--- a/src/connectors/autocomplete/connectAutocomplete.ts
+++ b/src/connectors/autocomplete/connectAutocomplete.ts
@@ -102,24 +102,36 @@ search.addWidgets([
     return {
       $$type: 'ais.autocomplete',
 
-      init({ instantSearchInstance, helper }) {
+      init(initOptions) {
+        const { helper, renderState, instantSearchInstance } = initOptions;
         connectorState.refine = (query: string) => {
           helper.setQuery(query).search();
         };
 
         renderFn(
           {
-            widgetParams,
-            currentRefinement: helper.state.query || '',
-            indices: [],
-            refine: connectorState.refine,
+            ...this.getWidgetRenderState!(renderState, initOptions)
+              .autocomplete!,
             instantSearchInstance,
           },
           true
         );
       },
 
-      render({ helper, scopedResults, instantSearchInstance }) {
+      render(renderOptions) {
+        const { renderState, instantSearchInstance } = renderOptions;
+
+        renderFn(
+          {
+            ...this.getWidgetRenderState!(renderState, renderOptions)
+              .autocomplete!,
+            instantSearchInstance,
+          },
+          false
+        );
+      },
+
+      getWidgetRenderState(renderState, { helper, scopedResults }) {
         const indices = scopedResults.map(scopedResult => {
           // We need to escape the hits because highlighting
           // exposes HTML tags to the end-user.
@@ -135,16 +147,15 @@ search.addWidgets([
           };
         });
 
-        renderFn(
-          {
-            widgetParams,
+        return {
+          ...renderState,
+          autocomplete: {
             currentRefinement: helper.state.query || '',
             indices,
             refine: connectorState.refine!,
-            instantSearchInstance,
+            widgetParams,
           },
-          false
-        );
+        };
       },
 
       getWidgetUiState(uiState, { searchParameters }) {

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -6,6 +6,10 @@ import {
   PlainSearchParameters,
 } from 'algoliasearch-helper';
 import { InstantSearch } from './instantsearch';
+import {
+  AutocompleteRendererOptions,
+  AutocompleteConnectorParams,
+} from '../connectors/autocomplete/connectAutocomplete';
 
 export type ScopedResult = {
   indexId: string;
@@ -133,6 +137,10 @@ export type IndexRenderState = Partial<{
     {
       queryHook?(query: string, refine: (query: string) => void);
     }
+  >;
+  autocomplete: WidgetRenderState<
+    AutocompleteRendererOptions,
+    AutocompleteConnectorParams
   >;
 }>;
 


### PR DESCRIPTION
This implements the `getWidgetRenderState` widget lifecycle hook in `autocomplete`.

⚠️ The following line throws a [TypeScript error](https://app.circleci.com/pipelines/github/algolia/instantsearch.js/4567/workflows/9954690f-500b-42af-8d85-4c986dc45b1e/jobs/19424/parallel-runs/0/steps/0-107) that I plan to fix in a later PR to move forward with this widget API (any help is welcome):

https://github.com/algolia/instantsearch.js/blob/3639991ce5f32199710d1bc9d685b88793465178/src/types/widget.ts#L147-L152