### PR TITLE
chore(ts): update typing of widgetParams

### DIFF
--- a/src/types/connector.ts
+++ b/src/types/connector.ts
@@ -64,13 +64,19 @@ export type Connector<TRendererOptions, TConnectorParams> = <TWidgetParams>(
   /**
    * The render function.
    */
-  renderFn: Renderer<TRendererOptions, TWidgetParams>,
+  renderFn: Renderer<TRendererOptions, TConnectorParams & TWidgetParams>,
 
   /**
    * The called function when unmounting a widget.
    */
   unmountFn?: Unmounter
-) => WidgetFactory<TRendererOptions, TConnectorParams, TWidgetParams>;
+) => WidgetFactory<
+  TRendererOptions,
+  // a connector doesn't know the difference between TWidgetParams and the
+  // TConnectorParams for the context of rendering.
+  TConnectorParams & TWidgetParams,
+  TConnectorParams & TWidgetParams
+>;
 
 /**
  * Transforms the given items.

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -427,9 +427,9 @@ export type Widget<
       /**
        * Returns the render state of the current widget to pass to the render function.
        */
-      getWidgetRenderState?: (
+      getWidgetRenderState?(
         renderOptions: InitOptions | RenderOptions
-      ) => unknown;
+      ): unknown;
       /**
        * Returns IndexRenderState of the current index component tree
        * to build the render state of the whole app.
@@ -449,7 +449,12 @@ export type WidgetFactory<TRendererOptions, TConnectorParams, TWidgetParams> = (
    */
   widgetParams: TConnectorParams & TWidgetParams
 ) => Widget<{
-  renderState: WidgetRenderState<TRendererOptions, TWidgetParams>;
+  renderState: WidgetRenderState<
+    TRendererOptions,
+    // widgetParams sent to the connector of builtin widgets are actually
+    // the connector params, therefore renderState uses TConnectorParams only
+    TConnectorParams
+  >;
 }>;
 
 export type Template<TTemplateData = void> =

--- a/src/widgets/analytics/analytics.ts
+++ b/src/widgets/analytics/analytics.ts
@@ -61,7 +61,11 @@ export type AnalyticsWidgetParams = {
 
 const withUsage = createDocumentationMessageGenerator({ name: 'analytics' });
 
-export type AnalyticsWidget = WidgetFactory<{}, {}, AnalyticsWidgetParams>;
+export type AnalyticsWidget = WidgetFactory<
+  {},
+  AnalyticsWidgetParams,
+  AnalyticsWidgetParams
+>;
 
 // @major this widget will be removed from the next major version.
 const analytics: AnalyticsWidget = function analytics(widgetParams) {

--- a/src/widgets/places/places.ts
+++ b/src/widgets/places/places.ts
@@ -30,18 +30,19 @@ type PlacesWidgetState = {
   isInitialLatLngViaIPSet: boolean;
 };
 
+export type PlacesWidget = WidgetFactory<
+  {},
+  PlacesWidgetParams,
+  PlacesWidgetParams
+>;
+
 /**
  * This widget sets the geolocation value for the search based on the selected
  * result in the Algolia Places autocomplete.
  */
-const placesWidget: WidgetFactory<{}, {}, PlacesWidgetParams> = (
-  widgetParams: PlacesWidgetParams
-) => {
-  const {
-    placesReference = undefined,
-    defaultPosition = [],
-    ...placesOptions
-  } = widgetParams || {};
+const placesWidget: PlacesWidget = (widgetParams: PlacesWidgetParams) => {
+  const { placesReference, defaultPosition = [], ...placesOptions } =
+    widgetParams || ({} as PlacesWidgetParams);
 
   if (typeof placesReference !== 'function') {
     throw new Error(


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

fix typing of widgetParams in the context of connectors & getWidgetRenderState 

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

wdigetParams in the context of getWidgetRenderState is different in the two contexts:
- in connectors it's connectorparams & twidgetparams (they pass all arguments from widgetParams through to widgetParams in getWidgetRenderState)
- in widgets it's actually only connectorparams (they don't pass all arguments through to the connector, and set defaults)
