### PR TITLE
chore(test): move to jest.requireActual

### DIFF
--- a/src/components/ClearRefinements/types.ts
+++ b/src/components/ClearRefinements/types.ts
@@ -1,0 +1,9 @@
+import { ClearRefinementsRendererOptions } from '../../connectors/clear-refinements/connectClearRefinements';
+import { ClearRefinementsCSSClasses } from '../../widgets/clear-refinements/clear-refinements';
+
+export type ClearRefinementsProps = {
+  refine: ClearRefinementsRendererOptions['refine'];
+  cssClasses: ClearRefinementsCSSClasses;
+  hasRefinements: ClearRefinementsRendererOptions['hasRefinements'];
+  templateProps: object;
+};

--- a/src/components/CurrentRefinements/CurrentRefinements.tsx
+++ b/src/components/CurrentRefinements/CurrentRefinements.tsx
@@ -12,7 +12,7 @@ export type CurrentRefinementsComponentCSSClasses = {
   [TClassName in keyof CurrentRefinementsCSSClasses]: string;
 };
 
-type CurrentRefinementsProps = {
+export type CurrentRefinementsProps = {
   items: CurrentRefinementsConnectorParamsItem[];
   cssClasses: CurrentRefinementsComponentCSSClasses;
 };

--- a/src/components/Hits/types.ts
+++ b/src/components/Hits/types.ts
@@ -1,0 +1,1 @@
+export type HitsProps = {};

--- a/src/components/InfiniteHits/InfiniteHits.tsx
+++ b/src/components/InfiniteHits/InfiniteHits.tsx
@@ -19,7 +19,7 @@ type InfiniteHitsCSSClasses = {
   disabledLoadMore: string;
 };
 
-type InfiniteHitsProps = {
+export type InfiniteHitsProps = {
   cssClasses: InfiniteHitsCSSClasses;
   hits: Hits;
   results: SearchResults;

--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -17,7 +17,7 @@ type PanelComponentCSSClasses = Required<
   >
 >;
 
-type PanelProps<TWidget extends UnknownWidgetFactory> = {
+export type PanelProps<TWidget extends UnknownWidgetFactory> = {
   hidden: boolean;
   collapsible: boolean;
   isCollapsed: boolean;

--- a/src/components/QueryRuleCustomData/QueryRuleCustomData.tsx
+++ b/src/components/QueryRuleCustomData/QueryRuleCustomData.tsx
@@ -7,7 +7,7 @@ import {
 } from '../../widgets/query-rule-custom-data/query-rule-custom-data';
 import Template from '../Template/Template';
 
-type QueryRuleCustomDataProps = {
+export type QueryRuleCustomDataProps = {
   cssClasses: QueryRuleCustomDataCSSClasses;
   templates: QueryRuleCustomDataTemplates;
   items: any[];

--- a/src/components/RefinementList/types.ts
+++ b/src/components/RefinementList/types.ts
@@ -1,0 +1,7 @@
+export type RefinementListProps = {
+  facetValues: Array<{
+    isRefined: boolean;
+    label: string;
+    value: string;
+  }>;
+};

--- a/src/components/Selector/types.ts
+++ b/src/components/Selector/types.ts
@@ -1,0 +1,13 @@
+export type SelectorProps = {
+  cssClasses?: {
+    root?: string | string[];
+    select?: string | string[];
+    option?: string | string[];
+  };
+  currentValue?: string | number;
+  options: Array<{
+    value?: string | number;
+    label: string;
+  }>;
+  setValue(value: string): void;
+};

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -18,7 +18,7 @@ import { runAllMicroTasks } from '../../../test/utils/runAllMicroTasks';
 jest.useFakeTimers();
 
 jest.mock('algoliasearch-helper', () => {
-  const module = require.requireActual('algoliasearch-helper');
+  const module = jest.requireActual('algoliasearch-helper');
   const mock = jest.fn((...args) => {
     const helper = module(...args);
 

--- a/src/widgets/breadcrumb/__tests__/breadcrumb-test.ts
+++ b/src/widgets/breadcrumb/__tests__/breadcrumb-test.ts
@@ -7,9 +7,8 @@ import {
 } from '../../../../test/mock/createWidget';
 
 const render = castToJestMock(preactRender);
-
 jest.mock('preact', () => {
-  const module = require.requireActual('preact');
+  const module = jest.requireActual('preact');
 
   module.render = jest.fn();
 

--- a/src/widgets/breadcrumb/__tests__/breadcrumb-test.ts
+++ b/src/widgets/breadcrumb/__tests__/breadcrumb-test.ts
@@ -1,4 +1,4 @@
-import { render as preactRender } from 'preact';
+import { render as preactRender, VNode } from 'preact';
 import breadcrumb from '../breadcrumb';
 import { castToJestMock } from '../../../../test/utils/castToJestMock';
 import {
@@ -118,9 +118,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
         })
       );
 
-      const [firstRender] = render.mock.calls;
+      const firstRender = render.mock.calls[0][0] as VNode;
 
-      expect(firstRender[0].props).toMatchSnapshot();
+      expect(firstRender.props).toMatchSnapshot();
     });
   });
 });

--- a/src/widgets/clear-refinements/__tests__/clear-refinements-test.ts
+++ b/src/widgets/clear-refinements/__tests__/clear-refinements-test.ts
@@ -1,4 +1,4 @@
-import { render as preactRender } from 'preact';
+import { render as preactRender, VNode } from 'preact';
 import algoliasearchHelper from 'algoliasearch-helper';
 import {
   createInitOptions,
@@ -7,6 +7,7 @@ import {
 import clearRefinements from '../clear-refinements';
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import { castToJestMock } from '../../../../test/utils/castToJestMock';
+import { ClearRefinementsProps } from '../../../components/ClearRefinements/types';
 
 const render = castToJestMock(preactRender);
 jest.mock('preact', () => {
@@ -51,13 +52,20 @@ describe('clearRefinements()', () => {
 
       expect(render).toHaveBeenCalledTimes(2);
 
-      const [firstRender, secondRender] = render.mock.calls;
+      const firstRender = render.mock.calls[0][0] as VNode<
+        ClearRefinementsProps
+      >;
+      const secondRender = render.mock.calls[1][0] as VNode<
+        ClearRefinementsProps
+      >;
+      const firstContainer = render.mock.calls[0][1];
+      const secondContainer = render.mock.calls[1][1];
 
-      expect(firstRender[0].props).toMatchSnapshot();
-      expect(firstRender[1]).toEqual(container);
+      expect(firstRender.props).toMatchSnapshot();
+      expect(firstContainer).toEqual(container);
 
-      expect(secondRender[0].props).toMatchSnapshot();
-      expect(secondRender[1]).toEqual(container);
+      expect(secondRender.props).toMatchSnapshot();
+      expect(secondContainer).toEqual(container);
     });
   });
 
@@ -79,13 +87,20 @@ describe('clearRefinements()', () => {
 
       expect(render).toHaveBeenCalledTimes(2);
 
-      const [firstRender, secondRender] = render.mock.calls;
+      const firstRender = render.mock.calls[0][0] as VNode<
+        ClearRefinementsProps
+      >;
+      const secondRender = render.mock.calls[1][0] as VNode<
+        ClearRefinementsProps
+      >;
+      const firstContainer = render.mock.calls[0][1];
+      const secondContainer = render.mock.calls[1][1];
 
-      expect(firstRender[0].props).toMatchSnapshot();
-      expect(firstRender[1]).toEqual(container);
+      expect(firstRender.props).toMatchSnapshot();
+      expect(firstContainer).toEqual(container);
 
-      expect(secondRender[0].props).toMatchSnapshot();
-      expect(secondRender[1]).toEqual(container);
+      expect(secondRender.props).toMatchSnapshot();
+      expect(secondContainer).toEqual(container);
     });
   });
 
@@ -100,7 +115,12 @@ describe('clearRefinements()', () => {
       widget.init!(createInitOptions({ helper }));
       widget.render!(createRenderOptions({ helper, state: helper.state }));
 
-      expect(render.mock.calls[0][0].props.cssClasses).toMatchInlineSnapshot(`
+      const firstRender = render.mock.calls[0][0] as VNode<
+        ClearRefinementsProps
+      >;
+      const { cssClasses } = firstRender.props as ClearRefinementsProps;
+
+      expect(cssClasses).toMatchInlineSnapshot(`
         Object {
           "button": "ais-ClearRefinements-button",
           "disabledButton": "ais-ClearRefinements-button--disabled",
@@ -124,7 +144,12 @@ describe('clearRefinements()', () => {
       widget.init!(createInitOptions({ helper }));
       widget.render!(createRenderOptions({ helper, state: helper.state }));
 
-      expect(render.mock.calls[0][0].props.cssClasses).toMatchInlineSnapshot(`
+      const firstRender = render.mock.calls[0][0] as VNode<
+        ClearRefinementsProps
+      >;
+      const { cssClasses } = firstRender.props as ClearRefinementsProps;
+
+      expect(cssClasses).toMatchInlineSnapshot(`
         Object {
           "button": "ais-ClearRefinements-button myButton myPrimaryButton",
           "disabledButton": "ais-ClearRefinements-button--disabled disabled",

--- a/src/widgets/clear-refinements/__tests__/clear-refinements-test.ts
+++ b/src/widgets/clear-refinements/__tests__/clear-refinements-test.ts
@@ -9,9 +9,8 @@ import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import { castToJestMock } from '../../../../test/utils/castToJestMock';
 
 const render = castToJestMock(preactRender);
-
 jest.mock('preact', () => {
-  const module = require.requireActual('preact');
+  const module = jest.requireActual('preact');
 
   module.render = jest.fn();
 

--- a/src/widgets/current-refinements/__tests__/current-refinements-test.ts
+++ b/src/widgets/current-refinements/__tests__/current-refinements-test.ts
@@ -1,6 +1,7 @@
-import { render as preactRender } from 'preact';
+import { render as preactRender, VNode } from 'preact';
 import algoliasearchHelper, { SearchResults } from 'algoliasearch-helper';
 import currentRefinements from '../current-refinements';
+import { CurrentRefinementsProps } from '../../../components/CurrentRefinements/CurrentRefinements';
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import {
   createInitOptions,
@@ -142,13 +143,20 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
       widget.render!(createRenderOptions(renderParameters));
       widget.render!(createRenderOptions(renderParameters));
 
-      const [firstRender, secondRender] = render.mock.calls;
+      const firstRender = render.mock.calls[0][0] as VNode<
+        CurrentRefinementsProps
+      >;
+      const secondRender = render.mock.calls[1][0] as VNode<
+        CurrentRefinementsProps
+      >;
+      const firstContainer = render.mock.calls[0][1];
+      const secondContainer = render.mock.calls[1][1];
 
       expect(render).toHaveBeenCalledTimes(2);
-      expect(firstRender[0].props).toMatchSnapshot();
-      expect(firstRender[1]).toBe(container);
-      expect(secondRender[0].props).toMatchSnapshot();
-      expect(secondRender[1]).toBe(container);
+      expect(firstRender.props).toMatchSnapshot();
+      expect(firstContainer).toBe(container);
+      expect(secondRender.props).toMatchSnapshot();
+      expect(secondContainer).toBe(container);
     });
 
     describe('options.container', () => {
@@ -171,11 +179,13 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
           })
         );
 
-        const [firstRender] = render.mock.calls;
+        const firstRender = render.mock.calls[0][0] as VNode<
+          CurrentRefinementsProps
+        >;
 
         expect(render).toHaveBeenCalledTimes(1);
-        expect(firstRender[0].props).toMatchSnapshot();
-        expect(firstRender[1]).toBe(container);
+        expect(firstRender.props).toMatchSnapshot();
+        expect(render.mock.calls[0][1]).toBe(container);
       });
     });
 
@@ -236,9 +246,13 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
           })
         );
 
-        const [firstRender] = render.mock.calls;
+        const firstRender = render.mock.calls[0][0] as VNode<
+          CurrentRefinementsProps
+        >;
+        const {
+          items: renderedItems,
+        } = firstRender.props as CurrentRefinementsProps;
 
-        const renderedItems = firstRender[0].props.items;
         expect(renderedItems).toHaveLength(1);
 
         const [item] = renderedItems;
@@ -298,9 +312,13 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
           })
         );
 
-        const [firstRender] = render.mock.calls;
+        const firstRender = render.mock.calls[0][0] as VNode<
+          CurrentRefinementsProps
+        >;
+        const {
+          items: renderedItems,
+        } = firstRender.props as CurrentRefinementsProps;
 
-        const renderedItems = firstRender[0].props.items;
         expect(renderedItems).toHaveLength(0);
       });
     });
