### PR TITLE
fix(infiniteHits): do not cache the cached hits inside the connector

### DIFF
--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -286,8 +286,8 @@ const connectInfiniteHits: InfiniteHitsConnector = function connectInfiniteHits(
         (results.hits as any).__escaped = initialEscaped;
 
         const cachedHits = cache.read({ state }) || {};
-        if (cachedHits![page] === undefined) {
-          cachedHits![page] = results.hits;
+        if (cachedHits[page] === undefined) {
+          cachedHits[page] = results.hits;
           cache.write({ state, hits: cachedHits });
         }
 
@@ -298,7 +298,7 @@ const connectInfiniteHits: InfiniteHitsConnector = function connectInfiniteHits(
 
         renderFn(
           {
-            hits: extractHitsFromCachedHits(cachedHits!),
+            hits: extractHitsFromCachedHits(cachedHits),
             results,
             sendEvent,
             bindEvent,

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -153,7 +153,6 @@ const connectInfiniteHits: InfiniteHitsConnector = function connectInfiniteHits(
       transformItems = (items: any[]) => items,
       cache = getInMemoryCache(),
     } = widgetParams || ({} as typeof widgetParams);
-    let prevState: Partial<SearchParameters>;
     let showPrevious: () => void;
     let showMore: () => void;
     let sendEvent;
@@ -232,37 +231,13 @@ const connectInfiniteHits: InfiniteHitsConnector = function connectInfiniteHits(
         // We're doing this to "reset" the widget if a refinement or the
         // query changes between renders, but we want to keep it as is
         // if we only change pages.
-        const {
-          page = 0,
-          facets,
-          hierarchicalFacets,
-          disjunctiveFacets,
-          maxValuesPerFacet,
-          ...currentState
-        } = state;
+        const { page = 0 } = state;
 
         if (!firstReceivedPage || page < firstReceivedPage) {
           firstReceivedPage = page;
         }
         if (!lastReceivedPage || lastReceivedPage < page) {
           lastReceivedPage = page;
-        }
-
-        currentState.facetsRefinements = filterEmptyRefinements(
-          currentState.facetsRefinements
-        );
-        currentState.hierarchicalFacetsRefinements = filterEmptyRefinements(
-          currentState.hierarchicalFacetsRefinements
-        );
-        currentState.disjunctiveFacetsRefinements = filterEmptyRefinements(
-          currentState.disjunctiveFacetsRefinements
-        );
-        currentState.numericRefinements = filterEmptyRefinements(
-          currentState.numericRefinements
-        );
-
-        if (!isEqual(currentState, prevState)) {
-          prevState = currentState;
         }
 
         if (escapeHTML && results.hits.length > 0) {

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -241,12 +241,6 @@ const connectInfiniteHits: InfiniteHitsConnector = function connectInfiniteHits(
       },
 
       render({ results, state, instantSearchInstance }) {
-        // Reset cache and received pages if anything changes in the
-        // search state, except for the page.
-        //
-        // We're doing this to "reset" the widget if a refinement or the
-        // query changes between renders, but we want to keep it as is
-        // if we only change pages.
         const { page = 0 } = state;
 
         if (escapeHTML && results.hits.length > 0) {

--- a/src/widgets/infinite-hits/__tests__/infinite-hits-integration-test.ts
+++ b/src/widgets/infinite-hits/__tests__/infinite-hits-integration-test.ts
@@ -78,7 +78,7 @@ describe('infiniteHits', () => {
       };
     }
 
-    it('calls read & write methods of custom cache', async () => {
+    it('writes to a custom cache', async () => {
       const { search } = createInstantSearch();
       const { customCache } = createCustomCache();
 
@@ -96,6 +96,23 @@ describe('infiniteHits', () => {
         ).length;
         expect(numberOfHits).toEqual(2);
       });
+      expect(customCache.write).toHaveBeenCalledTimes(1);
+      expect(customCache.write.mock.calls[0][0].hits).toMatchInlineSnapshot(`
+        Object {
+          "0": Array [
+            Object {
+              "__position": 1,
+              "objectID": "object-id0",
+              "title": "title 1",
+            },
+            Object {
+              "__position": 2,
+              "objectID": "object-id1",
+              "title": "title 2",
+            },
+          ],
+        }
+      `);
 
       fireEvent.click(getByText(container, 'Show more results'));
       await waitFor(() => {
@@ -104,9 +121,35 @@ describe('infiniteHits', () => {
         ).length;
         expect(numberOfHits).toEqual(4);
       });
-
-      expect(customCache.read).toHaveBeenCalledTimes(3); // init & render #0, render #1
-      expect(customCache.write).toHaveBeenCalledTimes(2); // page #0, page #1
+      expect(customCache.write).toHaveBeenCalledTimes(2);
+      expect(customCache.write.mock.calls[1][0].hits).toMatchInlineSnapshot(`
+Object {
+  "0": Array [
+    Object {
+      "__position": 1,
+      "objectID": "object-id0",
+      "title": "title 1",
+    },
+    Object {
+      "__position": 2,
+      "objectID": "object-id1",
+      "title": "title 2",
+    },
+  ],
+  "1": Array [
+    Object {
+      "__position": 3,
+      "objectID": "object-id0",
+      "title": "title 3",
+    },
+    Object {
+      "__position": 4,
+      "objectID": "object-id1",
+      "title": "title 4",
+    },
+  ],
+}
+`);
     });
 
     it('displays all the hits from cache', async () => {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR fixes an issue where `connectInfiniteHits` was caching the `cachedHits` internally. Even if the cache gets cleared, the connector cannot know it. It's an unnecessary double layer of caches.

fixes #4531 

**Result**

After the cache gets invalidated, the connect should read hits correctly from the results.

The following example works:
https://codesandbox.io/s/dreamy-forest-eofp6?file=/src/app.js