### PR TITLE
feat(widgets): annotate widget instances with $$widgetType

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
   "bundlesize": [
     {
       "path": "./dist/instantsearch.production.min.js",
-      "maxSize": "65.65 kB"
+      "maxSize": "65.75 kB"
     },
     {
       "path": "./dist/instantsearch.development.js",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
   "bundlesize": [
     {
       "path": "./dist/instantsearch.production.min.js",
-      "maxSize": "65.5 kB"
+      "maxSize": "65.65 kB"
     },
     {
       "path": "./dist/instantsearch.development.js",

--- a/src/lib/utils/checkIndexUiState.ts
+++ b/src/lib/utils/checkIndexUiState.ts
@@ -20,7 +20,7 @@ function getWidgetNames(connectorName: string): string[] {
 
 type StateDescription = {
   connectors: string[];
-  widgets: Array<Widget['$$type']>;
+  widgets: Array<Widget['$$widgetType']>;
 };
 
 type StateToWidgets = {

--- a/src/lib/utils/typedObject.ts
+++ b/src/lib/utils/typedObject.ts
@@ -1,0 +1,20 @@
+// https://stackoverflow.com/a/65117465/3185307
+
+export const keys = Object.keys as <TObject extends {}>(
+  yourObject: TObject
+) => Array<keyof TObject>;
+
+export const values = Object.values as <TObject extends {}>(
+  yourObject: TObject
+) => Array<TObject[keyof TObject]>;
+
+type Entries<TObject> = {
+  [TKey in keyof TObject]: [TKey, TObject[TKey]];
+}[keyof TObject];
+export const entries = Object.entries as <TObject extends {}>(
+  yourObject: TObject
+) => Array<Entries<TObject>>;
+
+export const fromEntries = Object.fromEntries as <TKey extends string, TValue>(
+  yourObjectEntries: Array<[TKey, TValue]>
+) => Record<TKey, TValue>;

--- a/src/lib/utils/typedObject.ts
+++ b/src/lib/utils/typedObject.ts
@@ -1,5 +1,7 @@
-// https://stackoverflow.com/a/65117465/3185307
-
+/**
+ * A typed version of Object.keys, to use when looping over a static object
+ * inspired from https://stackoverflow.com/a/65117465/3185307
+ */
 export const keys = Object.keys as <TObject extends {}>(
   yourObject: TObject
 ) => Array<keyof TObject>;

--- a/src/lib/utils/typedObject.ts
+++ b/src/lib/utils/typedObject.ts
@@ -3,18 +3,3 @@
 export const keys = Object.keys as <TObject extends {}>(
   yourObject: TObject
 ) => Array<keyof TObject>;
-
-export const values = Object.values as <TObject extends {}>(
-  yourObject: TObject
-) => Array<TObject[keyof TObject]>;
-
-type Entries<TObject> = {
-  [TKey in keyof TObject]: [TKey, TObject[TKey]];
-}[keyof TObject];
-export const entries = Object.entries as <TObject extends {}>(
-  yourObject: TObject
-) => Array<Entries<TObject>>;
-
-export const fromEntries = Object.fromEntries as <TKey extends string, TValue>(
-  yourObjectEntries: Array<[TKey, TValue]>
-) => Record<TKey, TValue>;

--- a/src/middlewares/__tests__/createMetadataMiddleware.ts
+++ b/src/middlewares/__tests__/createMetadataMiddleware.ts
@@ -101,13 +101,13 @@ describe('createMetadataMiddleware', () => {
       await wait(100);
 
       expect(document.head).toMatchInlineSnapshot(`
-<head>
-  <meta
-    content="{\\"widgets\\":[{\\"type\\":\\"ais.searchBox\\",\\"params\\":[]},{\\"type\\":\\"ais.searchBox\\",\\"params\\":[]},{\\"type\\":\\"ais.hits\\",\\"params\\":[\\"escapeHTML\\"]},{\\"type\\":\\"ais.index\\",\\"params\\":[]},{\\"type\\":\\"ais.pagination\\",\\"params\\":[]},{\\"type\\":\\"ais.configure\\",\\"params\\":[\\"searchParameters\\"]}]}"
-    name="instantsearch:widgets"
-  />
-</head>
-`);
+        <head>
+          <meta
+            content="{\\"widgets\\":[{\\"type\\":\\"ais.searchBox\\",\\"widgetType\\":\\"ais.searchBox\\",\\"params\\":[]},{\\"type\\":\\"ais.searchBox\\",\\"widgetType\\":\\"ais.searchBox\\",\\"params\\":[]},{\\"type\\":\\"ais.hits\\",\\"widgetType\\":\\"ais.hits\\",\\"params\\":[\\"escapeHTML\\"]},{\\"type\\":\\"ais.index\\",\\"widgetType\\":\\"ais.index\\",\\"params\\":[]},{\\"type\\":\\"ais.pagination\\",\\"widgetType\\":\\"ais.pagination\\",\\"params\\":[]},{\\"type\\":\\"ais.configure\\",\\"widgetType\\":\\"ais.configure\\",\\"params\\":[\\"searchParameters\\"]}]}"
+            name="instantsearch:widgets"
+          />
+        </head>
+      `);
 
       expect(JSON.parse(document.head.querySelector('meta')!.content))
         .toMatchInlineSnapshot(`
@@ -116,30 +116,36 @@ Object {
     Object {
       "params": Array [],
       "type": "ais.searchBox",
+      "widgetType": "ais.searchBox",
     },
     Object {
       "params": Array [],
       "type": "ais.searchBox",
+      "widgetType": "ais.searchBox",
     },
     Object {
       "params": Array [
         "escapeHTML",
       ],
       "type": "ais.hits",
+      "widgetType": "ais.hits",
     },
     Object {
       "params": Array [],
       "type": "ais.index",
+      "widgetType": "ais.index",
     },
     Object {
       "params": Array [],
       "type": "ais.pagination",
+      "widgetType": "ais.pagination",
     },
     Object {
       "params": Array [
         "searchParameters",
       ],
       "type": "ais.configure",
+      "widgetType": "ais.configure",
     },
   ],
 }

--- a/src/middlewares/createMetadataMiddleware.ts
+++ b/src/middlewares/createMetadataMiddleware.ts
@@ -3,6 +3,7 @@ import { Index } from '../widgets/index/index';
 
 type WidgetMetaData = {
   type: string | undefined;
+  widgetType: string | undefined;
   params: string[];
 };
 
@@ -50,6 +51,7 @@ function extractPayload(
 
     payload.widgets.push({
       type: widget.$$type,
+      widgetType: widget.$$widgetType,
       params,
     });
 

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -386,7 +386,7 @@ export type Widget<
     | 'ais.places'
     | 'ais.poweredBy'
     | 'ais.queryRules'
-    // @MAJOR: remove individual types for rangeSlider & rangeInput
+    // @TODO: remove individual types for rangeSlider & rangeInput once updating checkIndexUiState
     | 'ais.range'
     | 'ais.rangeSlider'
     | 'ais.rangeInput'

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -423,7 +423,6 @@ export type Widget<
     | 'ais.poweredBy'
     | 'ais.queryRuleCustomData'
     | 'ais.queryRuleContext'
-    | 'ais.range'
     | 'ais.rangeInput'
     | 'ais.rangeSlider'
     | 'ais.ratingMenu'

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -364,7 +364,7 @@ export type Widget<
   TWidgetOptions extends { renderState: unknown } = { renderState: unknown }
 > = {
   /**
-   * Identifier for official widgets
+   * Identifier for official connectors and widgets
    */
   $$type?:
     | 'ais.analytics'
@@ -386,6 +386,41 @@ export type Widget<
     | 'ais.places'
     | 'ais.poweredBy'
     | 'ais.queryRules'
+    // @MAJOR: remove individual types for rangeSlider & rangeInput
+    | 'ais.range'
+    | 'ais.rangeSlider'
+    | 'ais.rangeInput'
+    | 'ais.ratingMenu'
+    | 'ais.refinementList'
+    | 'ais.searchBox'
+    | 'ais.sortBy'
+    | 'ais.stats'
+    | 'ais.toggleRefinement'
+    | 'ais.voiceSearch';
+
+  /**
+   * Identifier for official widgets
+   */
+  $$widgetType?:
+    | 'ais.analytics'
+    | 'ais.autocomplete'
+    | 'ais.breadcrumb'
+    | 'ais.clearRefinements'
+    | 'ais.configure'
+    | 'ais.configureRelatedItems'
+    | 'ais.currentRefinements'
+    | 'ais.geoSearch'
+    | 'ais.hierarchicalMenu'
+    | 'ais.hits'
+    | 'ais.hitsPerPage'
+    | 'ais.index'
+    | 'ais.infiniteHits'
+    | 'ais.menu'
+    | 'ais.menuSelect'
+    | 'ais.numericMenu'
+    | 'ais.pagination'
+    | 'ais.places'
+    | 'ais.poweredBy'
     | 'ais.queryRuleCustomData'
     | 'ais.queryRuleContext'
     | 'ais.range'

--- a/src/widgets/__tests__/index.tests.ts
+++ b/src/widgets/__tests__/index.tests.ts
@@ -1,0 +1,164 @@
+import { PlacesInstance } from 'places.js';
+import * as widgets from '../';
+import { entries } from '../../lib/utils/typedObject';
+import { Widget } from '../../types';
+
+type Widgets = typeof widgets;
+type WidgetNames = keyof typeof widgets;
+function initiateAllWidgets(): Array<[WidgetNames, Widget]> {
+  return entries(widgets).map(([name, widget]) => {
+    return [name, initiateWidget(name, widget)];
+  });
+
+  function initiateWidget<TName extends WidgetNames>(
+    name: TName,
+    widget: Widgets[TName]
+  ) {
+    const container = document.createElement('div');
+
+    switch (name) {
+      case 'index': {
+        const index = widget as Widgets['index'];
+        return index({ indexName: 'index' });
+      }
+      case 'EXPERIMENTAL_configureRelatedItems': {
+        const EXPERIMENTAL_configureRelatedItems = widget as Widgets['EXPERIMENTAL_configureRelatedItems'];
+        return EXPERIMENTAL_configureRelatedItems({
+          hit: { objectID: 'x' },
+          matchingPatterns: {},
+        });
+      }
+      case 'geoSearch': {
+        const geoSearch = widget as Widgets['geoSearch'];
+        return geoSearch({
+          container,
+          googleReference: { maps: { OverlayView: class OverlayView {} } },
+        });
+      }
+      case 'hierarchicalMenu': {
+        const hierarchicalMenu = widget as Widgets['hierarchicalMenu'];
+        return hierarchicalMenu({
+          container,
+          attributes: ['attr1', 'attr2'],
+        });
+      }
+      case 'breadcrumb': {
+        const breadcrumb = widget as Widgets['breadcrumb'];
+        return breadcrumb({
+          container,
+          attributes: ['attr1', 'attr2'],
+        });
+      }
+      case 'hitsPerPage': {
+        const hitsPerPage = widget as Widgets['hitsPerPage'];
+        return hitsPerPage({
+          container,
+          items: [{ default: true, label: 'def', value: 1 }],
+        });
+      }
+      case 'numericMenu': {
+        const numericMenu = widget as Widgets['numericMenu'];
+        return numericMenu({
+          container,
+          attribute: 'attr',
+          items: [{ label: 'x', start: 1, end: 2 }],
+        });
+      }
+      case 'sortBy': {
+        const sortBy = widget as Widgets['sortBy'];
+        return sortBy({
+          container,
+          items: [{ label: 'x', value: 'x' }],
+        });
+      }
+      case 'analytics': {
+        const analytics = widget as Widgets['analytics'];
+        return analytics({
+          pushFunction() {},
+        });
+      }
+      case 'queryRuleContext': {
+        const queryRuleContext = widget as Widgets['queryRuleContext'];
+        return queryRuleContext({
+          trackedFilters: {
+            facet(values) {
+              return values;
+            },
+          },
+        });
+      }
+      case 'places': {
+        const places = widget as Widgets['places'];
+        return places({
+          container: document.createElement('input'),
+          placesReference: () => ({} as PlacesInstance),
+        });
+      }
+      case 'panel': {
+        const panel = widget as Widgets['panel'];
+        return panel()(widgets.hierarchicalMenu)({
+          container,
+          attributes: ['attr1', 'attr2'],
+        });
+      }
+      default: {
+        return widget({ container, attribute: 'attr' });
+      }
+    }
+  }
+}
+
+describe('widgets', () => {
+  describe('$$type', () => {
+    test('present in every widget', () => {
+      const widgetInstances = initiateAllWidgets();
+
+      widgetInstances.forEach(([name, widget]) =>
+        expect([name, widget.$$type]).toEqual([name, expect.any(String)])
+      );
+    });
+
+    test('starts with ais.', () => {
+      const widgetInstances = initiateAllWidgets();
+
+      widgetInstances.forEach(([name, widget]) =>
+        expect([name, widget.$$type!.substr(0, 4)]).toEqual([name, 'ais.'])
+      );
+    });
+  });
+
+  describe('$$widgetType', () => {
+    test('present in all widgets', () => {
+      const widgetInstances = initiateAllWidgets();
+
+      widgetInstances.forEach(([name, widget]) =>
+        expect([name, widget.$$widgetType]).toEqual([name, expect.any(String)])
+      );
+    });
+
+    test('starts with ais.', () => {
+      const widgetInstances = initiateAllWidgets();
+
+      widgetInstances.forEach(([name, widget]) =>
+        expect([name, widget.$$widgetType!.substr(0, 4)]).toEqual([
+          name,
+          'ais.',
+        ])
+      );
+    });
+
+    test('is the same as name', () => {
+      const widgetInstances = initiateAllWidgets();
+
+      widgetInstances.forEach(([name, widget]) => {
+        if (name === 'panel') {
+          // the widget type of panel is the wrapped widget
+          return;
+        }
+        expect(widget.$$widgetType).toBe(
+          `ais.${name.replace('EXPERIMENTAL_', '')}`
+        );
+      });
+    });
+  });
+});

--- a/src/widgets/__tests__/index.tests.ts
+++ b/src/widgets/__tests__/index.tests.ts
@@ -1,10 +1,18 @@
 import { PlacesInstance } from 'places.js';
 import * as widgets from '../';
-import { entries } from '../../lib/utils/typedObject';
 import { Widget } from '../../types';
+
+// @TODO: move to typedObject once this no longer needs to be polyfilled
+type Entries<TObject> = {
+  [TKey in keyof TObject]: [TKey, TObject[TKey]];
+}[keyof TObject];
+const entries = Object.entries as <TObject extends {}>(
+  yourObject: TObject
+) => Array<Entries<TObject>>;
 
 type Widgets = typeof widgets;
 type WidgetNames = keyof typeof widgets;
+
 function initiateAllWidgets(): Array<[WidgetNames, Widget]> {
   return entries(widgets).map(([name, widget]) => {
     return [name, initiateWidget(name, widget)];

--- a/src/widgets/__tests__/index.tests.ts
+++ b/src/widgets/__tests__/index.tests.ts
@@ -2,7 +2,9 @@ import { PlacesInstance } from 'places.js';
 import * as widgets from '../';
 import { Widget } from '../../types';
 
-// @TODO: move to typedObject once this no longer needs to be polyfilled
+// This is written in the test, since Object.entries is not allowed in the
+// source code. Once we use Object.entries without polyfill, we can move this
+// helper to the `typedObject` file.
 type Entries<TObject> = {
   [TKey in keyof TObject]: [TKey, TObject[TKey]];
 }[keyof TObject];

--- a/src/widgets/analytics/analytics.ts
+++ b/src/widgets/analytics/analytics.ts
@@ -225,6 +225,7 @@ For the migration, visit https://www.algolia.com/doc/guides/building-search-ui/u
 
   return {
     $$type: 'ais.analytics',
+    $$widgetType: 'ais.analytics',
 
     init() {
       if (triggerOnUIInteraction === true) {

--- a/src/widgets/breadcrumb/breadcrumb.tsx
+++ b/src/widgets/breadcrumb/breadcrumb.tsx
@@ -167,6 +167,7 @@ const breadcrumb: BreadcrumbWidget = function breadcrumb(widgetOptions) {
 
   return {
     ...makeWidget({ attributes, separator, rootPath, transformItems }),
+    $$widgetType: 'ais.breadcrumb',
   };
 };
 

--- a/src/widgets/clear-refinements/clear-refinements.tsx
+++ b/src/widgets/clear-refinements/clear-refinements.tsx
@@ -134,6 +134,7 @@ const clearRefinements: ClearRefinementsWidget = widgetOptions => {
       excludedAttributes,
       transformItems,
     }),
+    $$widgetType: 'ais.clearRefinements',
   };
 };
 

--- a/src/widgets/configure-related-items/configure-related-items.ts
+++ b/src/widgets/configure-related-items/configure-related-items.ts
@@ -21,6 +21,7 @@ const configureRelatedItems: ConfigureRelatedItemsWidget = function configureRel
 
   return {
     ...makeWidget(widgetParams),
+    $$widgetType: 'ais.configureRelatedItems',
   };
 };
 

--- a/src/widgets/configure/configure.ts
+++ b/src/widgets/configure/configure.ts
@@ -27,6 +27,7 @@ const configure: ConfigureWidget = function configure(widgetParams) {
 
   return {
     ...makeWidget({ searchParameters: widgetParams }),
+    $$widgetType: 'ais.configure',
   };
 };
 

--- a/src/widgets/current-refinements/current-refinements.tsx
+++ b/src/widgets/current-refinements/current-refinements.tsx
@@ -129,6 +129,7 @@ const currentRefinements: CurrentRefinementsWidget = function currentRefinements
       excludedAttributes,
       transformItems,
     }),
+    $$widgetType: 'ais.currentRefinements',
   };
 };
 

--- a/src/widgets/geo-search/geo-search.js
+++ b/src/widgets/geo-search/geo-search.js
@@ -230,6 +230,7 @@ const geoSearch = widgetOptions => {
       enableClearMapRefinement,
       enableRefineControl,
     }),
+    $$widgetType: 'ais.geoSearch',
   };
 };
 

--- a/src/widgets/hierarchical-menu/hierarchical-menu.js
+++ b/src/widgets/hierarchical-menu/hierarchical-menu.js
@@ -248,5 +248,6 @@ export default function hierarchicalMenu(widgetOptions) {
       sortBy,
       transformItems,
     }),
+    $$widgetType: 'ais.hierarchicalMenu',
   };
 }

--- a/src/widgets/hits-per-page/hits-per-page.tsx
+++ b/src/widgets/hits-per-page/hits-per-page.tsx
@@ -104,6 +104,7 @@ const hitsPerPage: HitsPerPageWidget = function hitsPerPage(widgetOptions) {
 
   return {
     ...makeWidget({ items, transformItems }),
+    $$widgetType: 'ais.hitsPerPage',
   };
 };
 

--- a/src/widgets/hits/hits.tsx
+++ b/src/widgets/hits/hits.tsx
@@ -163,6 +163,7 @@ const hits: HitsWidget = function hits(widgetOptions) {
 
   return {
     ...makeWidget({ escapeHTML, transformItems }),
+    $$widgetType: 'ais.hits',
   };
 };
 

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -194,6 +194,7 @@ const index = (props: IndexProps): Index => {
 
   return {
     $$type: 'ais.index',
+    $$widgetType: 'ais.index',
 
     getIndexName() {
       return indexName;

--- a/src/widgets/infinite-hits/infinite-hits.tsx
+++ b/src/widgets/infinite-hits/infinite-hits.tsx
@@ -236,6 +236,7 @@ const infiniteHits: InfiniteHitsWidget = widgetOptions => {
       showPrevious,
       cache,
     }),
+    $$widgetType: 'ais.infiniteHits',
   };
 };
 

--- a/src/widgets/menu-select/menu-select.js
+++ b/src/widgets/menu-select/menu-select.js
@@ -122,5 +122,6 @@ export default function menuSelect(widgetOptions) {
 
   return {
     ...makeWidget({ attribute, limit, sortBy, transformItems }),
+    $$widgetType: 'ais.menuSelect',
   };
 }

--- a/src/widgets/menu/menu.js
+++ b/src/widgets/menu/menu.js
@@ -182,5 +182,6 @@ export default function menu(widgetOptions) {
       sortBy,
       transformItems,
     }),
