### PR TITLE
POC: prevent downsides of getWidgetRenderState's refine identity

### DIFF
--- a/src/connectors/search-box/connectSearchBox.js
+++ b/src/connectors/search-box/connectSearchBox.js
@@ -122,7 +122,8 @@ export default function connectSearchBox(renderFn, unmountFn = noop) {
       },
 
       getWidgetRenderState({ helper, searchMetadata }) {
-        if (!this._refine) {
+        if (!this._refine || helper !== this.__oldHelper) {
+          this.__oldHelper = helper;
           const setQueryAndSearch = query => {
             if (query !== helper.state.query) {
               helper.setQuery(query).search();


### PR DESCRIPTION
prevents the downsides of https://github.com/algolia/instantsearch.js/commit/c2f35464b347817152d5936e66252ac03e38794e#diff-fc3d2403c81ac8eda4a7c4982cfbfff1017b041f08bba731cac19cd47bb8e33d,

fixes https://github.com/algolia/vue-instantsearch/issues/911

basically we should check somehow whether the helper reference is still correct, in Vue InstantSearch SSR we call init with a different helper than gets created after .start()

https://github.com/algolia/vue-instantsearch/blob/4fb73136fac84cdd8149238004051ea3381a740c/src/util/createServerRootMixin.js#L226-L230

We could also possibly inject the helper created by Vue InstantSearch into InstantSearch, so the reference is actually correct when calling init.

Before getWidgetRenderState this wasn't an issue, since calling init multiple times is not really an issue (since it would then set those variables multiple times)

We could also possibly roll back the changes in https://github.com/algolia/instantsearch.js/commit/c2f35464b347817152d5936e66252ac03e38794e and set all inner references in init (like before)

