### PR TITLE
fix(insights): don't reset page

### DIFF
--- a/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -207,7 +207,7 @@ describe('insights', () => {
       expect(getUserToken()).toEqual('abc');
     });
 
-    it('applies userToken without resetting the page', () => {
+    it('applies userToken before subscribe() without resetting the page', () => {
       const {
         insightsClient,
         instantSearchInstance,
@@ -235,6 +235,23 @@ describe('insights', () => {
       })({ instantSearchInstance });
       middleware.subscribe();
       insightsClient('setUserToken', 'def');
+      expect(getUserToken()).toEqual('def');
+    });
+
+    it('applies userToken which was set after subscribe() without resetting the page', () => {
+      const {
+        insightsClient,
+        instantSearchInstance,
+        helper,
+        getUserToken
+      } = createTestEnvironment();
+      const middleware = createInsightsMiddleware({
+        insightsClient,
+      })({ instantSearchInstance });
+      helper.setPage(100);
+      middleware.subscribe();
+      insightsClient('setUserToken', 'def');
+      expect(helper.state.page).toEqual(100);
       expect(getUserToken()).toEqual('def');
     });
 

--- a/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -243,7 +243,7 @@ describe('insights', () => {
         insightsClient,
         instantSearchInstance,
         helper,
-        getUserToken
+        getUserToken,
       } = createTestEnvironment();
       const middleware = createInsightsMiddleware({
         insightsClient,

--- a/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -176,6 +176,20 @@ describe('insights', () => {
       middleware.subscribe();
       expect(helper.state.clickAnalytics).toBe(true);
     });
+
+    it("doesn't reset page", () => {
+      const {
+        insightsClient,
+        instantSearchInstance,
+        helper,
+      } = createTestEnvironment();
+      const middleware = createInsightsMiddleware({
+        insightsClient,
+      })({ instantSearchInstance });
+      helper.setPage(100);
+      middleware.subscribe();
+      expect(helper.state.page).toBe(100);
+    });
   });
 
   describe('userToken', () => {
@@ -190,6 +204,23 @@ describe('insights', () => {
       })({ instantSearchInstance });
       insightsClient('setUserToken', 'abc');
       middleware.subscribe();
+      expect(getUserToken()).toEqual('abc');
+    });
+
+    it('applies userToken without resetting the page', () => {
+      const {
+        insightsClient,
+        instantSearchInstance,
+        getUserToken,
+        helper,
+      } = createTestEnvironment();
+      const middleware = createInsightsMiddleware({
+        insightsClient,
+      })({ instantSearchInstance });
+      insightsClient('setUserToken', 'abc');
+      helper.setPage(100);
+      middleware.subscribe();
+      expect(helper.state.page).toBe(100);
       expect(getUserToken()).toEqual('abc');
     });
 

--- a/src/middlewares/createInsightsMiddleware.ts
+++ b/src/middlewares/createInsightsMiddleware.ts
@@ -79,19 +79,19 @@ export const createInsightsMiddleware: CreateInsightsMiddleware = props => {
     return {
       onStateChange() {},
       subscribe() {
+        // At the time this middleware is subscribed, `mainIndex.init()` is already called.
+        // It means `mainIndex.getHelper()` exists.
+        const helper = instantSearchInstance.mainIndex.getHelper()!;
+
         const setUserTokenToSearch = (userToken?: string) => {
-          // At the time this middleware is subscribed, `mainIndex.init()` is already called.
-          // It means `mainIndex.getHelper()` exists.
           if (userToken) {
-            instantSearchInstance.mainIndex
-              .getHelper()!
-              .setQueryParameter('userToken', userToken);
+            helper.setState(
+              helper.state.setQueryParameter('userToken', userToken)
+            );
           }
         };
 
-        instantSearchInstance.mainIndex
-          .getHelper()!
-          .setQueryParameter('clickAnalytics', true);
+        helper.setState(helper.state.setQueryParameter('clickAnalytics', true));
 
         const anonymousUserToken = getInsightsAnonymousUserTokenInternal();
         if (hasInsightsClient && anonymousUserToken) {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

helper.setQueryParameter resets the page, unlike helper.state.setQueryParameter

Also added a new test for the correct state of the page in both cases of setQueryParameter.

see https://github.com/algolia/vue-instantsearch/issues/888 (doesn't fix that issue, but this issue is uncovered there)



<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

using insights middleware no longer resets the page