### PR TITLE
fix(insights): fix the regression that it didn't send events with instantsearch.insights()

### DIFF
--- a/src/lib/insights/listener.tsx
+++ b/src/lib/insights/listener.tsx
@@ -58,7 +58,9 @@ const insightsListener = (BaseComponent: any) => {
           const payload = parseInsightsEvent(targetWithEvent);
           props.sendEvent(payload);
         }
-      } else {
+      }
+
+      {
         // old way, e.g. instantsearch.insights("clickedObjectIDsAfterSearch", { .. })
         const insightsTarget = findInsightsTarget(
           event.target as HTMLElement | null,

--- a/src/lib/insights/listener.tsx
+++ b/src/lib/insights/listener.tsx
@@ -60,17 +60,15 @@ const insightsListener = (BaseComponent: any) => {
         }
       }
 
-      {
-        // old way, e.g. instantsearch.insights("clickedObjectIDsAfterSearch", { .. })
-        const insightsTarget = findInsightsTarget(
-          event.target as HTMLElement | null,
-          event.currentTarget as HTMLElement | null,
-          element => hasDataAttributes(element)
-        );
-        if (insightsTarget) {
-          const { method, payload } = readDataAttributes(insightsTarget);
-          props.insights(method, payload);
-        }
+      // old way, e.g. instantsearch.insights("clickedObjectIDsAfterSearch", { .. })
+      const insightsTarget = findInsightsTarget(
+        event.target as HTMLElement | null,
+        event.currentTarget as HTMLElement | null,
+        element => hasDataAttributes(element)
+      );
+      if (insightsTarget) {
+        const { method, payload } = readDataAttributes(insightsTarget);
+        props.insights(method, payload);
       }
     };
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR fixes the regression introduced since 4.8.0 where InstantSearch didn't send Insights events implemented with `instantsearch.insights()` in `hits` or `infiniteHits` widgets.

**Result**

It sends events now.

**Test**
If you run this [example ->](https://codesandbox.io/s/throbbing-worker-5or8z?file=/src/app.js), it will correctly send events when you click buttons. However if you change the version of InstantSearch to 4.8.0, it won't any more.