### PR TITLE
feat(refinement-list): implement `getRenderState` and `getWidgetRenderState`

### DIFF
--- a/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
+++ b/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
@@ -5,6 +5,11 @@ import jsHelper, {
 import { TAG_PLACEHOLDER } from '../../../lib/escape-highlight';
 import connectRefinementList from '../connectRefinementList';
 import { createInstantSearch } from '../../../../test/mock/createInstantSearch';
+import {
+  createInitOptions,
+  createRenderOptions,
+} from '../../../../test/mock/createWidget';
+import { createSingleSearchResponse } from '../../../../test/mock/createAPIResponse';
 
 describe('connectRefinementList', () => {
   const createWidgetFactory = () => {
@@ -2165,6 +2170,194 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
           brand: ['Apple', 'Microsoft'],
         },
       });
+    });
+  });
+
+  describe('getRenderState', () => {
+    it('returns the render state', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const createRefinementList = connectRefinementList(renderFn, unmountFn);
+      const refinementListWidget = createRefinementList({ attribute: 'brand' });
+      const helper = jsHelper({}, 'indexName', {
+        disjunctiveFacets: ['brand'],
+        disjunctiveFacetsRefinements: {
+          brand: ['Apple', 'Microsoft'],
+        },
+      });
+
+      const initOptions = createInitOptions({ state: helper.state, helper });
+
+      refinementListWidget.init(initOptions);
+
+      const renderState1 = refinementListWidget.getRenderState({}, initOptions);
+
+      expect(renderState1.refinementList).toEqual({
+        brand: {
+          createURL: expect.any(Function),
+          helperSpecializedSearchFacetValues: expect.any(Function),
+          isFirstSearch: true,
+          isFromSearch: false,
+          isShowingMore: false,
+          items: [],
+          refine: expect.any(Function),
+          state: helper.state,
+          toggleShowMore: expect.any(Function),
+        },
+      });
+
+      const results = new SearchResults(helper.state, [
+        createSingleSearchResponse({
+          hits: [],
+          facets: {
+            brand: {
+              Apple: 88,
+              Microsoft: 66,
+              Samsung: 44,
+            },
+          },
+        }),
+      ]);
+
+      const renderState2 = refinementListWidget.getRenderState(
+        {},
+        createRenderOptions({
+          helper,
+          state: helper.state,
+          results,
+        })
+      );
+
+      expect(renderState2.refinementList).toEqual({
+        brand: {
+          createURL: expect.any(Function),
+          helperSpecializedSearchFacetValues:
+            renderState1.refinementList.brand
+              .helperSpecializedSearchFacetValues,
+          isFirstSearch: false,
+          isFromSearch: false,
+          isShowingMore: false,
+          items: [
+            {
+              count: 88,
+              highlighted: 'Apple',
+              isRefined: true,
+              label: 'Apple',
+              value: 'Apple',
+            },
+            {
+              count: 66,
+              highlighted: 'Microsoft',
+              isRefined: true,
+              label: 'Microsoft',
+              value: 'Microsoft',
+            },
+            {
+              count: 44,
+              highlighted: 'Samsung',
+              isRefined: false,
+              label: 'Samsung',
+              value: 'Samsung',
+            },
+          ],
+          refine: renderState1.refinementList.brand.refine,
+          state: helper.state,
+          toggleShowMore: renderState1.refinementList.brand.toggleShowMore,
+        },
+      });
+    });
+  });
+
+  describe('getWidgetRenderState', () => {
+    it('returns the widget render state', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const createRefinementList = connectRefinementList(renderFn, unmountFn);
+      const refinementListWidget = createRefinementList({ attribute: 'brand' });
+      const helper = jsHelper({}, 'indexName', {
+        disjunctiveFacets: ['brand'],
+        disjunctiveFacetsRefinements: {
+          brand: ['Apple', 'Microsoft'],
+        },
+      });
+
+      const initOptions = createInitOptions({ state: helper.state, helper });
+
+      refinementListWidget.init(initOptions);
+
+      const renderState1 = refinementListWidget.getWidgetRenderState(
+        initOptions
+      );
+
+      expect(renderState1).toEqual({
+        createURL: expect.any(Function),
+        helperSpecializedSearchFacetValues: expect.any(Function),
+        isFirstSearch: true,
+        isFromSearch: false,
+        isShowingMore: false,
+        items: [],
+        refine: expect.any(Function),
+        state: helper.state,
+        toggleShowMore: expect.any(Function),
+      });
+
+      const results = new SearchResults(helper.state, [
+        createSingleSearchResponse({
+          hits: [],
+          facets: {
+            brand: {
+              Apple: 88,
+              Microsoft: 66,
+              Samsung: 44,
+            },
+          },
+        }),
+      ]);
+
+      const renderState2 = refinementListWidget.getWidgetRenderState(
+        createRenderOptions({
+          helper,
+          state: helper.state,
+          results,
+        })
+      );
+
+      expect(renderState2).toEqual(
+        expect.objectContaining({
+          createURL: expect.any(Function),
+          helperSpecializedSearchFacetValues:
+            renderState1.helperSpecializedSearchFacetValues,
+          isFirstSearch: false,
+          isFromSearch: false,
+          isShowingMore: false,
+          items: [
+            {
+              count: 88,
+              highlighted: 'Apple',
+              isRefined: true,
+              label: 'Apple',
+              value: 'Apple',
+            },
+            {
+              count: 66,
+              highlighted: 'Microsoft',
+              isRefined: true,
+              label: 'Microsoft',
+              value: 'Microsoft',
+            },
+            {
+              count: 44,
+              highlighted: 'Samsung',
+              isRefined: false,
+              label: 'Samsung',
+              value: 'Samsung',
+            },
+          ],
+          refine: renderState1.refine,
+          state: helper.state,
+          toggleShowMore: renderState1.toggleShowMore,
+        })
+      );
     });
   });
 

