### PR TITLE
fix(refinementList): cap `maxFacetHits` to 100 for SFFV

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     },
     {
       "path": "./dist/instantsearch.development.js",
-      "maxSize": "150.45 kB"
+      "maxSize": "160 kB"
     }
   ]
 }

--- a/src/connectors/refinement-list/connectRefinementList.js
+++ b/src/connectors/refinement-list/connectRefinementList.js
@@ -249,7 +249,15 @@ export default function connectRefinementList(renderFn, unmountFn = noop) {
         };
 
         helper
-          .searchForFacetValues(attribute, query, getLimit(isShowingMore), tags)
+          .searchForFacetValues(
+            attribute,
+            query,
+            // We cap the `maxFacetHits` value to 100 because the Algolia API
+            // doesn't support a greater number.
+            // See https://www.algolia.com/doc/api-reference/api-parameters/maxFacetHits/
+            Math.min(getLimit(isShowingMore), 100),
+            tags
+          )
           .then(results => {
             const facetValues = escapeFacetValues
               ? escapeFacets(results.facetHits)


### PR DESCRIPTION
We cap the [`maxFacetHits`](https://www.algolia.com/doc/api-reference/api-parameters/maxFacetHits/) value to 100 because the Algolia API doesn't support a greater number.

An Enterprise customer has faced this issue in Vue InstantSearch and it's challenging to fix user-land.

Closes #4521.