### PR TITLE
refactor: rename all references to widgetOptions as widgetParams

### DIFF
--- a/src/connectors/geo-search/connectGeoSearch.js
+++ b/src/connectors/geo-search/connectGeoSearch.js
@@ -27,7 +27,7 @@ const $$type = 'ais.geoSearch';
  */
 
 /**
- * @typedef {Object} CustomGeoSearchWidgetOptions
+ * @typedef {Object} CustomGeoSearchWidgetParams
  * @property {boolean} [enableRefineOnMapMove=true] If true, refine will be triggered as you move the map.
  * @property {function(object[]):object[]} [transformItems] Function to transform the items passed to the templates.
  */
@@ -44,7 +44,7 @@ const $$type = 'ais.geoSearch';
  * @property {function(): boolean} isRefineOnMapMove Return true if the user is able to refine on map move.
  * @property {function()} setMapMoveSinceLastRefine Set the fact that the map has moved since the last refinement, should be call on each map move. The call to the function triggers a new rendering only when the value change.
  * @property {function(): boolean} hasMapMoveSinceLastRefine Return true if the map has move since the last refinement.
- * @property {Object} widgetParams All original `CustomGeoSearchWidgetOptions` forwarded to the `renderFn`.
+ * @property {Object} widgetParams All original `CustomGeoSearchWidgetParams` forwarded to the `renderFn`.
  * @property {LatLng} [position] The current position of the search.
  */
 
@@ -59,7 +59,7 @@ const $$type = 'ais.geoSearch';
  *
  * @param {function(GeoSearchRenderingOptions, boolean)} renderFn Rendering function for the custom **GeoSearch** widget.
  * @param {function} unmountFn Unmount function called when the widget is disposed.
- * @return {function(CustomGeoSearchWidgetOptions)} Re-usable widget factory for a custom **GeoSearch** widget.
+ * @return {function(CustomGeoSearchWidgetParams)} Re-usable widget factory for a custom **GeoSearch** widget.
  * @staticExample
  * // This example use Leaflet for the rendering, be sure to have the library correctly setup
  * // before trying the demo. You can find more details in their documentation (link below).