--- a/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
+++ b/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
@@ -2192,8 +2192,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
 
       const initOptions = createInitOptions({ state: helper.state, helper });
 
-      refinementListWidget.init(initOptions);
-
       const renderState1 = refinementListWidget.getRenderState({}, initOptions);
 
       expect(renderState1.refinementList).toEqual({
@@ -2228,8 +2226,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       });
 
       const initOptions = createInitOptions({ state: helper.state, helper });
-
-      refinementListWidget.init(initOptions);
 
       const renderState1 = refinementListWidget.getRenderState({}, initOptions);
 
@@ -2314,8 +2310,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
 
       const initOptions = createInitOptions({ state: helper.state, helper });
 
-      refinementListWidget.init(initOptions);
-
       const renderState1 = refinementListWidget.getWidgetRenderState(
         initOptions
       );
@@ -2350,8 +2344,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       });
 
       const initOptions = createInitOptions({ state: helper.state, helper });
-
-      refinementListWidget.init(initOptions);
 
       const renderState1 = refinementListWidget.getWidgetRenderState(
         initOptions

--- a/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
+++ b/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
@@ -2178,7 +2178,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
   });
 
   describe('getRenderState', () => {
-    it('returns the render state', () => {
+    it('returns the render state without results', () => {
       const renderFn = jest.fn();
       const unmountFn = jest.fn();
       const createRefinementList = connectRefinementList(renderFn, unmountFn);
@@ -2213,6 +2213,25 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
           },
         },
       });
+    });
+
+    it('returns the render state with results', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const createRefinementList = connectRefinementList(renderFn, unmountFn);
+      const refinementListWidget = createRefinementList({ attribute: 'brand' });
+      const helper = jsHelper({}, 'indexName', {
+        disjunctiveFacets: ['brand'],
+        disjunctiveFacetsRefinements: {
+          brand: ['Apple', 'Microsoft'],
+        },
+      });
+
+      const initOptions = createInitOptions({ state: helper.state, helper });
+
+      refinementListWidget.init(initOptions);
+
+      const renderState1 = refinementListWidget.getRenderState({}, initOptions);
 
       const results = new SearchResults(helper.state, [
         createSingleSearchResponse({
@@ -2227,13 +2246,15 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
         }),
       ]);
 
+      const renderOptions = createRenderOptions({
+        helper,
+        state: helper.state,
+        results,
+      });
+
       const renderState2 = refinementListWidget.getRenderState(
         {},
-        createRenderOptions({
-          helper,
-          state: helper.state,
-          results,
-        })
+        renderOptions
       );
 
       expect(renderState2.refinementList).toEqual({
@@ -2279,7 +2300,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
   });
 
   describe('getWidgetRenderState', () => {
-    it('returns the widget render state', () => {
+    it('returns the widget render state without results', () => {
       const renderFn = jest.fn();
       const unmountFn = jest.fn();
       const createRefinementList = connectRefinementList(renderFn, unmountFn);
@@ -2314,6 +2335,27 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
           attribute: 'brand',
         },
       });
+    });
+
+    it('returns the widget render state with results', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const createRefinementList = connectRefinementList(renderFn, unmountFn);
+      const refinementListWidget = createRefinementList({ attribute: 'brand' });
+      const helper = jsHelper({}, 'indexName', {
+        disjunctiveFacets: ['brand'],
+        disjunctiveFacetsRefinements: {
+          brand: ['Apple', 'Microsoft'],
+        },
+      });
+
+      const initOptions = createInitOptions({ state: helper.state, helper });
+
+      refinementListWidget.init(initOptions);
+
+      const renderState1 = refinementListWidget.getWidgetRenderState(
+        initOptions
+      );
 
       const results = new SearchResults(helper.state, [
         createSingleSearchResponse({
@@ -2328,12 +2370,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
         }),
       ]);
 
+      const renderOptions = createRenderOptions({
+        helper,
+        state: helper.state,
+        results,
+      });
+
       const renderState2 = refinementListWidget.getWidgetRenderState(
-        createRenderOptions({
-          helper,
-          state: helper.state,
-          results,
-        })
+        renderOptions
       );
 
       expect(renderState2).toEqual(

--- a/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
+++ b/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
@@ -975,7 +975,33 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
     });
 
     const renderingOptions2 = rendering.mock.calls[1][0];
-    expect(renderingOptions2.items).toHaveLength(1);
+    expect(renderingOptions2).toEqual({
+      createURL: expect.any(Function),
+      items: [
+        {
+          count: 880,
+          highlighted: 'c1',
+          isRefined: false,
+          label: 'c1',
+          value: 'c1',
+        },
+      ],
+      refine: expect.any(Function),
+      searchForItems: expect.any(Function),
+      isFromSearch: false,
+      canRefine: true,
+      widgetParams: {
+        attribute: 'category',
+        limit: 1,
+        showMore: true,
+        showMoreLimit: 2,
+      },
+      isShowingMore: false,
+      canToggleShowMore: true,
+      toggleShowMore: expect.any(Function),
+      hasExhaustiveItems: false,
+      sendEvent: expect.any(Function),
+    });
 
     // `searchForItems` triggers a new render
     renderingOptions2.searchForItems('query triggering no results');
@@ -988,23 +1014,101 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       expect.anything()
     );
 
-    expect(rendering).toHaveBeenCalledTimes(2);
-    const renderingOptions3 = rendering.mock.calls[1][0];
+    expect(rendering).toHaveBeenCalledTimes(3);
+    const renderingOptions3 = rendering.mock.calls[2][0];
+    expect(renderingOptions3).toEqual({
+      createURL: expect.any(Function),
+      items: [],
+      refine: expect.any(Function),
+      searchForItems: expect.any(Function),
+      isFromSearch: true,
+      canRefine: true,
+      widgetParams: {
+        attribute: 'category',
+        limit: 1,
+        showMore: true,
+        showMoreLimit: 2,
+      },
+      isShowingMore: false,
+      canToggleShowMore: false,
+      toggleShowMore: expect.any(Function),
+      hasExhaustiveItems: false,
+      sendEvent: expect.any(Function),
+    });
 
     // `searchForItems` triggers a new render
     renderingOptions3.searchForItems('');
     await Promise.resolve();
 
-    expect(rendering).toHaveBeenCalledTimes(3);
-    const renderingOptions4 = rendering.mock.calls[2][0];
-    expect(renderingOptions4.toggleShowMore).toBeDefined();
+    expect(rendering).toHaveBeenCalledTimes(4);
+    const renderingOptions4 = rendering.mock.calls[3][0];
+    expect(renderingOptions4).toEqual({
+      createURL: expect.any(Function),
+      items: [
+        {
+          count: 880,
+          highlighted: 'c1',
+          isRefined: false,
+          label: 'c1',
+          value: 'c1',
+        },
+      ],
+      refine: expect.any(Function),
+      searchForItems: expect.any(Function),
+      isFromSearch: false,
+      canRefine: true,
+      widgetParams: {
+        attribute: 'category',
+        limit: 1,
+        showMore: true,
+        showMoreLimit: 2,
+      },
+      isShowingMore: false,
+      canToggleShowMore: true,
+      toggleShowMore: expect.any(Function),
+      hasExhaustiveItems: false,
+      sendEvent: expect.any(Function),
+    });
 
     // `toggleShowMore` triggers a new render
     renderingOptions4.toggleShowMore();
 
-    expect(rendering).toHaveBeenCalledTimes(4);
-    const renderingOptions5 = rendering.mock.calls[3][0];
-    expect(renderingOptions5.items).toHaveLength(2);
+    expect(rendering).toHaveBeenCalledTimes(5);
+    const renderingOptions5 = rendering.mock.calls[4][0];
+    expect(renderingOptions5).toEqual({
+      createURL: expect.any(Function),
+      items: [
+        {
+          count: 880,
+          highlighted: 'c1',
+          isRefined: false,
+          label: 'c1',
+          value: 'c1',
+        },
+        {
+          count: 880,
+          highlighted: 'c3',
+          isRefined: false,
+          label: 'c3',
+          value: 'c3',
+        },
+      ],
+      refine: expect.any(Function),
+      searchForItems: expect.any(Function),
+      isFromSearch: false,
+      canRefine: true,
+      widgetParams: {
+        attribute: 'category',
+        limit: 1,
+        showMore: true,
+        showMoreLimit: 2,
+      },
+      isShowingMore: true,
+      canToggleShowMore: true,
+      toggleShowMore: expect.any(Function),
+      hasExhaustiveItems: false,
+      sendEvent: expect.any(Function),
+    });
 
     renderingOptions5.searchForItems('new search');
     expect(helper.searchForFacetValues).toHaveBeenCalledWith(
@@ -2206,6 +2310,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
           refine: expect.any(Function),
           searchForItems: expect.any(Function),
           toggleShowMore: expect.any(Function),
+          sendEvent: expect.any(Function),
           widgetParams: {
             attribute: 'brand',
           },
@@ -2286,6 +2391,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
           ],
           refine: renderState1.refinementList.brand.refine,
           searchForItems: expect.any(Function),
+          sendEvent: expect.any(Function),
           toggleShowMore: renderState1.refinementList.brand.toggleShowMore,
           widgetParams: {
             attribute: 'brand',
@@ -2325,6 +2431,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
         refine: expect.any(Function),
         searchForItems: expect.any(Function),
         toggleShowMore: expect.any(Function),
+        sendEvent: expect.any(Function),
         widgetParams: {
           attribute: 'brand',
         },

--- a/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
+++ b/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
@@ -930,9 +930,13 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
     );
     helper.search = jest.fn();
     helper.searchForFacetValues = jest.fn().mockReturnValue(
-      Promise.resolve({
-        facetHits: [],
-      })
+      Promise.resolve(
+        new SearchResults(helper.state, [
+          {
+            facetHits: [],
+          },
+        ])
+      )
     );
 
     widget.init({
@@ -984,22 +988,22 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       expect.anything()
     );
 
-    expect(rendering).toHaveBeenCalledTimes(3);
-    const renderingOptions3 = rendering.mock.calls[2][0];
+    expect(rendering).toHaveBeenCalledTimes(2);
+    const renderingOptions3 = rendering.mock.calls[1][0];
 
     // `searchForItems` triggers a new render
     renderingOptions3.searchForItems('');
     await Promise.resolve();
 
-    expect(rendering).toHaveBeenCalledTimes(4);
-    const renderingOptions4 = rendering.mock.calls[3][0];
+    expect(rendering).toHaveBeenCalledTimes(3);
+    const renderingOptions4 = rendering.mock.calls[2][0];
     expect(renderingOptions4.toggleShowMore).toBeDefined();
 
     // `toggleShowMore` triggers a new render
     renderingOptions4.toggleShowMore();
 
-    expect(rendering).toHaveBeenCalledTimes(5);
-    const renderingOptions5 = rendering.mock.calls[4][0];
+    expect(rendering).toHaveBeenCalledTimes(4);
+    const renderingOptions5 = rendering.mock.calls[3][0];
     expect(renderingOptions5.items).toHaveLength(2);
 
     renderingOptions5.searchForItems('new search');
@@ -2194,15 +2198,19 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
 
       expect(renderState1.refinementList).toEqual({
         brand: {
+          canRefine: false,
+          canToggleShowMore: false,
           createURL: expect.any(Function),
-          helperSpecializedSearchFacetValues: expect.any(Function),
-          isFirstSearch: true,
+          hasExhaustiveItems: true,
           isFromSearch: false,
           isShowingMore: false,
           items: [],
           refine: expect.any(Function),
-          state: helper.state,
+          searchForItems: expect.any(Function),
           toggleShowMore: expect.any(Function),
+          widgetParams: {
+            attribute: 'brand',
+          },
         },
       });
 
@@ -2230,11 +2238,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
 
       expect(renderState2.refinementList).toEqual({
         brand: {
+          canRefine: true,
+          canToggleShowMore: false,
           createURL: expect.any(Function),
-          helperSpecializedSearchFacetValues:
-            renderState1.refinementList.brand
-              .helperSpecializedSearchFacetValues,
-          isFirstSearch: false,
+          hasExhaustiveItems: true,
           isFromSearch: false,
           isShowingMore: false,
           items: [
@@ -2261,8 +2268,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
             },
           ],
           refine: renderState1.refinementList.brand.refine,
-          state: helper.state,
+          searchForItems: expect.any(Function),
           toggleShowMore: renderState1.refinementList.brand.toggleShowMore,
+          widgetParams: {
+            attribute: 'brand',
+          },
         },
       });
     });
