### PR TITLE
fix(configureRelatedItems): support nested attributes

### DIFF
--- a/src/connectors/configure-related-items/__tests__/connectConfigureRelatedItems-test.ts
+++ b/src/connectors/configure-related-items/__tests__/connectConfigureRelatedItems-test.ts
@@ -137,6 +137,43 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure-r
       ]);
     });
 
+    test('sets the optionalFilters search parameter based on matchingPatterns with nested attributes', () => {
+      const searchClient = createSearchClient();
+      const search = instantsearch({
+        indexName: 'indexName',
+        searchClient,
+      });
+      const configureRelatedItems = connectConfigureRelatedItems(noop);
+
+      search.addWidgets([
+        configureRelatedItems({
+          hit,
+          matchingPatterns: {
+            brand: { score: 3 },
+            'hierarchicalCategories.lvl0': { score: 2 },
+          },
+        }),
+      ]);
+      search.start();
+
+      expect(searchClient.search).toHaveBeenCalledTimes(1);
+      expect(searchClient.search).toHaveBeenCalledWith([
+        {
+          indexName: 'indexName',
+          params: {
+            facets: [],
+            facetFilters: ['objectID:-1'],
+            tagFilters: '',
+            sumOrFiltersScores: true,
+            optionalFilters: [
+              'brand:Amazon<score=3>',
+              'hierarchicalCategories.lvl0:TV & Home Theater<score=2>',
+            ],
+          },
+        },
+      ]);
+    });
+
     test('sets transformed search parameters based on transformSearchParameters', () => {
       const searchClient = createSearchClient();
       const search = instantsearch({

--- a/src/connectors/configure-related-items/connectConfigureRelatedItems.ts
+++ b/src/connectors/configure-related-items/connectConfigureRelatedItems.ts
@@ -7,6 +7,7 @@ import {
   createDocumentationMessageGenerator,
   getObjectType,
   warning,
+  getPropertyByPath,
 } from '../../lib/utils';
 import connectConfigure, {
   ConfigureRendererOptions,
@@ -79,7 +80,7 @@ const connectConfigureRelatedItems: ConfigureRelatedItemsConnector = function co
       Array<string | string[]>
     >((acc, attributeName) => {
       const attribute = matchingPatterns[attributeName];
-      const attributeValue = hit[attributeName];
+      const attributeValue = getPropertyByPath(hit, attributeName);
       const attributeScore = attribute.score;
 
       if (Array.isArray(attributeValue)) {


### PR DESCRIPTION
This brings support for nested attributes in the [`configureRelatedItems`](https://www.algolia.com/doc/api-reference/widgets/configure-related-items/js/) widget.

## Description

Previously, an attribute like `hierarchicalCategories.lvl0` was considered as non-existant because we were accessing it as `hit[hierarchicalCategories.lvl0]`. We now access it with our `getPropertyByPath` which correctly picks up the attribute.

## Next steps

Implement the same fix in React InstantSearch.

## Related

- [Slack message](https://algolia.slack.com/archives/C2XP6HBKQ/p1597715211006100)