### PR TITLE
test(renderState): add tests for getWidgetRenderState at connectAutocomplete

### DIFF
--- a/src/connectors/autocomplete/__tests__/connectAutocomplete-test.ts
+++ b/src/connectors/autocomplete/__tests__/connectAutocomplete-test.ts
@@ -532,9 +532,20 @@ search.addWidgets([
         createRenderOptions({ helper })
       );
 
+      const hits = [];
+      // @ts-ignore-next-line
+      hits.__escaped = true;
+
       expect(renderState).toEqual({
         currentRefinement: 'query',
-        indices: expect.any(Array),
+        indices: [
+          expect.objectContaining({
+            results: expect.objectContaining({
+              hits,
+            }),
+            sendEvent: expect.any(Function),
+          }),
+        ],
         refine: expect.any(Function),
         widgetParams: {},
       });

--- a/src/connectors/autocomplete/__tests__/connectAutocomplete-test.ts
+++ b/src/connectors/autocomplete/__tests__/connectAutocomplete-test.ts
@@ -485,6 +485,62 @@ search.addWidgets([
     });
   });
 
+  describe('getWidgetRenderState', () => {
+    test('returns the widget render state', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const createAutocomplete = connectAutocomplete(renderFn, unmountFn);
+      const autocomplete = createAutocomplete({});
+
+      const renderState1 = autocomplete.getWidgetRenderState(
+        createInitOptions()
+      );
+
+      expect(renderState1).toEqual({
+        currentRefinement: '',
+        indices: [],
+        refine: undefined,
+        widgetParams: {},
+      });
+
+      autocomplete.init!(createInitOptions());
+
+      const renderState2 = autocomplete.getWidgetRenderState(
+        createRenderOptions()
+      );
+
+      expect(renderState2).toEqual({
+        currentRefinement: '',
+        indices: expect.any(Array),
+        refine: expect.any(Function),
+        widgetParams: {},
+      });
+    });
+
+    test('returns the widget render state with a query', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const createAutocomplete = connectAutocomplete(renderFn, unmountFn);
+      const autocomplete = createAutocomplete({});
+      const helper = algoliasearchHelper(createSearchClient(), 'indexName', {
+        query: 'query',
+      });
+
+      autocomplete.init!(createInitOptions());
+
+      const renderState = autocomplete.getWidgetRenderState(
+        createRenderOptions({ helper })
+      );
+
+      expect(renderState).toEqual({
+        currentRefinement: 'query',
+        indices: expect.any(Array),
+        refine: expect.any(Function),
+        widgetParams: {},
+      });
+    });
+  });
+
   describe('getWidgetUiState', () => {
     test('should give back the object unmodified if the default value is selected', () => {
       const [widget, helper] = getInitializedWidget();


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR adds the missing tests for `getWidgetRenderState` at `connectAutocomplete`.

DX-1356