@@ -2290,15 +2300,19 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       );
 
       expect(renderState1).toEqual({
+        canRefine: false,
+        canToggleShowMore: false,
         createURL: expect.any(Function),
-        helperSpecializedSearchFacetValues: expect.any(Function),
-        isFirstSearch: true,
+        hasExhaustiveItems: true,
         isFromSearch: false,
         isShowingMore: false,
         items: [],
         refine: expect.any(Function),
-        state: helper.state,
+        searchForItems: expect.any(Function),
         toggleShowMore: expect.any(Function),
+        widgetParams: {
+          attribute: 'brand',
+        },
       });
 
       const results = new SearchResults(helper.state, [
@@ -2324,10 +2338,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
 
       expect(renderState2).toEqual(
         expect.objectContaining({
+          canRefine: true,
+          canToggleShowMore: false,
           createURL: expect.any(Function),
-          helperSpecializedSearchFacetValues:
-            renderState1.helperSpecializedSearchFacetValues,
-          isFirstSearch: false,
+          hasExhaustiveItems: true,
           isFromSearch: false,
           isShowingMore: false,
           items: [
@@ -2354,8 +2368,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
             },
           ],
           refine: renderState1.refine,
-          state: helper.state,
+          searchForItems: expect.any(Function),
           toggleShowMore: renderState1.toggleShowMore,
+          widgetParams: {
+            attribute: 'brand',
+          },
         })
       );
     });

