### PR TITLE
feat(sortBy): implement `getRenderState` and `getWidgetRenderState`

### DIFF
--- a/src/connectors/sort-by/__tests__/connectSortBy-test.js
+++ b/src/connectors/sort-by/__tests__/connectSortBy-test.js
@@ -11,6 +11,7 @@ import {
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/mock/createWidget';
+import { createSingleSearchResponse } from '../../../../test/mock/createAPIResponse';
 
 describe('connectSortBy', () => {
   describe('Usage', () => {
@@ -255,6 +256,140 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
       expect(helper.state.index).toBe('bop');
       expect(helper.search).toHaveBeenCalledTimes(2);
     }
+  });
+
+  describe('getRenderState', () => {
+    test('returns the render state', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const createSortBy = connectSortBy(renderFn, unmountFn);
+      const sortBy = createSortBy({
+        items: [
+          { label: 'asc', value: 'asc' },
+          { label: 'desc', value: 'desc' },
+        ],
+      });
+      const helper = algoliasearchHelper(createSearchClient(), 'indexName', {
+        index: 'indexName',
+      });
+
+      const renderState1 = sortBy.getRenderState(
+        {
+          sortBy: {},
+        },
+        createInitOptions({ helper })
+      );
+
+      expect(renderState1.sortBy).toEqual({
+        currentRefinement: 'indexName',
+        refine: undefined,
+        hasNoResults: true,
+        options: [
+          { label: 'asc', value: 'asc' },
+          { label: 'desc', value: 'desc' },
+        ],
+        widgetParams: {
+          items: [
+            { label: 'asc', value: 'asc' },
+            { label: 'desc', value: 'desc' },
+          ],
+        },
+      });
+
+      sortBy.init(createInitOptions({ helper }));
+
+      const renderState2 = sortBy.getRenderState(
+        { sortBy: {} },
+        createRenderOptions({
+          helper,
+          state: helper.state,
+          results: new SearchResults(helper.state, [
+            createSingleSearchResponse(),
+          ]),
+        })
+      );
+
+      expect(renderState2.sortBy).toEqual({
+        currentRefinement: 'indexName',
+        refine: expect.any(Function),
+        hasNoResults: true,
+        options: [
+          { label: 'asc', value: 'asc' },
+          { label: 'desc', value: 'desc' },
+        ],
+        widgetParams: {
+          items: [
+            { label: 'asc', value: 'asc' },
+            { label: 'desc', value: 'desc' },
+          ],
+        },
+      });
+    });
+  });
+
+  describe('getWidgetRenderState', () => {
+    test('returns the widget render state', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const createSortBy = connectSortBy(renderFn, unmountFn);
+      const sortBy = createSortBy({
+        items: [
+          { label: 'asc', value: 'asc' },
+          { label: 'desc', value: 'desc' },
+        ],
+      });
+      const helper = algoliasearchHelper(createSearchClient(), 'indexName', {
+        index: 'indexName',
+      });
+
+      const renderState1 = sortBy.getWidgetRenderState(
+        createInitOptions({ helper })
+      );
+
+      expect(renderState1).toEqual({
+        currentRefinement: 'indexName',
+        refine: undefined,
+        hasNoResults: true,
+        options: [
+          { label: 'asc', value: 'asc' },
+          { label: 'desc', value: 'desc' },
+        ],
+        widgetParams: {
+          items: [
+            { label: 'asc', value: 'asc' },
+            { label: 'desc', value: 'desc' },
+          ],
+        },
+      });
+
+      sortBy.init(createInitOptions({ helper }));
+
+      const renderState2 = sortBy.getWidgetRenderState(
+        createRenderOptions({
+          helper,
+          state: helper.state,
+          results: new SearchResults(helper.state, [
+            createSingleSearchResponse(),
+          ]),
+        })
+      );
+
+      expect(renderState2).toEqual({
+        currentRefinement: 'indexName',
+        refine: expect.any(Function),
+        hasNoResults: true,
+        options: [
+          { label: 'asc', value: 'asc' },
+          { label: 'desc', value: 'desc' },
+        ],
+        widgetParams: {
+          items: [
+            { label: 'asc', value: 'asc' },
+            { label: 'desc', value: 'desc' },
+          ],
+        },
+      });
+    });
   });
 
   describe('options', () => {

--- a/src/connectors/sort-by/__tests__/connectSortBy-test.js
+++ b/src/connectors/sort-by/__tests__/connectSortBy-test.js
@@ -265,13 +265,18 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
       const createSortBy = connectSortBy(renderFn, unmountFn);
       const sortBy = createSortBy({
         items: [
-          { label: 'asc', value: 'asc' },
-          { label: 'desc', value: 'desc' },
+          { label: 'default', value: 'index_default' },
+          { label: 'asc', value: 'index_asc' },
+          { label: 'desc', value: 'index_desc' },
         ],
       });
-      const helper = algoliasearchHelper(createSearchClient(), 'indexName', {
-        index: 'indexName',
-      });
+      const helper = algoliasearchHelper(
+        createSearchClient(),
+        'index_default',
+        {
+          index: 'index_default',
+        }
+      );
 
       const renderState1 = sortBy.getRenderState(
         {
@@ -281,22 +286,25 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
       );
 
       expect(renderState1.sortBy).toEqual({
-        currentRefinement: 'indexName',
+        currentRefinement: 'index_default',
         refine: undefined,
         hasNoResults: true,
         options: [
-          { label: 'asc', value: 'asc' },
-          { label: 'desc', value: 'desc' },
+          { label: 'default', value: 'index_default' },
+          { label: 'asc', value: 'index_asc' },
+          { label: 'desc', value: 'index_desc' },
         ],
         widgetParams: {
           items: [
-            { label: 'asc', value: 'asc' },
-            { label: 'desc', value: 'desc' },
+            { label: 'default', value: 'index_default' },
+            { label: 'asc', value: 'index_asc' },
+            { label: 'desc', value: 'index_desc' },
           ],
         },
       });
 
       sortBy.init(createInitOptions({ helper }));
+      sortBy.getWidgetRenderState({ helper }).refine('index_desc');
 
       const renderState2 = sortBy.getRenderState(
         { sortBy: {} },
@@ -304,23 +312,32 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
           helper,
           state: helper.state,
           results: new SearchResults(helper.state, [
-            createSingleSearchResponse(),
+            createSingleSearchResponse({
+              hits: [
+                { brand: 'samsung', objectID: '1' },
+                { brand: 'apple', objectID: '2' },
+                { brand: 'sony', objectID: '3' },
+              ],
+              hitsPerPage: 1,
+            }),
           ]),
         })
       );
 
       expect(renderState2.sortBy).toEqual({
-        currentRefinement: 'indexName',
+        currentRefinement: 'index_desc',
         refine: expect.any(Function),
-        hasNoResults: true,
+        hasNoResults: false,
         options: [
-          { label: 'asc', value: 'asc' },
-          { label: 'desc', value: 'desc' },
+          { label: 'default', value: 'index_default' },
+          { label: 'asc', value: 'index_asc' },
+          { label: 'desc', value: 'index_desc' },
         ],
         widgetParams: {
           items: [
-            { label: 'asc', value: 'asc' },
-            { label: 'desc', value: 'desc' },
+            { label: 'default', value: 'index_default' },
+            { label: 'asc', value: 'index_asc' },
+            { label: 'desc', value: 'index_desc' },
           ],
         },
       });
@@ -334,12 +351,13 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
       const createSortBy = connectSortBy(renderFn, unmountFn);
       const sortBy = createSortBy({
         items: [
-          { label: 'asc', value: 'asc' },
-          { label: 'desc', value: 'desc' },
+          { label: 'default', value: 'index_default' },
+          { label: 'asc', value: 'index_asc' },
+          { label: 'desc', value: 'index_desc' },
         ],
       });
-      const helper = algoliasearchHelper(createSearchClient(), 'indexName', {
-        index: 'indexName',
+      const helper = algoliasearchHelper(createSearchClient(), 'index_desc', {
+        index: 'index_desc',
       });
 
       const renderState1 = sortBy.getWidgetRenderState(
@@ -347,45 +365,56 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
       );
 
       expect(renderState1).toEqual({
-        currentRefinement: 'indexName',
+        currentRefinement: 'index_desc',
         refine: undefined,
         hasNoResults: true,
         options: [
-          { label: 'asc', value: 'asc' },
-          { label: 'desc', value: 'desc' },
+          { label: 'default', value: 'index_default' },
+          { label: 'asc', value: 'index_asc' },
+          { label: 'desc', value: 'index_desc' },
         ],
         widgetParams: {
           items: [
-            { label: 'asc', value: 'asc' },
-            { label: 'desc', value: 'desc' },
+            { label: 'default', value: 'index_default' },
+            { label: 'asc', value: 'index_asc' },
+            { label: 'desc', value: 'index_desc' },
           ],
         },
       });
 
       sortBy.init(createInitOptions({ helper }));
+      sortBy.getWidgetRenderState({ helper }).refine('index_default');
 
       const renderState2 = sortBy.getWidgetRenderState(
         createRenderOptions({
           helper,
           state: helper.state,
           results: new SearchResults(helper.state, [
-            createSingleSearchResponse(),
+            createSingleSearchResponse({
+              hits: [
+                { brand: 'samsung', objectID: '1' },
+                { brand: 'apple', objectID: '2' },
+              ],
+              hitsPerPage: 20,
+            }),
           ]),
         })
       );
 
       expect(renderState2).toEqual({
-        currentRefinement: 'indexName',
+        currentRefinement: 'index_default',
         refine: expect.any(Function),
-        hasNoResults: true,
+        hasNoResults: false,
         options: [
-          { label: 'asc', value: 'asc' },
-          { label: 'desc', value: 'desc' },
+          { label: 'default', value: 'index_default' },
+          { label: 'asc', value: 'index_asc' },
+          { label: 'desc', value: 'index_desc' },
         ],
         widgetParams: {
           items: [
-            { label: 'asc', value: 'asc' },
-            { label: 'desc', value: 'desc' },
+            { label: 'default', value: 'index_default' },
+            { label: 'asc', value: 'index_asc' },
+            { label: 'desc', value: 'index_desc' },
           ],
         },
       });

--- a/src/connectors/sort-by/connectSortBy.js
+++ b/src/connectors/sort-by/connectSortBy.js
@@ -103,7 +103,8 @@ export default function connectSortBy(renderFn, unmountFn = noop) {
     return {
       $$type: 'ais.sortBy',
 
-      init({ helper, instantSearchInstance, parent }) {
+      init(initOptions) {
+        const { helper, instantSearchInstance, parent } = initOptions;
         const currentIndex = helper.state.index;
         const isCurrentIndexInItems = find(
           items,
@@ -122,25 +123,18 @@ export default function connectSortBy(renderFn, unmountFn = noop) {
 
         renderFn(
           {
-            currentRefinement: currentIndex,
-            options: transformItems(items),
-            refine: this.setIndex,
-            hasNoResults: true,
-            widgetParams,
+            ...this.getWidgetRenderState(initOptions),
             instantSearchInstance,
           },
           true
         );
       },
 
-      render({ helper, results, instantSearchInstance }) {
+      render(renderOptions) {
+        const { instantSearchInstance } = renderOptions;
         renderFn(
           {
-            currentRefinement: helper.state.index,
-            options: transformItems(items),
-            refine: this.setIndex,
-            hasNoResults: results.nbHits === 0,
-            widgetParams,
+            ...this.getWidgetRenderState(renderOptions),
             instantSearchInstance,
           },
           false
@@ -151,6 +145,23 @@ export default function connectSortBy(renderFn, unmountFn = noop) {
         unmountFn();
 
         return state.setIndex(this.initialIndex);
+      },
+
+      getRenderState(renderState, renderOptions) {
+        return {
+          ...renderState,
+          sortBy: this.getWidgetRenderState(renderOptions),
+        };
+      },
+
+      getWidgetRenderState({ results, helper }) {
+        return {
+          currentRefinement: helper.state.index,
+          options: transformItems(items),
+          refine: this.setIndex,
+          hasNoResults: results ? results.nbHits === 0 : true,
+          widgetParams,
+        };
       },
 
       getWidgetUiState(uiState, { searchParameters }) {


### PR DESCRIPTION
This implements the `getRenderState` and `getWidgetRenderState` widget lifecycle hooks in `sortBy`.