### PR TITLE
feat(currentRefinements): implement `getWidgetRenderState`

### DIFF
--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -22,6 +22,10 @@ import {
   ConfigureRendererOptions,
   ConfigureConnectorParams,
 } from '../connectors/configure/connectConfigure';
+import {
+  CurrentRefinementsRendererOptions,
+  CurrentRefinementsConnectorParams,
+} from '../connectors/current-refinements/connectCurrentRefinements';
 
 export type ScopedResult = {
   indexId: string;
@@ -166,6 +170,10 @@ export type IndexRenderState = Partial<{
   configure: WidgetRenderState<
     ConfigureRendererOptions,
     ConfigureConnectorParams
+  >;
+  currentRefinements: WidgetRenderState<
+    CurrentRefinementsRendererOptions,
+    CurrentRefinementsConnectorParams
   >;
 }>;
 


### PR DESCRIPTION
This implements the `getWidgetRenderState` widget lifecycle hook in `currentRefinements`.