### PR TITLE
feat(range): implement canRefine

### DIFF
--- a/src/connectors/range/__tests__/connectRange-test.ts
+++ b/src/connectors/range/__tests__/connectRange-test.ts
@@ -1599,6 +1599,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
             max: 0,
             min: 0,
           },
+          canRefine: false,
           refine: expect.any(Function),
           sendEvent: expect.any(Function),
           start: [0, 1000],
@@ -1633,6 +1634,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
             min: 10,
             max: 30,
           },
+          canRefine: true,
           refine: expect.any(Function),
           sendEvent: expect.any(Function),
           start: [0, 1000],
@@ -1676,6 +1678,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
           max: 0,
           min: 0,
         },
+        canRefine: false,
         refine: expect.any(Function),
         sendEvent: expect.any(Function),
         start: [0, 1000],
@@ -1707,9 +1710,54 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
           max: 30,
           min: 10,
         },
+        canRefine: true,
         refine: expect.any(Function),
         sendEvent: expect.any(Function),
         start: [0, 1000],
+        widgetParams: {
+          attribute: 'price',
+          precision: 0,
+        },
+      });
+    });
+
+    it('canRefine returns false when the result range is empty', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const createRange = connectRange(renderFn, unmountFn);
+      const rangeWidget = createRange({
+        attribute: 'price',
+      });
+      const helper = jsHelper(createSearchClient(), 'indexName', {
+        disjunctiveFacets: ['price'],
+      });
+
+      const renderState = rangeWidget.getWidgetRenderState(
+        createRenderOptions({
+          helper,
+          state: helper.state,
+          results: createFacetStatsResults({
+            min: 1000,
+            max: 1000,
+            helper,
+            attribute: 'price',
+          }),
+        })
+      );
+
+      expect(renderState).toEqual({
+        format: {
+          from: expect.any(Function),
+          to: expect.any(Function),
+        },
+        range: {
+          max: 1000,
+          min: 1000,
+        },
+        canRefine: false,
+        refine: expect.any(Function),
+        sendEvent: expect.any(Function),
+        start: [-Infinity, Infinity],
         widgetParams: {
           attribute: 'price',
           precision: 0,

--- a/src/connectors/range/connectRange.ts
+++ b/src/connectors/range/connectRange.ts
@@ -42,6 +42,11 @@ export type RangeRendererOptions = {
   refine(rangeValue: RangeBoundaries): void;
 
   /**
+   * Indicates whether this widget can be refined
+   */
+  canRefine: boolean;
+
+  /**
    * Send an event to the insights middleware
    */
   sendEvent: SendEventForFacet;
@@ -401,6 +406,7 @@ const connectRange: ConnectRange = function connectRange(
 
         return {
           refine,
+          canRefine: currentRange.min !== currentRange.max,
           format: rangeFormatter,
           range: currentRange,
           sendEvent: createSendEvent(


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

implements canRefine in connectRange as true when the resulting range's start and end are identical

DX-1307


**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

range now has a canRefine
