### PR TITLE
feat(range): implement `getRenderState` and `getWidgetRenderState`

### DIFF
--- a/src/connectors/range/__tests__/connectRange-test.js
+++ b/src/connectors/range/__tests__/connectRange-test.js
@@ -1196,19 +1196,21 @@ describe('getRenderState', () => {
     );
 
     expect(renderState1.range).toEqual({
-      format: {
-        from: expect.any(Function),
-        to: expect.any(Function),
-      },
-      range: {
-        max: 0,
-        min: 0,
-      },
-      refine: expect.any(Function),
-      start: [0, 1000],
-      widgetParams: {
-        attribute: 'price',
-        precision: 0,
+      price: {
+        format: {
+          from: expect.any(Function),
+          to: expect.any(Function),
+        },
+        range: {
+          max: 0,
+          min: 0,
+        },
+        refine: expect.any(Function),
+        start: [0, 1000],
+        widgetParams: {
+          attribute: 'price',
+          precision: 0,
+        },
       },
     });
 
@@ -1241,19 +1243,21 @@ describe('getRenderState', () => {
     );
 
     expect(renderState2.range).toEqual({
-      format: {
-        from: expect.any(Function),
-        to: expect.any(Function),
-      },
-      range: {
-        max: 30,
-        min: 10,
-      },
-      refine: expect.any(Function),
-      start: [0, 1000],
-      widgetParams: {
-        attribute: 'price',
-        precision: 0,
+      price: {
+        format: {
+          from: expect.any(Function),
+          to: expect.any(Function),
+        },
+        range: {
+          max: 30,
+          min: 10,
+        },
+        refine: expect.any(Function),
+        start: [0, 1000],
+        widgetParams: {
+          attribute: 'price',
+          precision: 0,
+        },
       },
     });
   });

--- a/src/connectors/range/__tests__/connectRange-test.js
+++ b/src/connectors/range/__tests__/connectRange-test.js
@@ -3,6 +3,12 @@ import jsHelper, {
   SearchParameters,
 } from 'algoliasearch-helper';
 import connectRange from '../connectRange';
+import {
+  createInitOptions,
+  createRenderOptions,
+} from '../../../../test/mock/createWidget';
+import { createSearchClient } from '../../../../test/mock/createSearchClient';
+import { createSingleSearchResponse } from '../../../../test/mock/createAPIResponse';
 
 describe('connectRange', () => {
   describe('Usage', () => {
@@ -1161,6 +1167,178 @@ describe('getWidgetUiState', () => {
       range: {
         age: '16:',
         price: '100:1000',
+      },
+    });
+  });
+});
+
+describe('getRenderState', () => {
+  it('returns the render state', () => {
+    const renderFn = jest.fn();
+    const unmountFn = jest.fn();
+    const createRange = connectRange(renderFn, unmountFn);
+    const rangeWidget = createRange({
+      attribute: 'price',
+    });
+    const helper = jsHelper(createSearchClient(), 'indexName', {
+      disjunctiveFacets: ['price'],
+      numericRefinements: {
+        price: {
+          '<=': [1000],
+          '>=': [0],
+        },
+      },
+    });
+
+    const renderState1 = rangeWidget.getRenderState(
+      {},
+      createInitOptions({ state: helper.state, helper })
+    );
+
+    expect(renderState1.range).toEqual({
+      format: {
+        from: expect.any(Function),
+        to: expect.any(Function),
+      },
+      range: {
+        max: 0,
+        min: 0,
+      },
+      refine: expect.any(Function),
+      start: [0, 1000],
+      widgetParams: {
+        attribute: 'price',
+        precision: 0,
+      },
+    });
+
+    const results = new SearchResults(helper.state, [
+      createSingleSearchResponse({
+        hits: [{ test: 'oneTime' }],
+        facets: { price: { 10: 1, 20: 1, 30: 1 } },
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        facets_stats: {
+          price: {
+            avg: 20,
+            max: 30,
+            min: 10,
+            sum: 60,
+          },
+        },
+        nbHits: 1,
+        nbPages: 1,
+        page: 0,
+      }),
+    ]);
+
+    const renderState2 = rangeWidget.getRenderState(
+      {},
+      createRenderOptions({
+        helper,
+        state: helper.state,
+        results,
+      })
+    );
+
+    expect(renderState2.range).toEqual({
+      format: {
+        from: expect.any(Function),
+        to: expect.any(Function),
+      },
+      range: {
+        max: 30,
+        min: 10,
+      },
+      refine: expect.any(Function),
+      start: [0, 1000],
+      widgetParams: {
+        attribute: 'price',
+        precision: 0,
+      },
+    });
+  });
+});
+
+describe('getWidgetRenderState', () => {
+  it('returns the widget render state', () => {
+    const renderFn = jest.fn();
+    const unmountFn = jest.fn();
+    const createRange = connectRange(renderFn, unmountFn);
+    const rangeWidget = createRange({
+      attribute: 'price',
+    });
+    const helper = jsHelper(createSearchClient(), 'indexName', {
+      disjunctiveFacets: ['price'],
+      numericRefinements: {
+        price: {
+          '<=': [1000],
+          '>=': [0],
+        },
+      },
+    });
+
+    const renderState1 = rangeWidget.getWidgetRenderState(
+      createInitOptions({ state: helper.state, helper })
+    );
+
+    expect(renderState1).toEqual({
+      format: {
+        from: expect.any(Function),
+        to: expect.any(Function),
+      },
+      range: {
+        max: 0,
+        min: 0,
+      },
+      refine: expect.any(Function),
+      start: [0, 1000],
+      widgetParams: {
+        attribute: 'price',
+        precision: 0,
+      },
+    });
+
+    const results = new SearchResults(helper.state, [
+      createSingleSearchResponse({
+        hits: [{ test: 'oneTime' }],
+        facets: { price: { 10: 1, 20: 1, 30: 1 } },
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        facets_stats: {
+          price: {
+            avg: 20,
+            max: 30,
+            min: 10,
+            sum: 60,
+          },
+        },
+        nbHits: 1,
+        nbPages: 1,
+        page: 0,
+      }),
+    ]);
+
+    const renderState2 = rangeWidget.getWidgetRenderState(
+      createRenderOptions({
+        helper,
+        state: helper.state,
+        results,
+      })
+    );
+
+    expect(renderState2).toEqual({
+      format: {
+        from: expect.any(Function),
+        to: expect.any(Function),
+      },
+      range: {
+        max: 30,
+        min: 10,
+      },
+      refine: expect.any(Function),
+      start: [0, 1000],
+      widgetParams: {
+        attribute: 'price',
+        precision: 0,
       },
     });
   });

--- a/src/connectors/range/connectRange.js
+++ b/src/connectors/range/connectRange.js
@@ -214,7 +214,10 @@ export default function connectRange(renderFn, unmountFn = noop) {
       getRenderState(renderState, renderOptions) {
         return {
           ...renderState,
-          range: this.getWidgetRenderState(renderOptions),
+          range: {
+            ...renderState.range,
+            [attribute]: this.getWidgetRenderState(renderOptions),
+          },
         };
       },
 

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -205,7 +205,28 @@ export type IndexRenderState = Partial<{
     >;
   };
   hits: WidgetRenderState<HitsRendererOptions, HitsConnectorParams>;
-  range: any; // @TODO type when connectRange is migrated to TypeScript
+  range: {
+    [attribute: string]: WidgetRenderState<
+      {
+        refine(rangeValue: Array<number | undefined>): void;
+        range: {
+          min: number | undefined;
+          max: number | undefined;
+        };
+        start: number[];
+        format: {
+          from(fromValue: number): string;
+          to(toValue: number): string;
+        };
+      },
+      {
+        attribute: string;
+        min?: number;
+        max?: number;
+        precision?: number;
+      }
+    >;
+  };
 }>;
 
 type WidgetRenderState<

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -205,6 +205,7 @@ export type IndexRenderState = Partial<{
     >;
   };
   hits: WidgetRenderState<HitsRendererOptions, HitsConnectorParams>;
+  range: any; // @TODO type when connectRange is migrated to TypeScript
 }>;
 
 type WidgetRenderState<


### PR DESCRIPTION
This implements the `getRenderState` and `getWidgetRenderState` widget lifecycle hooks in `range`.