### PR TITLE
fix(ratingMenu): use url in default template

### DIFF
--- a/examples/e-commerce/src/widgets/Ratings.ts
+++ b/examples/e-commerce/src/widgets/Ratings.ts
@@ -15,7 +15,7 @@ export const ratings = ratingsMenu({
   templates: {
     item: `
 {{#count}}
-  <a class="{{cssClasses.link}}" aria-label="{{value}} & up" href="{{href}}">
+  <a class="{{cssClasses.link}}" aria-label="{{value}} & up" href="{{url}}">
 {{/count}}
 {{^count}}
   <div class="{{cssClasses.link}}" aria-label="{{value}} & up" disabled>

--- a/src/widgets/rating-menu/__tests__/__snapshots__/rating-menu-test.ts.snap
+++ b/src/widgets/rating-menu/__tests__/__snapshots__/rating-menu-test.ts.snap
@@ -78,7 +78,7 @@ Object {
   ],
   "templateProps": Object {
     "templates": Object {
-      "item": "{{#count}}<a class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" href=\\"{{href}}\\">{{/count}}{{^count}}<div class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" disabled>{{/count}}
+      "item": "{{#count}}<a class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" href=\\"{{url}}\\">{{/count}}{{^count}}<div class=\\"{{cssClasses.link}}\\" aria-label=\\"{{value}} & up\\" disabled>{{/count}}
   {{#stars}}<svg class=\\"{{cssClasses.starIcon}} {{#.}}{{cssClasses.fullStarIcon}}{{/.}}{{^.}}{{cssClasses.emptyStarIcon}}{{/.}}\\" aria-hidden=\\"true\\" width=\\"24\\" height=\\"24\\">
     {{#.}}<use xlink:href=\\"#ais-RatingMenu-starSymbol\\"></use>{{/.}}{{^.}}<use xlink:href=\\"#ais-RatingMenu-starEmptySymbol\\"></use>{{/.}}
   </svg>{{/stars}}

--- a/src/widgets/rating-menu/__tests__/rating-menu-integration-test.ts
+++ b/src/widgets/rating-menu/__tests__/rating-menu-integration-test.ts
@@ -1,0 +1,118 @@
+import jsHelper, {
+  SearchResults,
+  SearchParameters,
+} from 'algoliasearch-helper';
+import { createSearchClient } from '../../../../test/mock/createSearchClient';
+import {
+  createInitOptions,
+  createRenderOptions,
+} from '../../../../test/mock/createWidget';
+import { createMultiSearchResponse } from '../../../../test/mock/createAPIResponse';
+import ratingMenu from '../rating-menu';
+
+function getInitializedWidget() {
+  const container = document.createElement('div');
+  const attribute = 'rating';
+  const widget = ratingMenu({
+    container,
+    attribute,
+  });
+
+  const helper = jsHelper(
+    createSearchClient(),
+    '',
+    widget.getWidgetSearchParameters!(new SearchParameters({}), {
+      uiState: {},
+    })
+  );
+
+  widget.init!(createInitOptions({ helper }));
+
+  return { widget, container, helper, attribute };
+}
+
+describe('rendering', () => {
+  it('has correct URLs', () => {
+    const { widget, container, helper, attribute } = getInitializedWidget();
+
+    widget.render!(
+      createRenderOptions({
+        helper,
+        results: new SearchResults(
+          helper.state,
+          createMultiSearchResponse({
+            facets: {
+              [attribute]: {
+                0: 5,
+                1: 10,
+                2: 20,
+                3: 50,
+                4: 900,
+                5: 100,
+              },
+            },
+          }).results
+        ),
+        createURL(searchParams) {
+          return JSON.stringify(searchParams);
+        },
+      })
+    );
+
+    const links = container.querySelectorAll('a');
+
+    expect(links).toHaveLength(4);
+
+    expect(JSON.parse(links[0].getAttribute('href')!)).toEqual({
+      facets: [],
+      disjunctiveFacets: ['rating'],
+      hierarchicalFacets: [],
+      facetsRefinements: {},
+      facetsExcludes: {},
+      disjunctiveFacetsRefinements: {},
+      numericRefinements: { rating: { '<=': [5], '>=': [4] } },
+      tagRefinements: [],
+      hierarchicalFacetsRefinements: {},
+      index: '',
+    });
+
+    expect(JSON.parse(links[1].getAttribute('href')!)).toEqual({
+      facets: [],
+      disjunctiveFacets: ['rating'],
+      hierarchicalFacets: [],
+      facetsRefinements: {},
+      facetsExcludes: {},
+      disjunctiveFacetsRefinements: {},
+      numericRefinements: { rating: { '<=': [5], '>=': [3] } },
+      tagRefinements: [],
+      hierarchicalFacetsRefinements: {},
+      index: '',
+    });
+
+    expect(JSON.parse(links[2].getAttribute('href')!)).toEqual({
+      facets: [],
+      disjunctiveFacets: ['rating'],
+      hierarchicalFacets: [],
+      facetsRefinements: {},
+      facetsExcludes: {},
+      disjunctiveFacetsRefinements: {},
+      numericRefinements: { rating: { '<=': [5], '>=': [2] } },
+      tagRefinements: [],
+      hierarchicalFacetsRefinements: {},
+      index: '',
+    });
+
+    expect(JSON.parse(links[3].getAttribute('href')!)).toEqual({
+      facets: [],
+      disjunctiveFacets: ['rating'],
+      hierarchicalFacets: [],
+      facetsRefinements: {},
+      facetsExcludes: {},
+      disjunctiveFacetsRefinements: {},
+      numericRefinements: { rating: { '<=': [5], '>=': [1] } },
+      tagRefinements: [],
+      hierarchicalFacetsRefinements: {},
+      index: '',
+    });
+  });
+});

--- a/src/widgets/rating-menu/__tests__/rating-menu-test.ts
+++ b/src/widgets/rating-menu/__tests__/rating-menu-test.ts
@@ -1,4 +1,4 @@
-import { render } from 'preact';
+import { render as preactRender, VNode } from 'preact';
 import jsHelper, {
   SearchResults,
   SearchParameters,
@@ -11,9 +11,9 @@ import {
 import { createSingleSearchResponse } from '../../../../test/mock/createAPIResponse';
 import { createInstantSearch } from '../../../../test/mock/createInstantSearch';
 import ratingMenu from '../rating-menu';
+import { castToJestMock } from '../../../../test/utils/castToJestMock';
 
-const mockedRender = render as jest.Mock;
-
+const render = castToJestMock(preactRender);
 jest.mock('preact', () => {
   const module = jest.requireActual('preact');
 
@@ -44,7 +44,7 @@ describe('ratingMenu()', () => {
   let results: SearchResults;
 
   beforeEach(() => {
-    mockedRender.mockClear();
+    render.mockClear();
 
     container = document.createElement('div');
     widget = ratingMenu({
@@ -98,11 +98,11 @@ describe('ratingMenu()', () => {
       createRenderOptions({ state: helper.state, helper, results, createURL })
     );
 
-    const [firstRender, secondRender] = mockedRender.mock.calls;
+    const [firstRender, secondRender] = render.mock.calls;
 
-    const { children, ...rootProps } = firstRender[0].props;
+    const { children, ...rootProps } = (firstRender[0] as VNode<any>).props;
 
-    expect(mockedRender).toHaveBeenCalledTimes(2);
+    expect(render).toHaveBeenCalledTimes(2);
     expect(rootProps).toMatchSnapshot();
     expect(firstRender[1]).toEqual(container);
     expect(secondRender[1]).toEqual(container);
@@ -127,10 +127,10 @@ describe('ratingMenu()', () => {
       })
     );
 
-    const [firstRender] = mockedRender.mock.calls;
+    const [firstRender] = render.mock.calls;
 
-    expect(mockedRender).toHaveBeenCalledTimes(1);
-    expect(firstRender[0].props.facetValues).toEqual([
+    expect(render).toHaveBeenCalledTimes(1);
+    expect((firstRender[0] as VNode<any>).props.facetValues).toEqual([
       {
         count: 42,
         isRefined: true,
@@ -266,7 +266,7 @@ describe('ratingMenu()', () => {
     );
 
     expect(
-      mockedRender.mock.calls[mockedRender.mock.calls.length - 1][0].props
+      (render.mock.calls[render.mock.calls.length - 1][0] as VNode<any>).props
         .facetValues
     ).toEqual([
       {

--- a/src/widgets/rating-menu/defaultTemplates.ts
+++ b/src/widgets/rating-menu/defaultTemplates.ts
@@ -1,5 +1,5 @@
 export default {
-  item: `{{#count}}<a class="{{cssClasses.link}}" aria-label="{{value}} & up" href="{{href}}">{{/count}}{{^count}}<div class="{{cssClasses.link}}" aria-label="{{value}} & up" disabled>{{/count}}
+  item: `{{#count}}<a class="{{cssClasses.link}}" aria-label="{{value}} & up" href="{{url}}">{{/count}}{{^count}}<div class="{{cssClasses.link}}" aria-label="{{value}} & up" disabled>{{/count}}
   {{#stars}}<svg class="{{cssClasses.starIcon}} {{#.}}{{cssClasses.fullStarIcon}}{{/.}}{{^.}}{{cssClasses.emptyStarIcon}}{{/.}}" aria-hidden="true" width="24" height="24">
     {{#.}}<use xlink:href="#ais-RatingMenu-starSymbol"></use>{{/.}}{{^.}}<use xlink:href="#ais-RatingMenu-starEmptySymbol"></use>{{/.}}
   </svg>{{/stars}}


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

this is the cause of the from time to time failing e2e test, basically sometimes the event.preventDefault didn't apply, which causes the page to refresh to / instead of the right url.

The actual url is `url`, and not in `href`, so this means that before now it always was wrong.

The docs are correct and use `url`: https://www.algolia.com/doc/api-reference/widgets/rating-menu/js/#templates

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

url in ratingMenu now is actually correct, e2e tests will pass
