### PR TITLE
fix(searchBox): pass "spellcheck" property correctly to input

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
     'new-cap': [
       'error',
       {
-        capIsNewException: [
+        capIsNewExceptions: [
           'EXPERIMENTAL_use',
           'EXPERIMENTAL_connectConfigureRelatedItems',
           'EXPERIMENTAL_configureRelatedItems',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,25 +2,20 @@ module.exports = {
   extends: ['algolia', 'algolia/jest', 'algolia/react', 'algolia/typescript'],
   plugins: ['react-hooks'],
   rules: {
-    'no-param-reassign': 0,
-    'import/no-extraneous-dependencies': 0,
+    'no-param-reassign': 'off',
+    'import/no-extraneous-dependencies': 'off',
     'new-cap': [
       'error',
       {
-        capIsNewExceptions: [
-          'EXPERIMENTAL_use',
-          'EXPERIMENTAL_configureRelatedItems',
-          'EXPERIMENTAL_connectConfigureRelatedItems',
-        ],
+        capIsNewExceptionPattern: '^EXPERIMENTAL_*',
       },
     ],
-    'react/no-string-refs': 1,
-    'react/no-unknown-property': [2, { ignore: ['spellcheck'] }],
+    'react/no-string-refs': 'error',
     // Avoid errors about `UNSAFE` lifecycles (e.g. `UNSAFE_componentWillMount`)
-    'react/no-deprecated': 0,
+    'react/no-deprecated': 'off',
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'warn',
-    'jest/no-test-callback': 0,
+    'jest/no-test-callback': 'off',
     '@typescript-eslint/no-unused-vars': [
       'error',
       { argsIgnorePattern: '^_', ignoreRestSiblings: true },
@@ -41,7 +36,7 @@ module.exports = {
     {
       files: ['*.ts', '*.tsx'],
       rules: {
-        'valid-jsdoc': 0,
+        'valid-jsdoc': 'off',
       },
     },
   ],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
       },
     ],
     'react/no-string-refs': 1,
+    'react/no-unknown-property': [2, { ignore: ['spellcheck'] }],
     // Avoid errors about `UNSAFE` lifecycles (e.g. `UNSAFE_componentWillMount`)
     'react/no-deprecated': 0,
     'react-hooks/rules-of-hooks': 'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,11 @@ module.exports = {
     'new-cap': [
       'error',
       {
-        capIsNewExceptionPattern: '^EXPERIMENTAL_*',
+        capIsNewException: [
+          'EXPERIMENTAL_use',
+          'EXPERIMENTAL_connectConfigureRelatedItems',
+          'EXPERIMENTAL_configureRelatedItems',
+        ],
       },
     ],
     'react/no-string-refs': 'error',

--- a/src/components/RefinementList/__tests__/__snapshots__/RefinementList-test.js.snap
+++ b/src/components/RefinementList/__tests__/__snapshots__/RefinementList-test.js.snap
@@ -104,6 +104,7 @@ exports[`RefinementList rendering with facets from search 1`] = `
             class="input"
             maxlength="512"
             placeholder="Search"
+            spellcheck="false"
             type="search"
           />
           <button
@@ -180,6 +181,7 @@ exports[`RefinementList rendering without facets from search 1`] = `
             class="input"
             maxlength="512"
             placeholder="Search"
+            spellcheck="false"
             type="search"
           />
           <button

--- a/src/components/SearchBox/SearchBox.js
+++ b/src/components/SearchBox/SearchBox.js
@@ -159,7 +159,7 @@ class SearchBox extends Component {
             autoComplete="off"
             autoCorrect="off"
             autoCapitalize="off"
-            spellcheck={false}
+            spellCheck="false"
             maxLength={512}
             onInput={this.onInput}
             onBlur={this.onBlur}

--- a/src/components/SearchBox/SearchBox.js
+++ b/src/components/SearchBox/SearchBox.js
@@ -159,7 +159,7 @@ class SearchBox extends Component {
             autoComplete="off"
             autoCorrect="off"
             autoCapitalize="off"
-            spellCheck={false}
+            spellcheck={false}
             maxLength={512}
             onInput={this.onInput}
             onBlur={this.onBlur}

--- a/src/components/SearchBox/__tests__/SearchBox-test.js
+++ b/src/components/SearchBox/__tests__/SearchBox-test.js
@@ -438,6 +438,20 @@ describe('SearchBox', () => {
       expect(mount(<SearchBox {...defaultProps} />)).toMatchSnapshot();
     });
 
+    test('sets autocorrect... properties', () => {
+      const res = render(
+        <SearchBox {...defaultProps} autofocus={true} query="sample query" />
+      );
+      const input = res.getByDisplayValue('sample query');
+
+      expect(input.getAttribute('autofocus')).toBe('true');
+      expect(input.getAttribute('autocomplete')).toBe('off');
+      expect(input.getAttribute('autocorrect')).toBe('off');
+      expect(input.getAttribute('autocapitalize')).toBe('off');
+      expect(input.getAttribute('spellcheck')).toBe('false');
+      expect(input.getAttribute('maxlength')).toBe('512');
+    });
+
     test('with custom templates', () => {
       const props = {
         ...defaultProps,

--- a/src/components/SearchBox/__tests__/SearchBox-test.js
+++ b/src/components/SearchBox/__tests__/SearchBox-test.js
@@ -438,18 +438,18 @@ describe('SearchBox', () => {
       expect(mount(<SearchBox {...defaultProps} />)).toMatchSnapshot();
     });
 
-    test('sets autocorrect... properties', () => {
+    test('sets search input attributes', () => {
       const res = render(
         <SearchBox {...defaultProps} autofocus={true} query="sample query" />
       );
       const input = res.getByDisplayValue('sample query');
 
-      expect(input.getAttribute('autofocus')).toBe('true');
-      expect(input.getAttribute('autocomplete')).toBe('off');
-      expect(input.getAttribute('autocorrect')).toBe('off');
-      expect(input.getAttribute('autocapitalize')).toBe('off');
-      expect(input.getAttribute('spellcheck')).toBe('false');
-      expect(input.getAttribute('maxlength')).toBe('512');
+      expect(input).toHaveAttribute('autofocus', 'true');
+      expect(input).toHaveAttribute('autocomplete', 'off');
+      expect(input).toHaveAttribute('autocorrect', 'off');
+      expect(input).toHaveAttribute('autocapitalize', 'off');
+      expect(input).toHaveAttribute('spellcheck', 'false');
+      expect(input).toHaveAttribute('maxlength', '512');
     });
 
     test('with custom templates', () => {

--- a/src/components/SearchBox/__tests__/__snapshots__/SearchBox-test.js.snap
+++ b/src/components/SearchBox/__tests__/__snapshots__/SearchBox-test.js.snap
@@ -25,7 +25,7 @@ Array [
         onFocus={[Function]}
         onInput={[Function]}
         placeholder=""
-        spellCheck={false}
+        spellcheck={false}
         type="search"
         value=""
       />
@@ -96,7 +96,7 @@ Array [
         onFocus={[Function]}
         onInput={[Function]}
         placeholder=""
-        spellCheck={false}
+        spellcheck={false}
         type="search"
         value=""
       />

--- a/src/components/SearchBox/__tests__/__snapshots__/SearchBox-test.js.snap
+++ b/src/components/SearchBox/__tests__/__snapshots__/SearchBox-test.js.snap
@@ -25,7 +25,7 @@ Array [
         onFocus={[Function]}
         onInput={[Function]}
         placeholder=""
-        spellcheck={false}
+        spellCheck="false"
         type="search"
         value=""
       />
@@ -96,7 +96,7 @@ Array [
         onFocus={[Function]}
         onInput={[Function]}
         placeholder=""
-        spellcheck={false}
+        spellCheck="false"
         type="search"
         value=""
       />


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

React and Preact differ slightly in how they pass attributes / properties. Therefore it seems like the correct value (although https://github.com/preactjs/preact/issues/485 says otherwise, that must have changed in preact X). This was causing `spellcheck` not to be applied.

see: https://github.com/preactjs/preact/blob/020d5e599b8b84745932f092a835f494b1dd2261/src/jsx.d.ts#L711

ref: https://discourse.algolia.com/t/how-to-add-spellcheck-property-to-search-box-widget/10741

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

The `spellcheck` property is actually on the dom node for input.

I have checked, and the other properties on the input are present.
