### PR TITLE
test(renderState): add tests for getWidgetRenderState at connectHierarchicalMenu and connectSearchBox

### DIFF
--- a/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.js
+++ b/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.js
@@ -551,6 +551,112 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
     });
   });
 
+  describe('getWidgetRenderState', () => {
+    test('returns the widget render state', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const createHierarchicalMenu = connectHierarchicalMenu(
+        renderFn,
+        unmountFn
+      );
+      const hierarchicalMenu = createHierarchicalMenu({
+        attributes: ['category', 'subCategory'],
+      });
+      const helper = algoliasearchHelper(
+        createSearchClient(),
+        'indexName',
+        hierarchicalMenu.getWidgetSearchParameters(new SearchParameters(), {
+          uiState: {},
+        })
+      );
+
+      expect(
+        hierarchicalMenu.getWidgetRenderState(
+          { hierarchicalMenu: { anotherCategory: {} } },
+          createInitOptions({ helper })
+        )
+      ).toEqual({
+        items: [],
+        refine: undefined,
+        sendEvent: expect.any(Function),
+        createURL: expect.any(Function),
+        widgetParams: { attributes: ['category', 'subCategory'] },
+        isShowingMore: false,
+        toggleShowMore: expect.any(Function),
+        canToggleShowMore: false,
+      });
+    });
+
+    test('returns the widget render state with results', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const createHierarchicalMenu = connectHierarchicalMenu(
+        renderFn,
+        unmountFn
+      );
+      const hierarchicalMenu = createHierarchicalMenu({
+        attributes: ['category', 'subCategory'],
+      });
+      const helper = algoliasearchHelper(
+        createSearchClient(),
+        'indexName',
+        hierarchicalMenu.getWidgetSearchParameters(new SearchParameters(), {
+          uiState: {},
+        })
+      );
+
+      hierarchicalMenu.init(createInitOptions({ helper }));
+
+      expect(
+        hierarchicalMenu.getWidgetRenderState(
+          createRenderOptions({
+            helper,
+            results: new SearchResults(helper.state, [
+              createSingleSearchResponse({
+                hits: [],
+                facets: {
+                  category: {
+                    Decoration: 880,
+                  },
+                  subCategory: {
+                    'Decoration > Candle holders & candles': 193,
+                    'Decoration > Frames & pictures': 173,
+                  },
+                },
+              }),
+              createSingleSearchResponse({
+                facets: {
+                  category: {
+                    Decoration: 880,
+                    Outdoor: 47,
+                  },
+                },
+              }),
+            ]),
+          })
+        )
+      ).toEqual({
+        items: [
+          {
+            count: 880,
+            data: null,
+            exhaustive: true,
+            isRefined: false,
+            label: 'Decoration',
+            value: 'Decoration',
+          },
+        ],
+        refine: expect.any(Function),
+        sendEvent: expect.any(Function),
+        createURL: expect.any(Function),
+        widgetParams: { attributes: ['category', 'subCategory'] },
+        isShowingMore: false,
+        toggleShowMore: expect.any(Function),
+        canToggleShowMore: false,
+      });
+    });
+  });
+
   describe('getWidgetUiState', () => {
     test('returns the `uiState` empty', () => {
       const render = () => {};

--- a/src/connectors/search-box/__tests__/connectSearchBox-test.js
+++ b/src/connectors/search-box/__tests__/connectSearchBox-test.js
@@ -391,6 +391,93 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
     });
   });
 
+  describe('getWidgetRenderState', () => {
+    test('returns the widget render state with default render options', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const queryHook = jest.fn();
+      const createSearchBox = connectSearchBox(renderFn, unmountFn);
+      const searchBox = createSearchBox({
+        queryHook,
+      });
+
+      const renderState1 = searchBox.getWidgetRenderState(createInitOptions());
+
+      expect(renderState1).toEqual({
+        clear: expect.any(Function),
+        isSearchStalled: false,
+        query: '',
+        refine: undefined,
+        widgetParams: { queryHook },
+      });
+
+      searchBox.init(createInitOptions());
+      const renderState2 = searchBox.getWidgetRenderState(
+        createRenderOptions()
+      );
+      expect(renderState2).toEqual({
+        clear: renderState2.clear,
+        isSearchStalled: false,
+        query: '',
+        refine: expect.any(Function),
+        widgetParams: {
+          queryHook,
+        },
+      });
+
+      searchBox.render(createRenderOptions());
+      const renderState3 = searchBox.getWidgetRenderState(
+        createRenderOptions()
+      );
+      expect(renderState3.clear).toBe(renderState2.clear);
+    });
+
+    test('returns the widget render state with a query', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const createSearchBox = connectSearchBox(renderFn, unmountFn);
+      const searchBox = createSearchBox();
+      const helper = algoliasearchHelper(createSearchClient(), 'indexName', {
+        query: 'query',
+      });
+
+      searchBox.init(createInitOptions());
+
+      const renderState = searchBox.getWidgetRenderState(
+        createRenderOptions({ helper })
+      );
+
+      expect(renderState).toEqual({
+        clear: expect.any(Function),
+        isSearchStalled: false,
+        query: 'query',
+        refine: expect.any(Function),
+        widgetParams: {},
+      });
+    });
+
+    test('returns the widget render state with stalled search', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const createSearchBox = connectSearchBox(renderFn, unmountFn);
+      const searchBox = createSearchBox();
+
+      searchBox.init(createInitOptions());
+
+      const renderState = searchBox.getWidgetRenderState(
+        createRenderOptions({ searchMetadata: { isSearchStalled: true } })
+      );
+
+      expect(renderState).toEqual({
+        clear: expect.any(Function),
+        isSearchStalled: true,
+        query: '',
+        refine: expect.any(Function),
+        widgetParams: {},
+      });
+    });
+  });
+
   describe('dispose', () => {
     it('calls the unmount function', () => {
       const helper = algoliasearchHelper({}, '');


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR adds the missing tests for getWidgetRenderState at connectHierarchicalMenu and connectSearchBox.