### PR TITLE
feat(routing): introduce stateMappings.singleIndexQ for compatibility with v2

### DIFF
--- a/src/lib/stateMappings/__tests__/singleIndexQ-test.ts
+++ b/src/lib/stateMappings/__tests__/singleIndexQ-test.ts
@@ -1,0 +1,215 @@
+import singleIndexQStateMapping from '../singleIndexQ';
+
+describe('singleIndexQStateMapping', () => {
+  describe('stateToRoute', () => {
+    it('passes normal state through', () => {
+      const stateMapping = singleIndexQStateMapping('indexName');
+      const actual = stateMapping.stateToRoute({
+        indexName: {
+          query: 'zamboni',
+          refinementList: {
+            color: ['red'],
+          },
+        },
+      });
+
+      expect(actual).toEqual({
+        q: 'zamboni',
+        refinementList: {
+          color: ['red'],
+        },
+      });
+    });
+
+    it('removes configure', () => {
+      const stateMapping = singleIndexQStateMapping('indexName');
+      const actual = stateMapping.stateToRoute({
+        indexName: {
+          query: 'zamboni',
+          refinementList: {
+            color: ['red'],
+          },
+          configure: {
+            advancedSyntax: false,
+          },
+        },
+      });
+
+      expect(actual).toEqual({
+        q: 'zamboni',
+        refinementList: {
+          color: ['red'],
+        },
+      });
+    });
+
+    it('passes non-UiState through', () => {
+      const stateMapping = singleIndexQStateMapping('indexName');
+      const actual = stateMapping.stateToRoute({
+        indexName: {
+          query: 'zamboni',
+          refinementList: {
+            color: ['red'],
+          },
+          // @ts-ignore
+          spy: ['stealing', 'all', 'your', 'searches'],
+        },
+      });
+
+      expect(actual).toEqual({
+        q: 'zamboni',
+        refinementList: {
+          color: ['red'],
+        },
+        spy: ['stealing', 'all', 'your', 'searches'],
+      });
+    });
+
+    it('picks the correct index', () => {
+      const stateMapping = singleIndexQStateMapping('indexName');
+      const actual = stateMapping.stateToRoute({
+        indexName: {
+          query: 'zamboni',
+          refinementList: {
+            color: ['red'],
+          },
+        },
+        anotherIndex: {
+          // @ts-ignore
+          totally: 'ignored',
+          refinementList: {
+            color: ['blue'],
+          },
+        },
+      });
+
+      expect(actual).toEqual({
+        q: 'zamboni',
+        refinementList: {
+          color: ['red'],
+        },
+      });
+    });
+
+    it('empty object if there is no matching index', () => {
+      const stateMapping = singleIndexQStateMapping('magicIndex');
+      const actual = stateMapping.stateToRoute({
+        indexName: {
+          query: 'zamboni',
+          refinementList: {
+            color: ['red'],
+          },
+        },
+        anotherIndex: {
+          // @ts-ignore
+          totally: 'ignored',
+          refinementList: {
+            color: ['blue'],
+          },
+        },
+      });
+
+      expect(actual).toEqual({});
+    });
+  });
+
+  describe('routeToState', () => {
+    it('passes normal state through', () => {
+      const stateMapping = singleIndexQStateMapping('indexName');
+      const actual = stateMapping.routeToState({
+        q: 'zamboni',
+        refinementList: {
+          color: ['red'],
+        },
+      });
+
+      expect(actual).toEqual({
+        indexName: {
+          query: 'zamboni',
+          refinementList: {
+            color: ['red'],
+          },
+        },
+      });
+    });
+
+    it('removes configure', () => {
+      const stateMapping = singleIndexQStateMapping('indexName');
+      const actual = stateMapping.routeToState({
+        q: 'zamboni',
+        refinementList: {
+          color: ['red'],
+        },
+        configure: {
+          advancedSyntax: false,
+        },
+      });
+
+      expect(actual).toEqual({
+        indexName: {
+          query: 'zamboni',
+          refinementList: {
+            color: ['red'],
+          },
+        },
+      });
+    });
+
+    it('passes non-UiState through', () => {
+      const stateMapping = singleIndexQStateMapping('indexName');
+      const actual = stateMapping.routeToState({
+        q: 'zamboni',
+        refinementList: {
+          color: ['red'],
+        },
+        // @ts-ignore
+        spy: ['stealing', 'all', 'your', 'searches'],
+      });
+
+      expect(actual).toEqual({
+        indexName: {
+          query: 'zamboni',
+          refinementList: {
+            color: ['red'],
+          },
+          spy: ['stealing', 'all', 'your', 'searches'],
+        },
+      });
+    });
+
+    it('returns wrong data if used with nested state', () => {
+      const stateMapping = singleIndexQStateMapping('indexName');
+      const actual = stateMapping.routeToState({
+        // @ts-ignore (we are passing wrong data)
+        indexName: {
+          query: 'zamboni',
+          refinementList: {
+            color: ['red'],
+          },
+        },
+        anotherIndex: {},
+      });
+
+      expect(actual).toEqual({
+        indexName: {
+          indexName: {
+            query: 'zamboni',
+            refinementList: {
+              color: ['red'],
+            },
+          },
+          anotherIndex: {},
+        },
+      });
+    });
+
+    it('keeps empty index empty', () => {
+      const stateMapping = singleIndexQStateMapping('indexName');
+      const actual = stateMapping.routeToState({});
+
+      expect(actual).toEqual({
+        indexName: {},
+      });
+    });
+  });
+});

--- a/src/lib/stateMappings/index.ts
+++ b/src/lib/stateMappings/index.ts
@@ -1,2 +1,3 @@
 export { default as simple } from './simple';
 export { default as singleIndex } from './singleIndex';
+export { default as singleIndexQ } from './singleIndexQ';

--- a/src/lib/stateMappings/singleIndexQ.ts
+++ b/src/lib/stateMappings/singleIndexQ.ts
@@ -1,0 +1,31 @@
+import { StateMapping, IndexUiState } from 'instantsearch.js/es/types';
+
+function getIndexStateWithoutConfigure(uiState: IndexUiState): IndexUiState {
+  const { configure, ...trackedUiState } = uiState;
+  return trackedUiState;
+}
+
+export default function singleIndexQStateMapping(
+  indexName: string
+): StateMapping {
+  return {
+    stateToRoute(uiState) {
+      let state = uiState[indexName] || {};
+      if (state.query) {
+        state.q = state.query;
+        delete state.query;
+      }
+      return getIndexStateWithoutConfigure(state);
+    },
+    routeToState(routeState = {}) {
+      let state = routeState;
+      if (state.q) {
+        state.query = state.q;
+        delete state.q;
+      }
+      return {
+        [indexName]: getIndexStateWithoutConfigure(state),
+      };
+    },
+  };
+}


### PR DESCRIPTION
**Summary**

In instantsearch.js v2, a developer was able to use `q` as a querystring parameter key by enabling `urlSync`.

This PR provides `q` querystring key instead of `query` with usage of `singleIndexQ`.
This feature helps developers update instantsearch.js from v2 to the latest (v4).

cf. singleIndex: https://www.algolia.com/doc/api-reference/widgets/single-index-state-mapping/js/

**Result**

Demo: http://715-update-instantsearch-to-4-7-1.178.62.207.141.nip.io/search/?q=helm

Demo code: https://gitlab.com/gitlab-org/gitlab-docs/-/merge_requests/1096

While documentation has not updated yet, it will be done when the feature is approved.