### PR TITLE
fix(insights): do not throw when sending event right after creating insights middleware

### DIFF
--- a/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -79,6 +79,22 @@ describe('insights', () => {
       });
     });
 
+    it('does not throw when an event is sent right after the creation', () => {
+      const { insightsClient, instantSearchInstance } = createTestEnvironment();
+      createInsightsMiddleware({
+        insightsClient,
+      })({ instantSearchInstance });
+
+      expect(() => {
+        insightsClient('viewedObjectIDs', {
+          userToken: 'my-user-token',
+          index: instantSearchInstance.indexName,
+          eventName: 'Products Viewed',
+          objectIDs: ['obj-id0', 'obj-id1'],
+        });
+      }).not.toThrow();
+    });
+
     it('warns dev if userToken is set before creating the middleware', () => {
       const { insightsClient, instantSearchInstance } = createTestEnvironment();
       insightsClient('setUserToken', 'abc');

--- a/src/middlewares/createInsightsMiddleware.ts
+++ b/src/middlewares/createInsightsMiddleware.ts
@@ -93,12 +93,12 @@ export const createInsightsMiddleware: CreateInsightsMiddleware = props => {
           setUserTokenToSearch(anonymousUserToken);
         }
 
-        if (queuedUserToken) {
-          insightsClient('setUserToken', queuedUserToken);
-        }
-
+        // We consider the `userToken` coming from a `init` call to have a higher
+        // importance than the one coming from the queue.
         if (userTokenBeforeInit) {
           insightsClient('setUserToken', userTokenBeforeInit);
+        } else if (queuedUserToken) {
+          insightsClient('setUserToken', queuedUserToken);
         }
 
         // This updates userToken which is set explicitly by `aa('setUserToken', userToken)`

--- a/src/middlewares/createInsightsMiddleware.ts
+++ b/src/middlewares/createInsightsMiddleware.ts
@@ -52,11 +52,11 @@ export const createInsightsMiddleware: CreateInsightsMiddleware = props => {
       // At this point, even though `search-insights` is not loaded yet,
       // we still want to read the token from the queue.
       // Otherwise, the first search call will be fired without the token.
-      (insightsClient as any).queue.forEach(([method, firstArgument]) => {
-        if (method === 'setUserToken') {
-          queuedUserToken = firstArgument;
-        }
-      });
+      [, queuedUserToken] =
+        (insightsClient as any).queue
+          .slice()
+          .reverse()
+          .find(([method]) => method === 'setUserToken') || [];
     }
     insightsClient('_get', '_userToken', (userToken: string) => {
       // If user has called `aa('setUserToken', 'my-user-token')` before creating

--- a/src/middlewares/createInsightsMiddleware.ts
+++ b/src/middlewares/createInsightsMiddleware.ts
@@ -41,7 +41,8 @@ export const createInsightsMiddleware: CreateInsightsMiddleware = props => {
     const [appId, apiKey] = getAppIdAndApiKey(instantSearchInstance.client);
     let queuedUserToken: string | undefined = undefined;
     let userTokenBeforeInit: string | undefined = undefined;
-    if (Array.isArray((insightsClient as any).queue)) {
+
+    if (Array.isArray(insightsClient.queue)) {
       // Context: The umd build of search-insights is asynchronously loaded by the snippet.
       //
       // When user calls `aa('setUserToken', 'my-user-token')` before `search-insights` is loaded,
@@ -53,7 +54,7 @@ export const createInsightsMiddleware: CreateInsightsMiddleware = props => {
       // we still want to read the token from the queue.
       // Otherwise, the first search call will be fired without the token.
       [, queuedUserToken] =
-        (insightsClient as any).queue
+        insightsClient.queue
           .slice()
           .reverse()
           .find(([method]) => method === 'setUserToken') || [];

--- a/src/types/insights.ts
+++ b/src/types/insights.ts
@@ -46,7 +46,9 @@ export type InsightsClient = InsightsSendEvent &
   InsightsOnUserTokenChange &
   InsightsGet &
   InsightsInit &
-  InsightsSetUserToken;
+  InsightsSetUserToken & {
+    queue?: Array<[string, any]>;
+  };
 
 export type InsightsClientWrapper = (
   method: InsightsClientMethod,

--- a/src/types/insights.ts
+++ b/src/types/insights.ts
@@ -12,6 +12,11 @@ export type InsightsClientPayload = {
   positions?: number[];
 };
 
+export type InsightsSetUserToken = (
+  method: 'setUserToken',
+  userToken: string
+) => void;
+
 export type InsightsSendEvent = (
   method: InsightsClientMethod,
   payload: InsightsClientPayload
@@ -40,7 +45,8 @@ export type InsightsInit = (
 export type InsightsClient = InsightsSendEvent &
   InsightsOnUserTokenChange &
   InsightsGet &
-  InsightsInit;
+  InsightsInit &
+  InsightsSetUserToken;
 
 export type InsightsClientWrapper = (
   method: InsightsClientMethod,

--- a/test/mock/createInsightsClient.ts
+++ b/test/mock/createInsightsClient.ts
@@ -74,6 +74,9 @@ export function createInsightsUmdVersion() {
       queue.push = ([methodName, ...args]) => {
         _aa(methodName, ...args);
       };
+      return {
+        algoliaAnalytics: instance,
+      };
     },
   };
 }

--- a/test/mock/createInsightsClient.ts
+++ b/test/mock/createInsightsClient.ts
@@ -26,13 +26,25 @@ export function createAlgoliaAnalytics() {
       callback(values._userToken);
     }
   };
+  const viewedObjectIDs = jest.fn(() => {
+    if (!values._apiKey) {
+      throw new Error(
+        'apiKey is missing, please provide it so we can authenticate the application'
+      );
+    }
+    if (!values._appId) {
+      throw new Error(
+        'appId is missing, please provide it, so we can properly attribute data to your application'
+      );
+    }
+  });
 
   return {
     setUserToken,
     init,
     _get,
     onUserTokenChange,
-    viewedObjectIDs: jest.fn(),
+    viewedObjectIDs,
   };
 }
 

--- a/test/mock/createInsightsClient.ts
+++ b/test/mock/createInsightsClient.ts
@@ -26,17 +26,15 @@ export function createAlgoliaAnalytics() {
       callback(values._userToken);
     }
   };
+  const sendEvent = () => {
+    if (!values._hasCredentials) {
+      throw new Error(
+        "Before calling any methods on the analytics, you first need to call the 'init' function with appId and apiKey parameters"
+      );
+    }
+  };
   const viewedObjectIDs = jest.fn(() => {
-    if (!values._apiKey) {
-      throw new Error(
-        'apiKey is missing, please provide it so we can authenticate the application'
-      );
-    }
-    if (!values._appId) {
-      throw new Error(
-        'appId is missing, please provide it, so we can properly attribute data to your application'
-      );
-    }
+    sendEvent();
   });
 
   return {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

## Summary

There is a bug where an error is thrown when sending events right after creating `insights` middleware.


## Details

It happens only when:

- The UMD version of `search-insights` is used.
- The `search-insights` is not loaded yet at the time of creation of `insights` middleware.

In `insights` middleware, the way it intializes `insightsClient` is asynchronous. If it happens too late (normally it happens when the library itself hasn't loaded yet), sending event will throw an error saying "the insightsClient is not intialized yet".

So, in this PR, we change to initialize `insightsClient` synchronously without checking if it was already initialized before.

## A behavioral change

Before this PR, userToken that was set before creating insights middleware was ignored. However since this PR, that has to  change, because although user has a code like the following:

```js
aa('init', { ... });
aa('setUserToken', 'token-a');

search.use(createInsightsMiddleware({ ... }));
```

`insights` middleware calls `aa('init', ...)` anyway. It means `aa(init', ...)` will override the token with an anonymous token. Of course, we can update `search-insights` not to override already given token with an anonymous one, but there is no guarantee that user upgrades search-insights correctly. So we cannot rely on it.

Since `insights` middleware initializes `insightsClient`, we guide not to call `aa('init')` by themselves, but we cannot stop it. And if they set userToken like above, we shouldn't lose the token (although before this PR, we used to ignore the token before creating the middleware).

This behavioral change can be considered as a breaking change, but we can also consider it as a "fix" because it is correct to prefer a userToken that was explicitly set by user over an anonymous token.

## Alternatives

There are a couple of other options requiring changes in `search-insights` side, but it's risky to have a change in InstantSearch that depends on a change in `search-insights` because we cannot guarantee users will upgrade them both.

## Future task

This doesn't concern another issue we've recently discussed about, which is to provide an option to disable cookie at all. It will be dealt separately.

## Result

1. When UMD search-insights is not loaded yet, it doesn't throw when sending events. It stores it in the queue and send it later correctly.
2. If user sets a token before creating `insights` middleware, it takes it into account. (It used to not.)