### PR TITLE
feat(relevantSort): implement canRefine

### DIFF
--- a/src/connectors/relevant-sort/__tests__/connectRelevantSort-test.ts
+++ b/src/connectors/relevant-sort/__tests__/connectRelevantSort-test.ts
@@ -193,7 +193,7 @@ describe('connectRelevantSort', () => {
       expect(renderState2.relevantSort).toEqual({
         isRelevantSorted: true,
         isVirtualReplica: true,
-        canRefine: false,
+        canRefine: true,
         refine: expect.any(Function),
         widgetParams: {},
       });
@@ -230,86 +230,6 @@ describe('connectRelevantSort', () => {
         })
       );
       expect(widgetRenderState2).toEqual({
-        isRelevantSorted: true,
-        isVirtualReplica: true,
-        canRefine: false,
-        refine: expect.any(Function),
-        widgetParams: {},
-      });
-    });
-
-    it('return canRefine as true with relevant sorted hits', () => {
-      const helper = createHelper();
-      const makeWidget = connectRelevantSort(noop);
-      const widget = makeWidget({});
-
-      const widgetRenderState = widget.getWidgetRenderState(
-        createRenderOptions({
-          helper,
-          results: new SearchResults(helper.state, [
-            createSingleSearchResponse({
-              hits: [{ objectID: 'a' }],
-              nbSortedHits: 1,
-              nbHits: 10,
-              appliedRelevancyStrictness: 20,
-            }),
-          ]),
-        })
-      );
-      expect(widgetRenderState).toEqual({
-        isRelevantSorted: true,
-        isVirtualReplica: true,
-        canRefine: true,
-        refine: expect.any(Function),
-        widgetParams: {},
-      });
-    });
-
-    it('return canRefine as true with 0 relevant sorted hit', () => {
-      const helper = createHelper();
-      const makeWidget = connectRelevantSort(noop);
-      const widget = makeWidget({});
-
-      const widgetRenderState = widget.getWidgetRenderState(
-        createRenderOptions({
-          helper,
-          results: new SearchResults(helper.state, [
-            createSingleSearchResponse({
-              hits: [],
-              nbSortedHits: 0,
-              nbHits: 10,
-              appliedRelevancyStrictness: 20,
-            }),
-          ]),
-        })
-      );
-      expect(widgetRenderState).toEqual({
-        isRelevantSorted: true,
-        isVirtualReplica: true,
-        canRefine: true,
-        refine: expect.any(Function),
-        widgetParams: {},
-      });
-    });
-
-    it('return canRefine as true with normally sorted hits', () => {
-      const helper = createHelper();
-      const makeWidget = connectRelevantSort(noop);
-      const widget = makeWidget({});
-
-      const widgetRenderState = widget.getWidgetRenderState(
-        createRenderOptions({
-          helper,
-          results: new SearchResults(helper.state, [
-            createSingleSearchResponse({
-              hits: [{ objectID: 'a' }],
-              nbHits: 1,
-              appliedRelevancyStrictness: 10,
-            }),
-          ]),
-        })
-      );
-      expect(widgetRenderState).toEqual({
         isRelevantSorted: true,
         isVirtualReplica: true,
         canRefine: true,

--- a/src/connectors/relevant-sort/__tests__/connectRelevantSort-test.ts
+++ b/src/connectors/relevant-sort/__tests__/connectRelevantSort-test.ts
@@ -172,6 +172,7 @@ describe('connectRelevantSort', () => {
       expect(renderState1.relevantSort).toEqual({
         isRelevantSorted: false,
         isVirtualReplica: false,
+        canRefine: false,
         refine: expect.any(Function),
         widgetParams: {},
       });
@@ -192,6 +193,7 @@ describe('connectRelevantSort', () => {
       expect(renderState2.relevantSort).toEqual({
         isRelevantSorted: true,
         isVirtualReplica: true,
+        canRefine: false,
         refine: expect.any(Function),
         widgetParams: {},
       });
@@ -210,6 +212,7 @@ describe('connectRelevantSort', () => {
       expect(widgetRenderState1).toEqual({
         isRelevantSorted: false,
         isVirtualReplica: false,
+        canRefine: false,
         refine: expect.any(Function),
         widgetParams: {},
       });
@@ -229,6 +232,87 @@ describe('connectRelevantSort', () => {
       expect(widgetRenderState2).toEqual({
         isRelevantSorted: true,
         isVirtualReplica: true,
+        canRefine: false,
+        refine: expect.any(Function),
+        widgetParams: {},
+      });
+    });
+
+    it('return canRefine as true with relevant sorted hits', () => {
+      const helper = createHelper();
+      const makeWidget = connectRelevantSort(noop);
+      const widget = makeWidget({});
+
+      const widgetRenderState = widget.getWidgetRenderState(
+        createRenderOptions({
+          helper,
+          results: new SearchResults(helper.state, [
+            createSingleSearchResponse({
+              hits: [{ objectID: 'a' }],
+              nbSortedHits: 1,
+              nbHits: 10,
+              appliedRelevancyStrictness: 20,
+            }),
+          ]),
+        })
+      );
+      expect(widgetRenderState).toEqual({
+        isRelevantSorted: true,
+        isVirtualReplica: true,
+        canRefine: true,
+        refine: expect.any(Function),
+        widgetParams: {},
+      });
+    });
+
+    it('return canRefine as true with 0 relevant sorted hit', () => {
+      const helper = createHelper();
+      const makeWidget = connectRelevantSort(noop);
+      const widget = makeWidget({});
+
+      const widgetRenderState = widget.getWidgetRenderState(
+        createRenderOptions({
+          helper,
+          results: new SearchResults(helper.state, [
+            createSingleSearchResponse({
+              hits: [],
+              nbSortedHits: 0,
+              nbHits: 10,
+              appliedRelevancyStrictness: 20,
+            }),
+          ]),
+        })
+      );
+      expect(widgetRenderState).toEqual({
+        isRelevantSorted: true,
+        isVirtualReplica: true,
+        canRefine: true,
+        refine: expect.any(Function),
+        widgetParams: {},
+      });
+    });
+
+    it('return canRefine as true with normally sorted hits', () => {
+      const helper = createHelper();
+      const makeWidget = connectRelevantSort(noop);
+      const widget = makeWidget({});
+
+      const widgetRenderState = widget.getWidgetRenderState(
+        createRenderOptions({
+          helper,
+          results: new SearchResults(helper.state, [
+            createSingleSearchResponse({
+              hits: [{ objectID: 'a' }],
+              nbHits: 1,
+              appliedRelevancyStrictness: 10,
+            }),
+          ]),
+        })
+      );
+      expect(widgetRenderState).toEqual({
+        isRelevantSorted: true,
+        isVirtualReplica: true,
+        canRefine: true,
         refine: expect.any(Function),
         widgetParams: {},
       });

--- a/src/connectors/relevant-sort/connectRelevantSort.ts
+++ b/src/connectors/relevant-sort/connectRelevantSort.ts
@@ -100,7 +100,7 @@ const connectRelevantSort: RelevantSortConnector = function connectRelevantSort(
             typeof appliedRelevancyStrictness !== 'undefined' &&
             appliedRelevancyStrictness > 0,
           isVirtualReplica,
-          canRefine: isVirtualReplica && results?.nbHits! > 0,
+          canRefine: isVirtualReplica,
           refine: connectorState.refine,
           widgetParams,
         };

--- a/src/connectors/relevant-sort/connectRelevantSort.ts
+++ b/src/connectors/relevant-sort/connectRelevantSort.ts
@@ -6,8 +6,24 @@ export type RelevantSortConnectorParams = Record<string, unknown>;
 type Refine = (relevancyStrictness: number) => void;
 
 export type RelevantSortRendererOptions = {
+  /**
+   * Indicates if it has appliedRelevancyStrictness greater than zero
+   */
   isRelevantSorted: boolean;
+
+  /**
+   * Indicates if the results come from a virtual replica
+   */
   isVirtualReplica: boolean;
+
+  /**
+   * Indicates if search state can be refined
+   */
+  canRefine: boolean;
+
+  /**
+   * Sets the value as relevancyStrictness and trigger a new search
+   */
   refine: Refine;
 };
 
@@ -77,11 +93,14 @@ const connectRelevantSort: RelevantSortConnector = function connectRelevantSort(
 
         const { appliedRelevancyStrictness } = results || {};
 
+        const isVirtualReplica = appliedRelevancyStrictness !== undefined;
+
         return {
           isRelevantSorted:
             typeof appliedRelevancyStrictness !== 'undefined' &&
             appliedRelevancyStrictness > 0,
-          isVirtualReplica: appliedRelevancyStrictness !== undefined,
+          isVirtualReplica,
+          canRefine: isVirtualReplica && results?.nbHits! > 0,
           refine: connectorState.refine,
           widgetParams,
         };


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

implements canRefine in connectRelevantSort as true when nbHits > 0 and it's a virtual replica.

**Result**

relevantSort now has a canRefine