### PR TITLE
feat(panel): smoother accessing of widgetRenderState

### DIFF
--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -5,7 +5,7 @@ import { useState, useEffect, useRef } from 'preact/hooks';
 import cx from 'classnames';
 import Template from '../Template/Template';
 import { PanelCSSClasses, PanelTemplates } from '../../widgets/panel/panel';
-import { RenderOptions } from '../../types';
+import { RenderOptions, WidgetFactory } from '../../types';
 
 type PanelComponentCSSClasses = Required<
   Omit<
@@ -17,17 +17,19 @@ type PanelComponentCSSClasses = Required<
   >
 >;
 
-type PanelProps = {
+type PanelProps<TWidget extends WidgetFactory<any, any, any>> = {
   hidden: boolean;
   collapsible: boolean;
   isCollapsed: boolean;
   data: RenderOptions;
   cssClasses: PanelComponentCSSClasses;
-  templates: Required<PanelTemplates>;
+  templates: Required<PanelTemplates<TWidget>>;
   bodyElement: HTMLElement;
 };
 
-function Panel(props: PanelProps) {
+function Panel<TWidget extends WidgetFactory<any, any, any>>(
+  props: PanelProps<TWidget>
+) {
   const [isCollapsed, setIsCollapsed] = useState<boolean>(props.isCollapsed);
   const [isControlled, setIsControlled] = useState<boolean>(false);
   const bodyRef = useRef<HTMLElement | null>(null);

--- a/src/widgets/panel/__tests__/panel-test.ts
+++ b/src/widgets/panel/__tests__/panel-test.ts
@@ -55,8 +55,8 @@ describe('Usage', () => {
 
   test('with `hidden` as boolean warns', () => {
     expect(() => {
+      // @ts-ignore wrong option type
       panel({
-        // @ts-expect-error wrong option type
         hidden: true,
       });
     }).toWarnDev(
@@ -66,8 +66,8 @@ describe('Usage', () => {
 
   test('with `collapsed` as boolean warns', () => {
     expect(() => {
+      // @ts-ignore wrong option type
       panel({
-        // @ts-expect-error wrong option type
         collapsed: true,
       });
     }).toWarnDev(

--- a/src/widgets/panel/__tests__/panel-test.ts
+++ b/src/widgets/panel/__tests__/panel-test.ts
@@ -55,8 +55,8 @@ describe('Usage', () => {
 
   test('with `hidden` as boolean warns', () => {
     expect(() => {
-      // @ts-ignore wrong option type
       panel({
+        // @ts-expect-error wrong option type
         hidden: true,
       });
     }).toWarnDev(
@@ -66,8 +66,8 @@ describe('Usage', () => {
 
   test('with `collapsed` as boolean warns', () => {
     expect(() => {
-      // @ts-ignore wrong option type
       panel({
+        // @ts-expect-error wrong option type
         collapsed: true,
       });
     }).toWarnDev(

--- a/src/widgets/panel/panel.tsx
+++ b/src/widgets/panel/panel.tsx
@@ -111,14 +111,14 @@ export type PanelWidgetOptions<TWidget extends WidgetFactory<any, any, any>> = {
 const withUsage = createDocumentationMessageGenerator({ name: 'panel' });
 const suit = component('Panel');
 
-const renderer = ({
+const renderer = <TWidget extends WidgetFactory<any, any, any>>({
   containerNode,
   bodyContainerNode,
   cssClasses,
   templates,
 }) => ({ options, hidden, collapsible, collapsed }) => {
   render(
-    <Panel
+    <Panel<TWidget>
       cssClasses={cssClasses}
       hidden={hidden}
       collapsible={collapsible}
@@ -222,7 +222,7 @@ const panel: PanelWidget = widgetParams => {
         </svg>`,
     };
 
-    const renderPanel = renderer({
+    const renderPanel = renderer<typeof widgetFactory>({
       containerNode: getContainerNode(container),
       bodyContainerNode,
       cssClasses,

--- a/src/widgets/panel/panel.tsx
+++ b/src/widgets/panel/panel.tsx
@@ -79,9 +79,11 @@ export type PanelTemplates = {
 export type PanelRenderOptions<
   TWidget extends WidgetFactory<any, any, any>
 > = RenderOptions & {
-  widgetRenderState: ReturnType<
-    Exclude<ReturnType<TWidget>['getWidgetRenderState'], undefined>
-  >;
+  widgetRenderState: ReturnType<TWidget>['getWidgetRenderState'] extends (
+    renderOptions: any
+  ) => infer TRenderState
+    ? TRenderState
+    : unknown;
 };
 
 export type PanelWidgetOptions<TWidget extends WidgetFactory<any, any, any>> = {
@@ -132,12 +134,12 @@ const renderer = ({
 };
 
 export type PanelWidget = <TWidget extends WidgetFactory<any, any, any>>(
-  params?: PanelWidgetOptions<TWidget>
+  widgetParams?: PanelWidgetOptions<TWidget>
 ) => <
-  TWidgetOptions extends { container: HTMLElement | string; [key: string]: any }
+  TWidgetParams extends { container: HTMLElement | string; [key: string]: any }
 >(
-  widgetFactory: (widgetOptions: TWidgetOptions) => Widget
-) => (widgetOptions: TWidgetOptions) => Widget;
+  widgetFactory: TWidget
+) => (widgetOptions: TWidgetParams) => Widget;
 
 /**
  * The panel widget wraps other widgets in a consistent panel design.
@@ -260,8 +262,7 @@ const panel: PanelWidget = widgetParams => {
 
         const options = {
           ...renderOptions,
-          widgetRenderState: (widget.getWidgetRenderState?.(renderOptions) ||
-            {}) as any,
+          widgetRenderState: widget.getWidgetRenderState?.(renderOptions) || {},
         };
 
         renderPanel({

--- a/src/widgets/panel/panel.tsx
+++ b/src/widgets/panel/panel.tsx
@@ -259,7 +259,9 @@ const panel: PanelWidget = widgetParams => {
         const [renderOptions] = args;
 
         const options = {
-          ...(widget.getWidgetRenderState?.(renderOptions) || {}),
+          ...(widget.getWidgetRenderState
+            ? widget.getWidgetRenderState(renderOptions)
+            : {}),
           ...renderOptions,
         };
 

--- a/src/widgets/panel/panel.tsx
+++ b/src/widgets/panel/panel.tsx
@@ -59,16 +59,16 @@ export type PanelCSSClasses = {
   footer?: string | string[];
 };
 
-export type PanelTemplates = {
+export type PanelTemplates<TWidget extends WidgetFactory<any, any, any>> = {
   /**
    * Template to use for the header.
    */
-  header?: Template<RenderOptions>;
+  header?: Template<PanelRenderOptions<TWidget>>;
 
   /**
    * Template to use for the footer.
    */
-  footer?: Template<RenderOptions>;
+  footer?: Template<PanelRenderOptions<TWidget>>;
 
   /**
    * Template to use for collapse button.
@@ -78,13 +78,11 @@ export type PanelTemplates = {
 
 export type PanelRenderOptions<
   TWidget extends WidgetFactory<any, any, any>
-> = RenderOptions & {
-  widgetRenderState: ReturnType<TWidget>['getWidgetRenderState'] extends (
-    renderOptions: any
-  ) => infer TRenderState
-    ? TRenderState
-    : unknown;
-};
+> = RenderOptions & ReturnType<TWidget>['getWidgetRenderState'] extends (
+  renderOptions: any
+) => infer TRenderState
+  ? TRenderState
+  : Record<string, any>;
 
 export type PanelWidgetOptions<TWidget extends WidgetFactory<any, any, any>> = {
   /**
@@ -102,7 +100,7 @@ export type PanelWidgetOptions<TWidget extends WidgetFactory<any, any, any>> = {
   /**
    * The templates to use for the widget.
    */
-  templates?: PanelTemplates;
+  templates?: PanelTemplates<TWidget>;
 
   /**
    * The CSS classes to override.
@@ -261,8 +259,8 @@ const panel: PanelWidget = widgetParams => {
         const [renderOptions] = args;
 
         const options = {
+          ...(widget.getWidgetRenderState?.(renderOptions) || {}),
           ...renderOptions,
-          widgetRenderState: widget.getWidgetRenderState?.(renderOptions) || {},
         };
 
         renderPanel({

--- a/stories/panel.stories.ts
+++ b/stories/panel.stories.ts
@@ -151,11 +151,13 @@ storiesOf('Basics/Panel', module)
     withHits(
       ({ search, container }) => {
         const breadcrumbInPanel = panel<typeof breadcrumb>({
-          collapsed({ widgetRenderState }) {
-            return widgetRenderState.canRefine;
+          collapsed({ canRefine }) {
+            return canRefine === false;
           },
           templates: {
-            header: 'Collapsible panel',
+            header({ items }) {
+              return `Breadcrumb with ${items?.length} items`;
+            },
             footer:
               'The panel collapses if it cannot refine. Click "Home". This panel will collapse and you will not see this footer anymore.',
           },

--- a/stories/panel.stories.ts
+++ b/stories/panel.stories.ts
@@ -155,8 +155,8 @@ storiesOf('Basics/Panel', module)
             return canRefine === false;
           },
           templates: {
-            header({ items }) {
-              return `Breadcrumb with ${items?.length} items`;
+            header({ canRefine }) {
+              return `Breadcrumb that can${canRefine ? '' : "'t "} refine`;
             },
             footer:
               'The panel collapses if it cannot refine. Click "Home". This panel will collapse and you will not see this footer anymore.',


### PR DESCRIPTION
this kinda works @eunjae-lee, although some parts still seem to be inferred as any. The public API works though

I also made a small change: not using widgetRenderState as key, but spreading the renderer. This way the usage is so much smoother (and you can use it for the templates too, which comes up from time to time)