### PR TITLE
feat(highlight): accept array for attribute

### DIFF
--- a/src/helpers/__tests__/highlight-test.ts
+++ b/src/helpers/__tests__/highlight-test.ts
@@ -138,4 +138,13 @@ describe('highlight', () => {
       `"Nested <mark class=\\"ais-Highlight-highlighted\\">Amazon</mark> name"`
     );
   });
+
+  test('with array attribute as array', () => {
+    expect(
+      highlight({
+        attribute: ['categories', 1],
+        hit,
+      })
+    ).toMatchInlineSnapshot(`"Streaming Media Players"`);
+  });
 });

--- a/src/helpers/__tests__/highlight-test.ts
+++ b/src/helpers/__tests__/highlight-test.ts
@@ -1,4 +1,7 @@
-import snippet from '../snippet';
+import highlight from '../highlight';
+
+const NONE = 'none' as const;
+const FULL = 'full' as const;
 
 /* eslint-disable @typescript-eslint/camelcase */
 const hit = {
@@ -20,92 +23,94 @@ const hit = {
   rating: 4,
   popularity: 21469,
   objectID: '5477500',
-  _snippetResult: {
+  _highlightResult: {
     name: {
       value:
         '<mark>Amazon</mark> - Fire TV Stick with Alexa Voice Remote - Black',
-      matchLevel: 'full',
+      matchLevel: FULL,
       fullyHighlighted: false,
       matchedWords: ['amazon'],
     },
     description: {
       value:
         'Enjoy smart access to videos, games and apps with this <mark>Amazon</mark> Fire TV stick. Its Alexa voice remote lets you deliver hands-free commands when you want to watch television or engage with other applications. With a quad-core processor, 1GB internal memory and 8GB of storage, this portable <mark>Amazon</mark> Fire TV stick works fast for buffer-free streaming.',
-      matchLevel: 'full',
+      matchLevel: FULL,
       fullyHighlighted: false,
       matchedWords: ['amazon'],
     },
     brand: {
       value: '<mark>Amazon</mark>',
-      matchLevel: 'full',
+      matchLevel: FULL,
       fullyHighlighted: true,
       matchedWords: ['amazon'],
     },
     categories: [
       {
         value: 'TV & Home Theater',
-        matchLevel: 'none',
+        matchLevel: NONE,
         matchedWords: [],
       },
       {
         value: 'Streaming Media Players',
-        matchLevel: 'none',
+        matchLevel: NONE,
         matchedWords: [],
       },
     ],
     type: {
       value: 'Streaming media plyr',
-      matchLevel: 'none',
+      matchLevel: NONE,
       matchedWords: [],
     },
     meta: {
       name: {
         value: 'Nested <mark>Amazon</mark> name',
+        matchLevel: NONE,
+        matchedWords: ['Amazon'],
       },
     },
   },
 };
 /* eslint-enable @typescript-eslint/camelcase */
 
-describe('snippet', () => {
+describe('highlight', () => {
   test('with default tag name', () => {
     expect(
-      snippet({
+      highlight({
         attribute: 'name',
         hit,
       })
     ).toMatchInlineSnapshot(
-      `"<mark class=\\"ais-Snippet-highlighted\\">Amazon</mark> - Fire TV Stick with Alexa Voice Remote - Black"`
+      `"<mark class=\\"ais-Highlight-highlighted\\">Amazon</mark> - Fire TV Stick with Alexa Voice Remote - Black"`
     );
   });
 
   test('with custom tag name', () => {
     expect(
-      snippet({
+      highlight({
         attribute: 'description',
         highlightedTagName: 'em',
         hit,
       })
     ).toMatchInlineSnapshot(
-      `"Enjoy smart access to videos, games and apps with this <em class=\\"ais-Snippet-highlighted\\">Amazon</em> Fire TV stick. Its Alexa voice remote lets you deliver hands-free commands when you want to watch television or engage with other applications. With a quad-core processor, 1GB internal memory and 8GB of storage, this portable <em class=\\"ais-Snippet-highlighted\\">Amazon</em> Fire TV stick works fast for buffer-free streaming."`
+      `"Enjoy smart access to videos, games and apps with this <em class=\\"ais-Highlight-highlighted\\">Amazon</em> Fire TV stick. Its Alexa voice remote lets you deliver hands-free commands when you want to watch television or engage with other applications. With a quad-core processor, 1GB internal memory and 8GB of storage, this portable <em class=\\"ais-Highlight-highlighted\\">Amazon</em> Fire TV stick works fast for buffer-free streaming."`
     );
   });
 
   test('with custom highlighted class name', () => {
     expect(
-      snippet({
+      highlight({
         attribute: 'description',
-        cssClasses: { highlighted: '__highlighted' },
+        cssClasses: { highlighted: '__highlighted class' },
         hit,
       })
     ).toMatchInlineSnapshot(
-      `"Enjoy smart access to videos, games and apps with this <mark class=\\"ais-Snippet-highlighted __highlighted\\">Amazon</mark> Fire TV stick. Its Alexa voice remote lets you deliver hands-free commands when you want to watch television or engage with other applications. With a quad-core processor, 1GB internal memory and 8GB of storage, this portable <mark class=\\"ais-Snippet-highlighted __highlighted\\">Amazon</mark> Fire TV stick works fast for buffer-free streaming."`
+      `"Enjoy smart access to videos, games and apps with this <mark class=\\"ais-Highlight-highlighted __highlighted class\\">Amazon</mark> Fire TV stick. Its Alexa voice remote lets you deliver hands-free commands when you want to watch television or engage with other applications. With a quad-core processor, 1GB internal memory and 8GB of storage, this portable <mark class=\\"ais-Highlight-highlighted __highlighted class\\">Amazon</mark> Fire TV stick works fast for buffer-free streaming."`
     );
   });
 
   test('with unknown attribute returns an empty string', () => {
     expect(
-      snippet({
+      highlight({
         attribute: 'wrong-attribute',
         hit,
       })
@@ -114,12 +119,23 @@ describe('snippet', () => {
 
   test('with nested attribute', () => {
     expect(
-      snippet({
+      highlight({
         attribute: 'meta.name',
         hit,
       })
     ).toMatchInlineSnapshot(
-      `"Nested <mark class=\\"ais-Snippet-highlighted\\">Amazon</mark> name"`
+      `"Nested <mark class=\\"ais-Highlight-highlighted\\">Amazon</mark> name"`
+    );
+  });
+
+  test('with nested attribute as array', () => {
+    expect(
+      highlight({
+        attribute: ['meta', 'name'],
+        hit,
+      })
+    ).toMatchInlineSnapshot(
+      `"Nested <mark class=\\"ais-Highlight-highlighted\\">Amazon</mark> name"`
     );
   });
 });

--- a/src/helpers/__tests__/highlight-test.ts
+++ b/src/helpers/__tests__/highlight-test.ts
@@ -142,7 +142,7 @@ describe('highlight', () => {
   test('with array attribute as array', () => {
     expect(
       highlight({
-        attribute: ['categories', 1],
+        attribute: ['categories', '1'],
         hit,
       })
     ).toMatchInlineSnapshot(`"Streaming Media Players"`);

--- a/src/helpers/__tests__/snippet-test.ts
+++ b/src/helpers/__tests__/snippet-test.ts
@@ -1,4 +1,7 @@
-import highlight from '../highlight';
+import snippet from '../snippet';
+
+const NONE = 'none' as const;
+const FULL = 'full' as const;
 
 /* eslint-disable @typescript-eslint/camelcase */
 const hit = {
@@ -20,92 +23,90 @@ const hit = {
   rating: 4,
   popularity: 21469,
   objectID: '5477500',
-  _highlightResult: {
+  _snippetResult: {
     name: {
       value:
         '<mark>Amazon</mark> - Fire TV Stick with Alexa Voice Remote - Black',
-      matchLevel: 'full',
+      matchLevel: FULL,
       fullyHighlighted: false,
       matchedWords: ['amazon'],
     },
     description: {
       value:
         'Enjoy smart access to videos, games and apps with this <mark>Amazon</mark> Fire TV stick. Its Alexa voice remote lets you deliver hands-free commands when you want to watch television or engage with other applications. With a quad-core processor, 1GB internal memory and 8GB of storage, this portable <mark>Amazon</mark> Fire TV stick works fast for buffer-free streaming.',
-      matchLevel: 'full',
+      matchLevel: FULL,
       fullyHighlighted: false,
       matchedWords: ['amazon'],
     },
     brand: {
       value: '<mark>Amazon</mark>',
-      matchLevel: 'full',
+      matchLevel: FULL,
       fullyHighlighted: true,
       matchedWords: ['amazon'],
     },
     categories: [
       {
         value: 'TV & Home Theater',
-        matchLevel: 'none',
-        matchedWords: [],
+        matchLevel: NONE,
       },
       {
         value: 'Streaming Media Players',
-        matchLevel: 'none',
-        matchedWords: [],
+        matchLevel: NONE,
       },
     ],
     type: {
       value: 'Streaming media plyr',
-      matchLevel: 'none',
-      matchedWords: [],
+      matchLevel: NONE,
     },
     meta: {
       name: {
         value: 'Nested <mark>Amazon</mark> name',
+        matchLevel: FULL,
       },
     },
   },
 };
 /* eslint-enable @typescript-eslint/camelcase */
 
-describe('highlight', () => {
+describe('snippet', () => {
   test('with default tag name', () => {
     expect(
-      highlight({
+      snippet({
         attribute: 'name',
         hit,
       })
     ).toMatchInlineSnapshot(
-      `"<mark class=\\"ais-Highlight-highlighted\\">Amazon</mark> - Fire TV Stick with Alexa Voice Remote - Black"`
+      `"<mark class=\\"ais-Snippet-highlighted\\">Amazon</mark> - Fire TV Stick with Alexa Voice Remote - Black"`
     );
   });
 
   test('with custom tag name', () => {
     expect(
-      highlight({
+      snippet({
         attribute: 'description',
         highlightedTagName: 'em',
         hit,
       })
     ).toMatchInlineSnapshot(
-      `"Enjoy smart access to videos, games and apps with this <em class=\\"ais-Highlight-highlighted\\">Amazon</em> Fire TV stick. Its Alexa voice remote lets you deliver hands-free commands when you want to watch television or engage with other applications. With a quad-core processor, 1GB internal memory and 8GB of storage, this portable <em class=\\"ais-Highlight-highlighted\\">Amazon</em> Fire TV stick works fast for buffer-free streaming."`
+      `"Enjoy smart access to videos, games and apps with this <em class=\\"ais-Snippet-highlighted\\">Amazon</em> Fire TV stick. Its Alexa voice remote lets you deliver hands-free commands when you want to watch television or engage with other applications. With a quad-core processor, 1GB internal memory and 8GB of storage, this portable <em class=\\"ais-Snippet-highlighted\\">Amazon</em> Fire TV stick works fast for buffer-free streaming."`
     );
   });
 
   test('with custom highlighted class name', () => {
     expect(
-      highlight({
+      snippet({
         attribute: 'description',
-        cssClasses: { highlighted: '__highlighted class' },
+        cssClasses: { highlighted: '__highlighted' },
         hit,
       })
     ).toMatchInlineSnapshot(
-      `"Enjoy smart access to videos, games and apps with this <mark class=\\"ais-Highlight-highlighted __highlighted class\\">Amazon</mark> Fire TV stick. Its Alexa voice remote lets you deliver hands-free commands when you want to watch television or engage with other applications. With a quad-core processor, 1GB internal memory and 8GB of storage, this portable <mark class=\\"ais-Highlight-highlighted __highlighted class\\">Amazon</mark> Fire TV stick works fast for buffer-free streaming."`
+      `"Enjoy smart access to videos, games and apps with this <mark class=\\"ais-Snippet-highlighted __highlighted\\">Amazon</mark> Fire TV stick. Its Alexa voice remote lets you deliver hands-free commands when you want to watch television or engage with other applications. With a quad-core processor, 1GB internal memory and 8GB of storage, this portable <mark class=\\"ais-Snippet-highlighted __highlighted\\">Amazon</mark> Fire TV stick works fast for buffer-free streaming."`
     );
   });
 
   test('with unknown attribute returns an empty string', () => {
     expect(
-      highlight({
+      snippet({
         attribute: 'wrong-attribute',
         hit,
       })
@@ -114,12 +115,23 @@ describe('highlight', () => {
 
   test('with nested attribute', () => {
     expect(
-      highlight({
+      snippet({
         attribute: 'meta.name',
         hit,
       })
     ).toMatchInlineSnapshot(
-      `"Nested <mark class=\\"ais-Highlight-highlighted\\">Amazon</mark> name"`
+      `"Nested <mark class=\\"ais-Snippet-highlighted\\">Amazon</mark> name"`
+    );
+  });
+
+  test('with nested attribute as array', () => {
+    expect(
+      snippet({
+        attribute: ['meta', 'name'],
+        hit,
+      })
+    ).toMatchInlineSnapshot(
+      `"Nested <mark class=\\"ais-Snippet-highlighted\\">Amazon</mark> name"`
     );
   });
 });

--- a/src/helpers/__tests__/snippet-test.ts
+++ b/src/helpers/__tests__/snippet-test.ts
@@ -134,4 +134,22 @@ describe('snippet', () => {
       `"Nested <mark class=\\"ais-Snippet-highlighted\\">Amazon</mark> name"`
     );
   });
+
+  test('with array attribute', () => {
+    expect(
+      snippet({
+        attribute: 'categories.1',
+        hit,
+      })
+    ).toMatchInlineSnapshot(`"Streaming Media Players"`);
+  });
+
+  test('with array attribute as array', () => {
+    expect(
+      snippet({
+        attribute: ['categories', 1],
+        hit,
+      })
+    ).toMatchInlineSnapshot(`"Streaming Media Players"`);
+  });
 });

--- a/src/helpers/__tests__/snippet-test.ts
+++ b/src/helpers/__tests__/snippet-test.ts
@@ -147,7 +147,7 @@ describe('snippet', () => {
   test('with array attribute as array', () => {
     expect(
       snippet({
-        attribute: ['categories', 1],
+        attribute: ['categories', '1'],
         hit,
       })
     ).toMatchInlineSnapshot(`"Streaming Media Players"`);

--- a/src/helpers/highlight.ts
+++ b/src/helpers/highlight.ts
@@ -4,7 +4,8 @@ import { TAG_REPLACEMENT } from '../lib/escape-highlight';
 import { component } from '../lib/suit';
 
 export type HighlightOptions = {
-  attribute: string;
+  // @MAJOR only accept string[] here
+  attribute: string | string[];
   highlightedTagName?: string;
   hit: Partial<Hit>;
   cssClasses?: {
@@ -20,9 +21,8 @@ export default function highlight({
   hit,
   cssClasses = {},
 }: HighlightOptions): string {
-  const attributeValue =
-    (getPropertyByPath(hit, `_highlightResult.${attribute}.value`) as string) ||
-    '';
+  const { value: attributeValue = '' } =
+    getPropertyByPath(hit._highlightResult, attribute) || {};
 
   // cx is not used, since it would be bundled as a dependency for Vue & Angular
   const className =

--- a/src/helpers/highlight.ts
+++ b/src/helpers/highlight.ts
@@ -4,8 +4,8 @@ import { TAG_REPLACEMENT } from '../lib/escape-highlight';
 import { component } from '../lib/suit';
 
 export type HighlightOptions = {
-  // @MAJOR only accept string[] here
-  attribute: string | string[];
+  // @MAJOR only accept array of paths here
+  attribute: string | Array<string | number>;
   highlightedTagName?: string;
   hit: Partial<Hit>;
   cssClasses?: {

--- a/src/helpers/highlight.ts
+++ b/src/helpers/highlight.ts
@@ -4,7 +4,7 @@ import { TAG_REPLACEMENT } from '../lib/escape-highlight';
 import { component } from '../lib/suit';
 
 export type HighlightOptions = {
-  // @MAJOR only accept array of paths here
+  // @MAJOR string should no longer be allowed to be a path, only array can be a path
   attribute: string | string[];
   highlightedTagName?: string;
   hit: Partial<Hit>;

--- a/src/helpers/highlight.ts
+++ b/src/helpers/highlight.ts
@@ -5,7 +5,7 @@ import { component } from '../lib/suit';
 
 export type HighlightOptions = {
   // @MAJOR only accept array of paths here
-  attribute: string | Array<string | number>;
+  attribute: string | string[];
   highlightedTagName?: string;
   hit: Partial<Hit>;
   cssClasses?: {

--- a/src/helpers/snippet.ts
+++ b/src/helpers/snippet.ts
@@ -4,7 +4,8 @@ import { TAG_REPLACEMENT } from '../lib/escape-highlight';
 import { component } from '../lib/suit';
 
 export type SnippetOptions = {
-  attribute: string;
+  // @MAJOR only accept string[] here
+  attribute: string | string[];
   highlightedTagName?: string;
   hit: Partial<Hit>;
   cssClasses?: {
@@ -20,9 +21,8 @@ export default function snippet({
   hit,
   cssClasses = {},
 }: SnippetOptions): string {
-  const attributeValue =
-    (getPropertyByPath(hit, `_snippetResult.${attribute}.value`) as string) ||
-    '';
+  const { value: attributeValue = '' } =
+    getPropertyByPath(hit._snippetResult, attribute) || {};
 
   // cx is not used, since it would be bundled as a dependency for Vue & Angular
   const className =

--- a/src/helpers/snippet.ts
+++ b/src/helpers/snippet.ts
@@ -4,7 +4,7 @@ import { TAG_REPLACEMENT } from '../lib/escape-highlight';
 import { component } from '../lib/suit';
 
 export type SnippetOptions = {
-  // @MAJOR only accept string[] here
+  // @MAJOR string should no longer be allowed to be a path, only array can be a path
   attribute: string | string[];
   highlightedTagName?: string;
   hit: Partial<Hit>;

--- a/src/helpers/snippet.ts
+++ b/src/helpers/snippet.ts
@@ -5,7 +5,7 @@ import { component } from '../lib/suit';
 
 export type SnippetOptions = {
   // @MAJOR only accept string[] here
-  attribute: string | Array<string | number>;
+  attribute: string | string[];
   highlightedTagName?: string;
   hit: Partial<Hit>;
   cssClasses?: {

--- a/src/helpers/snippet.ts
+++ b/src/helpers/snippet.ts
@@ -5,7 +5,7 @@ import { component } from '../lib/suit';
 
 export type SnippetOptions = {
   // @MAJOR only accept string[] here
-  attribute: string | string[];
+  attribute: string | Array<string | number>;
   highlightedTagName?: string;
   hit: Partial<Hit>;
   cssClasses?: {

--- a/src/lib/utils/__tests__/getPropertyByPath-test.ts
+++ b/src/lib/utils/__tests__/getPropertyByPath-test.ts
@@ -78,7 +78,7 @@ describe('getPropertyByPath', () => {
       expect(
         getPropertyByPath(
           { dog: { cat: ['test', { algolia: { cool: true } }] } },
-          ['dog', 'cat', 1, 'algolia', 'cool']
+          ['dog', 'cat', '1', 'algolia', 'cool']
         )
       ).toBe(true);
     });

--- a/src/lib/utils/__tests__/getPropertyByPath-test.ts
+++ b/src/lib/utils/__tests__/getPropertyByPath-test.ts
@@ -1,0 +1,107 @@
+import getPropertyByPath from '../getPropertyByPath';
+
+describe('getPropertyByPath', () => {
+  describe('path as string', () => {
+    it('gets an existing property', () => {
+      expect(getPropertyByPath({ dog: true }, 'dog')).toBe(true);
+    });
+
+    it('gets an existing, deep property', () => {
+      expect(getPropertyByPath({ dog: { cat: true } }, 'dog.cat')).toBe(true);
+    });
+
+    it('gets an existing, very deep property', () => {
+      expect(
+        getPropertyByPath(
+          { dog: { cat: { algolia: { cool: true } } } },
+          'dog.cat.algolia.cool'
+        )
+      ).toBe(true);
+    });
+
+    it('gets undefined for a non-existing, very deep property', () => {
+      expect(
+        getPropertyByPath(
+          { dog: { cat: { algolia: { cool: true } } } },
+          'dog.cat.algolia.nonexistent'
+        )
+      ).toBe(undefined);
+    });
+
+    it('gets undefined for a non-existing, very deep property (midway)', () => {
+      expect(
+        getPropertyByPath({ dog: { cat: true } }, 'dog.cat.algolia.nonexistent')
+      ).toBe(undefined);
+    });
+
+    it('gets undefined for a non-existing property', () => {
+      expect(getPropertyByPath({ dog: true }, 'algolia')).toBe(undefined);
+    });
+
+    it('gets undefined for an undefined object', () => {
+      expect(getPropertyByPath(undefined, 'algolia')).toBe(undefined);
+    });
+  });
+
+  describe('path as array', () => {
+    it('gets an existing property', () => {
+      expect(getPropertyByPath({ dog: true }, ['dog'])).toBe(true);
+    });
+
+    it('gets an existing, deep property', () => {
+      expect(getPropertyByPath({ dog: { cat: true } }, ['dog', 'cat'])).toBe(
+        true
+      );
+    });
+
+    it('gets an existing, very deep property', () => {
+      expect(
+        getPropertyByPath({ dog: { cat: { algolia: { cool: true } } } }, [
+          'dog',
+          'cat',
+          'algolia',
+          'cool',
+        ])
+      ).toBe(true);
+    });
+
+    it('gets undefined for a non-existing, very deep property', () => {
+      expect(
+        getPropertyByPath({ dog: { cat: { algolia: { cool: true } } } }, [
+          'dog',
+          'cat',
+          'algolia',
+          'nonexistent',
+        ])
+      ).toBe(undefined);
+    });
+
+    it('gets undefined for a non-existing, very deep property (midway)', () => {
+      expect(
+        getPropertyByPath({ dog: { cat: true } }, [
+          'dog',
+          'cat',
+          'algolia',
+          'nonexistent',
+        ])
+      ).toBe(undefined);
+    });
+
+    it('gets undefined for a non-existing property', () => {
+      expect(getPropertyByPath({ dog: true }, ['algolia'])).toBe(undefined);
+    });
+
+    it('gets undefined for an undefined object', () => {
+      expect(getPropertyByPath(undefined, ['algolia'])).toBe(undefined);
+    });
+
+    it('gets a path with . in the parts', () => {
+      expect(
+        getPropertyByPath({ 'this.that': { there: true } }, [
+          'this.that',
+          'there',
+        ])
+      ).toBe(true);
+    });
+  });
+});

--- a/src/lib/utils/__tests__/getPropertyByPath-test.ts
+++ b/src/lib/utils/__tests__/getPropertyByPath-test.ts
@@ -19,6 +19,15 @@ describe('getPropertyByPath', () => {
       ).toBe(true);
     });
 
+    it('gets an existing, very deep array property', () => {
+      expect(
+        getPropertyByPath(
+          { dog: { cat: ['test', { algolia: { cool: true } }] } },
+          'dog.cat.1.algolia.cool'
+        )
+      ).toBe(true);
+    });
+
     it('gets undefined for a non-existing, very deep property', () => {
       expect(
         getPropertyByPath(
@@ -62,6 +71,15 @@ describe('getPropertyByPath', () => {
           'algolia',
           'cool',
         ])
+      ).toBe(true);
+    });
+
+    it('gets an existing, very deep array property', () => {
+      expect(
+        getPropertyByPath(
+          { dog: { cat: ['test', { algolia: { cool: true } }] } },
+          ['dog', 'cat', 1, 'algolia', 'cool']
+        )
       ).toBe(true);
     });
 

--- a/src/lib/utils/getPropertyByPath.ts
+++ b/src/lib/utils/getPropertyByPath.ts
@@ -1,5 +1,8 @@
-function getPropertyByPath(object: object, path: string): any {
-  const parts = path.split('.');
+function getPropertyByPath(
+  object: object | undefined,
+  path: string | string[]
+): any {
+  const parts = Array.isArray(path) ? path : path.split('.');
 
   return parts.reduce((current, key) => current && current[key], object);
 }

--- a/src/lib/utils/getPropertyByPath.ts
+++ b/src/lib/utils/getPropertyByPath.ts
@@ -1,6 +1,6 @@
 function getPropertyByPath(
   object: object | undefined,
-  path: string | Array<number | string>
+  path: string | string[]
 ): any {
   const parts = Array.isArray(path) ? path : path.split('.');
 

--- a/src/lib/utils/getPropertyByPath.ts
+++ b/src/lib/utils/getPropertyByPath.ts
@@ -1,6 +1,6 @@
 function getPropertyByPath(
   object: object | undefined,
-  path: string | string[]
+  path: string | Array<number | string>
 ): any {
   const parts = Array.isArray(path) ? path : path.split('.');
 


### PR DESCRIPTION
React InstantSearch already supports this form for attribute, and it gets documented in https://github.com/algolia/doc/pull/5141

In a future major we can drop the string form for a safer access to the values (especially if eg. the value contains dots)

