### PR TITLE
fix(insights): do not throw when userToken is not given

### DIFF
--- a/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -194,6 +194,31 @@ describe('insights', () => {
       );
     });
 
+    it('warns when userToken is not set', () => {
+      const { insightsClient, instantSearchInstance } = createTestEnvironment();
+
+      const middleware = createInsightsMiddleware({
+        insightsClient,
+        insightsInitParams: { useCookie: false },
+      })({ instantSearchInstance });
+      middleware.subscribe();
+
+      expect(() =>
+        instantSearchInstance.sendEventToInsights({
+          eventType: 'view',
+          insightsMethod: 'viewedObjectIDs',
+          payload: {
+            eventName: 'Hits Viewed',
+            index: '',
+            objectIDs: ['1', '2'],
+          },
+          widgetType: 'ais.hits',
+        })
+      ).toWarnDev(
+        '[InstantSearch.js]: Cannot send event to Algolia Insights because `userToken` is not set.'
+      );
+    });
+
     it('applies clickAnalytics', () => {
       const {
         insightsClient,

--- a/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -217,7 +217,7 @@ describe('insights', () => {
       ).toWarnDev(
         `[InstantSearch.js]: Cannot send event to Algolia Insights because \`userToken\` is not set.
 
-See https://www.algolia.com/doc/guides/building-search-ui/going-further/send-insights-events/js/#setting-the-usertoken`
+See documentation: https://www.algolia.com/doc/guides/building-search-ui/going-further/send-insights-events/js/#setting-the-usertoken`
       );
     });
 

--- a/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -215,7 +215,9 @@ describe('insights', () => {
           widgetType: 'ais.hits',
         })
       ).toWarnDev(
-        '[InstantSearch.js]: Cannot send event to Algolia Insights because `userToken` is not set.'
+        `[InstantSearch.js]: Cannot send event to Algolia Insights because \`userToken\` is not set.
+
+See https://www.algolia.com/doc/guides/building-search-ui/going-further/send-insights-events/js/#setting-the-usertoken`
       );
     });
 

--- a/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -103,7 +103,7 @@ describe('insights', () => {
       });
     });
 