+    $$widgetType: 'ais.menu',
   };
 }

--- a/src/widgets/numeric-menu/numeric-menu.tsx
+++ b/src/widgets/numeric-menu/numeric-menu.tsx
@@ -215,6 +215,7 @@ const numericMenu: NumericMenuWidget = function numericMenu(widgetOptions) {
       items,
       transformItems,
     }),
+    $$widgetType: 'ais.numericMenu',
   };
 };
 

--- a/src/widgets/pagination/pagination.js
+++ b/src/widgets/pagination/pagination.js
@@ -223,5 +223,6 @@ export default function pagination(widgetOptions) {
 
   return {
     ...makeWidget({ totalPages, padding }),
+    $$widgetType: 'ais.pagination',
   };
 }

--- a/src/widgets/places/places.ts
+++ b/src/widgets/places/places.ts
@@ -60,6 +60,7 @@ const placesWidget: PlacesWidget = (widgetParams: PlacesWidgetParams) => {
 
   return {
     $$type: 'ais.places',
+    $$widgetType: 'ais.places',
 
     init({ helper }) {
       placesAutocomplete.on('change', (eventOptions: ChangeEvent) => {

--- a/src/widgets/powered-by/powered-by.js
+++ b/src/widgets/powered-by/powered-by.js
@@ -89,5 +89,6 @@ export default function poweredBy(widgetOptions) {
 
   return {
     ...makeWidget({ theme }),
+    $$widgetType: 'ais.poweredBy',
   };
 }

--- a/src/widgets/query-rule-context/__tests__/query-rule-context-test.ts
+++ b/src/widgets/query-rule-context/__tests__/query-rule-context-test.ts
@@ -29,7 +29,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rule-
 
       expect(widget).toEqual(
         expect.objectContaining({
-          $$type: 'ais.queryRuleContext',
+          $$type: 'ais.queryRules',
+          $$widgetType: 'ais.queryRuleContext',
         })
       );
     });

--- a/src/widgets/query-rule-context/query-rule-context.tsx
+++ b/src/widgets/query-rule-context/query-rule-context.tsx
@@ -31,8 +31,7 @@ const queryRuleContext: QueryRuleContext = (
 
   return {
     ...connectQueryRules<QueryRuleContextWidgetParams>(noop)(widgetParams),
-
-    $$type: 'ais.queryRuleContext',
+    $$widgetType: 'ais.queryRuleContext',
   };
 };
 

--- a/src/widgets/query-rule-custom-data/__tests__/query-rule-custom-data-test.ts
+++ b/src/widgets/query-rule-custom-data/__tests__/query-rule-custom-data-test.ts
@@ -61,7 +61,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rule-
 
       expect(widget).toEqual(
         expect.objectContaining({
-          $$type: 'ais.queryRuleCustomData',
+          $$type: 'ais.queryRules',
+          $$widgetType: 'ais.queryRuleCustomData',
         })
       );
     });

--- a/src/widgets/query-rule-custom-data/query-rule-custom-data.tsx
+++ b/src/widgets/query-rule-custom-data/query-rule-custom-data.tsx
@@ -95,8 +95,7 @@ const queryRuleCustomData: QueryRuleCustomDataWidget = widgetOptions => {
       templates,
       transformItems,
     }),
