### PR TITLE
chore: manage deprecated code

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,16 +24,16 @@ module.exports = {
     '@typescript-eslint/naming-convention': [
       'error',
       {
-        "selector": "variable",
-        "modifiers": ["destructured"],
-        "format": null
+        selector: 'variable',
+        modifiers: ['destructured'],
+        format: null,
       },
       {
         selector: 'variable',
         format: ['camelCase', 'PascalCase', 'UPPER_CASE'],
         leadingUnderscore: 'allow',
         filter: {
-          regex: '^EXPERIMENTAL_|__DEV__',
+          regex: '^EXPERIMENTAL_|__DEV__|__KEEP_DEPRECATION__',
           match: false,
         },
       },
@@ -82,5 +82,6 @@ module.exports = {
   },
   globals: {
     __DEV__: false,
+    __KEEP_DEPRECATION__: true,
   },
 };

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -14,9 +14,23 @@ module.exports = ({ config, mode }) => {
     ],
   });
 
+  console.log('webpack.config.js', {
+    mode,
+    'process.env.KEEP_DEPRECATION': process.env.KEEP_DEPRECATION,
+    plugin: {
+      __DEV__: JSON.stringify(mode === 'DEVELOPMENT'),
+      __KEEP_DEPRECATION__: JSON.stringify(
+        process.env.KEEP_DEPRECATION !== 'false'
+      ),
+    },
+  });
+
   config.plugins.push(
     new webpack.DefinePlugin({
       __DEV__: JSON.stringify(mode === 'DEVELOPMENT'),
+      __KEEP_DEPRECATION__: JSON.stringify(
+        process.env.KEEP_DEPRECATION !== 'false'
+      ),
     })
   );
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -43,6 +43,10 @@ module.exports = api => {
           type: 'node',
           replacement: "process.env.NODE_ENV === 'development'",
         },
+        __KEEP_DEPRECATION__: {
+          type: 'node',
+          replacement: JSON.stringify(process.env.KEEP_DEPRECATION !== 'false'),
+        },
       },
     ],
     // this plugin is used to test if we need polyfills, not to actually insert them
@@ -77,6 +81,7 @@ module.exports = api => {
         },
       },
     ],
+    'minify-dead-code-elimination',
   ]);
 
   return {

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,2 +1,3 @@
 declare const __DEV__: boolean;
+declare const __KEEP_DEPRECATION__: boolean;
 declare const jsdom: any;

--- a/jest.config.js
+++ b/jest.config.js
@@ -23,5 +23,6 @@ module.exports = {
   ],
   globals: {
     __DEV__: true,
+    __KEEP_DEPRECATION__: true,
   },
 };

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "babel-jest": "24.9.0",
     "babel-loader": "8.0.6",
     "babel-plugin-inline-replace-variables": "1.3.1",
+    "babel-plugin-minify-dead-code-elimination": "0.5.1",
     "babel-plugin-polyfill-es-shims": "0.0.7",
     "babel-plugin-transform-react-pure-class-to-function": "1.0.1",
     "babel-plugin-transform-react-remove-prop-types": "0.4.24",

--- a/scripts/rollup/config.js
+++ b/scripts/rollup/config.js
@@ -40,29 +40,37 @@ const plugins = [
   }),
 ];
 
