### PR TITLE
fix(breadcrumb): add attribute to render state

### DIFF
--- a/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.ts
+++ b/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.ts
@@ -75,36 +75,62 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
       const breadcrumb = createBreadcrumb({
         attributes: ['category', 'subCategory'],
       });
-      const helper = algoliasearchHelper(createSearchClient(), 'indexName', {
-        index: 'indexName',
-        hierarchicalFacets: [
-          {
-            name: 'category',
-            attributes: ['category', 'subCategory'],
-            separator: ' > ',
-          },
-        ],
-      });
+      const helper = algoliasearchHelper(
+        createSearchClient(),
+        'indexName',
+        breadcrumb.getWidgetSearchParameters!(new SearchParameters(), {
+          uiState: {},
+        })
+      );
 
       helper.toggleRefinement('category', 'Decoration');
 
       const renderState1 = breadcrumb.getWidgetRenderState!(
-        {},
+        {
+          breadcrumb: {
+            anotherCategory: {
+              canRefine: false,
+              createURL: () => '',
+              items: [],
+              refine: () => {},
+              widgetParams: { attributes: ['anotherCategory'] },
+            },
+          },
+        },
         createInitOptions({ helper })
       );
 
       expect(renderState1.breadcrumb).toEqual({
-        canRefine: false,
-        createURL: undefined,
-        items: [],
-        refine: undefined,
-        widgetParams: { attributes: ['category', 'subCategory'] },
+        anotherCategory: {
+          canRefine: false,
+          createURL: expect.any(Function),
+          items: [],
+          refine: expect.any(Function),
+          widgetParams: { attributes: ['anotherCategory'] },
+        },
+        category: {
+          canRefine: false,
+          createURL: undefined,
+          items: [],
+          refine: undefined,
+          widgetParams: { attributes: ['category', 'subCategory'] },
+        },
       });
 
       breadcrumb.init!(createInitOptions({ helper }));
 
       const renderState2 = breadcrumb.getWidgetRenderState!(
-        {},
+        {
+          breadcrumb: {
+            anotherCategory: {
+              canRefine: false,
+              createURL: () => '',
+              items: [],
+              refine: () => {},
+              widgetParams: { attributes: ['anotherCategory'] },
+            },
+          },
+        },
         createRenderOptions({
           helper,
           state: helper.state,
@@ -134,11 +160,20 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
       );
 
       expect(renderState2.breadcrumb).toEqual({
-        canRefine: true,
-        createURL: expect.any(Function),
-        items: [{ label: 'Decoration', value: null }],
-        refine: expect.any(Function),
-        widgetParams: { attributes: ['category', 'subCategory'] },
+        anotherCategory: {
+          canRefine: false,
+          createURL: expect.any(Function),
+          items: [],
+          refine: expect.any(Function),
+          widgetParams: { attributes: ['anotherCategory'] },
+        },
+        category: {
+          canRefine: true,
+          createURL: expect.any(Function),
+          items: [{ label: 'Decoration', value: null }],
+          refine: expect.any(Function),
+          widgetParams: { attributes: ['category', 'subCategory'] },
+        },
       });
     });
   });

--- a/src/connectors/breadcrumb/connectBreadcrumb.ts
+++ b/src/connectors/breadcrumb/connectBreadcrumb.ts
@@ -151,7 +151,7 @@ const connectBreadcrumb: BreadcrumbConnector = function connectBreadcrumb(
         renderFn(
           {
             ...this.getWidgetRenderState!(initOptions.renderState, initOptions)
-              .breadcrumb!,
+              .breadcrumb![hierarchicalFacetName],
             instantSearchInstance: initOptions.instantSearchInstance,
           },
           true
@@ -164,7 +164,7 @@ const connectBreadcrumb: BreadcrumbConnector = function connectBreadcrumb(
             ...this.getWidgetRenderState!(
               renderOptions.renderState,
               renderOptions
-            ).breadcrumb!,
+            ).breadcrumb![hierarchicalFacetName],
             instantSearchInstance: renderOptions.instantSearchInstance,
           },
           false
@@ -198,11 +198,14 @@ const connectBreadcrumb: BreadcrumbConnector = function connectBreadcrumb(
         return {
           ...renderState,
           breadcrumb: {
-            canRefine: items.length > 0,
-            createURL: connectorState.createURL,
-            items,
-            refine: connectorState.refine,
-            widgetParams,
+            ...renderState.breadcrumb,
+            [hierarchicalFacetName]: {
+              canRefine: items.length > 0,
+              createURL: connectorState.createURL,
+              items,
+              refine: connectorState.refine,
+              widgetParams,
+            },
           },
         };
       },

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -159,10 +159,12 @@ export type IndexRenderState = Partial<{
     AutocompleteRendererOptions,
     AutocompleteConnectorParams
   >;
-  breadcrumb: WidgetRenderState<
-    BreadcrumbRendererOptions,
-    BreadcrumbConnectorParams
-  >;
+  breadcrumb: {
+    [attribute: string]: WidgetRenderState<
+      BreadcrumbRendererOptions,
+      BreadcrumbConnectorParams
+    >;
+  };
   clearRefinements: WidgetRenderState<
     ClearRefinementsRendererOptions,
     ClearRefinementsConnectorParams


### PR DESCRIPTION
This fixes the `breadcrumb` widget where the attribute was missing in the render state.