### PR TITLE
fix(insights): don't quote values

### DIFF
--- a/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.js
+++ b/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.js
@@ -1401,7 +1401,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
         insightsMethod: 'clickedFilters',
         payload: {
           eventName: 'Filter Applied',
-          filters: ['category:"value"'],
+          filters: ['category:value'],
           index: '',
         },
         widgetType: 'ais.hierarchicalMenu',

--- a/src/connectors/menu/__tests__/connectMenu-test.js
+++ b/src/connectors/menu/__tests__/connectMenu-test.js
@@ -1244,7 +1244,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
         insightsMethod: 'clickedFilters',
         payload: {
           eventName: 'Filter Applied',
-          filters: ['category:"value"'],
+          filters: ['category:value'],
           index: '',
         },
         widgetType: 'ais.menu',

--- a/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
+++ b/src/connectors/refinement-list/__tests__/connectRefinementList-test.js
@@ -2864,7 +2864,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
         insightsMethod: 'clickedFilters',
         payload: {
           eventName: 'Filter Applied',
-          filters: ['category:"value"'],
+          filters: ['category:value'],
           index: '',
         },
         widgetType: 'ais.refinementList',

--- a/src/connectors/toggle-refinement/connectToggleRefinement.js
+++ b/src/connectors/toggle-refinement/connectToggleRefinement.js
@@ -35,7 +35,7 @@ const createSendEvent = ({ instantSearchInstance, attribute, on, helper }) => (
       payload: {
         eventName,
         index: helper.getIndex(),
-        filters: on.map(value => `${attribute}:${JSON.stringify(value)}`),
+        filters: on.map(value => `${attribute}:${value}`),
       },
     });
   }

--- a/src/lib/utils/__tests__/createSendEventForFacet-test.ts
+++ b/src/lib/utils/__tests__/createSendEventForFacet-test.ts
@@ -86,7 +86,7 @@ If you want to send a custom payload, you can pass one object: sendEvent(customP
         insightsMethod: 'clickedFilters',
         payload: {
           eventName: 'Filter Applied',
-          filters: ['category:"value"'],
+          filters: ['category:value'],
           index: '',
         },
         widgetType: 'ais.customWidget',
@@ -104,7 +104,7 @@ If you want to send a custom payload, you can pass one object: sendEvent(customP
         insightsMethod: 'clickedFilters',
         payload: {
           eventName: 'Category Clicked',
-          filters: ['category:"value"'],
+          filters: ['category:value'],
           index: '',
         },
         widgetType: 'ais.customWidget',

--- a/src/lib/utils/createSendEventForFacet.ts
+++ b/src/lib/utils/createSendEventForFacet.ts
@@ -40,7 +40,7 @@ export function createSendEventForFacet({
           payload: {
             eventName,
             index: helper.getIndex(),
-            filters: [`${attribute}:${JSON.stringify(facetValue)}`],
+            filters: [`${attribute}:${facetValue}`],
           },
         });
       }


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

The values for personalisation are meant to be identical to those of the engine, otherwise they show up twice


**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

Values to send to insights are no longer stringified