@@ -371,14 +389,27 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
           })
         );
 
-        const [firstRender] = render.mock.calls;
-
-        const renderedItems = firstRender[0].props.items;
+        const firstRender = render.mock.calls[0][0] as VNode<
+          CurrentRefinementsProps
+        >;
+        // @TODO: expose a way to transform the item type using transformItems
+        const renderedItems = (firstRender.props as CurrentRefinementsProps)
+          .items as Array<
+          CurrentRefinementsProps['items'][number] & {
+            refinements: Array<
+              CurrentRefinementsProps['items'][number]['refinements'][number] & {
+                transformed: boolean;
+              }
+            >;
+          }
+        >;
 
         expect(renderedItems[0].refinements[0].transformed).toBe(true);
         expect(renderedItems[0].refinements[1].transformed).toBe(true);
+
         expect(renderedItems[1].refinements[0].transformed).toBe(true);
         expect(renderedItems[1].refinements[1].transformed).toBe(true);
+
         expect(renderedItems[2].refinements[0].transformed).toBe(true);
         expect(renderedItems[2].refinements[1].transformed).toBe(true);
       });
@@ -406,9 +437,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
           })
         );
 
-        const [firstRender] = render.mock.calls;
+        const firstRender = render.mock.calls[0][0] as VNode<
+          CurrentRefinementsProps
+        >;
+        const props = firstRender.props as CurrentRefinementsProps;
 
