### PR TITLE
fix(renderState): initialize sendEvent before init

### DIFF
--- a/src/connectors/rating-menu/__tests__/connectRatingMenu-test.js
+++ b/src/connectors/rating-menu/__tests__/connectRatingMenu-test.js
@@ -428,7 +428,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
   });
 
   describe('getRenderState', () => {
-    it('returns the render state', () => {
+    it('returns the render state without results', () => {
       const renderFn = jest.fn();
       const unmountFn = jest.fn();
       const createRatingMenu = connectRatingMenu(renderFn, unmountFn);
@@ -444,12 +444,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
 
       const initOptions = createInitOptions({ state: helper.state, helper });
 
-      ratingMenuWidget.init(initOptions);
-
-      const renderState1 = ratingMenuWidget.getRenderState(
-        {},
-        createInitOptions({ state: helper.state, helper })
-      );
+      const renderState1 = ratingMenuWidget.getRenderState({}, initOptions);
 
       expect(renderState1.ratingMenu).toEqual({
         grade: {
@@ -463,6 +458,25 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
           },
         },
       });
+    });
+
+    it('returns the render state with results', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const createRatingMenu = connectRatingMenu(renderFn, unmountFn);
+      const ratingMenuWidget = createRatingMenu({
+        attribute: 'grade',
+      });
+      const helper = jsHelper({}, 'indexName', {
+        disjunctiveFacets: ['grade'],
+        disjunctiveFacetsRefinements: {
+          grade: ['2', '3', '4'],
+        },
+      });
+
+      const initOptions = createInitOptions({ state: helper.state, helper });
+
+      const renderState1 = ratingMenuWidget.getRenderState({}, initOptions);
 
       const results = new SearchResults(helper.state, [
         createSingleSearchResponse({
@@ -472,14 +486,13 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
         }),
       ]);
 
-      const renderState2 = ratingMenuWidget.getRenderState(
-        {},
-        createRenderOptions({
-          helper,
-          state: helper.state,
-          results,
-        })
-      );
+      const renderOptions = createRenderOptions({
+        helper,
+        state: helper.state,
+        results,
+      });
+
+      const renderState2 = ratingMenuWidget.getRenderState({}, renderOptions);
 
       expect(renderState2.ratingMenu).toEqual({
         grade: {
@@ -526,7 +539,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
   });
 
   describe('getWidgetRenderState', () => {
-    it('returns the widget render state', () => {
+    it('returns the widget render state without results', () => {
       const renderFn = jest.fn();
       const unmountFn = jest.fn();
       const createRatingMenu = connectRatingMenu(renderFn, unmountFn);
@@ -542,11 +555,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
 
       const initOptions = createInitOptions({ state: helper.state, helper });
 
-      ratingMenuWidget.init(initOptions);
-
-      const renderState1 = ratingMenuWidget.getWidgetRenderState(
-        createInitOptions({ state: helper.state, helper })
-      );
+      const renderState1 = ratingMenuWidget.getWidgetRenderState(initOptions);
 
       expect(renderState1).toEqual({
         items: [],
@@ -558,6 +567,25 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
           attribute: 'grade',
         },
       });
+    });
+
+    it('returns the widget render state with results', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const createRatingMenu = connectRatingMenu(renderFn, unmountFn);
+      const ratingMenuWidget = createRatingMenu({
+        attribute: 'grade',
+      });
+      const helper = jsHelper({}, 'indexName', {
+        disjunctiveFacets: ['grade'],
+        disjunctiveFacetsRefinements: {
+          grade: ['2', '3', '4'],
+        },
+      });
+
+      const initOptions = createInitOptions({ state: helper.state, helper });
+
+      const renderState1 = ratingMenuWidget.getWidgetRenderState(initOptions);
 
       const results = new SearchResults(helper.state, [
         createSingleSearchResponse({
@@ -567,13 +595,13 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
         }),
       ]);
 
-      const renderState2 = ratingMenuWidget.getWidgetRenderState(
-        createRenderOptions({
-          helper,
-          state: helper.state,
-          results,
-        })
-      );
+      const renderOptions = createRenderOptions({
+        helper,
+        state: helper.state,
+        results,
+      });
+
+      const renderState2 = ratingMenuWidget.getWidgetRenderState(renderOptions);
 
       expect(renderState2).toEqual({
         items: [

--- a/src/connectors/rating-menu/connectRatingMenu.js
+++ b/src/connectors/rating-menu/connectRatingMenu.js
@@ -168,28 +168,24 @@ export default function connectRatingMenu(renderFn, unmountFn = noop) {
       $$type,
 
       init(initOptions) {
-        const { helper, instantSearchInstance } = initOptions;
-        sendEvent = createSendEvent({
-          instantSearchInstance,
-          helper,
-          getRefinedStar: () => getRefinedStar(helper.state),
-          attribute,
-        });
+        const { instantSearchInstance } = initOptions;
 
         renderFn(
           {
             ...this.getWidgetRenderState(initOptions),
-            instantSearchInstance: initOptions.instantSearchInstance,
+            instantSearchInstance,
           },
           true
         );
       },
 
       render(renderOptions) {
+        const { instantSearchInstance } = renderOptions;
+
         renderFn(
           {
             ...this.getWidgetRenderState(renderOptions),
-            instantSearchInstance: renderOptions.instantSearchInstance,
+            instantSearchInstance,
           },
           false
         );
@@ -205,8 +201,23 @@ export default function connectRatingMenu(renderFn, unmountFn = noop) {
         };
       },
 
-      getWidgetRenderState({ helper, results, state, createURL }) {
+      getWidgetRenderState({
+        helper,
+        results,
+        state,
+        instantSearchInstance,
+        createURL,
+      }) {
         const facetValues = [];
+
+        if (!sendEvent) {
+          sendEvent = createSendEvent({
+            instantSearchInstance,
+            helper,
+            getRefinedStar: () => getRefinedStar(helper.state),
+            attribute,
+          });
+        }
 
         if (results) {
           const allValues = {};


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

Similar to https://github.com/algolia/instantsearch.js/pull/4579, this PR moves the `sendEvent` initialization into `getRenderState` so it is properly initialized if it gets called before `init`.

The `init` calls were also removed from the `getRenderState` and `getWidgetRenderState` tests and the tests were splitted (with and without results).