### PR TITLE
feat(stats): implement `getRenderState` and `getWidgetRenderState`

### DIFF
--- a/src/connectors/stats/__tests__/connectStats-test.js
+++ b/src/connectors/stats/__tests__/connectStats-test.js
@@ -1,5 +1,11 @@
 import jsHelper from 'algoliasearch-helper';
 const SearchResults = jsHelper.SearchResults;
+import { createSearchClient } from '../../../../test/mock/createSearchClient';
+import { createSingleSearchResponse } from '../../../../test/mock/createAPIResponse';
+import {
+  createInitOptions,
+  createRenderOptions,
+} from '../../../../test/mock/createWidget';
 
 import connectStats from '../connectStats';
 
@@ -30,6 +36,110 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/stats/js/#c
           dispose: expect.any(Function),
         })
       );
+    });
+  });
+
+  describe('getRenderState', () => {
+    test('returns the render state', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const createStats = connectStats(renderFn, unmountFn);
+      const stats = createStats();
+      const helper = jsHelper(createSearchClient(), 'indexName', {
+        index: 'indexName',
+      });
+      helper.search = jest.fn();
+
+      const renderState1 = stats.getRenderState(
+        { stats: {} },
+        createInitOptions({ helper })
+      );
+
+      expect(renderState1.stats).toEqual({
+        hitsPerPage: undefined,
+        nbHits: 0,
+        nbPages: 0,
+        page: 0,
+        processingTimeMS: -1,
+        query: '',
+        widgetParams: {},
+      });
+
+      stats.init(createInitOptions({ helper, state: helper.state }));
+
+      const results = new SearchResults(helper.state, [
+        createSingleSearchResponse(),
+      ]);
+
+      const renderState2 = stats.getRenderState(
+        { stats: {} },
+        createRenderOptions({
+          helper,
+          state: helper.state,
+          results,
+        })
+      );
+
+      expect(renderState2.stats).toEqual({
+        hitsPerPage: results.hitsPerPage,
+        nbHits: results.nbHits,
+        nbPages: results.nbPages,
+        page: results.page,
+        processingTimeMS: results.processingTimeMS,
+        query: results.query,
+        widgetParams: {},
+      });
+    });
+  });
+
+  describe('getWidgetRenderState', () => {
+    test('returns the widget render state', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const createStats = connectStats(renderFn, unmountFn);
+      const stats = createStats();
+      const helper = jsHelper(createSearchClient(), 'indexName', {
+        index: 'indexName',
+      });
+      helper.search = jest.fn();
+
+      const renderState1 = stats.getWidgetRenderState(
+        createInitOptions({ helper })
+      );
+
+      expect(renderState1).toEqual({
+        hitsPerPage: undefined,
+        nbHits: 0,
+        nbPages: 0,
+        page: 0,
+        processingTimeMS: -1,
+        query: '',
+        widgetParams: {},
+      });
+
+      stats.init(createInitOptions({ helper, state: helper.state }));
+
+      const results = new SearchResults(helper.state, [
+        createSingleSearchResponse(),
+      ]);
+
+      const renderState2 = stats.getWidgetRenderState(
+        createRenderOptions({
+          helper,
+          state: helper.state,
+          results,
+        })
+      );
+
+      expect(renderState2).toEqual({
+        hitsPerPage: results.hitsPerPage,
+        nbHits: results.nbHits,
+        nbPages: results.nbPages,
+        page: results.page,
+        processingTimeMS: results.processingTimeMS,
+        query: results.query,
+        widgetParams: {},
+      });
     });
   });
 

--- a/src/connectors/stats/__tests__/connectStats-test.js
+++ b/src/connectors/stats/__tests__/connectStats-test.js
@@ -120,7 +120,17 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/stats/js/#c
       stats.init(createInitOptions({ helper, state: helper.state }));
 
       const results = new SearchResults(helper.state, [
-        createSingleSearchResponse(),
+        createSingleSearchResponse({
+          hits: [
+            { brand: 'samsung', objectID: '1' },
+            { brand: 'apple', objectID: '2' },
+            { brand: 'sony', objectID: '3' },
+            { brand: 'benq', objectID: '4' },
+            { brand: 'dyson', objectID: '5' },
+          ],
+          hitsPerPage: 3,
+          query: 'apple',
+        }),
       ]);
 
       const renderState2 = stats.getWidgetRenderState(

--- a/src/connectors/stats/__tests__/connectStats-test.js
+++ b/src/connectors/stats/__tests__/connectStats-test.js
@@ -81,12 +81,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/stats/js/#c
       );
 
       expect(renderState2.stats).toEqual({
-        hitsPerPage: results.hitsPerPage,
-        nbHits: results.nbHits,
-        nbPages: results.nbPages,
-        page: results.page,
-        processingTimeMS: results.processingTimeMS,
-        query: results.query,
+        hitsPerPage: 20,
+        nbHits: 0,
+        nbPages: 0,
+        page: 0,
+        processingTimeMS: 0,
+        query: '',
         widgetParams: {},
       });
     });