-
-    $$type: 'ais.queryRuleCustomData',
+    $$widgetType: 'ais.queryRuleCustomData',
   };
 };
 

--- a/src/widgets/range-input/__tests__/range-input-test.ts
+++ b/src/widgets/range-input/__tests__/range-input-test.ts
@@ -44,6 +44,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       expect(widget).toEqual(
         expect.objectContaining({
           $$type: 'ais.rangeInput',
+          $$widgetType: 'ais.rangeInput',
         })
       );
     });

--- a/src/widgets/range-input/range-input.js
+++ b/src/widgets/range-input/range-input.js
@@ -170,5 +170,6 @@ export default function rangeInput(widgetOptions) {
     }),
 
     $$type: 'ais.rangeInput',
+    $$widgetType: 'ais.rangeInput',
   };
 }

--- a/src/widgets/range-slider/__tests__/range-slider-test.ts
+++ b/src/widgets/range-slider/__tests__/range-slider-test.ts
@@ -64,6 +64,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-slide
       expect(widget).toEqual(
         expect.objectContaining({
           $$type: 'ais.rangeSlider',
+          $$widgetType: 'ais.rangeSlider',
         })
       );
     });

--- a/src/widgets/range-slider/range-slider.js
+++ b/src/widgets/range-slider/range-slider.js
@@ -151,5 +151,6 @@ export default function rangeSlider(widgetOptions) {
     ...makeWidget({ attribute, min, max, precision }),
 
     $$type: 'ais.rangeSlider',
+    $$widgetType: 'ais.rangeSlider',
   };
 }

