### PR TITLE
chore(ci): make build fail when circular dependency is detected

### DIFF
--- a/scripts/rollup/config.js
+++ b/scripts/rollup/config.js
@@ -49,6 +49,12 @@ const createConfiguration = ({ mode, filename }) => ({
     banner: license,
     sourcemap: true,
   },
+  onwarn(warning, warn) {
+    if (warning.code === 'CIRCULAR_DEPENDENCY')
+      throw new Error(warning.message);
+
+    warn(warning);
+  },
   plugins: [
     ...plugins,
     replace({


### PR DESCRIPTION
**Summary**

The `build` command should fail when a circular dependency is detected, other warnings will be treated as before.

Related: https://github.com/algolia/instantsearch.js/pull/4680#issuecomment-801794688
Resources: [rollup doc](https://rollupjs.org/guide/en/#onwarn)

This PR should be merged after https://github.com/algolia/instantsearch.js/pull/4680 so that it can prove that it works