### PR TITLE
fix(compat): remove references to window

### DIFF
--- a/src/connectors/numeric-menu/connectNumericMenu.ts
+++ b/src/connectors/numeric-menu/connectNumericMenu.ts
@@ -42,7 +42,7 @@ export type NumericMenuRendererOptionsItem = {
    * URL encoded of the bounds object with the form `{start, end}`.
    * This value can be used verbatim in the webpage and can be read by `refine`
    * directly. If you want to inspect the value, you can do:
-   * `JSON.parse(window.decodeURI(value))` to get the object.
+   * `JSON.parse(decodeURI(value))` to get the object.
    */
   value: string;
 
@@ -166,7 +166,7 @@ const connectNumericMenu: NumericMenuConnector = function connectNumericMenu(
     const prepareItems = (state: SearchParameters) =>
       items.map(({ start, end, label }) => ({
         label,
-        value: (window as any).encodeURI(JSON.stringify({ start, end })),
+        value: encodeURI(JSON.stringify({ start, end })),
         isRefined: isRefined(state, attribute, { start, end, label }),
       }));
 
@@ -366,7 +366,7 @@ function getRefinedState(
 ) {
   let resolvedState = state;
 
-  const refinedOption = JSON.parse((window as any).decodeURI(facetValue));
+  const refinedOption = JSON.parse(decodeURI(facetValue));
 
   // @TODO: why is array / element mixed here & hasRefinements; seems wrong?
   const currentRefinements = resolvedState.getNumericRefinements(

--- a/stories/voice-search.stories.ts
+++ b/stories/voice-search.stories.ts
@@ -58,8 +58,8 @@ storiesOf('Basics/VoiceSearch', module)
   .add(
     'with a custom button text',
     withHits(({ search, container }) => {
-      const style = window.document.createElement('style');
-      window.document.head.appendChild(style);
+      const style = document.createElement('style');
+      document.head.appendChild(style);
       [
         `.ais-VoiceSearch-button.custom-button:hover {
         background: inherit;
@@ -130,8 +130,8 @@ storiesOf('Basics/VoiceSearch', module)
       container.appendChild(subContainer1);
       container.appendChild(subContainer2);
 
-      const style = window.document.createElement('style');
-      window.document.head.appendChild(style);
+      const style = document.createElement('style');
+      document.head.appendChild(style);
       [
         `.voice-search-button {
           position: absolute;


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

remove needless references to window in the source code

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

remaining references to window:
- analytics (but this widget is deprecated)
- geoSearch (but this is up to the user)
- sessionStorage (but this is feature-checked and has no alternative for node)
- poweredBy (but it's feature-checked)
- routing (this should likely be rethought with server side rendering in mind, for now people use custom routers)

fixes #4650
