### PR TITLE
fix(index): do not warn for nested index widget

### DIFF
--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -2810,5 +2810,29 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
         '[InstantSearch.js]: The `getWidgetState` method is renamed `getWidgetUiState` and will no longer exist under that name in InstantSearch.js 5.x. Please use `getWidgetUiState` instead.'
       );
     });
+
+    test('does not warn for index itself', () => {
+      warning.cache = {};
+
+      const instance = index({ indexName: 'indexName' });
+      const searchClient = createSearchClient();
+      const mainHelper = algoliasearchHelper(searchClient, '', {});
+      const instantSearchInstance = createInstantSearch({
+        mainHelper,
+      });
+
+      instance.addWidgets([index({ indexName: 'other' })]);
+
+      expect(() => {
+        instance.init(
+          createInitOptions({
+            instantSearchInstance,
+            parent: null,
+          })
+        );
+      }).not.toWarnDev(
+        '[InstantSearch.js]: The `getWidgetState` method is renamed `getWidgetUiState` and will no longer exist under that name in InstantSearch.js 5.x. Please use `getWidgetUiState` instead.'
+      );
+    });
   });
 });

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -508,7 +508,9 @@ const index = (props: IndexProps): Index => {
 
       localWidgets.forEach(widget => {
         warning(
-          !widget.getWidgetState,
+          // if it has NO getWidgetState or if it has getWidgetUiState, we don't warn
+          // aka we warn if there's _only_ getWidgetState
+          !widget.getWidgetState || Boolean(widget.getWidgetUiState),
           'The `getWidgetState` method is renamed `getWidgetUiState` and will no longer exist under that name in InstantSearch.js 5.x. Please use `getWidgetUiState` instead.'
         );
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

The warning for usage of getWidgetState was slightly too aggressive, and would trigger for index widgets as well (since they have getWidgetState on top of getWidgetUiState).

We no longer warn if there's both a getWidgetState and getWidgetUiState. 

As an alternative, we could also check widget's $$type and avoid warning specifically for index

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

No longer a warning when an index widget is a child of an index widget (aka index widget is used at all