### PR TITLE
feat(clearRefinements): implement `getWidgetRenderState`

### DIFF
--- a/src/connectors/clear-refinements/connectClearRefinements.ts
+++ b/src/connectors/clear-refinements/connectClearRefinements.ts
@@ -85,20 +85,27 @@ const connectClearRefinements: ClearRefinementsConnector = function connectClear
     return {
       $$type: 'ais.clearRefinements',
 
-      init({ instantSearchInstance }) {
+      init(initOptions) {
+        const { renderState, instantSearchInstance } = initOptions;
+
         renderFn(
           {
-            hasRefinements: false,
-            refine: cachedRefine,
-            createURL: cachedCreateURL,
+            ...this.getWidgetRenderState!(renderState, initOptions)
+              .clearRefinements!,
             instantSearchInstance,
-            widgetParams,
           },
           true
         );
       },
 
-      render({ scopedResults, createURL, instantSearchInstance }) {
+      render(renderOptions) {
+        const {
+          scopedResults,
+          createURL,
+          renderState,
+          instantSearchInstance,
+        } = renderOptions;
+
         const attributesToClear = scopedResults.reduce<
           Array<ReturnType<typeof getAttributesToClear>>
         >((results, scopedResult) => {
@@ -139,13 +146,9 @@ const connectClearRefinements: ClearRefinementsConnector = function connectClear
 
         renderFn(
           {
-            hasRefinements: attributesToClear.some(
-              attributeToClear => attributeToClear.items.length > 0
-            ),
-            refine: cachedRefine,
-            createURL: cachedCreateURL,
+            ...this.getWidgetRenderState!(renderState, renderOptions)
+              .clearRefinements!,
             instantSearchInstance,
-            widgetParams,
           },
           false
         );
@@ -153,6 +156,33 @@ const connectClearRefinements: ClearRefinementsConnector = function connectClear
 
       dispose() {
         unmountFn();
+      },
+
+      getWidgetRenderState(renderState, { scopedResults }) {
+        const attributesToClear = scopedResults.reduce<
+          Array<ReturnType<typeof getAttributesToClear>>
+        >((results, scopedResult) => {
+          return results.concat(
+            getAttributesToClear({
+              scopedResult,
+              includedAttributes,
+              excludedAttributes,
+              transformItems,
+            })
+          );
+        }, []);
+
+        return {
+          ...renderState,
+          clearRefinements: {
+            hasRefinements: attributesToClear.some(
+              attributeToClear => attributeToClear.items.length > 0
+            ),
+            refine: cachedRefine,
+            createURL: cachedCreateURL,
+            widgetParams,
+          },
+        };
       },
     };
   };

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -14,6 +14,10 @@ import {
   BreadcrumbRendererOptions,
   BreadcrumbConnectorParams,
 } from '../connectors/breadcrumb/connectBreadcrumb';
+import {
+  ClearRefinementsRendererOptions,
+  ClearRefinementsConnectorParams,
+} from '../connectors/clear-refinements/connectClearRefinements';
 
 export type ScopedResult = {
   indexId: string;
@@ -150,6 +154,10 @@ export type IndexRenderState = Partial<{
   breadcrumb: WidgetRenderState<
     BreadcrumbRendererOptions,
     BreadcrumbConnectorParams
+  >;
+  clearRefinements: WidgetRenderState<
+    ClearRefinementsRendererOptions,
+    ClearRefinementsConnectorParams
   >;
 }>;
 


### PR DESCRIPTION
This implements the `getWidgetRenderState` widget lifecycle hook in `clearRefinements`.