### PR TITLE
fix(hits): provide `sendEvent` and `bindEvent` to `init`

### DIFF
--- a/src/connectors/hits/__tests__/connectHits-test.ts
+++ b/src/connectors/hits/__tests__/connectHits-test.ts
@@ -461,6 +461,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
 
       expect(renderState1.hits).toEqual({
         hits: [],
+        sendEvent: expect.any(Function),
+        bindEvent: expect.any(Function),
         results: undefined,
         widgetParams: {},
       });
@@ -490,13 +492,13 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
 
       ((expectedHits as unknown) as EscapedHits).__escaped = true;
 
-      expect(renderState2.hits).toEqual(
-        expect.objectContaining({
-          hits: expectedHits,
-          results,
-          widgetParams: {},
-        })
-      );
+      expect(renderState2.hits).toEqual({
+        hits: expectedHits,
+        sendEvent: renderState1.hits!.sendEvent,
+        bindEvent: renderState1.hits!.bindEvent,
+        results,
+        widgetParams: {},
+      });
     });
   });
 
@@ -516,6 +518,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
 
       expect(renderState1).toEqual({
         hits: [],
+        sendEvent: expect.any(Function),
+        bindEvent: expect.any(Function),
         results: undefined,
         widgetParams: {},
       });
@@ -544,13 +548,13 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
 
       ((expectedHits as unknown) as EscapedHits).__escaped = true;
 
-      expect(renderState2).toEqual(
-        expect.objectContaining({
-          hits: expectedHits,
-          results,
-          widgetParams: {},
-        })
-      );
+      expect(renderState2).toEqual({
+        hits: expectedHits,
+        sendEvent: renderState1.sendEvent,
+        bindEvent: renderState2.bindEvent,
+        results,
+        widgetParams: {},
+      });
     });
   });
 

--- a/src/connectors/hits/connectHits.ts
+++ b/src/connectors/hits/connectHits.ts
@@ -115,6 +115,8 @@ const connectHits: HitsConnector = function connectHits(
         if (!results) {
           return {
             hits: [],
+            sendEvent,
+            bindEvent,
             results: undefined,
             widgetParams,
           };

--- a/src/connectors/powered-by/connectPoweredBy.ts
+++ b/src/connectors/powered-by/connectPoweredBy.ts
@@ -47,7 +47,7 @@ const connectPoweredBy: PoweredByConnector = function connectPoweredBy(
     'utm_campaign=poweredby';
 
   return widgetParams => {
-    const { url = defaultUrl } = widgetParams || {};
+    const { url = defaultUrl } = widgetParams || ({} as typeof widgetParams);
 
     return {
       $$type: 'ais.poweredBy',


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR fixes two minor issues:

1. In `connectHits`, it didn't return `sendEvent` and `bindEvent` in some condition. Now it does.
2. Casting an empty object as `typeof widgetParams` in `connectPoweredBy`.

Both discovered by `yarn type-check`.