### PR TITLE
fix(hitsPerPage): update link to hitsPerPage widget

### DIFF
--- a/src/connectors/hits-per-page/connectHitsPerPage.ts
+++ b/src/connectors/hits-per-page/connectHitsPerPage.ts
@@ -160,7 +160,7 @@ const connectHitsPerPage: HitsPerPageConnector = function connectHitsPerPage(
 \`hitsPerPage\` is not defined.
 The option \`hitsPerPage\` needs to be set using the \`configure\` widget.
 
-Learn more: https://community.algolia.com/instantsearch.js/v2/widgets/configure.html
+Learn more: https://www.algolia.com/doc/api-reference/widgets/hits-per-page/js/
             `
           );
 


### PR DESCRIPTION
**Summary**

Replaces a link to the docs on the old website with one on the new one.

**Result**

A developer would see v4 docs instead of v2.