-        expect(firstRender[0].props.cssClasses.root).toContain('customRoot');
+        expect(props.cssClasses.root).toContain('customRoot');
       });
 
       it('should work with an array', () => {
@@ -432,11 +466,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
           })
         );
 
-        const [firstRender] = render.mock.calls;
+        const firstRender = render.mock.calls[0][0] as VNode<
+          CurrentRefinementsProps
+        >;
+        const props = firstRender.props as CurrentRefinementsProps;
 
-        expect(firstRender[0].props.cssClasses.root).toContain('customRoot1');
+        expect(props.cssClasses.root).toContain('customRoot1');
 
-        expect(firstRender[0].props.cssClasses.root).toContain('customRoot2');
+        expect(props.cssClasses.root).toContain('customRoot2');
       });
     });
 
@@ -539,9 +576,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
           })
         );
 
-        const [firstRender] = render.mock.calls;
+        const firstRender = render.mock.calls[0][0] as VNode;
 
-        expect(firstRender[0].props).toMatchSnapshot();
+        expect(firstRender.props).toMatchSnapshot();
       });
     });
   });

--- a/src/widgets/current-refinements/__tests__/current-refinements-test.ts
+++ b/src/widgets/current-refinements/__tests__/current-refinements-test.ts
@@ -10,9 +10,8 @@ import { createSingleSearchResponse } from '../../../../test/mock/createAPIRespo
 import { castToJestMock } from '../../../../test/utils/castToJestMock';
 
 const render = castToJestMock(preactRender);
