### PR TITLE
chore(ts): convert voice search default templates

### DIFF
--- a/src/widgets/voice-search/defaultTemplates.ts
+++ b/src/widgets/voice-search/defaultTemplates.ts
@@ -1,4 +1,10 @@
-const getButtonInnerElement = (status, errorCode, isListening) => {
+import { VoiceSearchTemplates } from './voice-search';
+
+const getButtonInnerElement = (
+  status: string,
+  errorCode: string,
+  isListening: boolean
+) => {
   if (status === 'error' && errorCode === 'not-allowed') {
     return `<line x1="1" y1="1" x2="23" y2="23"></line>
             <path d="M9 9v3a3 3 0 0 0 5.12 2.12M15 9.34V4a3 3 0 0 0-5.94-.6"></path>
@@ -15,7 +21,7 @@ const getButtonInnerElement = (status, errorCode, isListening) => {
           <line x1="8" y1="23" x2="16" y2="23"></line>`;
 };
 
-export default {
+const defaultTemplates: VoiceSearchTemplates = {
   buttonText({ status, errorCode, isListening }) {
     return `<svg
        xmlns="http://www.w3.org/2000/svg"
@@ -33,3 +39,5 @@ export default {
   },
   status: `<p>{{transcript}}</p>`,
 };
+
+export default defaultTemplates;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

this file wasn't converted yet

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

voice search widget's default templates are TS now