--- a/src/connectors/refinement-list/connectRefinementList.js
+++ b/src/connectors/refinement-list/connectRefinementList.js
@@ -161,6 +161,7 @@ export default function connectRefinementList(renderFn, unmountFn = noop) {
     let searchForFacetValues;
     let triggerRefine;
     let sendEvent;
+    let toggleShowMore;
 
     /* eslint-disable max-params */
     const createSearchForFacetValues = function(helper) {
@@ -224,7 +225,7 @@ export default function connectRefinementList(renderFn, unmountFn = noop) {
       // has to only bind it once when `isFirstRendering` for instance
       toggleShowMore() {},
       cachedToggleShowMore() {
-        this.toggleShowMore();
+        toggleShowMore();
       },
 
       createToggleShowMore(renderOptions) {
@@ -239,26 +240,6 @@ export default function connectRefinementList(renderFn, unmountFn = noop) {
       },
 
       init(initOptions) {
-        const { instantSearchInstance, helper } = initOptions;
-        this.cachedToggleShowMore = this.cachedToggleShowMore.bind(this);
-
-        sendEvent = createSendEventForFacet({
-          instantSearchInstance,
-          helper,
-          attribute,
-          widgetType: this.$$type,
-        });
-
-        triggerRefine = facetValue => {
-          sendEvent('click', facetValue);
-          helper.toggleRefinement(attribute, facetValue).search();
-        };
-
-        searchForFacetValues = createSearchForFacetValues.call(
-          this,
-          initOptions.helper
-        );
-
         renderFn(
           {
             ...this.getWidgetRenderState(initOptions),
@@ -295,9 +276,26 @@ export default function connectRefinementList(renderFn, unmountFn = noop) {
           createURL,
           instantSearchInstance,
           isFromSearch = false,
+          helper,
         } = renderOptions;
         let items = [];
         let facetValues;
+
+        if (!sendEvent || !triggerRefine || !searchForFacetValues) {
+          sendEvent = createSendEventForFacet({
+            instantSearchInstance,
+            helper,
+            attribute,
+            widgetType: this.$$type,
+          });
+
+          triggerRefine = facetValue => {
+            sendEvent('click', facetValue);
+            helper.toggleRefinement(attribute, facetValue).search();
+          };
+
+          searchForFacetValues = createSearchForFacetValues.call(this, helper);
+        }
 
         if (results) {
           if (!isFromSearch) {
@@ -335,7 +333,7 @@ export default function connectRefinementList(renderFn, unmountFn = noop) {
           lastResultsFromMainSearch = results;
           lastItemsFromMainSearch = items;
 
-          this.toggleShowMore = this.createToggleShowMore(renderOptions);
+          toggleShowMore = this.createToggleShowMore(renderOptions);
         }
 
         // Compute a specific createURL method able to link to any facet value state change

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -328,6 +328,37 @@ export type IndexRenderState = Partial<{
     PaginationRendererOptions,
     PaginationConnectorParams
   >;
+  refinementList: {
+    [attribute: string]: WidgetRenderState<
+      {
+        createURL: CreateURL<string>;
+        helperSpecializedSearchFacetValues: any;
+        isFirstSearch: boolean;
+        isFromSearch: boolean;
+        isShowingMore: boolean;
+        items: Array<{
+          count: number;
+          highlighted: string;
+          isRefined: boolean;
+          label: string;
+          value: string;
+        }>;
+        refine(value: string): void;
+        state: SearchParameters;
+        toggleShowMore(): void;
+      },
+      {
+        attribute: string;
+        operator: string;
+        limit: number;
+        showMore: boolean;
+        showMoreLimit: number;
+        sortBy: ((firstItem: any, secondItem: any) => number) | string[];
+        escapeFacetValues: boolean;
+        transformItems(items: any): any;
+      }
+    >;
+  };
 }>;
 
 export type WidgetRenderState<


### PR DESCRIPTION
This implements the `getRenderState` and `getWidgetRenderState` widget lifecycle hooks in `refinementList`.