### PR TITLE
feat(configure): implement `getWidgetRenderState`

### DIFF
--- a/src/connectors/configure/__tests__/connectConfigure-test.ts
+++ b/src/connectors/configure/__tests__/connectConfigure-test.ts
@@ -7,6 +7,7 @@ import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import connectConfigure from '../connectConfigure';
 import {
   createInitOptions,
+  createRenderOptions,
   createDisposeOptions,
 } from '../../../../test/mock/createWidget';
 import { noop } from '../../../lib/utils';
@@ -238,6 +239,43 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
         clickAnalytics: true,
       })
     );
+  });
+
+  describe('getWidgetRenderState', () => {
+    test('returns the render state', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const createConfigure = connectConfigure(renderFn, unmountFn);
+      const configure = createConfigure({
+        searchParameters: { facetFilters: ['brand:Samsung'] },
+      });
+
+      const renderState1 = configure.getWidgetRenderState!(
+        {},
+        createInitOptions()
+      );
+
+      expect(renderState1.configure).toEqual({
+        refine: undefined,
+        widgetParams: {
+          searchParameters: { facetFilters: ['brand:Samsung'] },
+        },
+      });
+
+      configure.init!(createInitOptions());
+
+      const renderState2 = configure.getWidgetRenderState!(
+        {},
+        createRenderOptions()
+      );
+
+      expect(renderState2.configure).toEqual({
+        refine: expect.any(Function),
+        widgetParams: {
+          searchParameters: { facetFilters: ['brand:Samsung'] },
+        },
+      });
+    });
   });
 
   describe('getWidgetUiState', () => {

--- a/src/connectors/configure/connectConfigure.ts
+++ b/src/connectors/configure/connectConfigure.ts
@@ -99,25 +99,28 @@ const connectConfigure: ConfigureConnector = function connectConfigure(
     return {
       $$type: 'ais.configure',
 
-      init({ instantSearchInstance, helper }) {
+      init(initOptions) {
+        const { renderState, helper, instantSearchInstance } = initOptions;
+
         connectorState.refine = refine(helper);
 
         renderFn(
           {
-            refine: connectorState.refine,
+            ...this.getWidgetRenderState!(renderState, initOptions).configure!,
             instantSearchInstance,
-            widgetParams,
           },
           true
         );
       },
 
-      render({ instantSearchInstance }) {
+      render(renderOptions) {
+        const { renderState, instantSearchInstance } = renderOptions;
+
         renderFn(
           {
-            refine: connectorState.refine!,
+            ...this.getWidgetRenderState!(renderState, renderOptions)
+              .configure!,
             instantSearchInstance,
-            widgetParams,
           },
           false
         );
@@ -127,6 +130,16 @@ const connectConfigure: ConfigureConnector = function connectConfigure(
         unmountFn();
 
         return getInitialSearchParameters(state, widgetParams);
+      },
+
+      getWidgetRenderState(renderState) {
+        return {
+          ...renderState,
+          configure: {
+            refine: connectorState.refine!,
+            widgetParams,
+          },
+        };
       },
 
       getWidgetSearchParameters(state, { uiState }) {

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -18,6 +18,10 @@ import {
   ClearRefinementsRendererOptions,
   ClearRefinementsConnectorParams,
 } from '../connectors/clear-refinements/connectClearRefinements';
+import {
+  ConfigureRendererOptions,
+  ConfigureConnectorParams,
+} from '../connectors/configure/connectConfigure';
 
 export type ScopedResult = {
   indexId: string;
@@ -158,6 +162,10 @@ export type IndexRenderState = Partial<{
   clearRefinements: WidgetRenderState<
     ClearRefinementsRendererOptions,
     ClearRefinementsConnectorParams
+  >;
+  configure: WidgetRenderState<
+    ConfigureRendererOptions,
+    ConfigureConnectorParams
   >;
 }>;
 


### PR DESCRIPTION
This implements the `getWidgetRenderState` widget lifecycle hook in `configure`.