### PR TITLE
fix(smartSort): export the widget and the connector

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
   "bundlesize": [
     {
       "path": "./dist/instantsearch.production.min.js",
-      "maxSize": "66.50 kB"
+      "maxSize": "67.00 kB"
     },
     {
       "path": "./dist/instantsearch.development.js",

--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -24,3 +24,4 @@ export { default as EXPERIMENTAL_connectConfigureRelatedItems } from './configur
 export { default as connectAutocomplete } from './autocomplete/connectAutocomplete';
 export { default as connectQueryRules } from './query-rules/connectQueryRules';
 export { default as connectVoiceSearch } from './voice-search/connectVoiceSearch';
+export { default as connectSmartSort } from './smart-sort/connectSmartSort';

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -28,3 +28,4 @@ export { default as queryRuleCustomData } from './query-rule-custom-data/query-r
 export { default as queryRuleContext } from './query-rule-context/query-rule-context';
 export { default as index } from './index/index';
 export { default as places } from './places/places';
+export { default as smartSort } from './smart-sort/smart-sort';


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR exports the `smartSort` widget and the `connectSmartSort`, which was missed in the previous PR.

**Result**

Users can import and use them.