@@ -132,12 +132,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/stats/js/#c
       );
 
       expect(renderState2).toEqual({
-        hitsPerPage: results.hitsPerPage,
-        nbHits: results.nbHits,
-        nbPages: results.nbPages,
-        page: results.page,
-        processingTimeMS: results.processingTimeMS,
-        query: results.query,
+        hitsPerPage: 20,
+        nbHits: 0,
+        nbPages: 0,
+        page: 0,
+        processingTimeMS: 0,
+        query: '',
         widgetParams: {},
       });
     });
@@ -177,12 +177,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/stats/js/#c
       );
 
       expect(renderState).toEqual({
-        hitsPerPage: results.hitsPerPage,
-        nbHits: results.nbHits,
-        nbPages: results.nbPages,
-        page: results.page,
-        processingTimeMS: results.processingTimeMS,
-        query: results.query,
+        hitsPerPage: 3,
+        nbHits: 5,
+        nbPages: 2,
+        page: 0,
+        processingTimeMS: 0,
+        query: 'apple',
         widgetParams: {},
       });
     });

--- a/src/connectors/stats/__tests__/connectStats-test.js
+++ b/src/connectors/stats/__tests__/connectStats-test.js
@@ -120,6 +120,55 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/stats/js/#c
       stats.init(createInitOptions({ helper, state: helper.state }));
 
       const results = new SearchResults(helper.state, [
+        createSingleSearchResponse(),
+      ]);
+
+      const renderState2 = stats.getWidgetRenderState(
+        createRenderOptions({
+          helper,
+          state: helper.state,
+          results,
+        })
+      );
+
+      expect(renderState2).toEqual({
+        hitsPerPage: results.hitsPerPage,
+        nbHits: results.nbHits,
+        nbPages: results.nbPages,
+        page: results.page,
+        processingTimeMS: results.processingTimeMS,
+        query: results.query,
+        widgetParams: {},
+      });
+    });
+
+    test('returns the widget render state with results', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const createStats = connectStats(renderFn, unmountFn);
+      const stats = createStats();
+      const helper = jsHelper(createSearchClient(), 'indexName', {
+        index: 'indexName',
+      });
+      helper.search = jest.fn();
+
+      const renderState1 = stats.getWidgetRenderState(
+        createInitOptions({ helper })
+      );
+
+      expect(renderState1).toEqual({
+        hitsPerPage: undefined,
+        nbHits: 0,
+        nbPages: 0,
+        page: 0,
+        processingTimeMS: -1,
+        query: '',
+        widgetParams: {},
+      });
+
+      stats.init(createInitOptions({ helper, state: helper.state }));
+
+      const results = new SearchResults(helper.state, [
         createSingleSearchResponse({
           hits: [
             { brand: 'samsung', objectID: '1' },

--- a/src/connectors/stats/__tests__/connectStats-test.js
+++ b/src/connectors/stats/__tests__/connectStats-test.js
@@ -152,20 +152,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/stats/js/#c
       });
       helper.search = jest.fn();
 
-      const renderState1 = stats.getWidgetRenderState(
-        createInitOptions({ helper })
-      );
-
-      expect(renderState1).toEqual({
-        hitsPerPage: undefined,
-        nbHits: 0,
-        nbPages: 0,
-        page: 0,
-        processingTimeMS: -1,
-        query: '',
-        widgetParams: {},
-      });
-
       stats.init(createInitOptions({ helper, state: helper.state }));
 
       const results = new SearchResults(helper.state, [
@@ -182,7 +168,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/stats/js/#c
         }),
       ]);
 
-      const renderState2 = stats.getWidgetRenderState(
+      const renderState = stats.getWidgetRenderState(
         createRenderOptions({
           helper,
           state: helper.state,
@@ -190,7 +176,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/stats/js/#c
         })
       );
 
-      expect(renderState2).toEqual({
+      expect(renderState).toEqual({
         hitsPerPage: results.hitsPerPage,
         nbHits: results.nbHits,
         nbPages: results.nbPages,

--- a/src/connectors/stats/connectStats.js
+++ b/src/connectors/stats/connectStats.js
@@ -89,15 +89,27 @@ export default function connectStats(renderFn, unmountFn = noop) {
     },
 
     getWidgetRenderState({ results, helper }) {
-      return {
-        hitsPerPage: results ? results.hitsPerPage : helper.state.hitsPerPage,
-        nbHits: results ? results.nbHits : 0,
-        nbPages: results ? results.nbPages : 0,
-        page: results ? results.page : helper.state.page || 0,
-        processingTimeMS: results ? results.processingTimeMS : -1,
-        query: results ? results.query : helper.state.query || '',
-        widgetParams,
-      };
+      if (results) {
+        return {
+          hitsPerPage: results.hitsPerPage,
+          nbHits: results.nbHits,
+          nbPages: results.nbPages,
+          page: results.page,
+          processingTimeMS: results.processingTimeMS,
+          query: results.query,
+          widgetParams,
+        };
+      } else {
+        return {
+          hitsPerPage: helper.state.hitsPerPage,
+          nbHits: 0,
+          nbPages: 0,
+          page: helper.state.page || 0,
+          processingTimeMS: -1,
+          query: helper.state.query || '',
+          widgetParams,
+        };
+      }
     },
   });
 }

--- a/src/connectors/stats/connectStats.js
+++ b/src/connectors/stats/connectStats.js
@@ -53,33 +53,25 @@ export default function connectStats(renderFn, unmountFn = noop) {
   return (widgetParams = {}) => ({
     $$type: 'ais.stats',
 
-    init({ helper, instantSearchInstance }) {
+    init(initOptions) {
+      const { instantSearchInstance } = initOptions;
+
       renderFn(
         {
+          ...this.getWidgetRenderState(initOptions),
           instantSearchInstance,
-          hitsPerPage: helper.state.hitsPerPage,
-          nbHits: 0,
-          nbPages: 0,
-          page: helper.state.page || 0,
-          processingTimeMS: -1,
-          query: helper.state.query || '',
-          widgetParams,
         },
         true
       );
     },
 
-    render({ results, instantSearchInstance }) {
+    render(renderOptions) {
+      const { instantSearchInstance } = renderOptions;
+
       renderFn(
         {
+          ...this.getWidgetRenderState(renderOptions),
           instantSearchInstance,
-          hitsPerPage: results.hitsPerPage,
-          nbHits: results.nbHits,
-          nbPages: results.nbPages,
-          page: results.page,
-          processingTimeMS: results.processingTimeMS,
-          query: results.query,
-          widgetParams,
         },
         false
       );
@@ -87,6 +79,25 @@ export default function connectStats(renderFn, unmountFn = noop) {
 
     dispose() {
       unmountFn();
+    },
+
+    getRenderState(renderState, renderOptions) {
+      return {
+        ...renderState,
+        stats: this.getWidgetRenderState(renderOptions),
+      };
+    },
+
+    getWidgetRenderState({ results, helper }) {
+      return {
+        hitsPerPage: results ? results.hitsPerPage : helper.state.hitsPerPage,
+        nbHits: results ? results.nbHits : 0,
+        nbPages: results ? results.nbPages : 0,
+        page: results ? results.page : helper.state.page || 0,
+        processingTimeMS: results ? results.processingTimeMS : -1,
+        query: results ? results.query : helper.state.query || '',
+        widgetParams,
+      };
     },
   });
 }

--- a/src/connectors/stats/connectStats.js
+++ b/src/connectors/stats/connectStats.js
@@ -89,17 +89,7 @@ export default function connectStats(renderFn, unmountFn = noop) {
     },
 
     getWidgetRenderState({ results, helper }) {
-      if (results) {
-        return {
-          hitsPerPage: results.hitsPerPage,
-          nbHits: results.nbHits,
-          nbPages: results.nbPages,
-          page: results.page,
-          processingTimeMS: results.processingTimeMS,
-          query: results.query,
-          widgetParams,
-        };
-      } else {
+      if (!results) {
         return {
           hitsPerPage: helper.state.hitsPerPage,
           nbHits: 0,
@@ -110,6 +100,16 @@ export default function connectStats(renderFn, unmountFn = noop) {
           widgetParams,
         };
       }
+
+      return {
+        hitsPerPage: results.hitsPerPage,
+        nbHits: results.nbHits,
+        nbPages: results.nbPages,
+        page: results.page,
+        processingTimeMS: results.processingTimeMS,
+        query: results.query,
+        widgetParams,
+      };
     },
   });
 }


### PR DESCRIPTION
This implements the `getRenderState` and `getWidgetRenderState` widget lifecycle hooks in `stats`.