### PR TITLE
feat(index): expose createURL

### DIFF
--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -53,8 +53,11 @@ export type Index = Widget & {
   getResults(): SearchResults | null;
   getParent(): Index | null;
   getWidgets(): Widget[];
+  createURL(state: SearchParameters): string;
+
   addWidgets(widgets: Widget[]): Index;
   removeWidgets(widgets: Widget[]): Index;
+
   init(options: IndexInitOptions): void;
   render(options: IndexRenderOptions): void;
   dispose(): void;
@@ -196,14 +199,6 @@ const index = (props: IndexProps): Index => {
   let helper: Helper | null = null;
   let derivedHelper: DerivedHelper | null = null;
 
-  const createURL = (nextState: SearchParameters) =>
-    localInstantSearchInstance!._createURL!({
-      [indexId]: getLocalWidgetsState(localWidgets, {
-        searchParameters: nextState,
-        helper: helper!,
-      }),
-    });
-
   return {
     $$type: 'ais.index',
 
@@ -225,6 +220,15 @@ const index = (props: IndexProps): Index => {
 
     getParent() {
       return localParent;
+    },
+
+    createURL(nextState: SearchParameters) {
+      return localInstantSearchInstance!._createURL!({
+        [indexId]: getLocalWidgetsState(localWidgets, {
+          searchParameters: nextState,
+          helper: helper!,
+        }),
+      });
     },
 
     getWidgets() {
@@ -278,7 +282,7 @@ const index = (props: IndexProps): Index => {
                 state: helper!.state,
                 renderState: localInstantSearchInstance!.renderState,
                 templatesConfig: localInstantSearchInstance!.templatesConfig,
-                createURL,
+                createURL: this.createURL,
                 scopedResults: [],
                 searchMetadata: {
                   isSearchStalled: localInstantSearchInstance!._isSearchStalled,
@@ -304,7 +308,7 @@ const index = (props: IndexProps): Index => {
               state: helper!.state,
               renderState: localInstantSearchInstance!.renderState,
               templatesConfig: localInstantSearchInstance!.templatesConfig,
-              createURL,
+              createURL: this.createURL,
               scopedResults: [],
               searchMetadata: {
                 isSearchStalled: localInstantSearchInstance!._isSearchStalled,
@@ -484,7 +488,7 @@ const index = (props: IndexProps): Index => {
               state: helper!.state,
               renderState: instantSearchInstance.renderState,
               templatesConfig: instantSearchInstance.templatesConfig,
-              createURL,
+              createURL: this.createURL,
               scopedResults: [],
               searchMetadata: {
                 isSearchStalled: instantSearchInstance._isSearchStalled,
@@ -515,7 +519,7 @@ const index = (props: IndexProps): Index => {
             state: helper!.state,
             renderState: instantSearchInstance.renderState,
             templatesConfig: instantSearchInstance.templatesConfig,
-            createURL,
+            createURL: this.createURL,
             scopedResults: [],
             searchMetadata: {
               isSearchStalled: instantSearchInstance._isSearchStalled,
@@ -571,7 +575,7 @@ const index = (props: IndexProps): Index => {
               state: this.getResults()!._state,
               renderState: instantSearchInstance.renderState,
               templatesConfig: instantSearchInstance.templatesConfig,
-              createURL,
+              createURL: this.createURL,
               searchMetadata: {
                 isSearchStalled: instantSearchInstance._isSearchStalled,
               },
@@ -604,7 +608,7 @@ const index = (props: IndexProps): Index => {
             state: this.getResults()!._state,
             renderState: instantSearchInstance.renderState,
             templatesConfig: instantSearchInstance.templatesConfig,
-            createURL,
+            createURL: this.createURL,
             searchMetadata: {
               isSearchStalled: instantSearchInstance._isSearchStalled,
             },

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -106,7 +106,7 @@ function privateHelperSetState(
   }
 }
 
-function getLocalWidgetsState(
+function getLocalWidgetsUiState(
   widgets: Widget[],
   widgetStateOptions: WidgetUiStateOptions,
   initialUiState: IndexUiState = {}
@@ -224,7 +224,7 @@ const index = (props: IndexProps): Index => {
 
     createURL(nextState: SearchParameters) {
       return localInstantSearchInstance!._createURL!({
-        [indexId]: getLocalWidgetsState(localWidgets, {
+        [indexId]: getLocalWidgetsUiState(localWidgets, {
           searchParameters: nextState,
           helper: helper!,
         }),
@@ -348,7 +348,7 @@ const index = (props: IndexProps): Index => {
           return next || state;
         }, helper!.state);
 
-        localUiState = getLocalWidgetsState(localWidgets, {
+        localUiState = getLocalWidgetsUiState(localWidgets, {
           searchParameters: nextState,
           helper: helper!,
         });
@@ -540,7 +540,7 @@ const index = (props: IndexProps): Index => {
         // @ts-ignore _uiState comes from privateHelperSetState and thus isn't typed on the helper event
         const _uiState = event._uiState;
 
-        localUiState = getLocalWidgetsState(
+        localUiState = getLocalWidgetsUiState(
           localWidgets,
           {
             searchParameters: state,
@@ -669,7 +669,7 @@ const index = (props: IndexProps): Index => {
     },
 
     refreshUiState() {
-      localUiState = getLocalWidgetsState(localWidgets, {
+      localUiState = getLocalWidgetsUiState(localWidgets, {
         searchParameters: this.getHelper()!.state,
         helper: this.getHelper()!,
       });


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

This is useful for recreating what an index widget does when it renders, see ssr in Vue, as well as poc/telemetry2

I think in the future we might want a function to retrieve the parameters given to render / init.

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

index exposes the scoped `createURL` function to be used in render / init / getWidgetRenderState etc.