### PR TITLE
fix(typescript): export correct types

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@babel/preset-env": "7.8.3",
     "@babel/preset-react": "7.8.3",
     "@babel/preset-typescript": "7.8.3",
-    "@microsoft/api-extractor": "7.7.13",
+    "@microsoft/api-extractor": "7.9.2",
     "@storybook/addon-actions": "5.3.9",
     "@storybook/html": "5.3.9",
     "@storybook/theming": "5.3.9",
@@ -135,7 +135,7 @@
     "semver": "6.3.0",
     "shelljs": "0.8.3",
     "shipjs": "0.16.0",
-    "typescript": "3.7.5",
+    "typescript": "3.8.3",
     "webpack": "4.41.5"
   },
   "bundlesize": [

--- a/scripts/build/types.js
+++ b/scripts/build/types.js
@@ -18,49 +18,6 @@ shell.sed(
   path.join(__dirname, '../../es/**/*.d.ts')
 );
 
-// TypeScript uses `import()` types in very small files, but API extractor does not support that
-// We will hardcode the type definitions here, to avoid the build not passing.
-// "Error: The expression contains an import() type, which is not yet supported by API Extractor:"
-
-fs.writeFileSync(
-  path.join(
-    __dirname,
-    '../../es/connectors/infinite-hits/connectInfiniteHitsWithInsights.d.ts'
-  ),
-  `
-// edited by yarn build:types
-import { Connector } from '../../types';
-import {
-  InfiniteHitsRendererOptions,
-  InfiniteHitsConnectorParams,
-} from './connectInfiniteHits';
-
-declare const connectInfiniteHitsWithInsights: Connector<
-  InfiniteHitsRendererOptions,
-  InfiniteHitsConnectorParams
->;
-export default connectInfiniteHitsWithInsights;
-`
-);
-
-fs.writeFileSync(
-  path.join(__dirname, '../../es/connectors/hits/connectHitsWithInsights.d.ts'),
-  `
-// edited by yarn build:types
-import { Connector } from '../../types';
-import {
-  HitsRendererOptions,
-  HitsConnectorParams,
-} from './connectHits';
-
-declare const connectHitsWithInsights: Connector<
-  HitsRendererOptions,
-  HitsConnectorParams
->;
-export default connectHitsWithInsights;
-`
-);
-
 console.log();
 console.log(`Validating definitions...`);
 
@@ -69,7 +26,7 @@ const { Extractor, ExtractorConfig } = require('@microsoft/api-extractor');
 const publicExports = [
   // 'components' -> does not contains index.d.ts yet
   'connectors',
-  // 'lib', -> Api extrator "import * as ___ from ___;" is not supported yet for local files
+  // 'lib', -> Api extractor "import * as ___ from ___;" is not supported yet for local files
   // 'middleware',
   'helpers',
   'types',

--- a/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
+++ b/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
@@ -205,10 +205,10 @@ export default function connectHierarchicalMenu(renderFn, unmountFn = noop) {
         );
       },
 
-      // eslint-disable-next-line valid-jsdoc
       /**
-       * @param {Object} param0
-       * @param {import('algoliasearch-helper').SearchParameters} param0.state
+       * @param {Object} param0 cleanup arguments
+       * @param {any} param0.state current search parameters
+       * @returns {void}
        */
       dispose({ state }) {
         unmountFn();

--- a/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
+++ b/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
@@ -208,7 +208,7 @@ export default function connectHierarchicalMenu(renderFn, unmountFn = noop) {
       /**
        * @param {Object} param0 cleanup arguments
        * @param {any} param0.state current search parameters
-       * @returns {void}
+       * @returns {any}
        */
       dispose({ state }) {
         unmountFn();

--- a/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
+++ b/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
@@ -208,7 +208,7 @@ export default function connectHierarchicalMenu(renderFn, unmountFn = noop) {
       /**
        * @param {Object} param0 cleanup arguments
        * @param {any} param0.state current search parameters
-       * @returns {any}
+       * @returns {any} next search parameters
        */
       dispose({ state }) {
         unmountFn();

--- a/src/connectors/hits-per-page/connectHitsPerPage.ts
+++ b/src/connectors/hits-per-page/connectHitsPerPage.ts
@@ -58,7 +58,7 @@ export type HitsPerPageConnectorParams = {
   /**
    * Function to transform the items passed to the templates.
    */
-  transformItems?: TransformItems<HitsPerPageConnectorParamsItem>;
+  transformItems?: TransformItems<HitsPerPageRendererOptionsItem>;
 };
 
 export type HitsPerPageRendererOptions = {

--- a/src/connectors/hits/connectHitsWithInsights.ts
+++ b/src/connectors/hits/connectHitsWithInsights.ts
@@ -1,5 +1,19 @@
 import { withInsights } from '../../lib/insights';
-import connectHits from './connectHits';
+import connectHits, {
+  HitsRendererOptions,
+  HitsConnectorParams,
+} from './connectHits';
+import { Connector } from '../../types';
+
+/**
+ * Due to https://github.com/microsoft/web-build-tools/issues/1050, we need
+ * Connector<...> imported in this file, even though it is only used implicitly.
+ * This _uses_ Connector<...> so it is not accidentally removed by someone.
+ */
+declare type ImportWorkaround = Connector<
+  HitsRendererOptions,
+  HitsConnectorParams
+>;
 
 const connectHitsWithInsights = withInsights(connectHits);
 

--- a/src/connectors/infinite-hits/connectInfiniteHitsWithInsights.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHitsWithInsights.ts
@@ -1,5 +1,19 @@
 import { withInsights } from '../../lib/insights';
-import connectInfiniteHits from './connectInfiniteHits';
+import connectInfiniteHits, {
+  InfiniteHitsRendererOptions,
+  InfiniteHitsConnectorParams,
+} from './connectInfiniteHits';
+import { Connector } from '../../types';
+
+/**
+ * Due to https://github.com/microsoft/web-build-tools/issues/1050, we need
+ * Connector<...> imported in this file, even though it is only used implicitly.
+ * This _uses_ Connector<...> so it is not accidentally removed by someone.
+ */
+declare type ImportWorkaround = Connector<
+  InfiniteHitsRendererOptions,
+  InfiniteHitsConnectorParams
+>;
 
 const connectInfiniteHitsWithInsights = withInsights(connectInfiniteHits);
 

--- a/src/lib/voiceSearchHelper/index.ts
+++ b/src/lib/voiceSearchHelper/index.ts
@@ -42,8 +42,8 @@ const createVoiceSearchHelper: CreateVoiceSearchHelper = function createVoiceSea
     });
   };
 
-  const onError = (event: SpeechRecognitionError): void => {
-    setState({ status: 'error', errorCode: event.error });
+  const onError = (event: Event): void => {
+    setState({ status: 'error', errorCode: (event as any).error });
   };
 
   const onResult = (event: SpeechRecognitionEvent): void => {

--- a/src/types/algoliasearch.ts
+++ b/src/types/algoliasearch.ts
@@ -21,6 +21,7 @@ import {
   // eslint-disable-next-line prettier/prettier
   SearchForFacetValuesResponse as SearchForFacetValuesResponseV4
   /** @ts-ignore */
+  // @ts-ignore
   // eslint-disable-next-line import/no-unresolved
 } from '@algolia/client-search';
 

--- a/src/types/algoliasearch.ts
+++ b/src/types/algoliasearch.ts
@@ -2,19 +2,25 @@
 // `v3` and algoliasearch `v4` clients.
 
 import algoliasearch, {
-  // @ts-ignore
+  /** @ts-ignore */
+  // @ts-ignore (TypeScript 3.8.3 does not yet support multi-line ts-ignore, but 3.9.3 bugs when compiling. This is fixed when we migrate to 4)
   SearchClient as SearchClientV4,
+  /** @ts-ignore */
   // @ts-ignore
   Client as SearchClientV3,
+  /** @ts-ignore */
   // @ts-ignore
   Response as SearchResponseV3,
+  /** @ts-ignore */
   // @ts-ignore
   SearchForFacetValues as SearchForFacetValuesV3,
 } from 'algoliasearch';
 import {
   SearchResponse as SearchResponseV4,
-  SearchForFacetValuesResponse as SearchForFacetValuesResponseV4,
-  // @ts-ignore
+  // no comma, TS is particular about which nodes expose comments
+  // eslint-disable-next-line prettier/prettier
+  SearchForFacetValuesResponse as SearchForFacetValuesResponseV4
+  /** @ts-ignore */
   // eslint-disable-next-line import/no-unresolved
 } from '@algolia/client-search';
 

--- a/src/widgets/panel/__tests__/panel-test.ts
+++ b/src/widgets/panel/__tests__/panel-test.ts
@@ -55,8 +55,8 @@ describe('Usage', () => {
 
   test('with `hidden` as boolean warns', () => {
     expect(() => {
-      // @ts-ignore wrong option type
       panel({
+        // @ts-ignore wrong option type
         hidden: true,
       });
     }).toWarnDev(
@@ -66,8 +66,8 @@ describe('Usage', () => {
 
   test('with `collapsed` as boolean warns', () => {
     expect(() => {
-      // @ts-ignore wrong option type
       panel({
+        // @ts-ignore wrong option type
         collapsed: true,
       });
     }).toWarnDev(

--- a/src/widgets/places/places.ts
+++ b/src/widgets/places/places.ts
@@ -2,7 +2,10 @@ import {
   StaticOptions,
   ChangeEvent,
   PlacesInstance,
-  ReconfigurableOptions,
+  // no comma, TS is particular about which nodes expose comments
+  // eslint-disable-next-line prettier/prettier
+  ReconfigurableOptions
+  /** @ts-ignore places is only a peer dependency */
 } from 'places.js';
 import { WidgetFactory } from '../../types';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2194,28 +2194,29 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@microsoft/api-extractor-model@7.7.11":
-  version "7.7.11"
-  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor-model/-/api-extractor-model-7.7.11.tgz#9dfc5425f4a6a2b6b1ebc39332ae8101ab8da36a"
-  integrity sha512-Kf3RytYDq7sP4ASaaA9IcvaOPbVj1Xj34E2Wxd9DznI7sG4HzcpoOGmxaZHCzyYVh7wfAaAlvcXf3SV+djhNZw==
+"@microsoft/api-extractor-model@7.8.12":
+  version "7.8.12"
+  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor-model/-/api-extractor-model-7.8.12.tgz#d089193ef29275b8b20802498c6bdfab80dcef59"
+  integrity sha512-lE9xcNStS2hf5K+ZQy4L9DQ9Xd62bNsMqW+SyPQWXuQ5HJqUBSXJ2yxCWXP/+rcAkFCvZrikbql9M8Z88nKvwQ==
   dependencies:
     "@microsoft/tsdoc" "0.12.19"
-    "@rushstack/node-core-library" "3.19.7"
+    "@rushstack/node-core-library" "3.25.0"
 
-"@microsoft/api-extractor@7.7.13":
-  version "7.7.13"
-  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor/-/api-extractor-7.7.13.tgz#7ee70978825a36d294d26e50b5d888ca3789d1b0"
-  integrity sha512-7+EGunGd7OSfDxZl4aDI4qMWG98+I84vTryNadti+IfgpB9IyhJtgA4r3dCG7hewTwKACBhi5aPqpH2C7l/30A==
+"@microsoft/api-extractor@7.9.2":
+  version "7.9.2"
+  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor/-/api-extractor-7.9.2.tgz#3bb8c93f4280fcb94171e4214d714e1639f4fbd4"
+  integrity sha512-R4b3zXlYdicoS8bRLXEChTKLPyhUHrG1cb0GDtOX0zdoxlovU1p0JaPt97A/vC7N3Gm2E8gd2qsDWElKU3/wKQ==
   dependencies:
-    "@microsoft/api-extractor-model" "7.7.11"
+    "@microsoft/api-extractor-model" "7.8.12"
     "@microsoft/tsdoc" "0.12.19"
-    "@rushstack/node-core-library" "3.19.7"
-    "@rushstack/ts-command-line" "4.3.14"
+    "@rushstack/node-core-library" "3.25.0"
+    "@rushstack/ts-command-line" "4.4.6"
     colors "~1.2.1"
     lodash "~4.17.15"
-    resolve "1.8.1"
+    resolve "~1.17.0"
+    semver "~7.3.0"
     source-map "~0.6.1"
-    typescript "~3.7.2"
+    typescript "~3.9.5"
 
 "@microsoft/tsdoc@0.12.19":
   version "0.12.19"
@@ -2371,25 +2372,25 @@
     react-lifecycles-compat "^3.0.4"
     warning "^3.0.0"
 
-"@rushstack/node-core-library@3.19.7":
-  version "3.19.7"
-  resolved "https://registry.yarnpkg.com/@rushstack/node-core-library/-/node-core-library-3.19.7.tgz#8d8a193fd6f99536c92dd797ab50fd5fcb7630ea"
-  integrity sha512-gKE/OXH5GAj8yJ1kEyRW68UekJernilZ3QTRgmQ0MUHBCQmtZ9Q6T5PQ1sVbcL4teH8BMdpZeFy1DKnHs8h3PA==
+"@rushstack/node-core-library@3.25.0":
+  version "3.25.0"
+  resolved "https://registry.yarnpkg.com/@rushstack/node-core-library/-/node-core-library-3.25.0.tgz#ba40bc1b188ab5d31f5705999cd2b3b56b8a32cf"
+  integrity sha512-e2NCFtAu/eu14b8nlzRX6ZrE9Sb3J2wVt+pninQmTn/IgfnRLAtM0D4PzUO4+ktZwF9fCnpqrOGokLzw6RSVNw==
   dependencies:
     "@types/node" "10.17.13"
     colors "~1.2.1"
     fs-extra "~7.0.1"
     jju "~1.4.0"
-    semver "~5.3.0"
+    semver "~7.3.0"
     timsort "~0.3.0"
     z-schema "~3.18.3"
 
-"@rushstack/ts-command-line@4.3.14":
-  version "4.3.14"
-  resolved "https://registry.yarnpkg.com/@rushstack/ts-command-line/-/ts-command-line-4.3.14.tgz#5d7a437d4e9c564ff1b8e876215fca96c74858a1"
-  integrity sha512-YJZIyKvkm3f6ZdKSfMntHS9542Y2mmMWzaiPPoXxLFZntKxEIDE3WfUNlvOSo3yK4fNd09Tz3hfvTivQNHSiKQ==
+"@rushstack/ts-command-line@4.4.6":
+  version "4.4.6"
+  resolved "https://registry.yarnpkg.com/@rushstack/ts-command-line/-/ts-command-line-4.4.6.tgz#7818f19e444274e68564a756ef62a2b4e0ced0f8"
+  integrity sha512-ue3p2m773Yea/s4Ef2Q3gEyLd9T0NDjXCl+PlodGTrJHgxoiRwbROSWHAdYJL/LceGWa6Biqizu9qxUDEWFweQ==
   dependencies:
-    "@types/argparse" "1.0.33"
+    "@types/argparse" "1.0.38"
     argparse "~1.0.9"
     colors "~1.2.1"
 
@@ -2808,10 +2809,10 @@
     traverse "^0.6.6"
     unified "^6.1.6"
 
-"@types/argparse@1.0.33":
-  version "1.0.33"
-  resolved "https://registry.yarnpkg.com/@types/argparse/-/argparse-1.0.33.tgz#2728669427cdd74a99e53c9f457ca2866a37c52d"
-  integrity sha512-VQgHxyPMTj3hIlq9SY1mctqx+Jj8kpQfoLvDlVSDNOyuYs8JYfkuY3OW/4+dO657yPmNhHpePRx0/Tje5ImNVQ==
+"@types/argparse@1.0.38":
+  version "1.0.38"
+  resolved "https://registry.yarnpkg.com/@types/argparse/-/argparse-1.0.38.tgz#a81fd8606d481f873a3800c6ebae4f1d768a56a9"
+  integrity sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==
 
 "@types/babel__core@^7.1.0":
   version "7.1.3"
@@ -11541,7 +11542,7 @@ path-key@^3.0.0, path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-path-parse@^1.0.5, path-parse@^1.0.6:
+path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
@@ -12851,13 +12852,6 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
-  integrity sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==
-  dependencies:
-    path-parse "^1.0.5"
-
 resolve@^1.1.6, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.3.2, resolve@^1.5.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
@@ -12869,6 +12863,13 @@ resolve@^1.14.2:
   version "1.14.2"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.14.2.tgz#dbf31d0fa98b1f29aa5169783b9c290cb865fea2"
   integrity sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==
+  dependencies:
+    path-parse "^1.0.6"
+
+resolve@~1.17.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
+  integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
   dependencies:
     path-parse "^1.0.6"
 
@@ -13234,10 +13235,10 @@ semver@^7.1.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.1.tgz#29104598a197d6cbe4733eeecbe968f7b43a9667"
   integrity sha512-WfuG+fl6eh3eZ2qAf6goB7nhiCd7NPXhmyFxigB/TOkQyeLP8w8GsVehvtGNtnNmyboz4TgeK40B1Kbql/8c5A==
 
-semver@~5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
-  integrity sha1-myzl094C0XxgEq0yaqa00M9U+U8=
+semver@~7.3.0:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
+  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
 send@0.17.1:
   version "0.17.1"
@@ -14654,15 +14655,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.7.5, typescript@~3.7.2:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
-  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
-typescript@^3.5.3:
-  version "3.6.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.3.tgz#fea942fabb20f7e1ca7164ff626f1a9f3f70b4da"
-  integrity sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==
+typescript@^3.5.3, typescript@~3.9.5:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 ua-parser-js@^0.7.18:
   version "0.7.20"


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

This PR fixes some miscellaneous typescript issues discovered in angular instantsearch


**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->


- if JS client v3 is used, it's imperative that the ts-ignore comments stay present, since not the same exports are used. Solution is to double-annotate to keep the multi-line version in exposed to the d.ts (see e.g. https://github.com/microsoft/TypeScript/issues/39520)
- similar in places.js
- when updating TypeScript, I found that api-extractor can't deal with `import()` types, so those have to be transformed
- fix stricter behaviour of tranformItems in hitsPerPage (we send the user the "render" values, not the one they entered)
- SpeechRecognitionError is no longer exported in lib.d.ts, and is a generic Event now
- updated Typescript to 3.8.3. I've tried 3.9.2 as well, but that has a bug with `function()` (transforms to `(arg:any) => ;` instead of `(arg:any) => any;`). I didn't open a TS issue for it, since it's fixed in v4 which we can migrate to later

