### PR TITLE
fix(insights): use internal `find` util method

### DIFF
--- a/src/middlewares/createInsightsMiddleware.ts
+++ b/src/middlewares/createInsightsMiddleware.ts
@@ -1,6 +1,6 @@
 import { InsightsClient, InsightsClientMethod, Middleware } from '../types';
 import { getInsightsAnonymousUserTokenInternal } from '../helpers';
-import { warning, noop, getAppIdAndApiKey } from '../lib/utils';
+import { warning, noop, getAppIdAndApiKey, find } from '../lib/utils';
 
 export type InsightsEvent = {
   insightsMethod?: InsightsClientMethod;
@@ -54,10 +54,10 @@ export const createInsightsMiddleware: CreateInsightsMiddleware = props => {
       // we still want to read the token from the queue.
       // Otherwise, the first search call will be fired without the token.
       [, queuedUserToken] =
-        insightsClient.queue
-          .slice()
-          .reverse()
-          .find(([method]) => method === 'setUserToken') || [];
+        find(
+          insightsClient.queue.slice().reverse(),
+          ([method]) => method === 'setUserToken'
+        ) || [];
     }
     insightsClient('_get', '_userToken', (userToken: string) => {
       // If user has called `aa('setUserToken', 'my-user-token')` before creating


### PR DESCRIPTION
## Description

In #4575 we introduced a regression in IE because we used the native `find` method instead of our internal util.

## Related

- https://algolia.slack.com/archives/C2XP6HBKQ/p1605624265187700
- https://secure.helpscout.net/conversation/1340807801/309760?folderId=3647171