### PR TITLE
fix(bundlesize): remove prop-type imports

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -26,7 +26,13 @@ module.exports = api => {
   const buildPlugins = clean([
     '@babel/plugin-proposal-class-properties',
     '@babel/plugin-transform-react-constant-elements',
-    'babel-plugin-transform-react-remove-prop-types',
+    [
+      'babel-plugin-transform-react-remove-prop-types',
+      {
+        mode: 'remove',
+        removeImport: true,
+      },
+    ],
     'babel-plugin-transform-react-pure-class-to-function',
     wrapWarningWithDevCheck,
     (isCJS || isES) && [


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

While the prop-type values were removed, the package itself wasn't removed

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

removed the `prop-types` package import as well

bundle size pre:

```
 PASS  ./dist/instantsearch.production.min.js: 63.84KB < maxSize 64KB (gzip)

 PASS  ./dist/instantsearch.development.js: 148.86KB < maxSize 160KB (gzip)
 ```

 bundlesize post:

 ```
 PASS  ./dist/instantsearch.production.min.js: 62.39KB < maxSize 64KB (gzip)

 PASS  ./dist/instantsearch.development.js: 146.19KB < maxSize 160KB (gzip)
 ```

The change is 1.45KB or 2% of our size (in production)

I inspected the built files thoroughly, and apart from 1041 other rename changes (because minified), the only change is that the `prop-types` code base no longer was present.
