### PR TITLE
feat(sortBy): implement canRefine

### DIFF
--- a/src/connectors/sort-by/__tests__/connectSortBy-test.js
+++ b/src/connectors/sort-by/__tests__/connectSortBy-test.js
@@ -287,6 +287,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
 
       expect(renderState1.sortBy).toEqual({
         currentRefinement: 'index_default',
+        canRefine: false,
         refine: expect.any(Function),
         hasNoResults: true,
         options: [
@@ -326,6 +327,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
 
       expect(renderState2.sortBy).toEqual({
         currentRefinement: 'index_desc',
+        canRefine: true,
         refine: expect.any(Function),
         hasNoResults: false,
         options: [
@@ -366,6 +368,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
 
       expect(renderState1).toEqual({
         currentRefinement: 'index_desc',
+        canRefine: false,
         refine: expect.any(Function),
         hasNoResults: true,
         options: [
@@ -403,6 +406,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
 
       expect(renderState2).toEqual({
         currentRefinement: 'index_default',
+        canRefine: true,
         refine: expect.any(Function),
         hasNoResults: false,
         options: [

--- a/src/connectors/sort-by/connectSortBy.js
+++ b/src/connectors/sort-by/connectSortBy.js
@@ -27,6 +27,7 @@ const withUsage = createDocumentationMessageGenerator({
  * @typedef {Object} SortByRenderingOptions
  * @property {string} currentRefinement The currently selected index.
  * @property {SortByItem[]} options All the available indices
+ * @property {boolean} canRefine Indicates if search state can be refined.
  * @property {function(string)} refine Switches indices and triggers a new search.
  * @property {boolean} hasNoResults `true` if the last search contains no result.
  * @property {Object} widgetParams All original `CustomSortByWidgetParams` forwarded to the `renderFn`.
@@ -164,6 +165,7 @@ export default function connectSortBy(renderFn, unmountFn = noop) {
         return {
           currentRefinement: helper.state.index,
           options: transformItems(items),
+          canRefine: Boolean(results && results.nbHits > 0),
           refine: this.setIndex,
           hasNoResults: results ? results.nbHits === 0 : true,
           widgetParams,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

implements canRefine in connectSortBy as true when nbHits > 0.

DX-1314

**Result**

sortBy now has a canRefine