### PR TITLE
feat(hits): implement `getWidgetRenderState`

### DIFF
--- a/src/connectors/hits/__tests__/connectHits-test.ts
+++ b/src/connectors/hits/__tests__/connectHits-test.ts
@@ -444,6 +444,116 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
     expect(((results.hits as unknown) as EscapedHits).__escaped).toBe(true);
   });
 
+  describe('getRenderState', () => {
+    it('returns the render state', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const createHits = connectHits(renderFn, unmountFn);
+      const hitsWidget = createHits({});
+      const helper = algoliasearchHelper(createSearchClient(), 'indexName', {
+        index: 'indexName',
+      });
+
+      const renderState1 = hitsWidget.getRenderState(
+        {},
+        createInitOptions({ state: helper.state, helper })
+      );
+
+      expect(renderState1.hits).toEqual({
+        hits: [],
+        results: undefined,
+        widgetParams: {},
+      });
+
+      const hits = [
+        { objectID: '1', name: 'name 1' },
+        { objectID: '2', name: 'name 2' },
+      ];
+
+      const results = new SearchResults(helper.state, [
+        createSingleSearchResponse({ hits, queryID: 'theQueryID' }),
+      ]);
+
+      const renderState2 = hitsWidget.getRenderState(
+        {},
+        createRenderOptions({
+          helper,
+          state: helper.state,
+          results,
+        })
+      );
+
+      const expectedHits = [
+        { objectID: '1', name: 'name 1', __queryID: 'theQueryID' },
+        { objectID: '2', name: 'name 2', __queryID: 'theQueryID' },
+      ];
+
+      ((expectedHits as unknown) as EscapedHits).__escaped = true;
+
+      expect(renderState2.hits).toEqual(
+        expect.objectContaining({
+          hits: expectedHits,
+          results,
+          widgetParams: {},
+        })
+      );
+    });
+  });
+
+  describe('getWidgetRenderState', () => {
+    it('returns the widget render state', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const createHits = connectHits(renderFn, unmountFn);
+      const hitsWidget = createHits({});
+      const helper = algoliasearchHelper(createSearchClient(), 'indexName', {
+        index: 'indexName',
+      });
+
+      const renderState1 = hitsWidget.getWidgetRenderState(
+        createInitOptions({ state: helper.state, helper })
+      );
+
+      expect(renderState1).toEqual({
+        hits: [],
+        results: undefined,
+        widgetParams: {},
+      });
+
+      const hits = [
+        { objectID: '1', name: 'name 1' },
+        { objectID: '2', name: 'name 2' },
+      ];
+
+      const results = new SearchResults(helper.state, [
+        createSingleSearchResponse({ hits, queryID: 'theQueryID' }),
+      ]);
+
+      const renderState2 = hitsWidget.getWidgetRenderState(
+        createRenderOptions({
+          helper,
+          state: helper.state,
+          results,
+        })
+      );
+
+      const expectedHits = [
+        { objectID: '1', name: 'name 1', __queryID: 'theQueryID' },
+        { objectID: '2', name: 'name 2', __queryID: 'theQueryID' },
+      ];
+
+      ((expectedHits as unknown) as EscapedHits).__escaped = true;
+
+      expect(renderState2).toEqual(
+        expect.objectContaining({
+          hits: expectedHits,
+          results,
+          widgetParams: {},
+        })
+      );
+    });
+  });
+
   describe('getWidgetSearchParameters', () => {
     it('adds the TAG_PLACEHOLDER to the `SearchParameters`', () => {
       const render = () => {};

--- a/src/connectors/hits/connectHits.ts
+++ b/src/connectors/hits/connectHits.ts
@@ -55,19 +55,42 @@ const connectHits: HitsConnector = function connectHits(
     return {
       $$type: 'ais.hits',
 
-      init({ instantSearchInstance }) {
+      init(initOptions) {
         renderFn(
           {
-            hits: [],
-            results: undefined,
-            instantSearchInstance,
-            widgetParams,
+            ...this.getWidgetRenderState(initOptions),
+            instantSearchInstance: initOptions.instantSearchInstance,
           },
           true
         );
       },
 
-      render({ results, instantSearchInstance }) {
+      render(renderOptions) {
+        renderFn(
+          {
+            ...this.getWidgetRenderState(renderOptions),
+            instantSearchInstance: renderOptions.instantSearchInstance,
+          },
+          false
+        );
+      },
+
+      getRenderState(renderState, renderOptions) {
+        return {
+          ...renderState,
+          hits: this.getWidgetRenderState(renderOptions),
+        };
+      },
+
+      getWidgetRenderState({ results }) {
+        if (!results) {
+          return {
+            hits: [],
+            results: undefined,
+            widgetParams,
+          };
+        }
+
         if (escapeHTML && results.hits.length > 0) {
           results.hits = escapeHits(results.hits);
         }
@@ -92,15 +115,11 @@ const connectHits: HitsConnector = function connectHits(
           typeof escapeHits
         >).__escaped = initialEscaped;
 
-        renderFn(
-          {
-            hits: results.hits,
-            results,
-            instantSearchInstance,
-            widgetParams,
-          },
-          false
-        );
+        return {
+          hits: results.hits,
+          results,
+          widgetParams,
+        };
       },
 
       dispose({ state }) {

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -26,6 +26,10 @@ import {
   CurrentRefinementsRendererOptions,
   CurrentRefinementsConnectorParams,
 } from '../connectors/current-refinements/connectCurrentRefinements';
+import {
+  HitsRendererOptions,
+  HitsConnectorParams,
+} from '../connectors/hits/connectHits';
 
 export type ScopedResult = {
   indexId: string;
@@ -200,6 +204,7 @@ export type IndexRenderState = Partial<{
       }
     >;
   };
+  hits: WidgetRenderState<HitsRendererOptions, HitsConnectorParams>;
 }>;
 
 type WidgetRenderState<


### PR DESCRIPTION
This implements the `getWidgetRenderState` widget lifecycle hook in `hits`.