-const createConfiguration = ({ mode, filename }) => ({
-  input: 'src/index.ts',
-  output: {
-    file: `dist/${filename}`,
-    name: 'instantsearch',
-    format: 'umd',
-    banner: license,
-    sourcemap: true,
-  },
-  plugins: [
-    ...plugins,
-    replace({
-      __DEV__: mode === 'development',
-      'process.env.NODE_ENV': JSON.stringify('production'),
-    }),
-    mode === 'production' &&
-      uglify({
-        output: {
-          preamble: license,
-        },
+const createConfiguration = ({ mode, filename }) => {
+  console.log('rollup/config.js', {
+    __DEV__: mode === 'development',
+    'process.env.NODE_ENV': JSON.stringify('production'),
+    __KEEP_DEPRECATION__: process.env.KEEP_DEPRECATION !== 'false',
+  });
+  return {
+    input: 'src/index.ts',
+    output: {
+      file: `dist/${filename}`,
+      name: 'instantsearch',
+      format: 'umd',
+      banner: license,
+      sourcemap: true,
+    },
+    plugins: [
+      ...plugins,
+      replace({
+        __DEV__: mode === 'development',
+        'process.env.NODE_ENV': JSON.stringify('production'),
+        __KEEP_DEPRECATION__: process.env.KEEP_DEPRECATION !== 'false',
       }),
-  ].filter(Boolean),
-});
+      mode === 'production' &&
+        uglify({
+          output: {
+            preamble: license,
+          },
+        }),
+    ].filter(Boolean),
+  };
+};
 
 export default [
   createConfiguration({

--- a/scripts/rollup/config.js
+++ b/scripts/rollup/config.js
@@ -41,11 +41,6 @@ const plugins = [
 ];
 
 const createConfiguration = ({ mode, filename }) => {
-  console.log('rollup/config.js', {
-    __DEV__: mode === 'development',
-    'process.env.NODE_ENV': JSON.stringify('production'),
-    __KEEP_DEPRECATION__: process.env.KEEP_DEPRECATION !== 'false',
-  });
   return {
     input: 'src/index.ts',
     output: {

--- a/src/lib/insights/listener.tsx
+++ b/src/lib/insights/listener.tsx
@@ -1,7 +1,7 @@
 /** @jsx h */
 
 import { h } from 'preact';
-import { deserializePayload } from '../utils';
+import { deserializePayload, deprecated } from '../utils';
 import { readDataAttributes, hasDataAttributes } from '../../helpers/insights';
 import { InsightsClientWrapper } from '../../types';
 import { InsightsEvent } from '../../middlewares/createInsightsMiddleware';
@@ -63,7 +63,7 @@ const insightsListener = (BaseComponent: any) => {
         }
       }
 
-      if (__KEEP_DEPRECATION__) {
+      deprecated(() => {
         // old way, e.g. instantsearch.insights("clickedObjectIDsAfterSearch", { .. })
         const insightsTarget = findInsightsTarget(
           event.target as HTMLElement | null,
@@ -74,7 +74,7 @@ const insightsListener = (BaseComponent: any) => {
           const { method, payload } = readDataAttributes(insightsTarget);
           props.insights(method, payload);
         }
-      }
+      });
     };
 
     return (

--- a/src/lib/insights/listener.tsx
+++ b/src/lib/insights/listener.tsx
@@ -63,15 +63,17 @@ const insightsListener = (BaseComponent: any) => {
         }
       }
 
-      // old way, e.g. instantsearch.insights("clickedObjectIDsAfterSearch", { .. })
-      const insightsTarget = findInsightsTarget(
-        event.target as HTMLElement | null,
-        event.currentTarget as HTMLElement | null,
-        element => hasDataAttributes(element)
-      );
-      if (insightsTarget) {
-        const { method, payload } = readDataAttributes(insightsTarget);
-        props.insights(method, payload);
+      if (__KEEP_DEPRECATION__) {
+        // old way, e.g. instantsearch.insights("clickedObjectIDsAfterSearch", { .. })
+        const insightsTarget = findInsightsTarget(
+          event.target as HTMLElement | null,
+          event.currentTarget as HTMLElement | null,
+          element => hasDataAttributes(element)
+        );
+        if (insightsTarget) {
+          const { method, payload } = readDataAttributes(insightsTarget);
+          props.insights(method, payload);
+        }
       }
     };
 

--- a/src/lib/utils/__tests__/index-test.js
+++ b/src/lib/utils/__tests__/index-test.js
@@ -837,40 +837,6 @@ describe('utils.getRefinements', () => {
   });
 });
 
-describe('utils.deprecate', () => {
-  const sum = (...args) => args.reduce((acc, _) => acc + _, 0);
-
-  it('expect to call initial function and print message', () => {
-    const warn = jest.spyOn(global.console, 'warn');
-    const fn = utils.deprecate(sum, 'message');
-
-    const expectation = fn(1, 2, 3);
-    const actual = 6;
-
-    expect(actual).toBe(expectation);
-    expect(warn).toHaveBeenCalledWith('[InstantSearch.js]: message');
-
-    warn.mockReset();
-    warn.mockRestore();
-  });
-
-  it('expect to call initial function twice and print message once', () => {
-    const warn = jest.spyOn(global.console, 'warn');
-    const fn = utils.deprecate(sum, 'message');
-
-    const expectation0 = fn(1, 2, 3);
-    const expectation1 = fn(1, 2, 3);
-    const actual = 6;
-
-    expect(actual).toBe(expectation0);
-    expect(actual).toBe(expectation1);
-    expect(warn).toHaveBeenCalledTimes(1);
-
-    warn.mockReset();
-    warn.mockRestore();
-  });
-});
-
 describe('utils.warning', () => {
   let warn;
 

--- a/src/lib/utils/deprecated.ts
+++ b/src/lib/utils/deprecated.ts
@@ -1,0 +1,18 @@
+import noop from './noop';
+
+type Deprecated = (callback: Function, message?: string) => void;
+
+let deprecated: Deprecated = noop;
+const cache = {};
+
+if (__KEEP_DEPRECATION__) {
+  deprecated = (callback, message) => {
+    if (message && !cache[message]) {
+      cache[message] = true;
+      console.warn(`[InstantSearch.js]: ${message.trim()}`);
+    }
+    callback();
+  };
+}
+
+export { deprecated };

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -31,6 +31,7 @@ export { default as mergeSearchParameters } from './mergeSearchParameters';
 export { default as resolveSearchParameters } from './resolveSearchParameters';
 export { default as toArray } from './toArray';
 export { warning } from './logger';
+export { deprecated } from './deprecated';
 export {
   escapeHits,
   TAG_PLACEHOLDER,

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -30,7 +30,7 @@ export { default as findIndex } from './findIndex';
 export { default as mergeSearchParameters } from './mergeSearchParameters';
 export { default as resolveSearchParameters } from './resolveSearchParameters';
 export { default as toArray } from './toArray';
-export { warning, deprecate } from './logger';
+export { warning } from './logger';
 export {
   escapeHits,
   TAG_PLACEHOLDER,

--- a/src/lib/utils/logger.ts
+++ b/src/lib/utils/logger.ts
@@ -1,21 +1,11 @@
 import noop from './noop';
 
-type Deprecate<TCallback = (...args: any[]) => any> = (
-  fn: TCallback,
-  message: string
-) => TCallback;
-
 type Warn = (message: string) => void;
 
 type Warning = {
   (condition: boolean, message: string): void;
   cache: { [message: string]: boolean };
 };
-
-/**
- * Logs a warning when this function is called, in development environment only.
- */
-let deprecate: Deprecate = fn => fn;
 
 /**
  * Logs a warning
@@ -35,20 +25,6 @@ if (__DEV__) {
     console.warn(`[InstantSearch.js]: ${message.trim()}`);
   };
 
-  deprecate = (fn, message) => {
-    let hasAlreadyPrinted = false;
-
-    return function(...args) {
-      if (!hasAlreadyPrinted) {
-        hasAlreadyPrinted = true;
-
-        warn(message);
-      }
-
-      return fn(...args);
-    };
-  };
-
   warning = ((condition, message) => {
     if (condition) {
       return;
@@ -66,4 +42,4 @@ if (__DEV__) {
   warning.cache = {};
 }
 
-export { warn, deprecate, warning };
+export { warn, warning };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3409,29 +3409,7 @@ algoliasearch-helper@^3.4.4:
   dependencies:
     events "^1.1.1"
 
-"algoliasearch-v3@npm:algoliasearch@3.35.1":
-  name algoliasearch-v3
-  version "3.35.1"
-  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-3.35.1.tgz#297d15f534a3507cab2f5dfb996019cac7568f0c"
-  integrity sha512-K4yKVhaHkXfJ/xcUnil04xiSrB8B8yHZoFEhWNpXg23eiCnqvTZw1tn/SqvdsANlYHLJlKl0qi3I/Q2Sqo7LwQ==
-  dependencies:
-    agentkeepalive "^2.2.0"
-    debug "^2.6.9"
-    envify "^4.0.0"
-    es6-promise "^4.1.0"
-    events "^1.1.0"
-    foreach "^2.0.5"
-    global "^4.3.2"
-    inherits "^2.0.1"
-    isarray "^2.0.1"
-    load-script "^1.0.0"
-    object-keys "^1.0.11"
-    querystring-es3 "^0.2.1"
-    reduce "^1.0.1"
-    semver "^5.1.0"
-    tunnel-agent "^0.6.0"
-
-algoliasearch@^3.35.1:
+"algoliasearch-v3@npm:algoliasearch@3.35.1", algoliasearch@^3.35.1:
   version "3.35.1"
   resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-3.35.1.tgz#297d15f534a3507cab2f5dfb996019cac7568f0c"
   integrity sha512-K4yKVhaHkXfJ/xcUnil04xiSrB8B8yHZoFEhWNpXg23eiCnqvTZw1tn/SqvdsANlYHLJlKl0qi3I/Q2Sqo7LwQ==
@@ -4083,7 +4061,7 @@ babel-plugin-minify-constant-folding@^0.5.0:
   dependencies:
     babel-helper-evaluate-path "^0.5.0"
 
-babel-plugin-minify-dead-code-elimination@^0.5.1:
+babel-plugin-minify-dead-code-elimination@0.5.1, babel-plugin-minify-dead-code-elimination@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.5.1.tgz#1a0c68e44be30de4976ca69ffc535e08be13683f"
   integrity sha512-x8OJOZIrRmQBcSqxBcLbMIK8uPmTvNWPXH2bh5MDCW1latEqYiRMuUkPImKcfpo59pTUB2FT7HfcgtG8ZlR5Qg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3409,7 +3409,29 @@ algoliasearch-helper@^3.4.4:
   dependencies:
     events "^1.1.1"
 
-"algoliasearch-v3@npm:algoliasearch@3.35.1", algoliasearch@^3.35.1:
+"algoliasearch-v3@npm:algoliasearch@3.35.1":
+  name algoliasearch-v3
+  version "3.35.1"
+  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-3.35.1.tgz#297d15f534a3507cab2f5dfb996019cac7568f0c"
+  integrity sha512-K4yKVhaHkXfJ/xcUnil04xiSrB8B8yHZoFEhWNpXg23eiCnqvTZw1tn/SqvdsANlYHLJlKl0qi3I/Q2Sqo7LwQ==
+  dependencies:
+    agentkeepalive "^2.2.0"
+    debug "^2.6.9"
+    envify "^4.0.0"
+    es6-promise "^4.1.0"
+    events "^1.1.0"
+    foreach "^2.0.5"
+    global "^4.3.2"
+    inherits "^2.0.1"
+    isarray "^2.0.1"
+    load-script "^1.0.0"
+    object-keys "^1.0.11"
+    querystring-es3 "^0.2.1"
+    reduce "^1.0.1"
+    semver "^5.1.0"
+    tunnel-agent "^0.6.0"
+
+algoliasearch@^3.35.1:
   version "3.35.1"
   resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-3.35.1.tgz#297d15f534a3507cab2f5dfb996019cac7568f0c"
   integrity sha512-K4yKVhaHkXfJ/xcUnil04xiSrB8B8yHZoFEhWNpXg23eiCnqvTZw1tn/SqvdsANlYHLJlKl0qi3I/Q2Sqo7LwQ==


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR introduces `__KEEP_DEPRECATION__` to manage deprecated code better.
It's not meant to be merged quickly. It's more like a PoC for discussion. The namings aren't fixed either.

It's hard to manage the deprecated code, and get rid of them when it's time to do so.
In this PR, there is a new global variable `__KEEP_DEPRECATION__` which is `true` by default.
We can wrap the deprecated code with `if (__KEEP_DEPRECATION__) { ... }`. Running `yarn build` will transform it into `if (true) { ... }`.

If we create a branch like `next` for the next major version, there we can run `KEEP_DEPRECATION=false yarn build` to make it `if (false) { ... }` and get the dead code eliminated in the build.

Without this kind of way, we will have too much difference between `master` and `next` because we'd want to remove the deprecated code there. With this, we can still keep the same code but with the flag turned on, and safely test the new paths. Also we can actually remove the code once `next` is merged back to `master` or a little later.



---

Or, we could introduce a variable like `__NEXT_VERSION__` and wrap the deprecated code with `if (!__NEXT_VERSION__) { ... }`. This way, we can also write the code that will be introduced only in the next version.

What do you think?


- Edit1: By the way, I'm not suggesting to change the current ones we already wrote. It will be too much.
- Edit2: It cannot cover everything. We will still have imports, dependencies, etc that cannot be conditionally done with this.