-    it('does not throw without userToken in UMD (1)', () => {
+    it('does not throw without userToken in UMD with the library loaded after the event', () => {
       const {
         insightsClient,
         libraryLoadedAndProcessQueue,
@@ -136,7 +136,7 @@ describe('insights', () => {
       );
     });
 
-    it('does not throw without userToken in UMD (2)', () => {
+    it('does not throw without userToken in UMD with the library loaded before the event', () => {
       const {
         insightsClient,
         libraryLoadedAndProcessQueue,
@@ -149,7 +149,6 @@ describe('insights', () => {
       })({ instantSearchInstance });
       middleware.subscribe();
 
-      // When the library is loaded later, it consumes the queue and sends the event.
       libraryLoadedAndProcessQueue();
 
       expect(() => {

--- a/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -8,7 +8,6 @@ import {
 } from '../../../test/mock/createInsightsClient';
 import { warning } from '../../lib/utils';
 import { SearchClient } from '../../types';
-import { runAllMicroTasks } from '../../../test/utils/runAllMicroTasks';
 
 describe('insights', () => {
   const createTestEnvironment = () => {

--- a/src/middlewares/createInsightsMiddleware.ts
+++ b/src/middlewares/createInsightsMiddleware.ts
@@ -135,7 +135,7 @@ export const createInsightsMiddleware: CreateInsightsMiddleware = props => {
                 `
 Cannot send event to Algolia Insights because \`userToken\` is not set.
 
-See https://www.algolia.com/doc/guides/building-search-ui/going-further/send-insights-events/js/#setting-the-usertoken
+See documentation: https://www.algolia.com/doc/guides/building-search-ui/going-further/send-insights-events/js/#setting-the-usertoken
 `
               );
             }

--- a/src/middlewares/createInsightsMiddleware.ts
+++ b/src/middlewares/createInsightsMiddleware.ts
@@ -132,7 +132,11 @@ export const createInsightsMiddleware: CreateInsightsMiddleware = props => {
             } else {
               warning(
                 false,
-                'Cannot send event to Algolia Insights because `userToken` is not set.'
+                `
+Cannot send event to Algolia Insights because \`userToken\` is not set.
+
+See https://www.algolia.com/doc/guides/building-search-ui/going-further/send-insights-events/js/#setting-the-usertoken
+`
               );
             }
           } else {

--- a/src/middlewares/createInsightsMiddleware.ts
+++ b/src/middlewares/createInsightsMiddleware.ts
@@ -99,6 +99,7 @@ export const createInsightsMiddleware: CreateInsightsMiddleware = props => {
             );
           }
         };
+        const hasUserToken = () => Boolean((helper.state as any).userToken);
 
         helper.setState(helper.state.setQueryParameter('clickAnalytics', true));
 
@@ -126,7 +127,14 @@ export const createInsightsMiddleware: CreateInsightsMiddleware = props => {
           if (onEvent) {
             onEvent(event, _insightsClient);
           } else if (event.insightsMethod) {
-            insightsClient(event.insightsMethod, event.payload);
+            if (hasUserToken()) {
+              insightsClient(event.insightsMethod, event.payload);
+            } else {
+              warning(
+                false,
+                'Cannot send event to Algolia Insights because `userToken` is not set.'
+              );
+            }
           } else {
             warning(
               false,

--- a/src/types/insights.ts
+++ b/src/types/insights.ts
@@ -42,11 +42,18 @@ export type InsightsInit = (
   }
 ) => void;
 
+export type InsightsGetUserToken = (
+  method: 'getUserToken',
+  options?: any,
+  callback?: (err: any, userToken: string) => void
+) => void;
+
 export type InsightsClient = InsightsSendEvent &
   InsightsOnUserTokenChange &
   InsightsGetUserToken &
   InsightsInit &
-  InsightsSetUserToken & {
+  InsightsSetUserToken &
+  InsightsGetUserToken & {
     queue?: Array<[string, any]>;
   };
 

--- a/src/types/insights.ts
+++ b/src/types/insights.ts
@@ -42,12 +42,6 @@ export type InsightsInit = (
   }
 ) => void;
 
-export type InsightsGetUserToken = (
-  method: 'getUserToken',
-  options?: any,
-  callback?: (err: any, userToken: string) => void
-) => void;
-
 export type InsightsClient = InsightsSendEvent &
   InsightsOnUserTokenChange &
   InsightsGetUserToken &

--- a/src/types/insights.ts
+++ b/src/types/insights.ts
@@ -44,7 +44,6 @@ export type InsightsInit = (
 
 export type InsightsClient = InsightsSendEvent &
   InsightsOnUserTokenChange &
-  InsightsGetUserToken &
   InsightsInit &
   InsightsSetUserToken &
   InsightsGetUserToken & {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR prevents `insights` middleware from throwing when `userToken` is not given yet.
_(The previous description wasn't clear and I was confused myself too.)_

Adding the `insights` middleware to InstantSearch and assigning a userToken could happen at the same time, or not. For example, although InstantSearch is loaded, the user is not logged in, so there may not be a userToken to set (let's assume this customer is not using anonymous user token from cookie).

Without this PR, we can guide like

> Add the middleware only after you have a user token. Otherwise, the middleware will throw errors without the token. Oh, and when a user logs out and you want to call `aa('setUserToken', '')` to remove the user token, you need to unuse the middleware. Otherwise it will throw errors because there is no user token.

But after this PR, I'd like to guide like

> Add the insights middleware once. Whenever you have a user token, call `aa('setUserToken', 'something');`. If you want to remove the userToken, then do so. The middleware will stop sending events.

---

~This PR fixes the `insights` middleware not to throw when `userToken` is not given yet.
It's coming from the behavior of `search-insights`, but we might still allow customers to use the `insights` middleware without setting userToken. For example, they might want to leverage the `insights` middleware to send events to third-party trackers, but not necessarily to Algolia directly. In that case `userToken` for Algolia is not needed, but they still want the middleware to work.~

~Currently this PR is based on https://github.com/algolia/instantsearch.js/pull/4712, but I will rebase it on master once it's merged. So this PR shouldn't be merged until then.~
