### PR TITLE
feat(index): expose scoped results getter

### DIFF
--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -749,6 +749,139 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
     });
   });
 
+  describe('getScopedResults', () => {
+    it('gets deep results', async () => {
+      const level0 = index({ indexName: 'level0IndexName' });
+      const level1 = index({ indexName: 'level1IndexName' });
+      const level2 = index({ indexName: 'level2IndexName' });
+      const level21 = index({ indexName: 'level21IndexName' });
+      const level22 = index({ indexName: 'level22IndexName' });
+      const level221 = index({ indexName: 'level221IndexName' });
+      const level3 = index({ indexName: 'level3IndexName' });
+      const searchBoxLevel0 = createSearchBox();
+      const searchBoxLevel1 = createSearchBox();
+      const searchBoxLevel21 = createSearchBox();
+
+      level0.addWidgets([
+        searchBoxLevel0,
+        level1.addWidgets([searchBoxLevel1]),
+        level2.addWidgets([
+          createSearchBox(),
+          level21.addWidgets([searchBoxLevel21]),
+          level22.addWidgets([
+            createSearchBox(),
+            level221.addWidgets([createSearchBox()]),
+          ]),
+        ]),
+        level3.addWidgets([createSearchBox()]),
+      ]);
+
+      level0.init(createInitOptions({ parent: null }));
+
+      // Simulate a call to search from a widget - this step is required otherwise
+      // the DerivedHelper does not contain the results. The `lastResults` attribute
+      // is set once the `result` event is emitted.
+      level0.getHelper()!.search();
+
+      await runAllMicroTasks();
+
+      expect(level1.getScopedResults()).toEqual([
+        // Root index
+        {
+          indexId: 'level1IndexName',
+          results: expect.any(algoliasearchHelper.SearchResults),
+          helper: level1.getHelper(),
+        },
+        // Siblings and children
+        {
+          indexId: 'level2IndexName',
+          results: expect.any(algoliasearchHelper.SearchResults),
+          helper: level2.getHelper(),
+        },
+        {
+          indexId: 'level21IndexName',
+          results: expect.any(algoliasearchHelper.SearchResults),
+          helper: level21.getHelper(),
+        },
+        {
+          indexId: 'level22IndexName',
+          results: expect.any(algoliasearchHelper.SearchResults),
+          helper: level22.getHelper(),
+        },
+        {
+          indexId: 'level221IndexName',
+          results: expect.any(algoliasearchHelper.SearchResults),
+          helper: level221.getHelper(),
+        },
+        {
+          indexId: 'level3IndexName',
+          results: expect.any(algoliasearchHelper.SearchResults),
+          helper: level3.getHelper(),
+        },
+      ]);
+
+      expect(level21.getScopedResults()).toEqual([
+        // Root index
+        {
+          indexId: 'level21IndexName',
+          results: expect.any(algoliasearchHelper.SearchResults),
+          helper: level21.getHelper(),
+        },
+        // Siblings and children
+        {
+          indexId: 'level22IndexName',
+          results: expect.any(algoliasearchHelper.SearchResults),
+          helper: level22.getHelper(),
+        },
+        {
+          indexId: 'level221IndexName',
+          results: expect.any(algoliasearchHelper.SearchResults),
+          helper: level221.getHelper(),
+        },
+      ]);
+
+      expect(level0.getScopedResults()).toEqual([
+        // Root index
+        {
+          indexId: 'level0IndexName',
+          results: expect.any(algoliasearchHelper.SearchResults),
+          helper: level0.getHelper(),
+        },
+        // Siblings and children
+        {
+          indexId: 'level1IndexName',
+          results: expect.any(algoliasearchHelper.SearchResults),
+          helper: level1.getHelper(),
+        },
+        {
+          indexId: 'level2IndexName',
+          results: expect.any(algoliasearchHelper.SearchResults),
+          helper: level2.getHelper(),
+        },
+        {
+          indexId: 'level21IndexName',
+          results: expect.any(algoliasearchHelper.SearchResults),
+          helper: level21.getHelper(),
+        },
+        {
+          indexId: 'level22IndexName',
+          results: expect.any(algoliasearchHelper.SearchResults),
+          helper: level22.getHelper(),
+        },
+        {
+          indexId: 'level221IndexName',
+          results: expect.any(algoliasearchHelper.SearchResults),
+          helper: level221.getHelper(),
+        },
+        {
+          indexId: 'level3IndexName',
+          results: expect.any(algoliasearchHelper.SearchResults),
+          helper: level3.getHelper(),
+        },
+      ]);
+    });
+  });
+
   describe('init', () => {
     it('forwards the `search` call to the main instance', () => {
       const instance = index({ indexName: 'indexName' });

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -51,6 +51,7 @@ export type Index = Widget & {
   getIndexId(): string;
   getHelper(): Helper | null;
   getResults(): SearchResults | null;
+  getScopedResults(): ScopedResult[];
   getParent(): Index | null;
   getWidgets(): Widget[];
   createURL(state: SearchParameters): string;
@@ -177,14 +178,6 @@ function resolveScopedResultsFromWidgets(widgets: Widget[]): ScopedResult[] {
   }, []);
 }
 
-function resolveScopedResultsFromIndex(widget: Index): ScopedResult[] {
-  const widgetParent = widget.getParent();
-  // If the widget is the root, we consider itself as the only sibling.
-  const widgetSiblings = widgetParent ? widgetParent.getWidgets() : [widget];
-
-  return resolveScopedResultsFromWidgets(widgetSiblings);
-}
-
 const index = (props: IndexProps): Index => {
   if (props === undefined || props.indexName === undefined) {
     throw new Error(withUsage('The `indexName` option is required.'));
@@ -216,6 +209,15 @@ const index = (props: IndexProps): Index => {
 
     getResults() {
       return derivedHelper && derivedHelper.lastResults;
+    },
+
+    getScopedResults() {
+      const widgetParent = this.getParent();
+
+      // If the widget is the root, we consider itself as the only sibling.
+      const widgetSiblings = widgetParent ? widgetParent.getWidgets() : [this];
+
+      return resolveScopedResultsFromWidgets(widgetSiblings);
     },
 
     getParent() {
@@ -571,7 +573,7 @@ const index = (props: IndexProps): Index => {
               parent: this,
               instantSearchInstance,
               results: this.getResults()!,
-              scopedResults: resolveScopedResultsFromIndex(this),
+              scopedResults: this.getScopedResults(),
               state: this.getResults()!._state,
               renderState: instantSearchInstance.renderState,
               templatesConfig: instantSearchInstance.templatesConfig,
@@ -604,7 +606,7 @@ const index = (props: IndexProps): Index => {
             parent: this,
             instantSearchInstance,
             results: this.getResults()!,
-            scopedResults: resolveScopedResultsFromIndex(this),
+            scopedResults: this.getScopedResults(),
             state: this.getResults()!._state,
             renderState: instantSearchInstance.renderState,
             templatesConfig: instantSearchInstance.templatesConfig,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

like #4603, scoped results is also useful to be exposed for Vue InstantSearch & telemetry

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

new function on index widgets: `getScopedResults` which is used in render for all widgets already. 