--- a/src/widgets/rating-menu/rating-menu.js
+++ b/src/widgets/rating-menu/rating-menu.js
@@ -166,5 +166,6 @@ export default function ratingMenu(widgetOptions) {
 
   return {
     ...makeWidget({ attribute, max }),
+    $$widgetType: 'ais.ratingMenu',
   };
 }

--- a/src/widgets/refinement-list/refinement-list.js
+++ b/src/widgets/refinement-list/refinement-list.js
@@ -313,5 +313,6 @@ export default function refinementList(widgetOptions) {
       escapeFacetValues,
       transformItems,
     }),
+    $$widgetType: 'ais.refinementList',
   };
 }

--- a/src/widgets/search-box/search-box.js
+++ b/src/widgets/search-box/search-box.js
@@ -162,5 +162,6 @@ export default function searchBox(widgetOptions) {
 
   return {
     ...makeWidget({ queryHook }),
+    $$widgetType: 'ais.searchBox',
   };
 }

--- a/src/widgets/sort-by/sort-by.js
+++ b/src/widgets/sort-by/sort-by.js
@@ -103,5 +103,6 @@ export default function sortBy(widgetOptions) {
 
   return {
     ...makeWidget({ items, transformItems }),
+    $$widgetType: 'ais.sortBy',
   };
 }

--- a/src/widgets/stats/stats.js
+++ b/src/widgets/stats/stats.js
@@ -131,5 +131,6 @@ export default function stats(widgetOptions) {
 
   return {
     ...makeWidget(),
+    $$widgetType: 'ais.stats',
   };
 }

--- a/src/widgets/toggle-refinement/toggle-refinement.js
+++ b/src/widgets/toggle-refinement/toggle-refinement.js
@@ -140,5 +140,6 @@ export default function toggleRefinement(widgetOptions) {
 
   return {
     ...makeWidget({ attribute, on, off }),
+    $$widgetType: 'ais.toggleRefinement',
   };
 }

--- a/src/widgets/voice-search/voice-search.tsx
+++ b/src/widgets/voice-search/voice-search.tsx
@@ -127,6 +127,7 @@ const voiceSearch: VoiceSearch = widgetOptions => {
       additionalQueryParameters,
       createVoiceSearchHelper,
     }),
+    $$widgetType: 'ais.voiceSearch',
   };
 };
 


### PR DESCRIPTION
Adds a new $$widgetType to all widgets, so they can be differentiated from connectors, as well as differentiating between widgets that share a connector.

This differentiation hasn't been done for rangeInput & rangeSlider yet