### PR TITLE
fix(utils): circular dependency in createSendEventForHits

### DIFF
--- a/src/lib/utils/createSendEventForHits.ts
+++ b/src/lib/utils/createSendEventForHits.ts
@@ -1,5 +1,5 @@
 import { InstantSearch, Hit, Hits, EscapedHits } from '../../types';
-import { serializePayload } from '../../lib/utils';
+import { serializePayload } from '../../lib/utils/serializer';
 import { InsightsEvent } from '../../middlewares/createInsightsMiddleware';
 
 type BuiltInSendEventForHits = (


### PR DESCRIPTION
**Summary**

Fix circular dependency in createSendEventForHits

```
src/lib/utils/index.ts -> src/lib/utils/createSendEventForHits.ts -> src/lib/utils/index.ts
```