### PR TITLE
fix(index): only set listeners on init once

### DIFF
--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -2341,6 +2341,58 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
         expect.anything()
       );
     });
+
+    describe('multiple init calls', () => {
+      it('does not recreate helper', () => {
+        const instance = index({ indexName: 'test' });
+
+        expect(instance.getHelper()).toBe(null);
+
+        instance.init(createInitOptions());
+
+        const helper1 = instance.getHelper()!;
+
+        instance.init(createInitOptions());
+
+        const helper2 = instance.getHelper()!;
+
+        expect(helper1).toBe(helper2);
+      });
+
+      it('does not listen on change again multiple times', () => {
+        const instance = index({ indexName: 'test' });
+
+        expect(instance.getHelper()).toBe(null);
+
+        instance.init(createInitOptions());
+
+        const helper = instance.getHelper()!;
+
+        expect(helper.listenerCount('change')).toBe(2);
+
+        instance.init(createInitOptions());
+
+        expect(helper.listenerCount('change')).toBe(2);
+      });
+
+      it('derives only once', () => {
+        const instance = index({ indexName: 'test' });
+
+        const mainHelper = algoliasearchHelper(createSearchClient(), '');
+
+        const instantSearchInstance = createInstantSearch({ mainHelper });
+
+        expect(instance.getHelper()).toBe(null);
+
+        instance.init(createInitOptions({ instantSearchInstance }));
+
+        expect(mainHelper.derivedHelpers.length).toBe(1);
+
+        instance.init(createInitOptions({ instantSearchInstance }));
+
+        expect(mainHelper.derivedHelpers.length).toBe(1);
+      });
+    });
   });
 
   describe('render', () => {

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -372,6 +372,12 @@ const index = (props: IndexProps): Index => {
     },
 
     init({ instantSearchInstance, parent, uiState }: IndexInitOptions) {
+      if (helper !== null) {
+        // helper is already initialized, therefore we do not need to set up
+        // any listeners
+        return;
+      }
+
       localInstantSearchInstance = instantSearchInstance;
       localParent = parent;
       localUiState = uiState[indexId] || {};
@@ -416,7 +422,7 @@ const index = (props: IndexProps): Index => {
         return mainHelper.search();
       };
 
-      (helper as any).searchWithoutTriggeringOnStateChange = () => {
+      helper.searchWithoutTriggeringOnStateChange = () => {
         return mainHelper.search();
       };
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Without this, if init is called multiple times (like in Vue InstantSearch), multiple event listeners are attached, as well as the helper being recreated. This causes the references from the first init call to no longer being correct later in the instance.

Since we save the references in the very first call of getWidgetRenderState in most widgets (`if (!refine) refine =`), the helper reference needs to stay stable.

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

This fixes https://github.com/algolia/vue-instantsearch/issues/911 by avoiding to have a different helper instance when init gets called multiple times.


