### PR TITLE
test(renderState): add tests for getWidgetRenderState at connectClearRefinements, connectConfigure and connectCurrentRefinements

### DIFF
--- a/src/connectors/clear-refinements/__tests__/connectClearRefinements-test.ts
+++ b/src/connectors/clear-refinements/__tests__/connectClearRefinements-test.ts
@@ -203,6 +203,84 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/clear-refin
         });
       });
     });
+
+    describe('getWidgetRenderState', () => {
+      test('returns the widget render state', () => {
+        const renderFn = jest.fn();
+        const unmountFn = jest.fn();
+        const createClearRefinements = connectClearRefinements(
+          renderFn,
+          unmountFn
+        );
+        const clearRefinements = createClearRefinements({});
+        const helper = algoliasearchHelper(createSearchClient(), 'indexName', {
+          index: 'indexName',
+          hierarchicalFacets: [
+            {
+              name: 'category',
+              attributes: ['category', 'subCategory'],
+              separator: ' > ',
+            },
+          ],
+        });
+
+        const renderState1 = clearRefinements.getWidgetRenderState(
+          createInitOptions()
+        );
+
+        expect(renderState1).toEqual({
+          hasRefinements: false,
+          createURL: expect.any(Function),
+          refine: expect.any(Function),
+          widgetParams: {},
+        });
+
+        clearRefinements.init!(createInitOptions());
+
+        helper.toggleRefinement('category', 'Decoration');
+
+        const renderState2 = clearRefinements.getWidgetRenderState(
+          createRenderOptions({
+            helper,
+            scopedResults: [
+              {
+                indexId: 'indexName',
+                helper,
+                results: new SearchResults(helper.state, [
+                  createSingleSearchResponse({
+                    hits: [],
+                    facets: {
+                      category: {
+                        Decoration: 880,
+                      },
+                      subCategory: {
+                        'Decoration > Candle holders & candles': 193,
+                        'Decoration > Frames & pictures': 173,
+                      },
+                    },
+                  }),
+                  createSingleSearchResponse({
+                    facets: {
+                      category: {
+                        Decoration: 880,
+                        Outdoor: 47,
+                      },
+                    },
+                  }),
+                ]),
+              },
+            ],
+          })
+        );
+
+        expect(renderState2).toEqual({
+          hasRefinements: true,
+          createURL: expect.any(Function),
+          refine: expect.any(Function),
+          widgetParams: {},
+        });
+      });
+    });
   });
 
   describe('Instance options', () => {

--- a/src/connectors/configure/__tests__/connectConfigure-test.ts
+++ b/src/connectors/configure/__tests__/connectConfigure-test.ts
@@ -272,6 +272,39 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
     });
   });
 
+  describe('getWidgetRenderState', () => {
+    test('returns the widget render state', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const createConfigure = connectConfigure(renderFn, unmountFn);
+      const configure = createConfigure({
+        searchParameters: { facetFilters: ['brand:Samsung'] },
+      });
+
+      const renderState1 = configure.getWidgetRenderState(createInitOptions());
+
+      expect(renderState1).toEqual({
+        refine: undefined,
+        widgetParams: {
+          searchParameters: { facetFilters: ['brand:Samsung'] },
+        },
+      });
+
+      configure.init!(createInitOptions());
+
+      const renderState2 = configure.getWidgetRenderState(
+        createRenderOptions()
+      );
+
+      expect(renderState2).toEqual({
+        refine: expect.any(Function),
+        widgetParams: {
+          searchParameters: { facetFilters: ['brand:Samsung'] },
+        },
+      });
+    });
+  });
+
   describe('getWidgetUiState', () => {
     it('adds default parameters', () => {
       const makeWidget = connectConfigure(noop);

--- a/src/connectors/current-refinements/__tests__/connectCurrentRefinements-test.ts
+++ b/src/connectors/current-refinements/__tests__/connectCurrentRefinements-test.ts
@@ -228,6 +228,109 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
     });
   });
 
+  describe('getWidgetRenderState', () => {
+    test('returns the widget render state', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const createCurrentRefinements = connectCurrentRefinements(
+        renderFn,
+        unmountFn
+      );
+      const configure = createCurrentRefinements({});
+
+      const renderState = configure.getWidgetRenderState(createInitOptions());
+
+      expect(renderState).toEqual({
+        items: [],
+        refine: expect.any(Function),
+        createURL: expect.any(Function),
+        widgetParams: {},
+      });
+    });
+
+    test('returns the widget render state with scoped results', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const createCurrentRefinements = connectCurrentRefinements(
+        renderFn,
+        unmountFn
+      );
+      const configure = createCurrentRefinements({});
+      const helper = algoliasearchHelper(createSearchClient(), 'indexName', {
+        index: 'indexName',
+        hierarchicalFacets: [
+          {
+            name: 'category',
+            attributes: ['category', 'subCategory'],
+            separator: ' > ',
+          },
+        ],
+      });
+
+      configure.init!(createInitOptions());
+
+      helper.toggleRefinement('category', 'Decoration');
+
+      const renderState = configure.getWidgetRenderState(
+        createRenderOptions({
+          helper,
+          scopedResults: [
+            {
+              indexId: 'indexName',
+              helper,
+              results: new SearchResults(helper.state, [
+                createSingleSearchResponse({
+                  hits: [],
+                  facets: {
+                    category: {
+                      Decoration: 880,
+                    },
+                    subCategory: {
+                      'Decoration > Candle holders & candles': 193,
+                      'Decoration > Frames & pictures': 173,
+                    },
+                  },
+                }),
+                createSingleSearchResponse({
+                  facets: {
+                    category: {
+                      Decoration: 880,
+                      Outdoor: 47,
+                    },
+                  },
+                }),
+              ]),
+            },
+          ],
+        })
+      );
+
+      expect(renderState).toEqual({
+        items: [
+          {
+            attribute: 'category',
+            indexName: 'indexName',
+            label: 'category',
+            refine: expect.any(Function),
+            refinements: [
+              {
+                attribute: 'category',
+                count: 880,
+                exhaustive: true,
+                label: 'Decoration',
+                type: 'hierarchical',
+                value: 'Decoration',
+              },
+            ],
+          },
+        ],
+        refine: expect.any(Function),
+        createURL: expect.any(Function),
+        widgetParams: {},
+      });
+    });
+  });
+
   describe('Widget options', () => {
     let helper: AlgoliaSearchHelper;
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR adds the missing tests for `getWidgetRenderState` at connectClearRefinements, connectConfigure and connectCurrentRefinements.