### PR TITLE
fix(setUiState): make sure previous ui state is stored

### DIFF
--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -556,7 +556,7 @@ See ${createDocumentationLink({
         });
       }
 
-      indexWidget.getHelper()!.overrideStateWithoutTriggeringChangeEvent(
+      indexWidget.getHelper()!.setState(
         indexWidget.getWidgetSearchParameters(indexWidget.getHelper()!.state, {
           uiState: nextUiState[indexWidget.getIndexId()],
         })
@@ -571,7 +571,6 @@ See ${createDocumentationLink({
     setIndexHelperState(this.mainIndex);
 
     this.scheduleSearch();
-    this.onInternalStateChange();
   }
 
   public onInternalStateChange = () => {

--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -573,7 +573,7 @@ See ${createDocumentationLink({
     this.scheduleSearch();
   }
 
-  public onInternalStateChange = () => {
+  public onInternalStateChange = defer(() => {
     const nextUiState = this.mainIndex.getWidgetUiState({});
 
     this.middleware.forEach(m => {
@@ -581,7 +581,7 @@ See ${createDocumentationLink({
         uiState: nextUiState,
       });
     });
-  };
+  });
 
   public createURL(nextState: UiState = {}): string {
     if (!this.started) {

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -1615,7 +1615,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
     expect(searchClient.search).toHaveBeenCalledTimes(2);
   });
 
-  test('notifies all middleware', async () => {
+  test('notifies all middlewares', async () => {
     const searchClient = createSearchClient();
     const search = new InstantSearch({
       indexName: 'indexName',

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -1434,7 +1434,7 @@ describe('use', () => {
     const middleware = jest.fn(() => middlewareSpy);
 
     search.addWidgets([searchBox]);
-    search.EXPERIMENTAL_use(middleware);
+    search.use(middleware);
 
     expect(middleware).toHaveBeenCalledTimes(1);
     expect(middleware).toHaveBeenCalledWith({ instantSearchInstance: search });
@@ -1509,7 +1509,7 @@ describe('use', () => {
     const middlewareAfterStart = jest.fn(() => middlewareAfterStartSpy);
 
     search.addWidgets([searchBox({})]);
-    search.EXPERIMENTAL_use(middlewareBeforeStart);
+    search.use(middlewareBeforeStart);
     search.start();
 
     expect(middlewareBeforeStart).toHaveBeenCalledTimes(1);
@@ -1517,7 +1517,7 @@ describe('use', () => {
       instantSearchInstance: search,
     });
 
-    search.EXPERIMENTAL_use(middlewareAfterStart);
+    search.use(middlewareAfterStart);
 
     // The first middleware should still have been only called once
     expect(middlewareBeforeStart).toHaveBeenCalledTimes(1);
@@ -1630,7 +1630,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
       };
     };
 
-    search.EXPERIMENTAL_use(middleware);
+    search.use(middleware);
     search.start();
     expect(onMiddlewareStateChange).toHaveBeenCalledTimes(0);
 
@@ -1669,7 +1669,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
       };
     };
 
-    search.EXPERIMENTAL_use(middleware);
+    search.use(middleware);
     search.start();
     expect(onMiddlewareStateChange).toHaveBeenCalledTimes(0);
 
@@ -1973,7 +1973,7 @@ describe('onStateChange', () => {
     };
 
     search.addWidgets([searchBox({})]);
-    search.EXPERIMENTAL_use(middleware);
+    search.use(middleware);
     search.start();
 
     expect(middlewareOnStateChange).toHaveBeenCalledTimes(0);

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -1609,7 +1609,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
       indexName: 'indexName',
       searchClient,
     });
-
     const onMiddlewareStateChange = jest.fn();
     const middleware = () => {
       return {
@@ -1634,7 +1633,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
     });
   });
 
-  test('notifies all middlewarel in multi-index when called multiple times', () => {
+  test('notifies all middlewares in multi-index when called multiple times', () => {
     const searchClient = createSearchClient();
     const search = new InstantSearch({
       indexName: 'indexName',

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -1663,7 +1663,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
       test: {},
     });
 
-    expect(onMiddlewareStateChange).toHaveBeenCalledTimes(1);
+    expect(onMiddlewareStateChange).toHaveBeenCalledTimes(2);
     expect(onMiddlewareStateChange).toHaveBeenCalledWith({
       uiState: {
         indexName: {},
@@ -1676,7 +1676,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
       test: {},
     });
 
-    expect(onMiddlewareStateChange).toHaveBeenCalledTimes(2);
+    expect(onMiddlewareStateChange).toHaveBeenCalledTimes(4);
     expect(onMiddlewareStateChange).toHaveBeenCalledWith({
       uiState: {
         indexName: { query: 'test' },

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -1609,6 +1609,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
       indexName: 'indexName',
       searchClient,
     });
+
     const onMiddlewareStateChange = jest.fn();
     const middleware = () => {
       return {
@@ -1629,6 +1630,58 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
     expect(onMiddlewareStateChange).toHaveBeenCalledWith({
       uiState: {
         indexName: {},
+      },
+    });
+  });
+
+  test('notifies all middlewarel in multi-index when called multiple times', () => {
+    const searchClient = createSearchClient();
+    const search = new InstantSearch({
+      indexName: 'indexName',
+      searchClient,
+    });
+
+    search.addWidgets([
+      connectSearchBox(() => {})({}),
+      index({ indexName: 'test' }),
+    ]);
+
+    const onMiddlewareStateChange = jest.fn();
+    const middleware = () => {
+      return {
+        subscribe() {},
+        unsubscribe() {},
+        onStateChange: onMiddlewareStateChange,
+      };
+    };
+
+    search.EXPERIMENTAL_use(middleware);
+    search.start();
+    expect(onMiddlewareStateChange).toHaveBeenCalledTimes(0);
+
+    search.setUiState({
+      indexName: {},
+      test: {},
+    });
+
+    expect(onMiddlewareStateChange).toHaveBeenCalledTimes(1);
+    expect(onMiddlewareStateChange).toHaveBeenCalledWith({
+      uiState: {
+        indexName: {},
+        test: {},
+      },
+    });
+
+    search.setUiState({
+      indexName: { query: 'test' },
+      test: {},
+    });
+
+    expect(onMiddlewareStateChange).toHaveBeenCalledTimes(2);
+    expect(onMiddlewareStateChange).toHaveBeenCalledWith({
+      uiState: {
+        indexName: { query: 'test' },
+        test: {},
       },
     });
   });

--- a/src/lib/__tests__/InstantSearch-test.js
+++ b/src/lib/__tests__/InstantSearch-test.js
@@ -1409,7 +1409,7 @@ describe('refresh', () => {
 });
 
 describe('use', () => {
-  it('hooks middleware into the lifecycle before the instance starts', () => {
+  it('hooks middleware into the lifecycle before the instance starts', async () => {
     const searchClient = createSearchClient();
     const search = new InstantSearch({
       indexName: 'indexName',
@@ -1450,10 +1450,14 @@ describe('use', () => {
     // Checks that `mainIndex.init` was called before subscribing the middleware.
     expect(widgetsInitCallOrder).toBeLessThan(middlewareSubscribeCallOrder);
 
+    await runAllMicroTasks();
+
     expect(middlewareSpy.subscribe).toHaveBeenCalledTimes(1);
     expect(middlewareSpy.onStateChange).toHaveBeenCalledTimes(0);
 
     button.click();
+
+    await runAllMicroTasks();
 
     expect(middlewareSpy.onStateChange).toHaveBeenCalledTimes(1);
     expect(middlewareSpy.onStateChange).toHaveBeenCalledWith({
@@ -1466,6 +1470,8 @@ describe('use', () => {
 
     search.dispose();
 
+    await runAllMicroTasks();
+
     expect(middlewareSpy.onStateChange).toHaveBeenCalledTimes(2);
     expect(middlewareSpy.onStateChange).toHaveBeenCalledWith({
       uiState: {
@@ -1475,7 +1481,7 @@ describe('use', () => {
     expect(middlewareSpy.unsubscribe).toHaveBeenCalledTimes(1);
   });
 
-  it('hooks middleware into the lifecycle after the instance starts', () => {
+  it('hooks middleware into the lifecycle after the instance starts', async () => {
     const searchClient = createSearchClient();
     const search = new InstantSearch({
       indexName: 'indexName',
@@ -1520,6 +1526,8 @@ describe('use', () => {
       instantSearchInstance: search,
     });
 
+    await runAllMicroTasks();
+
     // The first middleware subscribe function should have been only called once
     expect(middlewareBeforeStartSpy.subscribe).toHaveBeenCalledTimes(1);
     expect(middlewareAfterStartSpy.subscribe).toHaveBeenCalledTimes(1);
@@ -1527,6 +1535,8 @@ describe('use', () => {
     expect(middlewareAfterStartSpy.onStateChange).toHaveBeenCalledTimes(0);
 
     button.click();
+
+    await runAllMicroTasks();
 
     expect(middlewareBeforeStartSpy.onStateChange).toHaveBeenCalledTimes(1);
     expect(middlewareAfterStartSpy.onStateChange).toHaveBeenCalledTimes(1);
@@ -1546,6 +1556,8 @@ describe('use', () => {
     });
 
     search.dispose();
+
+    await runAllMicroTasks();
 
     expect(middlewareBeforeStartSpy.onStateChange).toHaveBeenCalledTimes(2);
     expect(middlewareAfterStartSpy.onStateChange).toHaveBeenCalledTimes(2);
@@ -1603,7 +1615,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
     expect(searchClient.search).toHaveBeenCalledTimes(2);
   });
 
-  test('notifies all middleware', () => {
+  test('notifies all middleware', async () => {
     const searchClient = createSearchClient();
     const search = new InstantSearch({
       indexName: 'indexName',
@@ -1625,6 +1637,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
     search.setUiState({
       indexName: {},
     });
+
+    await runAllMicroTasks();
+
     expect(onMiddlewareStateChange).toHaveBeenCalledTimes(1);
     expect(onMiddlewareStateChange).toHaveBeenCalledWith({
       uiState: {
@@ -1633,7 +1648,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
     });
   });
 
-  test('notifies all middlewares in multi-index when called multiple times', () => {
+  test('notifies all middlewares in multi-index when called multiple times', async () => {
     const searchClient = createSearchClient();
     const search = new InstantSearch({
       indexName: 'indexName',
@@ -1663,7 +1678,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
       test: {},
     });
 
-    expect(onMiddlewareStateChange).toHaveBeenCalledTimes(2);
+    await runAllMicroTasks();
+
+    expect(onMiddlewareStateChange).toHaveBeenCalledTimes(1);
     expect(onMiddlewareStateChange).toHaveBeenCalledWith({
       uiState: {
         indexName: {},
@@ -1676,7 +1693,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
       test: {},
     });
 
-    expect(onMiddlewareStateChange).toHaveBeenCalledTimes(4);
+    await runAllMicroTasks();
+
+    expect(onMiddlewareStateChange).toHaveBeenCalledTimes(2);
     expect(onMiddlewareStateChange).toHaveBeenCalledWith({
       uiState: {
         indexName: { query: 'test' },

--- a/src/lib/__tests__/RoutingManager-test.ts
+++ b/src/lib/__tests__/RoutingManager-test.ts
@@ -138,14 +138,18 @@ describe('RoutingManager', () => {
 
       search.start();
 
-      search.once('render', () => {
+      search.once('render', async () => {
         // initialization is done at this point
         expect(widget.render).toHaveBeenCalledTimes(1);
         expect(widget.getWidgetSearchParameters).toHaveBeenCalledTimes(1);
 
+        await runAllMicroTasks();
+
         expect(router.write).toHaveBeenCalledTimes(0);
 
         search.mainIndex.getHelper()!.setQuery('q'); // routing write updates on change
+
+        await runAllMicroTasks();
 
         expect(router.write).toHaveBeenCalledTimes(1);
         expect(router.write).toHaveBeenCalledWith({
@@ -301,6 +305,8 @@ describe('RoutingManager', () => {
       // Trigger an update - push a change
       fakeSearchBox.refine('Apple');
 
+      await runAllMicroTasks();
+
       expect(router.write).toHaveBeenCalledTimes(1);
       expect(router.write).toHaveBeenLastCalledWith({
         indexName: {
@@ -403,6 +409,8 @@ describe('RoutingManager', () => {
       // Trigger an update - push a change
       fakeSearchBox.refine('Apple');
 
+      await runAllMicroTasks();
+
       expect(router.write).toHaveBeenCalledTimes(1);
       expect(router.write).toHaveBeenLastCalledWith({
         indexName: {
@@ -412,6 +420,8 @@ describe('RoutingManager', () => {
 
       // Trigger an update - push a change
       fakeSearchBox.refine('Apple iPhone');
+
+      await runAllMicroTasks();
 
       expect(router.write).toHaveBeenCalledTimes(2);
       expect(router.write).toHaveBeenLastCalledWith({
@@ -492,6 +502,8 @@ describe('RoutingManager', () => {
       // Trigger an update - push a change
       fakeSearchBox.refine('Apple');
 
+      await runAllMicroTasks();
+
       expect(router.write).toHaveBeenCalledTimes(1);
       expect(router.write).toHaveBeenLastCalledWith({
         indexName: {
@@ -502,6 +514,8 @@ describe('RoutingManager', () => {
       // Trigger change without UI state change
       search.removeWidgets([fakeHitsPerPage1]);
 
+      await runAllMicroTasks();
+
       expect(router.write).toHaveBeenCalledTimes(1);
 
       await runAllMicroTasks();
@@ -509,6 +523,8 @@ describe('RoutingManager', () => {
       triggerChange = true;
       // Trigger change without UI state change but with a route change
       search.removeWidgets([fakeHitsPerPage2]);
+
+      await runAllMicroTasks();
 
       expect(router.write).toHaveBeenCalledTimes(2);
       expect(router.write).toHaveBeenLastCalledWith({

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -1904,7 +1904,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
       it('updates the local `uiState` when they differ on first render', () => {
         const instance = index({ indexName: 'indexName' });
         const instantSearchInstance = createInstantSearch({
-          onInternalStateChange: jest.fn(),
+          onInternalStateChange: jest.fn() as any,
         });
 
         instance.addWidgets([createSearchBox()]);
@@ -1967,7 +1967,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
         const topLevelInstance = index({ indexName: 'topLevelIndexName' });
         const subLevelInstance = index({ indexName: 'subLevelIndexName' });
         const instantSearchInstance = createInstantSearch({
-          onInternalStateChange: jest.fn(),
+          onInternalStateChange: jest.fn() as any,
         });
 
         topLevelInstance.addWidgets([

--- a/test/mock/createInstantSearch.ts
+++ b/test/mock/createInstantSearch.ts
@@ -39,7 +39,10 @@ export const createInstantSearch = (
     _createURL: jest.fn(() => '#'),
     onStateChange: null,
     setUiState: jest.fn(),
-    // if it's deferred, we can't test it has been called
+    // Since we defer `onInternalStateChange` with our `defer` util which
+    // creates a scoped deferred function, we're not able to spy that method.
+    // We'll therefore need to override it when calling `createInstantSearch`.
+    // See https://github.com/algolia/instantsearch.js/blob/f3213b2f118d75acac31a1f6cf4640241c438e9d/src/lib/utils/defer.ts#L13-L28
     onInternalStateChange: jest.fn() as any,
     createURL: jest.fn(() => '#'),
     addWidget: jest.fn(),

--- a/test/mock/createInstantSearch.ts
+++ b/test/mock/createInstantSearch.ts
@@ -39,7 +39,8 @@ export const createInstantSearch = (
     _createURL: jest.fn(() => '#'),
     onStateChange: null,
     setUiState: jest.fn(),
-    onInternalStateChange: jest.fn(),
+    // if it's deferred, we can't test it has been called
+    onInternalStateChange: jest.fn() as any,
     createURL: jest.fn(() => '#'),
     addWidget: jest.fn(),
     addWidgets: jest.fn(),


### PR DESCRIPTION
currently if you call setUiState, the localUiState in index widgets doesn't get updated to prevent middlewares being called multiple times, but that means if you call setUiState multiple times, the local state doesn't change