--- a/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
+++ b/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
@@ -22,7 +22,7 @@ const withUsage = createDocumentationMessageGenerator({
  */
 
 /**
- * @typedef {Object} CustomHierarchicalMenuWidgetOptions
+ * @typedef {Object} CustomHierarchicalMenuWidgetParams
  * @property {string[]} attributes Attributes to use to generate the hierarchy of the menu.
  * @property {string} [separator = '>'] Separator used in the attributes to separate level values.
  * @property {string} [rootPath = null] Prefix path to use if the first level is not the root level.
@@ -42,7 +42,7 @@ const withUsage = createDocumentationMessageGenerator({
  * @property {function(item.value): string} createURL Creates an url for the next state for a clicked item.
  * @property {HierarchicalMenuItem[]} items Values to be rendered.
  * @property {function(item.value)} refine Sets the path of the hierarchical filter and triggers a new search.
- * @property {Object} widgetParams All original `CustomHierarchicalMenuWidgetOptions` forwarded to the `renderFn`.
+ * @property {Object} widgetParams All original `CustomHierarchicalMenuWidgetParams` forwarded to the `renderFn`.
  */
 
 /**
@@ -56,7 +56,7 @@ const withUsage = createDocumentationMessageGenerator({
  * @type {Connector}
  * @param {function(HierarchicalMenuRenderingOptions, boolean)} renderFn Rendering function for the custom **HierarchicalMenu** widget.
  * @param {function} unmountFn Unmount function called when the widget is disposed.
- * @return {function(CustomHierarchicalMenuWidgetOptions)} Re-usable widget factory for a custom **HierarchicalMenu** widget.
+ * @return {function(CustomHierarchicalMenuWidgetParams)} Re-usable widget factory for a custom **HierarchicalMenu** widget.
  */
 export default function connectHierarchicalMenu(renderFn, unmountFn = noop) {
   checkRendering(renderFn, withUsage());

--- a/src/connectors/menu/connectMenu.js
+++ b/src/connectors/menu/connectMenu.js
@@ -19,7 +19,7 @@ const withUsage = createDocumentationMessageGenerator({
  */
 
 /**
- * @typedef {Object} CustomMenuWidgetOptions
+ * @typedef {Object} CustomMenuWidgetParams
  * @property {string} attribute Name of the attribute for faceting (eg. "free_shipping").
  * @property {number} [limit = 10] How many facets values to retrieve.
  * @property {boolean} [showMore = false] Whether to display a button that expands the number of items.
@@ -36,7 +36,7 @@ const withUsage = createDocumentationMessageGenerator({
  * @property {function(item.value): string} createURL Creates the URL for a single item name in the list.
  * @property {function(item.value)} refine Filter the search to item value.
  * @property {boolean} canRefine True if refinement can be applied.
- * @property {Object} widgetParams All original `CustomMenuWidgetOptions` forwarded to the `renderFn`.
+ * @property {Object} widgetParams All original `CustomMenuWidgetParams` forwarded to the `renderFn`.
  * @property {boolean} isShowingMore True if the menu is displaying all the menu items.
  * @property {function} toggleShowMore Toggles the number of values displayed between `limit` and `showMore.limit`.
  * @property {boolean} canToggleShowMore `true` if the toggleShowMore button can be activated (enough items to display more or
@@ -54,7 +54,7 @@ const withUsage = createDocumentationMessageGenerator({
  * @type {Connector}
  * @param {function(MenuRenderingOptions, boolean)} renderFn Rendering function for the custom **Menu** widget. widget.
  * @param {function} unmountFn Unmount function called when the widget is disposed.
- * @return {function(CustomMenuWidgetOptions)} Re-usable widget factory for a custom **Menu** widget.
+ * @return {function(CustomMenuWidgetParams)} Re-usable widget factory for a custom **Menu** widget.
  * @example
  * // custom `renderFn` to render the custom Menu widget
  * function renderFn(MenuRenderingOptions, isFirstRendering) {

--- a/src/connectors/rating-menu/connectRatingMenu.js
+++ b/src/connectors/rating-menu/connectRatingMenu.js
@@ -51,7 +51,7 @@ const createSendEvent = ({
  */
 
 /**
- * @typedef {Object} CustomStarRatingWidgetOptions
+ * @typedef {Object} CustomStarRatingWidgetParams
  * @property {string} attribute Name of the attribute for faceting (eg. "free_shipping").
  * @property {number} [max = 5] The maximum rating value.
  */
@@ -64,7 +64,7 @@ const createSendEvent = ({
  * @property {function(string)} refine Selects a rating to filter the results
  * (takes the filter value as parameter). Takes the value of an item as parameter.
  * @property {boolean} hasNoResults `true` if the last search contains no result.
- * @property {Object} widgetParams All original `CustomStarRatingWidgetOptions` forwarded to the `renderFn`.
+ * @property {Object} widgetParams All original `CustomStarRatingWidgetParams` forwarded to the `renderFn`.
  */
 
 /**
@@ -77,7 +77,7 @@ const createSendEvent = ({
  * @type {Connector}
  * @param {function(StarRatingRenderingOptions, boolean)} renderFn Rendering function for the custom **StarRating** widget.
  * @param {function} unmountFn Unmount function called when the widget is disposed.
- * @return {function(CustomStarRatingWidgetOptions)} Re-usable widget factory for a custom **StarRating** widget.
+ * @return {function(CustomStarRatingWidgetParams)} Re-usable widget factory for a custom **StarRating** widget.
  * @example
  * // custom `renderFn` to render the custom StarRating widget
  * function renderFn(StarRatingRenderingOptions, isFirstRendering) {

--- a/src/connectors/refinement-list/connectRefinementList.js
+++ b/src/connectors/refinement-list/connectRefinementList.js
@@ -22,7 +22,7 @@ const withUsage = createDocumentationMessageGenerator({
  */
 
 /**
- * @typedef {Object} CustomRefinementListWidgetOptions
+ * @typedef {Object} CustomRefinementListWidgetParams
  * @property {string} attribute The name of the attribute in the records.
  * @property {"and"|"or"} [operator = 'or'] How the filters are combined together.
  * @property {number} [limit = 10] The max number of items to display when
@@ -45,7 +45,7 @@ const withUsage = createDocumentationMessageGenerator({
  * @property {boolean} canRefine `true` if a refinement can be applied.
  * @property {boolean} canToggleShowMore `true` if the toggleShowMore button can be activated (enough items to display more or
  * already displaying more than `limit` items)
- * @property {Object} widgetParams All original `CustomRefinementListWidgetOptions` forwarded to the `renderFn`.
+ * @property {Object} widgetParams All original `CustomRefinementListWidgetParams` forwarded to the `renderFn`.
  * @property {boolean} isShowingMore True if the menu is displaying all the menu items.
  * @property {function} toggleShowMore Toggles the number of values displayed between `limit` and `showMoreLimit`.
  */
@@ -59,7 +59,7 @@ const withUsage = createDocumentationMessageGenerator({
  * @type {Connector}
  * @param {function(RefinementListRenderingOptions, boolean)} renderFn Rendering function for the custom **RefinementList** widget.
  * @param {function} unmountFn Unmount function called when the widget is disposed.
- * @return {function(CustomRefinementListWidgetOptions)} Re-usable widget factory for a custom **RefinementList** widget.
+ * @return {function(CustomRefinementListWidgetParams)} Re-usable widget factory for a custom **RefinementList** widget.
  * @example
  * // custom `renderFn` to render the custom RefinementList widget
  * function renderFn(RefinementListRenderingOptions, isFirstRendering) {

--- a/src/connectors/search-box/connectSearchBox.js
+++ b/src/connectors/search-box/connectSearchBox.js
@@ -10,7 +10,7 @@ const withUsage = createDocumentationMessageGenerator({
 });
 
 /**
- * @typedef {Object} CustomSearchBoxWidgetOptions
+ * @typedef {Object} CustomSearchBoxWidgetParams
  * @property {function(string, function(string))} [queryHook = undefined] A function that will be called every time
  * a new value for the query is set. The first parameter is the query and the second is a
  * function to actually trigger the search. The function takes the query as the parameter.
@@ -23,7 +23,7 @@ const withUsage = createDocumentationMessageGenerator({
  * @property {string} query The query from the last search.
  * @property {function(string)} refine Sets a new query and searches.
  * @property {function()} clear Remove the query and perform search.
- * @property {Object} widgetParams All original `CustomSearchBoxWidgetOptions` forwarded to the `renderFn`.
+ * @property {Object} widgetParams All original `CustomSearchBoxWidgetParams` forwarded to the `renderFn`.
  * @property {boolean} isSearchStalled `true` if the search results takes more than a certain time to come back
  * from Algolia servers. This can be configured on the InstantSearch constructor with the attribute
  * `stalledSearchDelay` which is 200ms, by default.
@@ -37,7 +37,7 @@ const withUsage = createDocumentationMessageGenerator({
  * @type {Connector}
  * @param {function(SearchBoxRenderingOptions, boolean)} renderFn Rendering function for the custom **SearchBox** widget.
  * @param {function} unmountFn Unmount function called when the widget is disposed.
- * @return {function(CustomSearchBoxWidgetOptions)} Re-usable widget factory for a custom **SearchBox** widget.
+ * @return {function(CustomSearchBoxWidgetParams)} Re-usable widget factory for a custom **SearchBox** widget.
  * @example
  * // custom `renderFn` to render the custom SearchBox widget
  * function renderFn(SearchBoxRenderingOptions, isFirstRendering) {

--- a/src/connectors/sort-by/connectSortBy.js
+++ b/src/connectors/sort-by/connectSortBy.js
@@ -18,7 +18,7 @@ const withUsage = createDocumentationMessageGenerator({
  */
 
 /**
- * @typedef {Object} CustomSortByWidgetOptions
+ * @typedef {Object} CustomSortByWidgetParams
  * @property {SortByItem[]} items Array of objects defining the different indices to choose from.
  * @property {function(object[]):object[]} [transformItems] Function to transform the items passed to the templates.
  */
@@ -29,7 +29,7 @@ const withUsage = createDocumentationMessageGenerator({
  * @property {SortByItem[]} options All the available indices
  * @property {function(string)} refine Switches indices and triggers a new search.
  * @property {boolean} hasNoResults `true` if the last search contains no result.
- * @property {Object} widgetParams All original `CustomSortByWidgetOptions` forwarded to the `renderFn`.
+ * @property {Object} widgetParams All original `CustomSortByWidgetParams` forwarded to the `renderFn`.
  */
 
 /**
@@ -44,7 +44,7 @@ const withUsage = createDocumentationMessageGenerator({
  * @type {Connector}
  * @param {function(SortByRenderingOptions, boolean)} renderFn Rendering function for the custom **SortBy** widget.
  * @param {function} unmountFn Unmount function called when the widget is disposed.
- * @return {function(CustomSortByWidgetOptions)} Re-usable widget factory for a custom **SortBy** widget.
+ * @return {function(CustomSortByWidgetParams)} Re-usable widget factory for a custom **SortBy** widget.
  * @example
  * // custom `renderFn` to render the custom SortBy widget
  * function renderFn(SortByRenderingOptions, isFirstRendering) {

--- a/src/connectors/stats/connectStats.js
+++ b/src/connectors/stats/connectStats.js
@@ -17,11 +17,11 @@ const withUsage = createDocumentationMessageGenerator({
  * @property {number} page The current page.
  * @property {number} processingTimeMS The time taken to compute the results inside the Algolia engine.
  * @property {string} query The query used for the current search.
- * @property {object} widgetParams All original `CustomStatsWidgetOptions` forwarded to the `renderFn`.
+ * @property {object} widgetParams All original `CustomStatsWidgetParams` forwarded to the `renderFn`.
  */
 
 /**
- * @typedef {Object} CustomStatsWidgetOptions
+ * @typedef {Object} CustomStatsWidgetParams
  */
 
 /**
@@ -31,7 +31,7 @@ const withUsage = createDocumentationMessageGenerator({
  * @type {Connector}
  * @param {function(StatsRenderingOptions, boolean)} renderFn Rendering function for the custom **Stats** widget.
  * @param {function} unmountFn Unmount function called when the widget is disposed.
- * @return {function(CustomStatsWidgetOptions)} Re-usable widget factory for a custom **Stats** widget.
+ * @return {function(CustomStatsWidgetParams)} Re-usable widget factory for a custom **Stats** widget.
  * @example
  * // custom `renderFn` to render the custom Stats widget
  * function renderFn(StatsRenderingOptions, isFirstRendering) {

--- a/src/connectors/toggle-refinement/connectToggleRefinement.js
+++ b/src/connectors/toggle-refinement/connectToggleRefinement.js
@@ -50,7 +50,7 @@ const createSendEvent = ({ instantSearchInstance, attribute, on, helper }) => (
  */
 
 /**
- * @typedef {Object} CustomToggleWidgetOptions
+ * @typedef {Object} CustomToggleWidgetParams
  * @property {string} attribute Name of the attribute for faceting (eg. "free_shipping").
  * @property {Object} [on = true] Value to filter on when toggled.
  * @property {Object} [off] Value to filter on when not toggled.
@@ -61,7 +61,7 @@ const createSendEvent = ({ instantSearchInstance, attribute, on, helper }) => (
  * @property {ToggleValue} value The current toggle value.
  * @property {function():string} createURL Creates an URL for the next state.
  * @property {function(value)} refine Updates to the next state by applying the toggle refinement.
- * @property {Object} widgetParams All original `CustomToggleWidgetOptions` forwarded to the `renderFn`.
+ * @property {Object} widgetParams All original `CustomToggleWidgetParams` forwarded to the `renderFn`.
  */
 
 /**
@@ -75,7 +75,7 @@ const createSendEvent = ({ instantSearchInstance, attribute, on, helper }) => (
  * @type {Connector}
  * @param {function(ToggleRenderingOptions, boolean)} renderFn Rendering function for the custom **Toggle** widget.
  * @param {function} unmountFn Unmount function called when the widget is disposed.
- * @return {function(CustomToggleWidgetOptions)} Re-usable widget factory for a custom **Toggle** widget.
+ * @return {function(CustomToggleWidgetParams)} Re-usable widget factory for a custom **Toggle** widget.
  * @example
  * // custom `renderFn` to render the custom ClearAll widget
  * function renderFn(ToggleRenderingOptions, isFirstRendering) {

--- a/src/widgets/breadcrumb/breadcrumb.tsx
+++ b/src/widgets/breadcrumb/breadcrumb.tsx
@@ -95,7 +95,7 @@ export type BreadcrumbTemplates = {
   separator?: Template;
 };
 
-export type BreadcrumbWidgetOptions = {
+export type BreadcrumbWidgetParams = {
   /**
    * CSS Selector or HTMLElement to insert the widget.
    */
@@ -115,10 +115,10 @@ export type BreadcrumbWidgetOptions = {
 export type BreadcrumbWidget = WidgetFactory<
   BreadcrumbRendererOptions,
   BreadcrumbConnectorParams,
-  BreadcrumbWidgetOptions
+  BreadcrumbWidgetParams
 >;
 
-const breadcrumb: BreadcrumbWidget = function breadcrumb(widgetOptions) {
+const breadcrumb: BreadcrumbWidget = function breadcrumb(widgetParams) {
   const {
     container,
     attributes,
@@ -127,7 +127,7 @@ const breadcrumb: BreadcrumbWidget = function breadcrumb(widgetOptions) {
     transformItems,
     templates = defaultTemplates,
     cssClasses: userCssClasses = {},
-  } = widgetOptions || ({} as typeof widgetOptions);
+  } = widgetParams || ({} as typeof widgetParams);
 
   if (!container) {
     throw new Error(withUsage('The `container` option is required.'));

--- a/src/widgets/clear-refinements/clear-refinements.tsx
+++ b/src/widgets/clear-refinements/clear-refinements.tsx
@@ -69,7 +69,7 @@ export type ClearRefinementsTemplates = {
   resetLabel?: Template;
 };
 
-export type ClearRefinementsWidgetOptions = {
+export type ClearRefinementsWidgetParams = {
   /**
    * CSS Selector or HTMLElement to insert the widget.
    */
@@ -89,10 +89,10 @@ export type ClearRefinementsWidgetOptions = {
 export type ClearRefinementsWidget = WidgetFactory<
   ClearRefinementsRendererOptions,
   ClearRefinementsConnectorParams,
-  ClearRefinementsWidgetOptions
+  ClearRefinementsWidgetParams
 >;
 
-const clearRefinements: ClearRefinementsWidget = widgetOptions => {
+const clearRefinements: ClearRefinementsWidget = widgetParams => {
   const {
     container,
     templates = defaultTemplates,
@@ -100,7 +100,7 @@ const clearRefinements: ClearRefinementsWidget = widgetOptions => {
     excludedAttributes,
     transformItems,
     cssClasses: userCssClasses = {},
-  } = widgetOptions || ({} as typeof widgetOptions);
+  } = widgetParams || ({} as typeof widgetParams);
 
   if (!container) {
     throw new Error(withUsage('The `container` option is required.'));

--- a/src/widgets/geo-search/geo-search.js
+++ b/src/widgets/geo-search/geo-search.js
@@ -61,7 +61,7 @@ const suit = component('GeoSearch');
  */
 
 /**
- * @typedef {object} GeoSearchWidgetOptions
+ * @typedef {object} GeoSearchWidgetParams
  * @property {string|HTMLElement} container CSS Selector or HTMLElement to insert the widget.
  * @property {object} googleReference Reference to the global `window.google` object. <br />
  * See [the documentation](https://developers.google.com/maps/documentation/javascript/tutorial) for more information.
@@ -94,7 +94,7 @@ const suit = component('GeoSearch');
  * Don't forget to explicitly set the `height` of the map container (default class `.ais-geo-search--map`), otherwise it won't be shown (it's a requirement of Google Maps).
  *
  * @devNovel GeoSearch
- * @param {GeoSearchWidgetOptions} widgetOptions Options of the GeoSearch widget.
+ * @param {GeoSearchWidgetParams} widgetParams Options of the GeoSearch widget.
  * @return {Widget} A new instance of GeoSearch widget.
  * @staticExample
  * search.addWidgets([
@@ -104,7 +104,7 @@ const suit = component('GeoSearch');
  *   })
  * ]);
  */
-const geoSearch = widgetOptions => {
+const geoSearch = widgetParams => {
   const {
     initialZoom = 1,
     initialPosition = { lat: 0, lng: 0 },
@@ -117,8 +117,8 @@ const geoSearch = widgetOptions => {
     enableRefineControl = true,
     container,
     googleReference,
-    ...widgetParams
-  } = widgetOptions || {};
+    ...otherWidgetParams
+  } = widgetParams || {};
 
   const defaultBuiltInMarker = {
     createOptions: noop,
@@ -216,7 +216,7 @@ const geoSearch = widgetOptions => {
 
   return {
     ...makeWidget({
-      ...widgetParams,
+      ...otherWidgetParams,
       renderState: {},
       container: containerNode,
       googleReference,

--- a/src/widgets/hierarchical-menu/hierarchical-menu.js
+++ b/src/widgets/hierarchical-menu/hierarchical-menu.js
@@ -83,7 +83,7 @@ const renderer = ({
  */
 
 /**
- * @typedef {Object} HierarchicalMenuWidgetOptions
+ * @typedef {Object} HierarchicalMenuWidgetParams
  * @property {string|HTMLElement} container CSS Selector or HTMLElement to insert the widget.
  * @property {string[]} attributes Array of attributes to use to generate the hierarchy of the menu.
  * @property {string} [separator = " > "] Separator used in the attributes to separate level values.
@@ -162,7 +162,7 @@ const renderer = ({
  * @type {WidgetFactory}
  * @devNovel HierarchicalMenu
  * @category filter
- * @param {HierarchicalMenuWidgetOptions} widgetOptions The HierarchicalMenu widget options.
+ * @param {HierarchicalMenuWidgetParams} widgetParams The HierarchicalMenu widget options.
  * @return {Widget} A new HierarchicalMenu widget instance.
  * @example
  * search.addWidgets([
@@ -172,7 +172,7 @@ const renderer = ({
  *   })
  * ]);
  */
-export default function hierarchicalMenu(widgetOptions) {
+export default function hierarchicalMenu(widgetParams) {
   const {
     container,
     attributes,
@@ -186,7 +186,7 @@ export default function hierarchicalMenu(widgetOptions) {
     transformItems,
     templates = defaultTemplates,
     cssClasses: userCssClasses = {},
-  } = widgetOptions || {};
+  } = widgetParams || {};
 
   if (!container) {
     throw new Error(withUsage('The `container` option is required.'));

--- a/src/widgets/hits-per-page/hits-per-page.tsx
+++ b/src/widgets/hits-per-page/hits-per-page.tsx
@@ -59,7 +59,7 @@ export type HitsPerPageCSSClasses = {
   option?: string | string[];
 };
 
-export type HitsPerPageWidgetOptions = {
+export type HitsPerPageWidgetParams = {
   /**
    * CSS Selector or HTMLElement to insert the widget.
    */
@@ -74,12 +74,12 @@ export type HitsPerPageWidgetOptions = {
 export type HitsPerPageWidget = WidgetFactory<
   HitsPerPageRendererOptions,
   HitsPerPageConnectorParams,
-  HitsPerPageWidgetOptions
+  HitsPerPageWidgetParams
 >;
 
-const hitsPerPage: HitsPerPageWidget = function hitsPerPage(widgetOptions) {
+const hitsPerPage: HitsPerPageWidget = function hitsPerPage(widgetParams) {
   const { container, items, cssClasses: userCssClasses = {}, transformItems } =
-    widgetOptions || ({} as typeof widgetOptions);
+    widgetParams || ({} as typeof widgetParams);
 
   if (!container) {
     throw new Error(withUsage('The `container` option is required.'));

--- a/src/widgets/hits/hits.tsx
+++ b/src/widgets/hits/hits.tsx
@@ -34,7 +34,7 @@ const renderer = ({
   cssClasses,
   containerNode,
   templates,
-}): Renderer<HitsRendererOptions, Partial<HitsWidgetOptions>> => (
+}): Renderer<HitsRendererOptions, Partial<HitsWidgetParams>> => (
   { hits: receivedHits, results, instantSearchInstance, insights, bindEvent },
   isFirstRendering
 ) => {
@@ -106,7 +106,7 @@ export type HitsTemplates = {
   >;
 };
 
-export type HitsWidgetOptions = {
+export type HitsWidgetParams = {
   /**
    * CSS Selector or HTMLElement to insert the widget.
    */
@@ -126,17 +126,17 @@ export type HitsWidgetOptions = {
 export type HitsWidget = WidgetFactory<
   HitsRendererOptions,
   HitsConnectorParams,
-  HitsWidgetOptions
+  HitsWidgetParams
 >;
 
-const hits: HitsWidget = function hits(widgetOptions) {
+const hits: HitsWidget = function hits(widgetParams) {
   const {
     container,
     escapeHTML,
     transformItems,
     templates = defaultTemplates,
     cssClasses: userCssClasses = {},
-  } = widgetOptions || ({} as typeof widgetOptions);
+  } = widgetParams || ({} as typeof widgetParams);
 
   if (!container) {
     throw new Error(withUsage('The `container` option is required.'));

--- a/src/widgets/infinite-hits/infinite-hits.tsx
+++ b/src/widgets/infinite-hits/infinite-hits.tsx
@@ -180,7 +180,7 @@ const renderer = ({
   );
 };
 
-const infiniteHits: InfiniteHitsWidget = widgetOptions => {
+const infiniteHits: InfiniteHitsWidget = widgetParams => {
   const {
     container,
     escapeHTML,
@@ -189,7 +189,7 @@ const infiniteHits: InfiniteHitsWidget = widgetOptions => {
     cssClasses: userCssClasses = {},
     showPrevious,
     cache,
-  } = widgetOptions || ({} as InfiniteHitsWidgetParams);
+  } = widgetParams || ({} as InfiniteHitsWidgetParams);
 
   if (!container) {
     throw new Error(withUsage('The `container` option is required.'));

--- a/src/widgets/menu-select/menu-select.js
+++ b/src/widgets/menu-select/menu-select.js
@@ -56,7 +56,7 @@ const renderer = ({ containerNode, cssClasses, renderState, templates }) => (
  */
 
 /**
- * @typedef {Object} MenuSelectWidgetOptions
+ * @typedef {Object} MenuSelectWidgetParams
  * @property {string|HTMLElement} container CSS Selector or HTMLElement to insert the widget.
  * @property {string} attribute Name of the attribute for faceting
  * @property {string[]|function} [sortBy=['name:asc']] How to sort refinements. Possible values: `count|isRefined|name:asc|name:desc`.
@@ -72,7 +72,7 @@ const renderer = ({ containerNode, cssClasses, renderState, templates }) => (
  * Create a menu select out of a facet
  * @type {WidgetFactory}
  * @category filter
- * @param {MenuSelectWidgetOptions} widgetOptions The Menu select widget options.
+ * @param {MenuSelectWidgetParams} widgetParams The Menu select widget options.
  * @return {Widget} Creates a new instance of the Menu select widget.
  * @example
  * search.addWidgets([
@@ -83,7 +83,7 @@ const renderer = ({ containerNode, cssClasses, renderState, templates }) => (
  *   })
  * ]);
  */
-export default function menuSelect(widgetOptions) {
+export default function menuSelect(widgetParams) {
   const {
     container,
     attribute,
@@ -92,7 +92,7 @@ export default function menuSelect(widgetOptions) {
     cssClasses: userCssClasses = {},
     templates = defaultTemplates,
     transformItems,
-  } = widgetOptions || {};
+  } = widgetParams || {};
 
   if (!container) {
     throw new Error(withUsage('The `container` option is required.'));

--- a/src/widgets/menu/menu.js
+++ b/src/widgets/menu/menu.js
@@ -84,7 +84,7 @@ const renderer = ({
  */
 
 /**
- * @typedef {Object} MenuWidgetOptions
+ * @typedef {Object} MenuWidgetParams
  * @property {string|HTMLElement} container CSS Selector or HTMLElement to insert the widget.
  * @property {string} attribute Name of the attribute for faceting
  * @property {string[]|function} [sortBy=['isRefined', 'name:asc']] How to sort refinements. Possible values: `count|isRefined|name:asc|name:desc`.
@@ -109,7 +109,7 @@ const renderer = ({
  * @type {WidgetFactory}
  * @devNovel Menu
  * @category filter
- * @param {MenuWidgetOptions} widgetOptions The Menu widget options.
+ * @param {MenuWidgetParams} widgetParams The Menu widget options.
  * @return {Widget} Creates a new instance of the Menu widget.
  * @example
  * search.addWidgets([
@@ -120,7 +120,7 @@ const renderer = ({
  *   })
  * ]);
  */
-export default function menu(widgetOptions) {
+export default function menu(widgetParams) {
   const {
     container,
     attribute,
@@ -131,7 +131,7 @@ export default function menu(widgetOptions) {
     cssClasses: userCssClasses = {},
     templates = defaultTemplates,
     transformItems,
-  } = widgetOptions || {};
+  } = widgetParams || {};
 
   if (!container) {
     throw new Error(withUsage('The `container` option is required.'));

--- a/src/widgets/numeric-menu/numeric-menu.tsx
+++ b/src/widgets/numeric-menu/numeric-menu.tsx
@@ -133,7 +133,7 @@ export type NumericMenuTemplates = {
   }>;
 };
 
-export type NumericMenuWidgetOptions = {
+export type NumericMenuWidgetParams = {
   /**
    * CSS Selector or HTMLElement to insert the widget.
    */
@@ -158,10 +158,10 @@ export type NumericMenuWidgetOptions = {
 export type NumericMenuWidget = WidgetFactory<
   NumericMenuRendererOptions,
   NumericMenuConnectorParams,
-  NumericMenuWidgetOptions
+  NumericMenuWidgetParams
 >;
 
-const numericMenu: NumericMenuWidget = function numericMenu(widgetOptions) {
+const numericMenu: NumericMenuWidget = function numericMenu(widgetParams) {
   const {
     container,
     attribute,
@@ -169,7 +169,7 @@ const numericMenu: NumericMenuWidget = function numericMenu(widgetOptions) {
     cssClasses: userCssClasses = {},
     templates = defaultTemplates,
     transformItems,
-  } = widgetOptions || ({} as typeof widgetOptions);
+  } = widgetParams || ({} as typeof widgetParams);
 
   if (!container) {
     throw new Error(withUsage('The `container` option is required.'));

--- a/src/widgets/pagination/pagination.js
+++ b/src/widgets/pagination/pagination.js
@@ -100,7 +100,7 @@ const renderer = ({
  */
 
 /**
- * @typedef {Object} PaginationWidgetOptions
+ * @typedef {Object} PaginationWidgetParams
  * @property  {string|HTMLElement} container CSS Selector or HTMLElement to insert the widget.
  * @property  {number} [totalPages] The max number of pages to browse.
  * @property  {number} [padding=3] The number of pages to display on each side of the current page.
@@ -127,7 +127,7 @@ const renderer = ({
  * @type {WidgetFactory}
  * @devNovel Pagination
  * @category navigation
- * @param {PaginationWidgetOptions} widgetOptions Options for the Pagination widget.
+ * @param {PaginationWidgetParams} widgetParams Options for the Pagination widget.
  * @return {Widget} A new instance of Pagination widget.
  * @example
  * search.addWidgets([
@@ -141,7 +141,7 @@ const renderer = ({
  *   })
  * ]);
  */
-export default function pagination(widgetOptions) {
+export default function pagination(widgetParams) {
   const {
     container,
     templates: userTemplates = {},
@@ -153,7 +153,7 @@ export default function pagination(widgetOptions) {
     showPrevious = true,
     showNext = true,
     scrollTo: userScrollTo = 'body',
-  } = widgetOptions || {};
+  } = widgetParams || {};
 
   if (!container) {
     throw new Error(withUsage('The `container` option is required.'));

--- a/src/widgets/panel/panel.tsx
+++ b/src/widgets/panel/panel.tsx
@@ -90,7 +90,7 @@ export type PanelRenderOptions<
     ? TRenderState
     : Record<string, any>);
 
-export type PanelWidgetOptions<TWidget extends UnknownWidgetFactory> = {
+export type PanelWidgetParams<TWidget extends UnknownWidgetFactory> = {
   /**
    * A function that is called on each render to determine if the
    * panel should be hidden based on the render options.
@@ -138,24 +138,24 @@ const renderer = <TWidget extends UnknownWidgetFactory>({
 };
 
 export type PanelWidget = <TWidget extends UnknownWidgetFactory>(
-  widgetParams?: PanelWidgetOptions<TWidget>
+  widgetParams?: PanelWidgetParams<TWidget>
 ) => <
   TWidgetParams extends { container: HTMLElement | string; [key: string]: any }
 >(
   widgetFactory: TWidget
-) => (widgetOptions: TWidgetParams) => Widget;
+) => (widgetParams: TWidgetParams) => Widget;
 
 /**
  * The panel widget wraps other widgets in a consistent panel design.
  * It also reacts, indicates and sets CSS classes when widgets are no longer relevant for refining.
  */
-const panel: PanelWidget = widgetParams => {
+const panel: PanelWidget = panelWidgetParams => {
   const {
     templates = {},
     hidden = () => false,
     collapsed,
     cssClasses: userCssClasses = {},
-  } = widgetParams || {};
+  } = panelWidgetParams || {};
 
   warning(
     typeof hidden === 'function',
@@ -201,8 +201,8 @@ const panel: PanelWidget = widgetParams => {
     footer: cx(suit({ descendantName: 'footer' }), userCssClasses.footer),
   };
 
-  return widgetFactory => widgetOptions => {
-    const { container } = widgetOptions || ({} as typeof widgetOptions);
+  return widgetFactory => widgetParams => {
+    const { container } = widgetParams || ({} as typeof widgetParams);
 
     if (!container) {
       throw new Error(
@@ -246,7 +246,7 @@ const panel: PanelWidget = widgetParams => {
     });
 
     const widget = widgetFactory({
-      ...widgetOptions,
+      ...widgetParams,
       container: bodyContainerNode,
     });
 

--- a/src/widgets/powered-by/powered-by.js
+++ b/src/widgets/powered-by/powered-by.js
@@ -37,7 +37,7 @@ const renderer = ({ containerNode, cssClasses }) => (
  */
 
 /**
- * @typedef {Object} PoweredByWidgetOptions
+ * @typedef {Object} PoweredByWidgetParams
  * @property {string|HTMLElement} container Place where to insert the widget in your webpage.
  * @property {string} [theme] The theme of the logo ("light" or "dark").
  * @property {PoweredByWidgetCssClasses} [cssClasses] CSS classes to add.
@@ -48,7 +48,7 @@ const renderer = ({ containerNode, cssClasses }) => (
  * @type {WidgetFactory}
  * @devNovel PoweredBy
  * @category metadata
- * @param {PoweredByWidgetOptions} widgetOptions PoweredBy widget options. Some keys are mandatory: `container`,
+ * @param {PoweredByWidgetParams} widgetParams PoweredBy widget options. Some keys are mandatory: `container`,
  * @return {Widget} A new poweredBy widget instance
  * @example
  * search.addWidgets([
@@ -58,9 +58,9 @@ const renderer = ({ containerNode, cssClasses }) => (
  *   })
  * ]);
  */
-export default function poweredBy(widgetOptions) {
+export default function poweredBy(widgetParams) {
   const { container, cssClasses: userCssClasses = {}, theme = 'light' } =
-    widgetOptions || {};
+    widgetParams || {};
 
   if (!container) {
     throw new Error(withUsage('The `container` option is required.'));

--- a/src/widgets/query-rule-custom-data/query-rule-custom-data.tsx
+++ b/src/widgets/query-rule-custom-data/query-rule-custom-data.tsx
@@ -59,13 +59,13 @@ const renderer: Renderer<
   );
 };
 
-const queryRuleCustomData: QueryRuleCustomDataWidget = widgetOptions => {
+const queryRuleCustomData: QueryRuleCustomDataWidget = widgetParams => {
   const {
     container,
     cssClasses: userCssClasses = {} as QueryRuleCustomDataCSSClasses,
     templates: userTemplates = {},
     transformItems = items => items,
-  } = widgetOptions || ({} as QueryRuleCustomDataWidgetParams);
+  } = widgetParams || ({} as QueryRuleCustomDataWidgetParams);
 
   if (!container) {
     throw new Error(withUsage('The `container` option is required.'));

--- a/src/widgets/range-input/range-input.js
+++ b/src/widgets/range-input/range-input.js
@@ -70,7 +70,7 @@ const renderer = ({ containerNode, cssClasses, renderState, templates }) => (
  */
 
 /**
- * @typedef {Object} RangeInputWidgetOptions
+ * @typedef {Object} RangeInputWidgetParams
  * @property {string|HTMLElement} container Valid CSS Selector as a string or DOMElement.
  * @property {string} attribute Name of the attribute for faceting.
  * @property {number} [min] Minimal slider value, default to automatically computed from the result set.
@@ -92,7 +92,7 @@ const renderer = ({ containerNode, cssClasses, renderState, templates }) => (
  * @type {WidgetFactory}
  * @devNovel RangeInput
  * @category filter
- * @param {RangeInputWidgetOptions} widgetOptions The RangeInput widget options.
+ * @param {RangeInputWidgetParams} widgetParams The RangeInput widget options.
  * @return {Widget} A new instance of RangeInput widget.
  * @example
  * search.addWidgets([
@@ -106,7 +106,7 @@ const renderer = ({ containerNode, cssClasses, renderState, templates }) => (
  *   })
  * ]);
  */
-export default function rangeInput(widgetOptions) {
+export default function rangeInput(widgetParams) {
   const {
     container,
     attribute,
@@ -115,7 +115,7 @@ export default function rangeInput(widgetOptions) {
     precision = 0,
     cssClasses: userCssClasses = {},
     templates: userTemplates = {},
-  } = widgetOptions || {};
+  } = widgetParams || {};
 
   if (!container) {
     throw new Error(withUsage('The `container` option is required.'));

--- a/src/widgets/range-slider/range-slider.js
+++ b/src/widgets/range-slider/range-slider.js
@@ -65,7 +65,7 @@ const renderer = ({ containerNode, cssClasses, pips, step, tooltips }) => (
  */
 
 /**
- * @typedef {Object} RangeSliderWidgetOptions
+ * @typedef {Object} RangeSliderWidgetParams
  * @property  {string|HTMLElement} container CSS Selector or DOMElement to insert the widget.
  * @property  {string} attribute Name of the attribute for faceting.
  * @property  {boolean|RangeSliderTooltipOptions} [tooltips=true] Should we show tooltips or not.
@@ -94,7 +94,7 @@ const renderer = ({ containerNode, cssClasses, pips, step, tooltips }) => (
  * @type {WidgetFactory}
  * @devNovel RangeSlider
  * @category filter
- * @param {RangeSliderWidgetOptions} widgetOptions RangeSlider widget options.
+ * @param {RangeSliderWidgetParams} widgetParams RangeSlider widget options.
  * @return {Widget} A new RangeSlider widget instance.
  * @example
  * search.addWidgets([
@@ -109,7 +109,7 @@ const renderer = ({ containerNode, cssClasses, pips, step, tooltips }) => (
  *   })
  * ]);
  */
-export default function rangeSlider(widgetOptions) {
+export default function rangeSlider(widgetParams) {
   const {
     container,
     attribute,
@@ -120,7 +120,7 @@ export default function rangeSlider(widgetOptions) {
     pips = true,
     precision = 0,
     tooltips = true,
-  } = widgetOptions || {};
+  } = widgetParams || {};
   if (!container) {
     throw new Error(withUsage('The `container` option is required.'));
   }

--- a/src/widgets/rating-menu/rating-menu.js
+++ b/src/widgets/rating-menu/rating-menu.js
@@ -75,7 +75,7 @@ const renderer = ({ containerNode, cssClasses, templates, renderState }) => (
  */
 
 /**
- * @typedef {Object} RatingMenuWidgetOptions
+ * @typedef {Object} RatingMenuWidgetParams
  * @property {string|HTMLElement} container Place where to insert the widget in your webpage.
  * @property {string} attribute Name of the attribute in your records that contains the ratings.
  * @property {number} [max = 5] The maximum rating value.
@@ -98,7 +98,7 @@ const renderer = ({ containerNode, cssClasses, templates, renderState }) => (
  * @type {WidgetFactory}
  * @devNovel RatingMenu
  * @category filter
- * @param {RatingMenuWidgetOptions} widgetOptions RatingMenu widget options.
+ * @param {RatingMenuWidgetParams} widgetParams RatingMenu widget options.
  * @return {Widget} A new RatingMenu widget instance.
  * @example
  * search.addWidgets([
@@ -109,14 +109,14 @@ const renderer = ({ containerNode, cssClasses, templates, renderState }) => (
  *   })
  * ]);
  */
-export default function ratingMenu(widgetOptions) {
+export default function ratingMenu(widgetParams) {
   const {
     container,
     attribute,
     max = 5,
     cssClasses: userCssClasses = {},
     templates = defaultTemplates,
-  } = widgetOptions || {};
+  } = widgetParams || {};
   if (!container) {
     throw new Error(withUsage('The `container` option is required.'));
   }

--- a/src/widgets/refinement-list/refinement-list.js
+++ b/src/widgets/refinement-list/refinement-list.js
@@ -132,7 +132,7 @@ const renderer = ({
  */
 
 /**
- * @typedef {Object} RefinementListWidgetOptions
+ * @typedef {Object} RefinementListWidgetParams
  * @property {string|HTMLElement} container CSS Selector or HTMLElement to insert the widget.
  * @property {string} attribute Name of the attribute for faceting.
  * @property {"and"|"or"} [operator="or"] How to apply refinements. Possible values: `or`, `and`
@@ -175,7 +175,7 @@ const renderer = ({
  * @type {WidgetFactory}
  * @devNovel RefinementList
  * @category filter
- * @param {RefinementListWidgetOptions} widgetOptions The RefinementList widget options that you use to customize the widget.
+ * @param {RefinementListWidgetParams} widgetParams The RefinementList widget options that you use to customize the widget.
  * @return {Widget} Creates a new instance of the RefinementList widget.
  * @example
  * search.addWidgets([
@@ -187,7 +187,7 @@ const renderer = ({
  *   })
  * ]);
  */
-export default function refinementList(widgetOptions) {
+export default function refinementList(widgetParams) {
   const {
     container,
     attribute,
@@ -203,7 +203,7 @@ export default function refinementList(widgetOptions) {
     cssClasses: userCssClasses = {},
     templates: userTemplates = defaultTemplates,
     transformItems,
-  } = widgetOptions || {};
+  } = widgetParams || {};
 
   if (!container) {
     throw new Error(withUsage('The `container` option is required.'));

--- a/src/widgets/search-box/search-box.js
+++ b/src/widgets/search-box/search-box.js
@@ -64,7 +64,7 @@ const renderer = ({
  */
 
 /**
- * @typedef {Object} SearchBoxWidgetOptions
+ * @typedef {Object} SearchBoxWidgetParams
  * @property {string|HTMLElement} container CSS Selector or HTMLElement to insert the widget
  * @property {string} [placeholder] The placeholder of the input
  * @property {boolean} [autofocus=false] Whether the input should be autofocused
@@ -91,7 +91,7 @@ const renderer = ({
  * @type {WidgetFactory}
  * @devNovel SearchBox
  * @category basic
- * @param {SearchBoxWidgetOptions} widgetOptions Options used to configure a SearchBox widget.
+ * @param {SearchBoxWidgetParams} widgetParams Options used to configure a SearchBox widget.
  * @return {Widget} Creates a new instance of the SearchBox widget.
  * @example
  * search.addWidgets([
@@ -101,7 +101,7 @@ const renderer = ({
  *   })
  * ]);
  */
-export default function searchBox(widgetOptions) {
+export default function searchBox(widgetParams) {
   const {
     container,
     placeholder = '',
@@ -113,7 +113,7 @@ export default function searchBox(widgetOptions) {
     showLoadingIndicator = true,
     queryHook,
     templates,
-  } = widgetOptions || {};
+  } = widgetParams || {};
   if (!container) {
     throw new Error(withUsage('The `container` option is required.'));
   }

--- a/src/widgets/sort-by/sort-by.js
+++ b/src/widgets/sort-by/sort-by.js
@@ -48,7 +48,7 @@ const renderer = ({ containerNode, cssClasses }) => (
  */
 
 /**
- * @typedef {Object} SortByWidgetOptions
+ * @typedef {Object} SortByWidgetParams
  * @property {string|HTMLElement} container CSS Selector or HTMLElement to insert the widget.
  * @property {SortByIndexDefinition[]} items Array of objects defining the different indices to choose from.
  * @property {SortByWidgetCssClasses} [cssClasses] CSS classes to be added.
@@ -63,7 +63,7 @@ const renderer = ({ containerNode, cssClasses }) => (
  * @type {WidgetFactory}
  * @devNovel SortBy
  * @category sort
- * @param {SortByWidgetOptions} widgetOptions Options for the SortBy widget
+ * @param {SortByWidgetParams} widgetParams Options for the SortBy widget
  * @return {Widget} Creates a new instance of the SortBy widget.
  * @example
  * search.addWidgets([
@@ -77,9 +77,9 @@ const renderer = ({ containerNode, cssClasses }) => (
  *   })
  * ]);
  */
-export default function sortBy(widgetOptions) {
+export default function sortBy(widgetParams) {
   const { container, items, cssClasses: userCssClasses = {}, transformItems } =
-    widgetOptions || {};
+    widgetParams || {};
   if (!container) {
     throw new Error(withUsage('The `container` option is required.'));
   }

--- a/src/widgets/stats/stats.js
+++ b/src/widgets/stats/stats.js
@@ -78,7 +78,7 @@ const renderer = ({ containerNode, cssClasses, renderState, templates }) => (
  */
 
 /**
- * @typedef {Object} StatsWidgetOptions
+ * @typedef {Object} StatsWidgetParams
  * @property {string|HTMLElement} container Place where to insert the widget in your webpage.
  * @property {StatsWidgetTemplates} [templates] Templates to use for the widget.
  * @property {StatsWidgetCssClasses} [cssClasses] CSS classes to add.
@@ -92,7 +92,7 @@ const renderer = ({ containerNode, cssClasses, renderState, templates }) => (
  * @type {WidgetFactory}
  * @devNovel Stats
  * @category metadata
- * @param {StatsWidgetOptions} widgetOptions Stats widget options. Some keys are mandatory: `container`,
+ * @param {StatsWidgetParams} widgetParams Stats widget options. Some keys are mandatory: `container`,
  * @return {Widget} A new stats widget instance
  * @example
  * search.addWidgets([
@@ -101,12 +101,12 @@ const renderer = ({ containerNode, cssClasses, renderState, templates }) => (
  *   })
  * ]);
  */
-export default function stats(widgetOptions) {
+export default function stats(widgetParams) {
   const {
     container,
     cssClasses: userCssClasses = {},
     templates = defaultTemplates,
-  } = widgetOptions || {};
+  } = widgetParams || {};
   if (!container) {
     throw new Error(withUsage('The `container` option is required.'));
   }

--- a/src/widgets/toggle-refinement/toggle-refinement.js
+++ b/src/widgets/toggle-refinement/toggle-refinement.js
@@ -61,7 +61,7 @@ const renderer = ({ containerNode, cssClasses, renderState, templates }) => (
  */
 
 /**
- * @typedef {Object} ToggleWidgetOptions
+ * @typedef {Object} ToggleWidgetParams
  * @property {string|HTMLElement} container Place where to insert the widget in your webpage.
  * @property {string} attribute Name of the attribute for faceting (eg. "free_shipping").
  * @property {string|number|boolean|array} on Value to filter on when checked.
@@ -88,7 +88,7 @@ const renderer = ({ containerNode, cssClasses, renderState, templates }) => (
  * @type {WidgetFactory}
  * @devNovel ToggleRefinement
  * @category filter
- * @param {ToggleWidgetOptions} widgetOptions Options for the ToggleRefinement widget.
+ * @param {ToggleWidgetParams} widgetParams Options for the ToggleRefinement widget.
  * @return {Widget} A new instance of the ToggleRefinement widget
  * @example
  * search.addWidgets([
@@ -102,7 +102,7 @@ const renderer = ({ containerNode, cssClasses, renderState, templates }) => (
  *   })
  * ]);
  */
-export default function toggleRefinement(widgetOptions) {
+export default function toggleRefinement(widgetParams) {
   const {
     container,
     attribute,
@@ -110,7 +110,7 @@ export default function toggleRefinement(widgetOptions) {
     templates = defaultTemplates,
     on = true,
     off,
-  } = widgetOptions || {};
+  } = widgetParams || {};
   if (!container) {
     throw new Error(withUsage('The `container` option is required.'));
   }

--- a/src/widgets/voice-search/voice-search.tsx
+++ b/src/widgets/voice-search/voice-search.tsx
@@ -91,7 +91,7 @@ const renderer: Renderer<
   );
 };
 
-const voiceSearch: VoiceSearch = widgetOptions => {
+const voiceSearch: VoiceSearch = widgetParams => {
   const {
     container,
     cssClasses: userCssClasses = {} as VoiceSearchCSSClasses,
@@ -100,7 +100,7 @@ const voiceSearch: VoiceSearch = widgetOptions => {
     language,
     additionalQueryParameters,
     createVoiceSearchHelper,
-  } = widgetOptions || ({} as VoiceSearchWidgetParams);
+  } = widgetParams || ({} as VoiceSearchWidgetParams);
   if (!container) {
     throw new Error(withUsage('The `container` option is required.'));
   }

--- a/stories/configure-related-items.stories.ts
+++ b/stories/configure-related-items.stories.ts
@@ -7,7 +7,7 @@ import {
   index,
 } from '../src/widgets';
 import { connectHits, connectPagination } from '../src/connectors';
-import { HitsWidgetOptions } from '../src/widgets/hits/hits';
+import { HitsWidgetParams } from '../src/widgets/hits/hits';
 import { AlgoliaHit } from '../src/types';
 
 storiesOf('Basics/ConfigureRelatedItems', module).add(
@@ -72,7 +72,7 @@ storiesOf('Basics/ConfigureRelatedItems', module).add(
       referenceHit: null,
     };
 
-    const relatedHits = connectHits<HitsWidgetOptions>(
+    const relatedHits = connectHits<HitsWidgetParams>(
       ({ hits: items, widgetParams, instantSearchInstance }) => {
         const [hit] = items;
 


### PR DESCRIPTION
The two terms were used interchangeably, mostly in comments and in function arguments. There's now only `TWidgetOptions` in the Widget generic, which isn't widgetParams

BREAKING CHANGE: if you're using experimental-typescript and importing a type of the form `...WidgetOptions` (eg. replace `HitsWidgetOptions` with `HitsWidgetParams`)

