### PR TITLE
feat(hierarchicalMenu): implement canRefine

### DIFF
--- a/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.js
+++ b/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.js
@@ -472,6 +472,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
         category: {
           items: [],
           refine: expect.any(Function),
+          canRefine: false,
           createURL: expect.any(Function),
           sendEvent: expect.any(Function),
           widgetParams: { attributes: ['category', 'subCategory'] },
@@ -543,6 +544,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
           },
         ],
         refine: expect.any(Function),
+        canRefine: true,
         createURL: expect.any(Function),
         sendEvent: expect.any(Function),
         widgetParams: { attributes: ['category', 'subCategory'] },
@@ -580,6 +582,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
       ).toEqual({
         items: [],
         refine: expect.any(Function),
+        canRefine: false,
         sendEvent: expect.any(Function),
         createURL: expect.any(Function),
         widgetParams: { attributes: ['category', 'subCategory'] },
@@ -649,6 +652,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
           },
         ],
         refine: expect.any(Function),
+        canRefine: true,
         sendEvent: expect.any(Function),
         createURL: expect.any(Function),
         widgetParams: { attributes: ['category', 'subCategory'] },

--- a/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
+++ b/src/connectors/hierarchical-menu/connectHierarchicalMenu.js
@@ -232,6 +232,7 @@ export default function connectHierarchicalMenu(renderFn, unmountFn = noop) {
         return {
           items,
           refine: this._refine,
+          canRefine: items.length > 0,
           createURL: _createURL,
           sendEvent,
           widgetParams,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

implements canRefine in connectHierarchicalMenu as true when more than 0 items are possible available (a single item can still refine, even if the value of that is small, this way it's consistent with breadcrumb)

DX-1305


**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

hierarchicalMenu now has a canRefine