-
 jest.mock('preact', () => {
-  const module = require.requireActual('preact');
+  const module = jest.requireActual('preact');
 
   module.render = jest.fn();
 

--- a/src/widgets/geo-search/__tests__/geo-search-test.js
+++ b/src/widgets/geo-search/__tests__/geo-search-test.js
@@ -6,7 +6,7 @@ import geoSearch from '../geo-search';
 import { createInstantSearch } from '../../../../test/mock/createInstantSearch';
 
 jest.mock('preact', () => {
-  const module = require.requireActual('preact');
+  const module = jest.requireActual('preact');
 
   module.render = jest.fn();
 
@@ -14,7 +14,7 @@ jest.mock('preact', () => {
 });
 
 jest.mock('../GeoSearchRenderer', () => {
-  const module = require.requireActual('../GeoSearchRenderer');
+  const module = jest.requireActual('../GeoSearchRenderer');
 
   return jest.fn((...args) => module.default(...args));
 });

--- a/src/widgets/hierarchical-menu/__tests__/hierarchical-menu-test.js
+++ b/src/widgets/hierarchical-menu/__tests__/hierarchical-menu-test.js
@@ -7,7 +7,7 @@ import {
 } from '../../../../test/mock/createWidget';
 
 jest.mock('preact', () => {
-  const module = require.requireActual('preact');
+  const module = jest.requireActual('preact');
 
   module.render = jest.fn();
 

--- a/src/widgets/hits-per-page/__tests__/hits-per-page-test.ts
+++ b/src/widgets/hits-per-page/__tests__/hits-per-page-test.ts
@@ -1,7 +1,8 @@
-import { render as preactRender } from 'preact';
+import { render as preactRender, VNode, ComponentChildren } from 'preact';
 import { SearchParameters } from 'algoliasearch-helper';
 import hitsPerPage from '../hits-per-page';
 import { castToJestMock } from '../../../../test/utils/castToJestMock';
+import { SelectorProps } from '../../../components/Selector/types';
 
 const render = castToJestMock(preactRender);
 jest.mock('preact', () => {
@@ -88,12 +89,12 @@ describe('hitsPerPage()', () => {
     widget.render({ results, state });
     widget.render({ results, state });
 
-    const [firstRender] = render.mock.calls;
-    const { children, ...rootProps } = firstRender[0].props;
+    const firstRender = render.mock.calls[0][0] as VNode;
+    const { children, ...rootProps } = firstRender.props as any;
 
     expect(render).toHaveBeenCalledTimes(2);
     expect(rootProps).toMatchSnapshot();
-    expect(firstRender[0].props.children.props).toMatchSnapshot();
+    expect(children.props).toMatchSnapshot();
   });
 
   it('renders transformed items', () => {
@@ -110,9 +111,12 @@ describe('hitsPerPage()', () => {
     widget.init({ helper, state: helper.state });
     widget.render({ results, state });
 
-    const [firstRender] = render.mock.calls;
+    const selectorRender = ((render.mock.calls[0][0] as VNode).props as {
+      children: ComponentChildren;
+    }).children as VNode<SelectorProps>;
+    const props = selectorRender.props as SelectorProps;
 
-    expect(firstRender[0].props.children.props.options).toEqual([
+    expect(props.options).toEqual([
       {
         isRefined: true,
         label: '10 results',

--- a/src/widgets/hits-per-page/__tests__/hits-per-page-test.ts
+++ b/src/widgets/hits-per-page/__tests__/hits-per-page-test.ts
@@ -4,9 +4,8 @@ import hitsPerPage from '../hits-per-page';
 import { castToJestMock } from '../../../../test/utils/castToJestMock';
 
 const render = castToJestMock(preactRender);
-
 jest.mock('preact', () => {
-  const module = require.requireActual('preact');
+  const module = jest.requireActual('preact');
 
   module.render = jest.fn();
 

--- a/src/widgets/hits/__tests__/hits-test.ts
+++ b/src/widgets/hits/__tests__/hits-test.ts
@@ -1,9 +1,10 @@
-import { render as preactRender } from 'preact';
+import { render as preactRender, VNode } from 'preact';
 import algoliasearchHelper from 'algoliasearch-helper';
 import { SearchClient } from '../../../types';
 import hits from '../hits';
 import { castToJestMock } from '../../../../test/utils/castToJestMock';
 import { createInstantSearch } from '../../../../test/mock/createInstantSearch';
+import { HitsProps } from '../../../components/Hits/types';
 
 const render = castToJestMock(preactRender);
 jest.mock('preact', () => {
@@ -56,13 +57,16 @@ describe('hits()', () => {
     widget.render({ results });
     widget.render({ results });
 
-    const [firstRender, secondRender] = render.mock.calls;
+    const firstRender = render.mock.calls[0][0] as VNode<HitsProps>;
+    const secondRender = render.mock.calls[1][0] as VNode<HitsProps>;
+    const firstContainer = render.mock.calls[0][1];
+    const secondContainer = render.mock.calls[1][1];
 
     expect(render).toHaveBeenCalledTimes(2);
-    expect(firstRender[0].props).toMatchSnapshot();
-    expect(firstRender[1]).toEqual(container);
-    expect(secondRender[0].props).toMatchSnapshot();
-    expect(secondRender[1]).toEqual(container);
+    expect(firstRender.props).toMatchSnapshot();
+    expect(firstContainer).toEqual(container);
+    expect(secondRender.props).toMatchSnapshot();
+    expect(secondContainer).toEqual(container);
   });
 
   it('renders transformed items', () => {
@@ -80,9 +84,9 @@ describe('hits()', () => {
     });
     widget.render({ results });
 
-    const [firstRender] = render.mock.calls;
+    const firstRender = render.mock.calls[0][0] as VNode<HitsProps>;
 
-    expect(firstRender[0].props).toMatchSnapshot();
+    expect(firstRender.props).toMatchSnapshot();
   });
 
   it('should add __position key with absolute position', () => {

--- a/src/widgets/hits/__tests__/hits-test.ts
+++ b/src/widgets/hits/__tests__/hits-test.ts
@@ -6,9 +6,8 @@ import { castToJestMock } from '../../../../test/utils/castToJestMock';
 import { createInstantSearch } from '../../../../test/mock/createInstantSearch';
 
 const render = castToJestMock(preactRender);
-
 jest.mock('preact', () => {
-  const module = require.requireActual('preact');
+  const module = jest.requireActual('preact');
 
   module.render = jest.fn();
 

--- a/src/widgets/infinite-hits/__tests__/infinite-hits-test.ts
+++ b/src/widgets/infinite-hits/__tests__/infinite-hits-test.ts
@@ -1,7 +1,8 @@
-import { render as preactRender } from 'preact';
+import { render as preactRender, VNode } from 'preact';
 import algoliasearchHelper from 'algoliasearch-helper';
 import { SearchClient } from '../../../types';
 import infiniteHits from '../infinite-hits';
+import { InfiniteHitsProps } from '../../../components/InfiniteHits/InfiniteHits';
 import { castToJestMock } from '../../../../test/utils/castToJestMock';
 import { createInstantSearch } from '../../../../test/mock/createInstantSearch';
 
@@ -63,13 +64,16 @@ describe('infiniteHits()', () => {
     widget.render({ results, state });
     widget.render({ results, state });
 
-    const [firstRender, secondRender] = render.mock.calls;
+    const firstRender = render.mock.calls[0][0] as VNode<InfiniteHitsProps>;
+    const secondRender = render.mock.calls[1][0] as VNode<InfiniteHitsProps>;
+    const firstContainer = render.mock.calls[0][1];
+    const secondContainer = render.mock.calls[1][1];
 
     expect(render).toHaveBeenCalledTimes(2);
-    expect(firstRender[0].props).toMatchSnapshot();
-    expect(firstRender[1]).toEqual(container);
-    expect(secondRender[0].props).toMatchSnapshot();
-    expect(secondRender[1]).toEqual(container);
+    expect(firstRender.props).toMatchSnapshot();
+    expect(firstContainer).toEqual(container);
+    expect(secondRender.props).toMatchSnapshot();
+    expect(secondContainer).toEqual(container);
   });
 
   it('renders transformed items', () => {
@@ -91,9 +95,9 @@ describe('infiniteHits()', () => {
       instantSearchInstance: {},
     });
 
-    const [firstRender] = render.mock.calls;
+    const firstRender = render.mock.calls[0][0] as VNode<InfiniteHitsProps>;
 
-    expect(firstRender[0].props).toMatchSnapshot();
+    expect(firstRender.props).toMatchSnapshot();
   });
 
   it('if it is the last page, then the props should contain isLastPage true', () => {
@@ -108,13 +112,18 @@ describe('infiniteHits()', () => {
       state: { page: 1 },
     });
 
-    const [firstRender, secondRender] = render.mock.calls;
+    const firstRender = render.mock.calls[0][0] as VNode<InfiniteHitsProps>;
+    const firstProps = firstRender.props as InfiniteHitsProps;
+    const secondRender = render.mock.calls[1][0] as VNode<InfiniteHitsProps>;
+    const secondProps = secondRender.props as InfiniteHitsProps;
+    const firstContainer = render.mock.calls[0][1];
+    const secondContainer = render.mock.calls[1][1];
 
     expect(render).toHaveBeenCalledTimes(2);
-    expect(firstRender[0].props.isLastPage).toEqual(false);
-    expect(firstRender[1]).toEqual(container);
-    expect(secondRender[0].props.isLastPage).toEqual(true);
-    expect(secondRender[1]).toEqual(container);
+    expect(firstProps.isLastPage).toEqual(false);
+    expect(firstContainer).toEqual(container);
+    expect(secondProps.isLastPage).toEqual(true);
+    expect(secondContainer).toEqual(container);
   });
 
   it('updates the search state properly when showMore is called', () => {
@@ -126,9 +135,8 @@ describe('infiniteHits()', () => {
 
     widget.render({ results, state });
 
-    const [firstRender] = render.mock.calls;
-
-    const { showMore } = firstRender[0].props;
+    const firstRender = render.mock.calls[0][0] as VNode<InfiniteHitsProps>;
+    const { showMore } = firstRender.props as InfiniteHitsProps;
 
     showMore();
 
@@ -161,13 +169,18 @@ describe('infiniteHits()', () => {
 
     expect(render).toHaveBeenCalledTimes(2);
 
-    const [firstRender, secondRender] = render.mock.calls;
+    const firstRender = render.mock.calls[0][0] as VNode<InfiniteHitsProps>;
+    const firstProps = firstRender.props as InfiniteHitsProps;
+    const secondRender = render.mock.calls[1][0] as VNode<InfiniteHitsProps>;
+    const secondProps = secondRender.props as InfiniteHitsProps;
+    const firstContainer = render.mock.calls[0][1];
+    const secondContainer = render.mock.calls[1][1];
 
-    expect(firstRender[0].props.isFirstPage).toEqual(true);
-    expect(firstRender[1]).toEqual(container);
+    expect(firstProps.isFirstPage).toEqual(true);
+    expect(firstContainer).toEqual(container);
 
-    expect(secondRender[0].props.isFirstPage).toEqual(true);
-    expect(secondRender[1]).toEqual(container);
+    expect(secondProps.isFirstPage).toEqual(true);
+    expect(secondContainer).toEqual(container);
   });
 
   it('if it is not the first page, then the props should contain isFirstPage false', () => {
@@ -180,11 +193,13 @@ describe('infiniteHits()', () => {
       state,
     });
 
-    const [firstRender] = render.mock.calls;
+    const firstRender = render.mock.calls[0][0] as VNode<InfiniteHitsProps>;
+    const { isFirstPage } = firstRender.props as InfiniteHitsProps;
+    const firstContainer = render.mock.calls[0][1];
 
     expect(render).toHaveBeenCalledTimes(1);
-    expect(firstRender[0].props.isFirstPage).toEqual(false);
-    expect(firstRender[1]).toEqual(container);
+    expect(isFirstPage).toEqual(false);
+    expect(firstContainer).toEqual(container);
   });
 
   describe('cache', () => {
@@ -252,8 +267,9 @@ describe('infiniteHits()', () => {
     ],
   }
   `);
-      const firstCall = render.mock.calls[0];
-      expect(firstCall[0].props.hits).toMatchInlineSnapshot(`
+      const firstRender = render.mock.calls[0][0] as VNode<InfiniteHitsProps>;
+      const { hits } = firstRender.props as InfiniteHitsProps;
+      expect(hits).toMatchInlineSnapshot(`
   Array [
     Object {
       "__position": 1,
@@ -299,8 +315,10 @@ describe('infiniteHits()', () => {
         },
         state,
       });
-      const firstCall = render.mock.calls[0];
-      expect(firstCall[0].props.hits).toMatchInlineSnapshot(`
+      const firstRender = render.mock.calls[0][0] as VNode<InfiniteHitsProps>;
+      const { hits } = firstRender.props as InfiniteHitsProps;
+
+      expect(hits).toMatchInlineSnapshot(`
 Array [
   Object {
     "__position": 1,

--- a/src/widgets/infinite-hits/__tests__/infinite-hits-test.ts
+++ b/src/widgets/infinite-hits/__tests__/infinite-hits-test.ts
@@ -6,9 +6,8 @@ import { castToJestMock } from '../../../../test/utils/castToJestMock';
 import { createInstantSearch } from '../../../../test/mock/createInstantSearch';
 
 const render = castToJestMock(preactRender);
-
 jest.mock('preact', () => {
-  const module = require.requireActual('preact');
+  const module = jest.requireActual('preact');
 
   module.render = jest.fn();
 

--- a/src/widgets/menu-select/__tests__/menu-select-test.ts
+++ b/src/widgets/menu-select/__tests__/menu-select-test.ts
@@ -1,4 +1,4 @@
-import { render as _originalRender, VNode } from 'preact';
+import { render as preactRender, VNode } from 'preact';
 import algoliasearchHelper, { SearchParameters } from 'algoliasearch-helper';
 import menuSelect from '../menu-select';
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
@@ -6,7 +6,9 @@ import {
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/mock/createWidget';
+import { castToJestMock } from '../../../../test/utils/castToJestMock';
 
+const render = castToJestMock(preactRender);
 jest.mock('preact', () => {
   const module = jest.requireActual('preact');
 
@@ -14,7 +16,6 @@ jest.mock('preact', () => {
 
   return module;
 });
-const render = _originalRender as jest.MockedFunction<typeof _originalRender>;
 
 describe('menuSelect', () => {
   describe('Usage', () => {

--- a/src/widgets/menu/__tests__/menu-test.ts
+++ b/src/widgets/menu/__tests__/menu-test.ts
@@ -2,15 +2,17 @@ import jsHelper, {
   SearchParameters,
   SearchResults,
 } from 'algoliasearch-helper';
-import { render as _originalRender, VNode } from 'preact';
+import { render as preactRender, VNode } from 'preact';
 import { createSingleSearchResponse } from '../../../../test/mock/createAPIResponse';
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import {
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/mock/createWidget';
+import { castToJestMock } from '../../../../test/utils/castToJestMock';
 import menu from '../menu';
 
+const render = castToJestMock(preactRender);
 jest.mock('preact', () => {
   const module = jest.requireActual('preact');
 
@@ -18,7 +20,6 @@ jest.mock('preact', () => {
 
   return module;
 });
-const render = _originalRender as jest.MockedFunction<typeof _originalRender>;
 
 describe('menu', () => {
   it('throws without container', () => {

--- a/src/widgets/numeric-menu/__tests__/numeric-menu-test.ts
+++ b/src/widgets/numeric-menu/__tests__/numeric-menu-test.ts
@@ -1,4 +1,4 @@
-import { render as preactRender } from 'preact';
+import { render as preactRender, VNode } from 'preact';
 import numericMenu from '../numeric-menu';
 import algoliasearchHelper, {
   SearchParameters,
@@ -13,6 +13,7 @@ import {
 } from '../../../../test/mock/createWidget';
 import { createSingleSearchResponse } from '../../../../test/mock/createAPIResponse';
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
+import { RefinementListProps } from '../../../components/RefinementList/types';
 
 const render = castToJestMock(preactRender);
 jest.mock('preact', () => {
@@ -84,13 +85,16 @@ describe('numericMenu()', () => {
     widget.render!(createRenderOptions({ state, results }));
     widget.render!(createRenderOptions({ state, results }));
 
-    const [firstRender, secondRender] = render.mock.calls;
+    const firstRender = render.mock.calls[0][0] as VNode<RefinementListProps>;
+    const secondRender = render.mock.calls[1][0] as VNode<RefinementListProps>;
+    const firstContainer = render.mock.calls[0][1];
+    const secondContainer = render.mock.calls[1][1];
 
     expect(render).toHaveBeenCalledTimes(2);
-    expect(firstRender[0].props).toMatchSnapshot();
-    expect(firstRender[1]).toEqual(container);
-    expect(secondRender[0].props).toMatchSnapshot();
-    expect(secondRender[1]).toEqual(container);
+    expect(firstRender.props).toMatchSnapshot();
+    expect(firstContainer).toEqual(container);
+    expect(secondRender.props).toMatchSnapshot();
+    expect(secondContainer).toEqual(container);
   });
 
   it('renders with transformed items', () => {
@@ -105,9 +109,10 @@ describe('numericMenu()', () => {
     widget.init!(createInitOptions({ helper }));
     widget.render!(createRenderOptions({ state, results }));
 
-    const [firstRender] = render.mock.calls;
+    const firstRender = render.mock.calls[0][0] as VNode<RefinementListProps>;
+    const { facetValues } = firstRender.props as RefinementListProps;
 
-    expect(firstRender[0].props.facetValues).toEqual([
+    expect(facetValues).toEqual([
       {
         isRefined: true,
         label: 'All',

--- a/src/widgets/numeric-menu/__tests__/numeric-menu-test.ts
+++ b/src/widgets/numeric-menu/__tests__/numeric-menu-test.ts
@@ -15,9 +15,8 @@ import { createSingleSearchResponse } from '../../../../test/mock/createAPIRespo
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
 
 const render = castToJestMock(preactRender);
-
 jest.mock('preact', () => {
-  const module = require.requireActual('preact');
+  const module = jest.requireActual('preact');
 
   module.render = jest.fn();
 

--- a/src/widgets/pagination/__tests__/pagination-test.js
+++ b/src/widgets/pagination/__tests__/pagination-test.js
@@ -6,7 +6,7 @@ import { SearchResults, SearchParameters } from 'algoliasearch-helper';
 import { createSingleSearchResponse } from '../../../../test/mock/createAPIResponse';
 
 jest.mock('preact', () => {
-  const module = require.requireActual('preact');
+  const module = jest.requireActual('preact');
 
   module.render = jest.fn();
 
@@ -14,7 +14,7 @@ jest.mock('preact', () => {
 });
 
 jest.mock('../../../lib/utils/getContainerNode', () => {
-  const module = require.requireActual('../../../lib/utils/getContainerNode');
+  const module = jest.requireActual('../../../lib/utils/getContainerNode');
 
   const _getContainerNode = module.default;
   module.default = jest.fn((...args) => _getContainerNode(...args));

--- a/src/widgets/panel/__tests__/panel-test.ts
+++ b/src/widgets/panel/__tests__/panel-test.ts
@@ -8,15 +8,14 @@ import {
 } from '../../../../test/mock/createWidget';
 import algoliasearchHelper from 'algoliasearch-helper';
 
+const render = castToJestMock(preactRender);
 jest.mock('preact', () => {
-  const module = require.requireActual('preact');
+  const module = jest.requireActual('preact');
 
   module.render = jest.fn();
 
   return module;
 });
-
-const render = castToJestMock(preactRender);
 
 beforeEach(() => {
   render.mockClear();

--- a/src/widgets/panel/__tests__/panel-test.ts
+++ b/src/widgets/panel/__tests__/panel-test.ts
@@ -1,6 +1,7 @@
-import { render as preactRender } from 'preact';
+import { render as preactRender, VNode } from 'preact';
 import { castToJestMock } from '../../../../test/utils/castToJestMock';
 import panel from '../panel';
+import { PanelProps } from '../../../components/Panel/Panel';
 import {
   createInitOptions,
   createRenderOptions,
@@ -108,7 +109,10 @@ describe('Templates', () => {
       container: document.createElement('div'),
     });
 
-    const { templates } = render.mock.calls[0][0].props;
+    const firstRender = render.mock.calls[0][0] as VNode<
+      PanelProps<typeof widgetFactory>
+    >;
+    const { templates } = firstRender.props as PanelProps<typeof widgetFactory>;
 
     expect(templates).toEqual({
       header: '',
@@ -128,7 +132,10 @@ describe('Templates', () => {
       container: document.createElement('div'),
     });
 
-    const { templates } = render.mock.calls[0][0].props;
+    const firstRender = render.mock.calls[0][0] as VNode<
+      PanelProps<typeof widgetFactory>
+    >;
+    const { templates } = firstRender.props as PanelProps<typeof widgetFactory>;
 
     expect(templates.header).toBe('Custom header');
   });
@@ -144,7 +151,10 @@ describe('Templates', () => {
       container: document.createElement('div'),
     });
 
-    const { templates } = render.mock.calls[0][0].props;
+    const firstRender = render.mock.calls[0][0] as VNode<
+      PanelProps<typeof widgetFactory>
+    >;
+    const { templates } = firstRender.props as PanelProps<typeof widgetFactory>;
 
     expect(templates.footer).toBe('Custom footer');
   });
@@ -160,7 +170,10 @@ describe('Templates', () => {
       container: document.createElement('div'),
     });
 
-    const { templates } = render.mock.calls[0][0].props;
+    const firstRender = render.mock.calls[0][0] as VNode<
+      PanelProps<typeof widgetFactory>
+    >;
+    const { templates } = firstRender.props as PanelProps<typeof widgetFactory>;
 
     expect(templates.collapseButtonText).toBe('Custom collapseButtonText');
   });

--- a/src/widgets/powered-by/__tests__/powered-by-test.js
+++ b/src/widgets/powered-by/__tests__/powered-by-test.js
@@ -2,7 +2,7 @@ import { render } from 'preact';
 import poweredBy from '../powered-by';
 
 jest.mock('preact', () => {
-  const module = require.requireActual('preact');
+  const module = jest.requireActual('preact');
 
   module.render = jest.fn();
 

--- a/src/widgets/query-rule-custom-data/__tests__/query-rule-custom-data-test.ts
+++ b/src/widgets/query-rule-custom-data/__tests__/query-rule-custom-data-test.ts
@@ -1,4 +1,4 @@
-import { render as preactRender } from 'preact';
+import { render as preactRender, VNode } from 'preact';
 import algoliasearchHelper, {
   AlgoliaSearchHelper as Helper,
 } from 'algoliasearch-helper';
@@ -6,11 +6,11 @@ import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import { createInitOptions } from '../../../../test/mock/createWidget';
 import { castToJestMock } from '../../../../test/utils/castToJestMock';
 import queryRuleCustomData from '../query-rule-custom-data';
+import { QueryRuleCustomDataProps } from '../../../components/QueryRuleCustomData/QueryRuleCustomData';
 
 const render = castToJestMock(preactRender);
 jest.mock('preact', () => {
   const module = jest.requireActual('preact');
-
   module.render = jest.fn();
 
   return module;
@@ -82,7 +82,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rule-
           })
         );
 
-        const { cssClasses } = render.mock.calls[0][0].props;
+        const firstRender = render.mock.calls[0][0] as VNode<
+          QueryRuleCustomDataProps
+        >;
+        const { cssClasses } = firstRender.props as QueryRuleCustomDataProps;
 
         expect(cssClasses).toEqual({
           root: 'ais-QueryRuleCustomData',
@@ -105,7 +108,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rule-
           })
         );
 
-        const { cssClasses } = render.mock.calls[0][0].props;
+        const firstRender = render.mock.calls[0][0] as VNode<
+          QueryRuleCustomDataProps
+        >;
+        const { cssClasses } = firstRender.props as QueryRuleCustomDataProps;
 
         expect(cssClasses).toEqual({
           root: 'ais-QueryRuleCustomData CustomRoot',
@@ -127,13 +133,16 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rule-
           })
         );
 
-        const { templates } = render.mock.calls[0][0].props;
+        const firstRender = render.mock.calls[0][0] as VNode<
+          QueryRuleCustomDataProps
+        >;
+        const { templates } = firstRender.props as QueryRuleCustomDataProps;
 
         expect(templates).toEqual({
           default: expect.any(Function),
         });
         expect(
-          templates.default({
+          (templates.default as Function)({
             items: [{ banner: '1.jpg' }, { banner: '2.jpg' }],
           })
         ).toMatchInlineSnapshot(`
@@ -164,7 +173,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rule-
           })
         );
 
-        const { templates } = render.mock.calls[0][0].props;
+        const firstRender = render.mock.calls[0][0] as VNode<
+          QueryRuleCustomDataProps
+        >;
+        const { templates } = firstRender.props as QueryRuleCustomDataProps;
 
         expect(templates).toEqual({
           default: 'default',

--- a/src/widgets/query-rule-custom-data/__tests__/query-rule-custom-data-test.ts
+++ b/src/widgets/query-rule-custom-data/__tests__/query-rule-custom-data-test.ts
@@ -8,9 +8,8 @@ import { castToJestMock } from '../../../../test/utils/castToJestMock';
 import queryRuleCustomData from '../query-rule-custom-data';
 
 const render = castToJestMock(preactRender);
-
 jest.mock('preact', () => {
-  const module = require.requireActual('preact');
+  const module = jest.requireActual('preact');
 
   module.render = jest.fn();
 

--- a/src/widgets/range-input/__tests__/range-input-test.ts
+++ b/src/widgets/range-input/__tests__/range-input-test.ts
@@ -1,10 +1,12 @@
 /** @jsx h */
 
-import { render as _originalRender, VNode } from 'preact';
+import { render as preactRender, VNode } from 'preact';
 import algoliasearchHelper from 'algoliasearch-helper';
 import rangeInput from '../range-input';
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
+import { castToJestMock } from '../../../../test/utils/castToJestMock';
 
+const render = castToJestMock(preactRender);
 jest.mock('preact', () => {
   const module = jest.requireActual('preact');
 
@@ -12,7 +14,6 @@ jest.mock('preact', () => {
 
   return module;
 });
-const render = _originalRender as jest.MockedFunction<typeof _originalRender>;
 
 describe('rangeInput', () => {
   const attribute = 'aNumAttr';

--- a/src/widgets/range-slider/__tests__/range-slider-test.ts
+++ b/src/widgets/range-slider/__tests__/range-slider-test.ts
@@ -1,4 +1,4 @@
-import { render as _originalRender, VNode } from 'preact';
+import { render as preactRender, VNode } from 'preact';
 import algoliasearchHelper, {
   AlgoliaSearchHelper,
   SearchParameters,
@@ -10,7 +10,9 @@ import { createRenderOptions } from '../../../../test/mock/createWidget';
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import { InstantSearch } from '../../../types';
 import { createSingleSearchResponse } from '../../../../test/mock/createAPIResponse';
+import { castToJestMock } from '../../../../test/utils/castToJestMock';
 
+const render = castToJestMock(preactRender);
 jest.mock('preact', () => {
   const module = jest.requireActual('preact');
 
@@ -18,7 +20,6 @@ jest.mock('preact', () => {
 
   return module;
 });
-const render = _originalRender as jest.MockedFunction<typeof _originalRender>;
 
 function createFacetStatsResults({
   helper,

--- a/src/widgets/rating-menu/__tests__/rating-menu-test.js
+++ b/src/widgets/rating-menu/__tests__/rating-menu-test.js
@@ -7,7 +7,7 @@ import ratingMenu from '../rating-menu';
 import { createInstantSearch } from '../../../../test/mock/createInstantSearch';
 
 jest.mock('preact', () => {
-  const module = require.requireActual('preact');
+  const module = jest.requireActual('preact');
 
   module.render = jest.fn();
 

--- a/src/widgets/refinement-list/__tests__/refinement-list-test.js
+++ b/src/widgets/refinement-list/__tests__/refinement-list-test.js
@@ -3,7 +3,7 @@ import { SearchParameters } from 'algoliasearch-helper';
 import refinementList from '../refinement-list';
 
 jest.mock('preact', () => {
-  const module = require.requireActual('preact');
+  const module = jest.requireActual('preact');
 
   module.render = jest.fn();
 

--- a/src/widgets/search-box/__tests__/search-box-test.js
+++ b/src/widgets/search-box/__tests__/search-box-test.js
@@ -6,7 +6,7 @@ import {
 } from '../../../../test/mock/createWidget';
 
 jest.mock('preact', () => {
-  const module = require.requireActual('preact');
+  const module = jest.requireActual('preact');
 
   module.render = jest.fn();
 

--- a/src/widgets/sort-by/__tests__/sort-by-test.js
+++ b/src/widgets/sort-by/__tests__/sort-by-test.js
@@ -9,7 +9,7 @@ import {
 } from '../../../../test/mock/createWidget';
 
 jest.mock('preact', () => {
-  const module = require.requireActual('preact');
+  const module = jest.requireActual('preact');
 
   module.render = jest.fn();
 

--- a/src/widgets/stats/__tests__/stats-test.js
+++ b/src/widgets/stats/__tests__/stats-test.js
@@ -2,7 +2,7 @@ import { render } from 'preact';
 import stats from '../stats';
 
 jest.mock('preact', () => {
-  const module = require.requireActual('preact');
+  const module = jest.requireActual('preact');
 
   module.render = jest.fn();
 

--- a/src/widgets/toggle-refinement/__tests__/toggle-refinement-test.js
+++ b/src/widgets/toggle-refinement/__tests__/toggle-refinement-test.js
@@ -5,7 +5,7 @@ import RefinementList from '../../../components/RefinementList/RefinementList';
 import { createInstantSearch } from '../../../../test/mock/createInstantSearch';
 
 jest.mock('preact', () => {
-  const module = require.requireActual('preact');
+  const module = jest.requireActual('preact');
 
   module.render = jest.fn();
 

--- a/src/widgets/voice-search/__tests__/voice-search-test.ts
+++ b/src/widgets/voice-search/__tests__/voice-search-test.ts
@@ -16,9 +16,8 @@ import voiceSearch, { VoiceSearchWidgetParams } from '../voice-search';
 import { VoiceSearchHelper } from '../../../lib/voiceSearchHelper/types';
 
 const render = castToJestMock(preactRender);
-
 jest.mock('preact', () => {
-  const module = require.requireActual('preact');
+  const module = jest.requireActual('preact');
 
   module.render = jest.fn();
 

--- a/src/widgets/voice-search/__tests__/voice-search-test.ts
+++ b/src/widgets/voice-search/__tests__/voice-search-test.ts
@@ -1,4 +1,4 @@
-import { render as preactRender } from 'preact';
+import { render as preactRender, VNode } from 'preact';
 import algoliasearch from 'algoliasearch';
 import algoliasearchHelper, {
   AlgoliaSearchHelper as Helper,
@@ -14,6 +14,7 @@ import { castToJestMock } from '../../../../test/utils/castToJestMock';
 import { Widget } from '../../../types';
 import voiceSearch, { VoiceSearchWidgetParams } from '../voice-search';
 import { VoiceSearchHelper } from '../../../lib/voiceSearchHelper/types';
+import { VoiceSearchProps } from '../../../components/VoiceSearch/VoiceSearch';
 
 const render = castToJestMock(preactRender);
 jest.mock('preact', () => {
@@ -124,10 +125,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/voice-searc
       const { widgetInit } = defaultSetup();
       widgetInit(helper);
 
-      const [firstRender] = render.mock.calls;
+      const firstRender = render.mock.calls[0][0] as VNode<VoiceSearchProps>;
 
       expect(render).toHaveBeenCalledTimes(1);
-      expect(firstRender[0].props).toMatchSnapshot();
+      expect(firstRender.props).toMatchSnapshot();
     });
 
     test('renders during render()', () => {
@@ -135,13 +136,16 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/voice-searc
       widgetInit(helper);
       widgetRender(helper);
 
-      const [firstRender, secondRender] = render.mock.calls;
+      const firstRender = render.mock.calls[0][0] as VNode<VoiceSearchProps>;
+      const secondRender = render.mock.calls[1][0] as VNode<VoiceSearchProps>;
+      const firstContainer = render.mock.calls[0][1];
+      const secondContainer = render.mock.calls[1][1];
 
       expect(render).toHaveBeenCalledTimes(2);
-      expect(firstRender[0].props).toMatchSnapshot();
-      expect(firstRender[1]).toEqual(container);
-      expect(secondRender[0].props).toMatchSnapshot();
-      expect(secondRender[1]).toEqual(container);
+      expect(firstRender.props).toMatchSnapshot();
+      expect(firstContainer).toEqual(container);
+      expect(secondRender.props).toMatchSnapshot();
+      expect(secondContainer).toEqual(container);
     });
 
     test('sets the correct CSS classes', () => {
@@ -149,9 +153,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/voice-searc
 
       widgetInit(helper);
 
-      const [firstRender] = render.mock.calls;
+      const firstRender = render.mock.calls[0][0] as VNode<VoiceSearchProps>;
 
-      expect(firstRender[0].props.cssClasses).toMatchSnapshot();
+      expect(
+        (firstRender.props as VoiceSearchProps).cssClasses
+      ).toMatchSnapshot();
     });
   });
 });

--- a/test/utils/castToJestMock.ts
+++ b/test/utils/castToJestMock.ts
@@ -1,1 +1,2 @@
-export const castToJestMock = (obj: any): jest.Mock => obj;
+export const castToJestMock = <T extends (...args: any[]) => any>(obj: T) =>
+  obj as jest.MockedFunction<typeof obj>;

--- a/test/utils/castToJestMock.ts
+++ b/test/utils/castToJestMock.ts
@@ -1,2 +1,3 @@
-export const castToJestMock = <T extends (...args: any[]) => any>(obj: T) =>
-  obj as jest.MockedFunction<typeof obj>;
+export const castToJestMock = <TFunction extends (...args: any[]) => any>(
+  func: TFunction
+) => func as jest.MockedFunction<typeof func>;


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

I noticed that require.requireActual is deprecated, so that was changed here

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

no more require.requireActual, and at the same time made castToJestMock consistent and slightly type-safer