### PR TITLE
feat(queryRuleContext): allow to make refinements based on query

### DIFF
--- a/src/connectors/clear-refinements/connectClearRefinements.ts
+++ b/src/connectors/clear-refinements/connectClearRefinements.ts
@@ -195,7 +195,7 @@ function getAttributesToClear({
   excludedAttributes,
   transformItems,
 }): AttributesToClear {
-  const clearsQuery =
+  const includesQuery =
     includedAttributes.indexOf('query') !== -1 ||
     excludedAttributes.indexOf('query') === -1;
 
@@ -206,7 +206,7 @@ function getAttributesToClear({
         getRefinements(
           scopedResult.results,
           scopedResult.helper.state,
-          clearsQuery
+          includesQuery
         )
           .map(refinement => refinement.attribute)
           .filter(
@@ -219,7 +219,7 @@ function getAttributesToClear({
           .filter(
             attribute =>
               // If the query is included, we ignore the default `excludedAttributes = ['query']`
-              (attribute === 'query' && clearsQuery) ||
+              (attribute === 'query' && includesQuery) ||
               // Otherwise, ignore the excluded attributes
               excludedAttributes.indexOf(attribute) === -1
           )

--- a/src/connectors/current-refinements/connectCurrentRefinements.ts
+++ b/src/connectors/current-refinements/connectCurrentRefinements.ts
@@ -249,7 +249,7 @@ function getRefinementsItems({
   includedAttributes: CurrentRefinementsConnectorParams['includedAttributes'];
   excludedAttributes: CurrentRefinementsConnectorParams['excludedAttributes'];
 }): CurrentRefinementsConnectorParamsItem[] {
-  const clearsQuery =
+  const includesQuery =
     (includedAttributes || []).indexOf('query') !== -1 ||
     (excludedAttributes || []).indexOf('query') === -1;
 
@@ -259,7 +259,7 @@ function getRefinementsItems({
     : (item: CurrentRefinementsConnectorParamsRefinement) =>
         excludedAttributes!.indexOf(item.attribute) === -1;
 
-  const items = getRefinements(results, helper.state, clearsQuery)
+  const items = getRefinements(results, helper.state, includesQuery)
     .map(normalizeRefinement)
     .filter(filterFunction);
 

--- a/src/connectors/query-rules/connectQueryRules.ts
+++ b/src/connectors/query-rules/connectQueryRules.ts
@@ -74,7 +74,8 @@ function getRuleContextsFromTrackedFilters({
         // An empty object is technically not a `SearchResults` but `getRefinements`
         // only accesses properties, meaning it will not throw with an empty object.
         helper.lastResults || ({} as SearchResults),
-        sharedHelperState
+        sharedHelperState,
+        true
       )
         .filter(
           (refinement: InternalRefinement) => refinement.attribute === facetName

--- a/src/lib/utils/getRefinements.ts
+++ b/src/lib/utils/getRefinements.ts
@@ -93,7 +93,7 @@ function getRefinement(
 function getRefinements(
   results: SearchResults,
   state: SearchParameters,
-  clearsQuery: boolean = false
+  includesQuery: boolean = false
 ): Refinement[] {
   const refinements: Refinement[] = [];
   const {
@@ -188,7 +188,7 @@ function getRefinements(
     refinements.push({ type: 'tag', attribute: '_tags', name: refinementName });
   });
 
-  if (clearsQuery && state.query && state.query.trim()) {
+  if (includesQuery && state.query && state.query.trim()) {
     refinements.push({
       attribute: 'query',
       type: 'query',


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

this use case came up in a support ticket, they wanted to add a query rule when the query _did not_ match something. The engine only has positive matches, so negative matches need to be done frontend.


**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

Before that use case was implemented like this: https://codesandbox.io/s/dynamically-deactivate-rule-forked-wouf8?file=/src/app.js 

With this PR it can be implemented like this: https://codesandbox.io/s/dynamically-deactivate-rule-forked-h9w20?file=/src/app.js

(still a bit longer than I wanted, but that's because you can't transform inside trackedFilters, and enabling it would be a breaking change)
