### PR TITLE
fix(infiniteHits): fix wrong behavior of showPrevious regarding cachedHits

### DIFF
--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -255,6 +255,38 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     expect(thirdRenderOptions.results).toEqual(previousResults);
   });
 
+  it('Renders previous page after showing next page', () => {
+    const renderFn = jest.fn();
+    const makeWidget = connectInfiniteHits(renderFn);
+    const widget = makeWidget({});
+
+    const helper = algoliasearchHelper(createSearchClient(), '', {});
+    helper.setPage(4);
+    helper.overrideStateWithoutTriggeringChangeEvent = jest.fn(() => helper);
+    helper.searchWithoutTriggeringOnStateChange = jest.fn();
+
+    widget.init!(
+      createInitOptions({
+        state: helper.state,
+        helper,
+      })
+    );
+
+    const { showMore, showPrevious } = widget.getWidgetRenderState(
+      createRenderOptions({
+        state: helper.state,
+        helper,
+      })
+    );
+    showMore();
+    expect(helper.state.page).toBe(5);
+
+    showPrevious();
+    expect(
+      helper.overrideStateWithoutTriggeringChangeEvent
+    ).toHaveBeenCalledWith(expect.objectContaining({ page: 3 }));
+  });
+
   it('Provides the hits and flush hists cache on query changes', () => {
     const renderFn = jest.fn();
     const makeWidget = connectInfiniteHits(renderFn);

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -188,25 +188,29 @@ const connectInfiniteHits: InfiniteHitsConnector = function connectInfiniteHits(
       }
     };
 
-    const getShowPrevious = (
-      helper: Helper,
-      cachedHits: InfiniteHitsCachedHits
-    ): (() => void) => () => {
+    const getShowPrevious = (helper: Helper): (() => void) => () => {
       // Using the helper's `overrideStateWithoutTriggeringChangeEvent` method
       // avoid updating the browser URL when the user displays the previous page.
       helper
         .overrideStateWithoutTriggeringChangeEvent({
           ...helper.state,
-          page: getFirstReceivedPage(helper.state, cachedHits) - 1,
+          page:
+            getFirstReceivedPage(
+              helper.state,
+              cache.read({ state: helper.state }) || {}
+            ) - 1,
         })
         .searchWithoutTriggeringOnStateChange();
     };
-    const getShowMore = (
-      helper: Helper,
-      cachedHits: InfiniteHitsCachedHits
-    ): (() => void) => () => {
+
+    const getShowMore = (helper: Helper): (() => void) => () => {
       helper
-        .setPage(getLastReceivedPage(helper.state, cachedHits) + 1)
+        .setPage(
+          getLastReceivedPage(
+            helper.state,
+            cache.read({ state: helper.state }) || {}
+          ) + 1
+        )
         .search();
     };
 
@@ -252,8 +256,8 @@ const connectInfiniteHits: InfiniteHitsConnector = function connectInfiniteHits(
         const cachedHits = cache.read({ state }) || {};
 
         if (!results) {
-          showPrevious = getShowPrevious(helper, cachedHits);
-          showMore = getShowMore(helper, cachedHits);
+          showPrevious = getShowPrevious(helper);
+          showMore = getShowMore(helper);
           sendEvent = createSendEventForHits({
             instantSearchInstance,
             index: helper.getIndex(),


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR fixes the wrong behavior of `showPrevious` and `showMore` because the functions were created at `init` with `cachedHits`. It means `showPrevious` and `showMore` always have wrong (empty) `cachedHits` object. Instead, we need to read from `cache` every time.

fixes https://github.com/algolia/vue-instantsearch/issues/945

**Reproduction of the issue from Vue InstantSearch**

https://fyn4y.csb.app/?instant_search[page]=4 (https://codesandbox.io/s/instantsearchjs-forked-fyn4y?file=/src/app.js)

- Click "Show more results" and you will see more results.
- Click "Show previous results" and you expect previous hits to be added, but nothing happens.
- Click "Show previous results" again, and it works now.

And the following is the same example with the InstantSearch.js version from this PR and it works fine:

https://tdmbd.csb.app/?instant_search[page]=4 (https://codesandbox.io/s/instantsearchjs-forked-tdmbd?file=/src/app.js)


**Result**

`showPrevious` and `showMore` work correctly.