### PR TITLE
fix(renderState): initialize connectorState before init

### DIFF
--- a/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.ts
+++ b/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.ts
@@ -1131,6 +1131,68 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
   });
 
   describe('getWidgetRenderState', () => {
+    it('returns the widget render state before init', () => {
+      const rendering = jest.fn();
+      const makeWidget = connectNumericMenu(rendering);
+      const widget = makeWidget({
+        attribute: 'numerics',
+        items: [
+          { label: 'below 10', end: 10 },
+          { label: '10 - 20', start: 10, end: 20 },
+          { label: 'more than 20', start: 20 },
+        ],
+      });
+
+      const helper = jsHelper(createSearchClient(), '');
+      helper.search = () => helper;
+
+      const renderState = widget.getWidgetRenderState(
+        createInitOptions({ state: helper.state, helper })
+      );
+
+      expect(renderState).toEqual({
+        items: [
+          {
+            isRefined: false,
+            label: 'below 10',
+            value: '%7B%22end%22:10%7D',
+          },
+          {
+            isRefined: false,
+            label: '10 - 20',
+            value: '%7B%22start%22:10,%22end%22:20%7D',
+          },
+          {
+            isRefined: false,
+            label: 'more than 20',
+            value: '%7B%22start%22:20%7D',
+          },
+        ],
+        createURL: expect.any(Function),
+        refine: expect.any(Function),
+        sendEvent: expect.any(Function),
+        hasNoResults: true,
+        widgetParams: {
+          attribute: 'numerics',
+          items: [
+            {
+              end: 10,
+              label: 'below 10',
+            },
+            {
+              end: 20,
+              label: '10 - 20',
+              start: 10,
+            },
+            {
+              label: 'more than 20',
+              start: 20,
+            },
+          ],
+        },
+      });
+    });
+
     it('returns the widget render state', () => {
       const [widget, helper] = getInitializedWidget();
 

--- a/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.ts
+++ b/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.ts
@@ -1144,7 +1144,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
       });
 
       const helper = jsHelper(createSearchClient(), '');
-      helper.search = () => helper;
 
       const renderState = widget.getWidgetRenderState(
         createInitOptions({ state: helper.state, helper })

--- a/src/connectors/numeric-menu/connectNumericMenu.ts
+++ b/src/connectors/numeric-menu/connectNumericMenu.ts
@@ -175,20 +175,7 @@ const connectNumericMenu: NumericMenuConnector = function connectNumericMenu(
       $$type,
 
       init(initOptions) {
-        const { helper, createURL, instantSearchInstance } = initOptions;
-
-        connectorState.refine = facetValue => {
-          const refinedState = getRefinedState(
-            helper.state,
-            attribute,
-            facetValue
-          );
-          connectorState.sendEvent!('click', facetValue);
-          helper.setState(refinedState).search();
-        };
-
-        connectorState.createURL = state => facetValue =>
-          createURL(getRefinedState(state, attribute, facetValue));
+        const { instantSearchInstance } = initOptions;
 
         renderFn(
           {
@@ -293,7 +280,30 @@ const connectNumericMenu: NumericMenuConnector = function connectNumericMenu(
         };
       },
 
-      getWidgetRenderState({ results, state, instantSearchInstance, helper }) {
+      getWidgetRenderState({
+        results,
+        state,
+        instantSearchInstance,
+        helper,
+        createURL,
+      }) {
+        if (!connectorState.refine) {
+          connectorState.refine = facetValue => {
+            const refinedState = getRefinedState(
+              helper.state,
+              attribute,
+              facetValue
+            );
+            connectorState.sendEvent!('click', facetValue);
+            helper.setState(refinedState).search();
+          };
+        }
+
+        if (!connectorState.createURL) {
+          connectorState.createURL = newState => facetValue =>
+            createURL(getRefinedState(newState, attribute, facetValue));
+        }
+
         if (!connectorState.sendEvent) {
           connectorState.sendEvent = createSendEvent({
             instantSearchInstance,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR intializes `connectorState` before `init`. Since `refine` and `createURL` was initialized in `init`, it threw an exception when `getRenderState` was called inside `index` widget.

It's fixed with a regression test.