### PR TITLE
refactor(ts): migrate connectors to new Widget type

### DIFF
--- a/src/connectors/answers/connectAnswers.ts
+++ b/src/connectors/answers/connectAnswers.ts
@@ -14,6 +14,7 @@ import {
   Hit,
   FindAnswersOptions,
   FindAnswersResponse,
+  WidgetRenderState,
 } from '../../types';
 
 type IndexWithAnswers = {
@@ -31,7 +32,7 @@ const withUsage = createDocumentationMessageGenerator({
   connector: true,
 });
 
-export type AnswersRendererOptions = {
+export type AnswersRenderState = {
   /**
    * The matched hits from Algolia API.
    */
@@ -89,8 +90,16 @@ export type AnswersConnectorParams = {
   extraParameters?: FindAnswersOptions;
 };
 
+export type AnswersWidgetDescription = {
+  $$type: 'ais.answers';
+  renderState: AnswersRenderState;
+  indexRenderState: {
+    answers: WidgetRenderState<AnswersRenderState, AnswersConnectorParams>;
+  };
+};
+
 export type AnswersConnector = Connector<
-  AnswersRendererOptions,
+  AnswersWidgetDescription,
   AnswersConnectorParams
 >;
 

--- a/src/connectors/autocomplete/__tests__/connectAutocomplete-test.ts
+++ b/src/connectors/autocomplete/__tests__/connectAutocomplete-test.ts
@@ -10,14 +10,14 @@ import {
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import { createSingleSearchResponse } from '../../../../test/mock/createAPIResponse';
 import connectAutocomplete, {
-  AutocompleteRendererOptions,
+  AutocompleteRenderState,
 } from '../connectAutocomplete';
 import { TAG_PLACEHOLDER } from '../../../lib/utils';
 import { SearchClient } from '../../../types';
 
 describe('connectAutocomplete', () => {
   const getInitializedWidget = (config = {}) => {
-    const renderFn = jest.fn<any, [AutocompleteRendererOptions, boolean]>();
+    const renderFn = jest.fn<any, [AutocompleteRenderState, boolean]>();
     const makeWidget = connectAutocomplete(renderFn);
     const widget = makeWidget({
       ...config,

--- a/src/connectors/autocomplete/connectAutocomplete.ts
+++ b/src/connectors/autocomplete/connectAutocomplete.ts
@@ -9,7 +9,7 @@ import {
   noop,
   warning,
 } from '../../lib/utils';
-import { Hits, Connector } from '../../types';
+import { Hits, Connector, WidgetRenderState } from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'autocomplete',
@@ -25,7 +25,7 @@ export type AutocompleteConnectorParams = {
   escapeHTML?: boolean;
 };
 
-export type AutocompleteRendererOptions = {
+export type AutocompleteRenderState = {
   /**
    * The current value of the query.
    */
@@ -62,8 +62,20 @@ export type AutocompleteRendererOptions = {
   refine: (query: string) => void;
 };
 
+export type AutocompleteWidgetDescription = {
+  $$type: 'ais.autocomplete';
+  renderState: AutocompleteRenderState;
+  indexRenderState: {
+    autocomplete: WidgetRenderState<
+      AutocompleteRenderState,
+      AutocompleteConnectorParams
+    >;
+  };
+  indexUiState: { query: string };
+};
+
 export type AutocompleteConnector = Connector<
-  AutocompleteRendererOptions,
+  AutocompleteWidgetDescription,
   AutocompleteConnectorParams
 >;
 

--- a/src/connectors/breadcrumb/connectBreadcrumb.ts
+++ b/src/connectors/breadcrumb/connectBreadcrumb.ts
@@ -6,7 +6,12 @@ import {
   noop,
 } from '../../lib/utils';
 import { SearchParameters, SearchResults } from 'algoliasearch-helper';
-import { Connector, TransformItems, CreateURL } from '../../types';
+import {
+  Connector,
+  TransformItems,
+  CreateURL,
+  WidgetRenderState,
+} from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'breadcrumb',
@@ -49,7 +54,7 @@ export type BreadcrumbConnectorParams = {
   separator?: string;
 };
 
-export type BreadcrumbRendererOptions = {
+export type BreadcrumbRenderState = {
   /**
    * Creates the URL for a single item name in the list.
    */
@@ -71,8 +76,21 @@ export type BreadcrumbRendererOptions = {
   canRefine: boolean;
 };
 
+export type BreadcrumbWidgetDescription = {
+  $$type: 'ais.breadcrumb';
+  renderState: BreadcrumbRenderState;
+  indexRenderState: {
+    breadcrumb: {
+      [rootAttribute: string]: WidgetRenderState<
+        BreadcrumbRenderState,
+        BreadcrumbConnectorParams
+      >;
+    };
+  };
+};
+
 export type BreadcrumbConnector = Connector<
-  BreadcrumbRendererOptions,
+  BreadcrumbWidgetDescription,
   BreadcrumbConnectorParams
 >;
 
@@ -83,8 +101,8 @@ const connectBreadcrumb: BreadcrumbConnector = function connectBreadcrumb(
   checkRendering(renderFn, withUsage());
 
   type ConnectorState = {
-    refine?: BreadcrumbRendererOptions['refine'];
-    createURL?: BreadcrumbRendererOptions['createURL'];
+    refine?: BreadcrumbRenderState['refine'];
+    createURL?: BreadcrumbRenderState['createURL'];
   };
 
   const connectorState: ConnectorState = {};

--- a/src/connectors/clear-refinements/connectClearRefinements.ts
+++ b/src/connectors/clear-refinements/connectClearRefinements.ts
@@ -8,7 +8,12 @@ import {
   uniq,
   mergeSearchParameters,
 } from '../../lib/utils';
-import { TransformItems, CreateURL, Connector } from '../../types';
+import {
+  TransformItems,
+  CreateURL,
+  Connector,
+  WidgetRenderState,
+} from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'clear-refinements',
@@ -32,7 +37,7 @@ export type ClearRefinementsConnectorParams = {
   transformItems?: TransformItems<string>;
 };
 
-export type ClearRefinementsRendererOptions = {
+export type ClearRefinementsRenderState = {
   /**
    * Triggers the clear of all the currently refined values.
    */
@@ -55,8 +60,19 @@ export type ClearRefinementsRendererOptions = {
   createURL: CreateURL<void>;
 };
 
+export type ClearRefinementsWidgetDescription = {
+  $$type: 'ais.clearRefinements';
+  renderState: ClearRefinementsRenderState;
+  indexRenderState: {
+    clearRefinements: WidgetRenderState<
+      ClearRefinementsRenderState,
+      ClearRefinementsConnectorParams
+    >;
+  };
+};
+
 export type ClearRefinementsConnector = Connector<
-  ClearRefinementsRendererOptions,
+  ClearRefinementsWidgetDescription,
   ClearRefinementsConnectorParams
 >;
 

--- a/src/connectors/configure-related-items/connectConfigureRelatedItems.ts
+++ b/src/connectors/configure-related-items/connectConfigureRelatedItems.ts
@@ -10,7 +10,7 @@ import {
   getPropertyByPath,
 } from '../../lib/utils';
 import connectConfigure, {
-  ConfigureRendererOptions,
+  ConfigureWidgetDescription,
 } from '../configure/connectConfigure';
 
 export type MatchingPatterns = {
@@ -57,8 +57,12 @@ function createOptionalFilter({
   return `${attributeName}:${attributeValue}<score=${attributeScore || 1}>`;
 }
 
+export type ConfigureRelatedItemsWidgetDescription = {
+  $$type: 'ais.configureRelatedItems';
+} & Omit<ConfigureWidgetDescription, '$$type'>;
+
 export type ConfigureRelatedItemsConnector = Connector<
-  ConfigureRendererOptions,
+  ConfigureRelatedItemsWidgetDescription,
   ConfigureRelatedItemsConnectorParams
 >;
 

--- a/src/connectors/configure/connectConfigure.ts
+++ b/src/connectors/configure/connectConfigure.ts
@@ -3,7 +3,7 @@ import algoliasearchHelper, {
   PlainSearchParameters,
   AlgoliaSearchHelper,
 } from 'algoliasearch-helper';
-import { Connector } from '../../types';
+import { Connector, WidgetRenderState } from '../../types';
 import {
   createDocumentationMessageGenerator,
   isPlainObject,
@@ -24,7 +24,7 @@ export type ConfigureConnectorParams = {
   searchParameters: PlainSearchParameters;
 };
 
-export type ConfigureRendererOptions = {
+export type ConfigureRenderState = {
   /**
    * Refine the given search parameters.
    */
@@ -54,8 +54,22 @@ function getInitialSearchParameters(
   );
 }
 
+export type ConfigureWidgetDescription = {
+  $$type: 'ais.configure';
+  renderState: ConfigureRenderState;
+  indexRenderState: {
+    configure: WidgetRenderState<
+      ConfigureRenderState,
+      ConfigureConnectorParams
+    >;
+  };
+  indexUiState: {
+    configure: PlainSearchParameters;
+  };
+};
+
 export type ConfigureConnector = Connector<
-  ConfigureRendererOptions,
+  ConfigureWidgetDescription,
   ConfigureConnectorParams
 >;
 

--- a/src/connectors/current-refinements/connectCurrentRefinements.ts
+++ b/src/connectors/current-refinements/connectCurrentRefinements.ts
@@ -15,7 +15,12 @@ import {
   FacetRefinement,
   NumericRefinement,
 } from '../../lib/utils/getRefinements';
-import { Connector, TransformItems, CreateURL } from '../../types';
+import {
+  Connector,
+  TransformItems,
+  CreateURL,
+  WidgetRenderState,
+} from '../../types';
 
 export type CurrentRefinementsConnectorParamsRefinement = {
   /**
@@ -106,7 +111,7 @@ export type CurrentRefinementsConnectorParams = {
   transformItems?: TransformItems<CurrentRefinementsConnectorParamsItem>;
 };
 
-export type CurrentRefinementsRendererOptions = {
+export type CurrentRefinementsRenderState = {
   /**
    * All the currently refined items, grouped by attribute.
    */
@@ -133,8 +138,19 @@ const withUsage = createDocumentationMessageGenerator({
   connector: true,
 });
 
+export type CurrentRefinementsWidgetDescription = {
+  $$type: 'ais.currentRefinements';
+  renderState: CurrentRefinementsRenderState;
+  indexRenderState: {
+    currentRefinements: WidgetRenderState<
+      CurrentRefinementsRenderState,
+      CurrentRefinementsConnectorParams
+    >;
+  };
+};
+
 export type CurrentRefinementsConnector = Connector<
-  CurrentRefinementsRendererOptions,
+  CurrentRefinementsWidgetDescription,
   CurrentRefinementsConnectorParams
 >;
 

--- a/src/connectors/geo-search/types.ts
+++ b/src/connectors/geo-search/types.ts
@@ -1,0 +1,61 @@
+import { SendEventForHits } from '../../lib/utils';
+import {
+  Connector,
+  GeoLoc,
+  Hit,
+  TransformItems,
+  WidgetRenderState,
+} from '../../types';
+
+export type GeoHit = Hit & Required<Pick<Hit, '_geoLoc'>>;
+
+type Bounds = {
+  northEast: GeoLoc;
+  southWest: GeoLoc;
+};
+
+export type GeoSearchRenderState = {
+  currentRefinement?: Bounds;
+  position?: GeoLoc;
+  items: GeoHit[];
+  refine(bounds: Bounds): void;
+  clearMapRefinement(): void;
+  hasMapMoveSinceLastRefine(): boolean;
+  isRefineOnMapMove(): boolean;
+  isRefinedWithMap(): boolean;
+  setMapMoveSinceLastRefine(): void;
+  toggleRefineOnMapMove(): void;
+  sendEvent: SendEventForHits;
+};
+
+export type GeoSearchConnectorParams = {
+  enableRefineOnMapMove: boolean;
+  transformItems: TransformItems<GeoHit>;
+};
+
+export type GeoSearchWidgetDescription = {
+  $$type: 'ais.geoSearch';
+  renderState: GeoSearchRenderState;
+  indexRenderState: {
+    geoSearch: WidgetRenderState<
+      GeoSearchRenderState,
+      GeoSearchConnectorParams
+    >;
+  };
+  indexUiState: {
+    geoSearch: {
+      /**
+       * The rectangular area in geo coordinates.
+       * The rectangle is defined by two diagonally opposite points, hence by 4 floats separated by commas.
+       *
+       * @example '47.3165,4.9665,47.3424,5.0201'
+       */
+      boundingBox: string;
+    };
+  };
+};
+
+export type GeoSearchConnector = Connector<
+  GeoSearchWidgetDescription,
+  GeoSearchConnectorParams
+>;

--- a/src/connectors/hits-per-page/connectHitsPerPage.ts
+++ b/src/connectors/hits-per-page/connectHitsPerPage.ts
@@ -12,6 +12,7 @@ import {
   CreateURL,
   InitOptions,
   RenderOptions,
+  WidgetRenderState,
 } from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -19,7 +20,7 @@ const withUsage = createDocumentationMessageGenerator({
   connector: true,
 });
 
-export type HitsPerPageRendererOptionsItem = {
+export type HitsPerPageRenderStateItem = {
   /**
    * Label to display in the option.
    */
@@ -64,14 +65,14 @@ export type HitsPerPageConnectorParams = {
   /**
    * Function to transform the items passed to the templates.
    */
-  transformItems?: TransformItems<HitsPerPageRendererOptionsItem>;
+  transformItems?: TransformItems<HitsPerPageRenderStateItem>;
 };
 
-export type HitsPerPageRendererOptions = {
+export type HitsPerPageRenderState = {
   /**
    * Array of objects defining the different values and labels.
    */
-  items: HitsPerPageRendererOptionsItem[];
+  items: HitsPerPageRenderStateItem[];
 
   /**
    * Creates the URL for a single item name in the list.
@@ -91,8 +92,22 @@ export type HitsPerPageRendererOptions = {
   hasNoResults: boolean;
 };
 
+export type HitsPerPageWidgetDescription = {
+  $$type: 'ais.hitsPerPage';
+  renderState: HitsPerPageRenderState;
+  indexRenderState: {
+    hitsPerPage: WidgetRenderState<
+      HitsPerPageRenderState,
+      HitsPerPageConnectorParams
+    >;
+  };
+  indexUiState: {
+    hitsPerPage: number;
+  };
+};
+
 export type HitsPerPageConnector = Connector<
-  HitsPerPageRendererOptions,
+  HitsPerPageWidgetDescription,
   HitsPerPageConnectorParams
 >;
 
@@ -106,7 +121,7 @@ const connectHitsPerPage: HitsPerPageConnector = function connectHitsPerPage(
     const {
       items: userItems,
       transformItems = (items => items) as TransformItems<
-        HitsPerPageRendererOptionsItem
+        HitsPerPageRenderStateItem
       >,
     } = widgetParams || {};
 
@@ -148,7 +163,7 @@ const connectHitsPerPage: HitsPerPageConnector = function connectHitsPerPage(
       createURLFactory: (props: {
         state: SearchParameters;
         createURL: (InitOptions | RenderOptions)['createURL'];
-      }) => HitsPerPageRendererOptions['createURL'];
+      }) => HitsPerPageRenderState['createURL'];
     };
 
     const connectorState: ConnectorState = {

--- a/src/connectors/hits/connectHits.ts
+++ b/src/connectors/hits/connectHits.ts
@@ -11,7 +11,14 @@ import {
   BindEventForHits,
   noop,
 } from '../../lib/utils';
-import { TransformItems, Connector, Hits, Hit, AlgoliaHit } from '../../types';
+import {
+  TransformItems,
+  Connector,
+  Hits,
+  Hit,
+  AlgoliaHit,
+  WidgetRenderState,
+} from '../../types';
 import { SearchResults } from 'algoliasearch-helper';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -19,7 +26,7 @@ const withUsage = createDocumentationMessageGenerator({
   connector: true,
 });
 
-export type HitsRendererOptions = {
+export type HitsRenderState = {
   /**
    * The matched hits from Algolia API.
    */
@@ -55,7 +62,18 @@ export type HitsConnectorParams = {
   transformItems?: TransformItems<Hit>;
 };
 
-export type HitsConnector = Connector<HitsRendererOptions, HitsConnectorParams>;
+export type HitsWidgetDescription = {
+  $$type: 'ais.hits';
+  renderState: HitsRenderState;
+  indexRenderState: {
+    hits: WidgetRenderState<HitsRenderState, HitsConnectorParams>;
+  };
+};
+
+export type HitsConnector = Connector<
+  HitsWidgetDescription,
+  HitsConnectorParams
+>;
 
 const connectHits: HitsConnector = function connectHits(
   renderFn,

--- a/src/connectors/hits/connectHitsWithInsights.ts
+++ b/src/connectors/hits/connectHitsWithInsights.ts
@@ -1,7 +1,7 @@
 import { withInsights } from '../../lib/insights';
 import connectHits, {
-  HitsRendererOptions,
   HitsConnectorParams,
+  HitsWidgetDescription,
 } from './connectHits';
 import { Connector } from '../../types';
 
@@ -12,7 +12,7 @@ import { Connector } from '../../types';
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 declare type ImportWorkaround = Connector<
-  HitsRendererOptions,
+  HitsWidgetDescription,
   HitsConnectorParams
 >;
 

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -1,8 +1,15 @@
 import {
   AlgoliaSearchHelper as Helper,
+  PlainSearchParameters,
   SearchParameters,
 } from 'algoliasearch-helper';
-import { Hits, Connector, TransformItems, Hit } from '../../types';
+import {
+  Hits,
+  Connector,
+  TransformItems,
+  Hit,
+  WidgetRenderState,
+} from '../../types';
 import {
   escapeHits,
   TAG_PLACEHOLDER,
@@ -70,7 +77,7 @@ export type InfiniteHitsConnectorParams = {
   cache?: InfiniteHitsCache;
 };
 
-export type InfiniteHitsRendererOptions = {
+export type InfiniteHitsRenderState = {
   /**
    * Loads the previous results.
    */
@@ -112,19 +119,33 @@ const withUsage = createDocumentationMessageGenerator({
   connector: true,
 });
 
+export type InfiniteHitsWidgetDescription = {
+  $$type: 'ais.infiniteHits';
+  renderState: InfiniteHitsRenderState;
+  indexRenderState: {
+    infiniteHits: WidgetRenderState<
+      InfiniteHitsRenderState,
+      InfiniteHitsConnectorParams
+    >;
+  };
+  indexUiState: {
+    page: number;
+  };
+};
+
 export type InfiniteHitsConnector = Connector<
-  InfiniteHitsRendererOptions,
+  InfiniteHitsWidgetDescription,
   InfiniteHitsConnectorParams
 >;
 
-function getStateWithoutPage(state) {
+function getStateWithoutPage(state: PlainSearchParameters) {
   const { page, ...rest } = state || {};
   return rest;
 }
 
 function getInMemoryCache(): InfiniteHitsCache {
   let cachedHits: InfiniteHitsCachedHits | null = null;
-  let cachedState = undefined;
+  let cachedState: PlainSearchParameters | null = null;
   return {
     read({ state }) {
       return isEqual(cachedState, getStateWithoutPage(state))

--- a/src/connectors/infinite-hits/connectInfiniteHitsWithInsights.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHitsWithInsights.ts
@@ -1,6 +1,6 @@
 import { withInsights } from '../../lib/insights';
 import connectInfiniteHits, {
-  InfiniteHitsRendererOptions,
+  InfiniteHitsWidgetDescription,
   InfiniteHitsConnectorParams,
 } from './connectInfiniteHits';
 import { Connector } from '../../types';
@@ -12,7 +12,7 @@ import { Connector } from '../../types';
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 declare type ImportWorkaround = Connector<
-  InfiniteHitsRendererOptions,
+  InfiniteHitsWidgetDescription,
   InfiniteHitsConnectorParams
 >;
 

--- a/src/connectors/menu/__tests__/connectMenu-test.ts
+++ b/src/connectors/menu/__tests__/connectMenu-test.ts
@@ -12,13 +12,14 @@ import {
 import connectMenu, {
   MenuConnectorParams,
   MenuRenderState,
+  MenuWidgetDescription,
 } from '../connectMenu';
 import { WidgetFactory } from '../../../types';
 
 describe('connectMenu', () => {
   let rendering: jest.Mock<any, [MenuRenderState, boolean]>;
   let makeWidget: WidgetFactory<
-    MenuRenderState,
+    MenuWidgetDescription,
     MenuConnectorParams,
     MenuConnectorParams
   >;

--- a/src/connectors/menu/__tests__/connectMenu-test.ts
+++ b/src/connectors/menu/__tests__/connectMenu-test.ts
@@ -11,14 +11,14 @@ import {
 } from '../../../../test/mock/createWidget';
 import connectMenu, {
   MenuConnectorParams,
-  MenuRendererOptions,
+  MenuRenderState,
 } from '../connectMenu';
 import { WidgetFactory } from '../../../types';
 
 describe('connectMenu', () => {
-  let rendering: jest.Mock<any, [MenuRendererOptions, boolean]>;
+  let rendering: jest.Mock<any, [MenuRenderState, boolean]>;
   let makeWidget: WidgetFactory<
-    MenuRendererOptions,
+    MenuRenderState,
     MenuConnectorParams,
     MenuConnectorParams
   >;

--- a/src/connectors/menu/connectMenu.ts
+++ b/src/connectors/menu/connectMenu.ts
@@ -11,6 +11,7 @@ import {
   SortBy,
   TransformItems,
   Widget,
+  WidgetRenderState,
 } from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -66,7 +67,7 @@ export type MenuConnectorParams = {
   transformItems?: TransformItems<MenuItem>;
 };
 
-export type MenuRendererOptions = {
+export type MenuRenderState = {
   /**
    * The elements that can be refined for the current search results.
    */
@@ -102,7 +103,28 @@ export type MenuRendererOptions = {
   sendEvent: SendEventForFacet;
 };
 
-export type MenuConnector = Connector<MenuRendererOptions, MenuConnectorParams>;
+export type MenuWidgetDescription = {
+  $$type: 'ais.menu';
+  renderState: MenuRenderState;
+  indexRenderState: {
+    menu: {
+      [attribute: string]: WidgetRenderState<
+        MenuRenderState,
+        MenuConnectorParams
+      >;
+    };
+  };
+  indexUiState: {
+    menu: {
+      [attribute: string]: string;
+    };
+  };
+};
+
+export type MenuConnector = Connector<
+  MenuWidgetDescription,
+  MenuConnectorParams
+>;
 
 /**
  * **Menu** connector provides the logic to build a widget that will give the user the ability to choose a single value for a specific facet. The typical usage of menu is for navigation in categories.
@@ -139,9 +161,13 @@ const connectMenu: MenuConnector = function connectMenu(
       );
     }
 
-    let sendEvent: MenuRendererOptions['sendEvent'] | undefined;
-    let _createURL: MenuRendererOptions['createURL'] | undefined;
-    let _refine: MenuRendererOptions['refine'] | undefined;
+    type ThisWidget = Widget<
+      MenuWidgetDescription & { widgetParams: typeof widgetParams }
+    >;
+
+    let sendEvent: MenuRenderState['sendEvent'] | undefined;
+    let _createURL: MenuRenderState['createURL'] | undefined;
+    let _refine: MenuRenderState['refine'] | undefined;
 
     // Provide the same function to the `renderFn` so that way the user
     // has to only bind it once when `isFirstRendering` for instance
@@ -149,7 +175,7 @@ const connectMenu: MenuConnector = function connectMenu(
     let toggleShowMore = () => {};
     function createToggleShowMore(
       renderOptions: RenderOptions,
-      widget: Widget
+      widget: ThisWidget
     ) {
       return () => {
         isShowingMore = !isShowingMore;
@@ -217,7 +243,7 @@ const connectMenu: MenuConnector = function connectMenu(
           helper,
         } = renderOptions;
 
-        let items: MenuRendererOptions['items'] = [];
+        let items: MenuRenderState['items'] = [];
         let canToggleShowMore = false;
 
         if (!sendEvent) {

--- a/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.ts
+++ b/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.ts
@@ -4,8 +4,8 @@ import jsHelper, {
 } from 'algoliasearch-helper';
 import connectNumericMenu, {
   NumericMenuConnectorParamsItem,
-  NumericMenuRendererOptions,
-  NumericMenuRendererOptionsItem,
+  NumericMenuRenderState,
+  NumericMenuRenderStateItem,
 } from '../connectNumericMenu';
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import {
@@ -20,7 +20,7 @@ const encodeValue = (
 ) => window.encodeURI(JSON.stringify({ start, end }));
 const mapOptionsToItems: (
   item: NumericMenuConnectorParamsItem
-) => NumericMenuRendererOptionsItem = ({ start, end, label }) => ({
+) => NumericMenuRenderStateItem = ({ start, end, label }) => ({
   label,
   value: encodeValue(start, end),
   isRefined: false,
@@ -28,7 +28,7 @@ const mapOptionsToItems: (
 
 describe('connectNumericMenu', () => {
   const getInitializedWidget = () => {
-    const rendering = jest.fn<any, [NumericMenuRendererOptions, boolean]>();
+    const rendering = jest.fn<any, [NumericMenuRenderState, boolean]>();
     const makeWidget = connectNumericMenu(rendering);
     const widget = makeWidget({
       attribute: 'numerics',

--- a/src/connectors/numeric-menu/connectNumericMenu.ts
+++ b/src/connectors/numeric-menu/connectNumericMenu.ts
@@ -6,7 +6,12 @@ import {
   convertNumericRefinementsToFilters,
   noop,
 } from '../../lib/utils';
-import { Connector, CreateURL, TransformItems } from '../../types';
+import {
+  Connector,
+  CreateURL,
+  TransformItems,
+  WidgetRenderState,
+} from '../../types';
 import { SearchParameters } from 'algoliasearch-helper';
 import { InsightsEvent } from '../../middlewares';
 
@@ -32,7 +37,7 @@ export type NumericMenuConnectorParamsItem = {
   end?: number;
 };
 
-export type NumericMenuRendererOptionsItem = {
+export type NumericMenuRenderStateItem = {
   /**
    *  Name of the option.
    */
@@ -66,19 +71,19 @@ export type NumericMenuConnectorParams = {
   /**
    * Function to transform the items passed to the templates
    */
-  transformItems?: TransformItems<NumericMenuRendererOptionsItem>;
+  transformItems?: TransformItems<NumericMenuRenderStateItem>;
 };
 
-export type NumericMenuRendererOptions = {
+export type NumericMenuRenderState = {
   /**
    * The list of available choices
    */
-  items: NumericMenuRendererOptionsItem[];
+  items: NumericMenuRenderStateItem[];
 
   /**
    * Creates URLs for the next state, the string is the name of the selected option
    */
-  createURL: CreateURL<NumericMenuRendererOptionsItem['value']>;
+  createURL: CreateURL<NumericMenuRenderStateItem['value']>;
 
   /**
    * `true` if the last search contains no result
@@ -96,8 +101,27 @@ export type NumericMenuRendererOptions = {
   sendEvent: SendEventForFacet;
 };
 
+export type NumericMenuWidgetDescription = {
+  $$type: 'ais.numericMenu';
+  renderState: NumericMenuRenderState;
+  indexRenderState: {
+    numericMenu: {
+      [attribute: string]: WidgetRenderState<
+        NumericMenuRenderState,
+        NumericMenuConnectorParams
+      >;
+    };
+  };
+  indexUiState: {
+    numericMenu: {
+      // @TODO: this could possibly become `${number}:${number}` later
+      [attribute: string]: string;
+    };
+  };
+};
+
 export type NumericMenuConnector = Connector<
-  NumericMenuRendererOptions,
+  NumericMenuWidgetDescription,
   NumericMenuConnectorParams
 >;
 
@@ -148,9 +172,7 @@ const connectNumericMenu: NumericMenuConnector = function connectNumericMenu(
     const {
       attribute = '',
       items = [],
-      transformItems = (x => x) as TransformItems<
-        NumericMenuRendererOptionsItem
-      >,
+      transformItems = (x => x) as TransformItems<NumericMenuRenderStateItem>,
     } = widgetParams || {};
 
     if (attribute === '') {

--- a/src/connectors/pagination/__tests__/connectPagination-test.ts
+++ b/src/connectors/pagination/__tests__/connectPagination-test.ts
@@ -5,7 +5,7 @@ import algoliasearchHelper, {
 
 import connectPagination, {
   PaginationConnectorParams,
-  PaginationRendererOptions,
+  PaginationRenderState,
 } from '../connectPagination';
 import {
   createInitOptions,
@@ -18,7 +18,7 @@ describe('connectPagination', () => {
   const getInitializedWidget = (
     widgetParams: PaginationConnectorParams = {}
   ) => {
-    const renderFn = jest.fn<any, [PaginationRendererOptions, boolean]>();
+    const renderFn = jest.fn<any, [PaginationRenderState, boolean]>();
     const makeWidget = connectPagination(renderFn);
     const widget = makeWidget(widgetParams);
 

--- a/src/connectors/pagination/connectPagination.ts
+++ b/src/connectors/pagination/connectPagination.ts
@@ -4,7 +4,7 @@ import {
   noop,
 } from '../../lib/utils';
 import Paginator from './Paginator';
-import { Connector } from '../../types';
+import { Connector, WidgetRenderState } from '../../types';
 import { SearchParameters } from 'algoliasearch-helper';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -25,7 +25,7 @@ export type PaginationConnectorParams = {
   padding?: number;
 };
 
-export type PaginationRendererOptions = {
+export type PaginationRenderState = {
   /** Creates URLs for the next state, the number is the page to generate the URL for. */
   createURL(page: number): string;
 
@@ -54,8 +54,22 @@ export type PaginationRendererOptions = {
   isLastPage: boolean;
 };
 
-type ConnectPagination = Connector<
-  PaginationRendererOptions,
+export type PaginationWidgetDescription = {
+  $$type: 'ais.pagination';
+  renderState: PaginationRenderState;
+  indexRenderState: {
+    pagination: WidgetRenderState<
+      PaginationRenderState,
+      PaginationConnectorParams
+    >;
+  };
+  indexUiState: {
+    page: number;
+  };
+};
+
+type PaginationConnector = Connector<
+  PaginationWidgetDescription,
   PaginationConnectorParams
 >;
 
@@ -66,7 +80,7 @@ type ConnectPagination = Connector<
  * When using the pagination with Algolia, you should be aware that the engine won't provide you pages
  * beyond the 1000th hits by default. You can find more information on the [Algolia documentation](https://www.algolia.com/doc/guides/searching/pagination/#pagination-limitations).
  */
-const connectPagination: ConnectPagination = function connectPagination(
+const connectPagination: PaginationConnector = function connectPagination(
   renderFn,
   unmountFn = noop
 ) {

--- a/src/connectors/powered-by/connectPoweredBy.ts
+++ b/src/connectors/powered-by/connectPoweredBy.ts
@@ -3,14 +3,14 @@ import {
   createDocumentationMessageGenerator,
   noop,
 } from '../../lib/utils';
-import { Connector } from '../../types';
+import { Connector, WidgetRenderState } from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'powered-by',
   connector: true,
 });
 
-export type PoweredByRendererOptions = {
+export type PoweredByRenderState = {
   /** the url to redirect to on click */
   url: string;
 };
@@ -20,8 +20,19 @@ export type PoweredByConnectorParams = {
   url?: string;
 };
 
+export type PoweredByWidgetDescription = {
+  $$type: 'ais.poweredBy';
+  renderState: PoweredByRenderState;
+  indexRenderState: {
+    poweredBy: WidgetRenderState<
+      PoweredByRenderState,
+      PoweredByConnectorParams
+    >;
+  };
+};
+
 export type PoweredByConnector = Connector<
-  PoweredByRendererOptions,
+  PoweredByWidgetDescription,
   PoweredByConnectorParams
 >;
 

--- a/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
+++ b/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
@@ -10,9 +10,7 @@ import {
   createRenderOptions,
 } from '../../../../test/mock/createWidget';
 import { createSingleSearchResponse } from '../../../../test/mock/createAPIResponse';
-import connectQueryRules, {
-  QueryRulesRendererOptions,
-} from '../connectQueryRules';
+import connectQueryRules from '../connectQueryRules';
 
 describe('connectQueryRules', () => {
   function createWidget() {
@@ -200,12 +198,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
     test('does not throw without the unmount function', () => {
       const helper = createFakeHelper();
       const rendering = () => {};
-      const makeWidget = connectQueryRules<QueryRulesRendererOptions>(
-        rendering
-      );
-      const widget = makeWidget({
-        items: [] as any[],
-      });
+      const makeWidget = connectQueryRules(rendering);
+      const widget = makeWidget({});
 
       widget.init!(
         createInitOptions({

--- a/src/connectors/query-rules/connectQueryRules.ts
+++ b/src/connectors/query-rules/connectQueryRules.ts
@@ -2,7 +2,7 @@ import {
   AlgoliaSearchHelper as Helper,
   SearchParameters,
 } from 'algoliasearch-helper';
-import { Connector, TransformItems } from '../../types';
+import { Connector, TransformItems, WidgetRenderState } from '../../types';
 import {
   checkRendering,
   createDocumentationMessageGenerator,
@@ -32,7 +32,7 @@ export type QueryRulesConnectorParams = {
   transformItems?: ParamTransformItems;
 };
 
-export type QueryRulesRendererOptions = {
+export type QueryRulesRenderState = {
   items: any[];
 };
 
@@ -146,8 +146,19 @@ Consider using \`transformRuleContexts\` to minimize the number of rules sent to
   }
 }
 
+export type QueryRulesWidgetDescription = {
+  $$type: 'ais.queryRules';
+  renderState: QueryRulesRenderState;
+  indexRenderState: {
+    queryRules: WidgetRenderState<
+      QueryRulesRenderState,
+      QueryRulesConnectorParams
+    >;
+  };
+};
+
 export type QueryRulesConnector = Connector<
-  QueryRulesRendererOptions,
+  QueryRulesWidgetDescription,
   QueryRulesConnectorParams
 >;
 

--- a/src/connectors/range/connectRange.ts
+++ b/src/connectors/range/connectRange.ts
@@ -13,7 +13,7 @@ import {
   SendEventForFacet,
 } from '../../lib/utils';
 import { InsightsEvent } from '../../middlewares';
-import { Connector, InstantSearch } from '../../types';
+import { Connector, InstantSearch, WidgetRenderState } from '../../types';
 
 const withUsage = createDocumentationMessageGenerator(
   { name: 'range-input', connector: true },
@@ -32,7 +32,7 @@ export type Range = {
   max: RangeMax;
 };
 
-export type RangeRendererOptions = {
+export type RangeRenderState = {
   /**
    * Sets a range to filter the results on. Both values
    * are optional, and will default to the higher and lower bounds. You can use `undefined` to remove a
@@ -93,8 +93,27 @@ export type RangeConnectorParams = {
   precision?: number;
 };
 
-export type ConnectRange = Connector<
-  RangeRendererOptions,
+export type RangeWidgetDescription = {
+  $$type: 'ais.range';
+  renderState: RangeRenderState;
+  indexRenderState: {
+    range: {
+      [attribute: string]: WidgetRenderState<
+        RangeRenderState,
+        RangeConnectorParams
+      >;
+    };
+  };
+  indexUiState: {
+    range: {
+      // @TODO: this could possibly become `${number}:${number}` later
+      [attribute: string]: string;
+    };
+  };
+};
+
+export type RangeConnector = Connector<
+  RangeWidgetDescription,
   RangeConnectorParams
 >;
 
@@ -114,7 +133,7 @@ function toPrecision({ min, max, precision }) {
  * This connectors provides a `refine()` function that accepts bounds. It will also provide
  * information about the min and max bounds for the current result set.
  */
-const connectRange: ConnectRange = function connectRange(
+const connectRange: RangeConnector = function connectRange(
   renderFn,
   unmountFn = noop
 ) {

--- a/src/connectors/rating-menu/connectRatingMenu.ts
+++ b/src/connectors/rating-menu/connectRatingMenu.ts
@@ -10,7 +10,12 @@ import {
   noop,
   warning,
 } from '../../lib/utils';
-import { Connector, InstantSearch, CreateURL } from '../../types';
+import {
+  Connector,
+  InstantSearch,
+  CreateURL,
+  WidgetRenderState,
+} from '../../types';
 import { InsightsEvent } from '../../middlewares';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -101,7 +106,7 @@ export type RatingMenuConnectorParams = {
   max?: number;
 };
 
-export type RatingMenuRendererOptions = {
+export type RatingMenuRenderState = {
   /**
    * Possible star ratings the user can apply.
    */
@@ -133,8 +138,26 @@ export type RatingMenuRendererOptions = {
   sendEvent: SendEvent;
 };
 
-export type ConnectRatingMenu = Connector<
-  RatingMenuRendererOptions,
+export type RatingMenuWidgetDescription = {
+  $$type: 'ais.ratingMenu';
+  renderState: RatingMenuRenderState;
+  indexRenderState: {
+    ratingMenu: {
+      [attribute: string]: WidgetRenderState<
+        RatingMenuRenderState,
+        RatingMenuConnectorParams
+      >;
+    };
+  };
+  indexUiState: {
+    ratingMenu: {
+      [attribute: string]: number;
+    };
+  };
+};
+
+export type RatingMenuConnector = Connector<
+  RatingMenuWidgetDescription,
   RatingMenuConnectorParams
 >;
 
@@ -146,7 +169,7 @@ export type ConnectRatingMenu = Connector<
  * `items` that are the values that can be selected. `refine` should be used
  * with `items.value`.
  */
-const connectRatingMenu: ConnectRatingMenu = function connectRatingMenu(
+const connectRatingMenu: RatingMenuConnector = function connectRatingMenu(
   renderFn,
   unmountFn = noop
 ) {

--- a/src/connectors/relevant-sort/__tests__/connectRelevantSort-test.ts
+++ b/src/connectors/relevant-sort/__tests__/connectRelevantSort-test.ts
@@ -249,7 +249,7 @@ describe('connectRelevantSort', () => {
         {},
         { helper, searchParameters: helper.state }
       );
-      expect(widgetUiState.relevantSort?.relevancyStrictness).toBeUndefined();
+      expect(widgetUiState.relevantSort).toBeUndefined();
     });
 
     it('add refined parameters', () => {
@@ -266,7 +266,7 @@ describe('connectRelevantSort', () => {
       expect(
         widget.getWidgetUiState!({}, { helper, searchParameters: helper.state })
       ).toEqual({
-        relevantSort: { relevancyStrictness: 25 },
+        relevantSort: 25,
       });
     });
 
@@ -277,11 +277,11 @@ describe('connectRelevantSort', () => {
 
       expect(
         widget.getWidgetUiState!(
-          { relevantSort: { relevancyStrictness: 25 } },
+          { relevantSort: 25 },
           { helper, searchParameters: helper.state }
         )
       ).toEqual({
-        relevantSort: { relevancyStrictness: undefined },
+        relevantSort: undefined,
       });
 
       const { refine } = widget.getWidgetRenderState(
@@ -292,11 +292,11 @@ describe('connectRelevantSort', () => {
       // applies 30 from searchParameters
       expect(
         widget.getWidgetUiState!(
-          { relevantSort: { relevancyStrictness: 25 } },
+          { relevantSort: 25 },
           { helper, searchParameters: helper.state }
         )
       ).toEqual({
-        relevantSort: { relevancyStrictness: 30 },
+        relevantSort: 30,
       });
     });
   });
@@ -323,9 +323,7 @@ describe('connectRelevantSort', () => {
         new SearchParameters(),
         {
           uiState: {
-            relevantSort: {
-              relevancyStrictness: 15,
-            },
+            relevantSort: 15,
           },
         }
       );
@@ -364,9 +362,7 @@ describe('connectRelevantSort', () => {
         new SearchParameters(),
         {
           uiState: {
-            relevantSort: {
-              relevancyStrictness: 15,
-            },
+            relevantSort: 15,
           },
         }
       );

--- a/src/connectors/relevant-sort/__tests__/connectRelevantSort-test.ts
+++ b/src/connectors/relevant-sort/__tests__/connectRelevantSort-test.ts
@@ -281,7 +281,7 @@ describe('connectRelevantSort', () => {
           { helper, searchParameters: helper.state }
         )
       ).toEqual({
-        relevantSort: undefined,
+        relevantSort: 25,
       });
 
       const { refine } = widget.getWidgetRenderState(

--- a/src/connectors/relevant-sort/connectRelevantSort.ts
+++ b/src/connectors/relevant-sort/connectRelevantSort.ts
@@ -131,7 +131,7 @@ const connectRelevantSort: RelevantSortConnector = function connectRelevantSort(
         return {
           ...uiState,
           relevantSort:
-            uiState.relevantSort || searchParameters.relevancyStrictness,
+            searchParameters.relevancyStrictness || uiState.relevantSort,
         };
       },
     };

--- a/src/connectors/relevant-sort/connectRelevantSort.ts
+++ b/src/connectors/relevant-sort/connectRelevantSort.ts
@@ -1,11 +1,11 @@
-import { Connector } from '../../types';
+import { Connector, WidgetRenderState } from '../../types';
 import { noop } from '../../lib/utils';
 
 export type RelevantSortConnectorParams = Record<string, unknown>;
 
 type Refine = (relevancyStrictness: number) => void;
 
-export type RelevantSortRendererOptions = {
+export type RelevantSortRenderState = {
   /**
    * Indicates if it has appliedRelevancyStrictness greater than zero
    */
@@ -27,8 +27,22 @@ export type RelevantSortRendererOptions = {
   refine: Refine;
 };
 
+export type RelevantSortWidgetDescription = {
+  $$type: 'ais.relevantSort';
+  renderState: RelevantSortRenderState;
+  indexRenderState: {
+    relevantSort: WidgetRenderState<
+      RelevantSortRenderState,
+      RelevantSortConnectorParams
+    >;
+  };
+  indexUiState: {
+    relevantSort: number;
+  };
+};
+
 export type RelevantSortConnector = Connector<
-  RelevantSortRendererOptions,
+  RelevantSortWidgetDescription,
   RelevantSortConnectorParams
 >;
 
@@ -109,17 +123,15 @@ const connectRelevantSort: RelevantSortConnector = function connectRelevantSort(
       getWidgetSearchParameters(state, { uiState }) {
         return state.setQueryParameter(
           'relevancyStrictness',
-          uiState.relevantSort?.relevancyStrictness ?? state.relevancyStrictness
+          uiState.relevantSort ?? state.relevancyStrictness
         );
       },
 
       getWidgetUiState(uiState, { searchParameters }) {
         return {
           ...uiState,
-          relevantSort: {
-            ...uiState.relevantSort,
-            relevancyStrictness: searchParameters.relevancyStrictness,
-          },
+          relevantSort:
+            uiState.relevantSort || searchParameters.relevancyStrictness,
         };
       },
     };

--- a/src/connectors/search-box/connectSearchBox.ts
+++ b/src/connectors/search-box/connectSearchBox.ts
@@ -4,7 +4,7 @@ import {
   createDocumentationMessageGenerator,
   noop,
 } from '../../lib/utils';
-import { Connector } from '../../types';
+import { Connector, WidgetRenderState } from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'search-box',
@@ -31,7 +31,7 @@ export type SearchBoxConnectorParams = {
  * This queryHook can be used to debounce the number of searches done from the searchBox.
  */
 
-export type SearchBoxRendererOptions = {
+export type SearchBoxRenderState = {
   /**
    * The query from the last search.
    */
@@ -52,8 +52,22 @@ export type SearchBoxRendererOptions = {
   isSearchStalled: boolean;
 };
 
-export type ConnectSearchBox = Connector<
-  SearchBoxRendererOptions,
+export type SearchBoxWidgetDescription = {
+  $$type: 'ais.searchBox';
+  renderState: SearchBoxRenderState;
+  indexRenderState: {
+    searchBox: WidgetRenderState<
+      SearchBoxRenderState,
+      SearchBoxConnectorParams
+    >;
+  };
+  indexUiState: {
+    query: string;
+  };
+};
+
+export type SearchBoxConnector = Connector<
+  SearchBoxWidgetDescription,
   SearchBoxConnectorParams
 >;
 
@@ -63,7 +77,7 @@ export type ConnectSearchBox = Connector<
  * The connector provides to the rendering: `refine()` to set the query. The behaviour of this function
  * may be impacted by the `queryHook` widget parameter.
  */
-const connectSearchBox: ConnectSearchBox = function connectSearchBox(
+const connectSearchBox: SearchBoxConnector = function connectSearchBox(
   renderFn,
   unmountFn = noop
 ) {
@@ -78,7 +92,7 @@ const connectSearchBox: ConnectSearchBox = function connectSearchBox(
       };
     }
 
-    let _refine: SearchBoxRendererOptions['refine'];
+    let _refine: SearchBoxRenderState['refine'];
     let _clear = () => {};
     function _cachedClear() {
       _clear();

--- a/src/connectors/sort-by/__tests__/connectSortBy-test.ts
+++ b/src/connectors/sort-by/__tests__/connectSortBy-test.ts
@@ -3,7 +3,7 @@ import algoliasearchHelper, {
   SearchParameters,
 } from 'algoliasearch-helper';
 
-import connectSortBy, { SortByRendererOptions } from '../connectSortBy';
+import connectSortBy, { SortByRenderState } from '../connectSortBy';
 import index from '../../../widgets/index/index';
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import { createInstantSearch } from '../../../../test/mock/createInstantSearch';
@@ -510,7 +510,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
 
   describe('routing', () => {
     const getInitializedWidget = (config = {}) => {
-      const rendering = jest.fn<any, [SortByRendererOptions, boolean]>();
+      const rendering = jest.fn<any, [SortByRenderState, boolean]>();
       const makeWidget = connectSortBy(rendering);
       const instantSearchInstance = createInstantSearch({
         indexName: 'relevance',

--- a/src/connectors/sort-by/connectSortBy.ts
+++ b/src/connectors/sort-by/connectSortBy.ts
@@ -5,7 +5,7 @@ import {
   warning,
   noop,
 } from '../../lib/utils';
-import { Connector, TransformItems } from '../../types';
+import { Connector, TransformItems, WidgetRenderState } from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'sort-by',
@@ -40,7 +40,7 @@ export type SortByConnectorParams = {
   transformItems?: TransformItems<SortByItem>;
 };
 
-export type SortByRendererOptions = {
+export type SortByRenderState = {
   /**
    * The initially selected index.
    */
@@ -63,8 +63,19 @@ export type SortByRendererOptions = {
   hasNoResults: boolean;
 };
 
+export type SortByWidgetDescription = {
+  $$type: 'ais.sortBy';
+  renderState: SortByRenderState;
+  indexRenderState: {
+    sortBy: WidgetRenderState<SortByRenderState, SortByConnectorParams>;
+  };
+  indexUiState: {
+    sortBy: string;
+  };
+};
+
 export type SortByConnector = Connector<
-  SortByRendererOptions,
+  SortByWidgetDescription,
   SortByConnectorParams
 >;
 

--- a/src/connectors/stats/__tests__/connectStats-test.ts
+++ b/src/connectors/stats/__tests__/connectStats-test.ts
@@ -7,11 +7,11 @@ import {
   createRenderOptions,
 } from '../../../../test/mock/createWidget';
 
-import connectStats, { StatsRendererOptions } from '../connectStats';
+import connectStats, { StatsRenderState } from '../connectStats';
 
 describe('connectStats', () => {
   const getInitializedWidget = (config = {}) => {
-    const renderFn = jest.fn<any, [StatsRendererOptions, boolean]>();
+    const renderFn = jest.fn<any, [StatsRenderState, boolean]>();
     const makeWidget = connectStats(renderFn);
     const widget = makeWidget({
       ...config,

--- a/src/connectors/stats/connectStats.ts
+++ b/src/connectors/stats/connectStats.ts
@@ -3,7 +3,7 @@ import {
   createDocumentationMessageGenerator,
   noop,
 } from '../../lib/utils';
-import { Connector } from '../../types';
+import { Connector, WidgetRenderState } from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'stats',
@@ -15,7 +15,7 @@ const withUsage = createDocumentationMessageGenerator({
  * search statistics (hits number and processing time).
  */
 
-export type StatsRendererOptions = {
+export type StatsRenderState = {
   /**
    * The maximum number of hits per page returned by Algolia.
    */
@@ -52,8 +52,16 @@ export type StatsRendererOptions = {
 
 export type StatsConnectorParams = Record<string, unknown>;
 
+export type StatsWidgetDescription = {
+  $$type: 'ais.stats';
+  renderState: StatsRenderState;
+  indexRenderState: {
+    stats: WidgetRenderState<StatsRenderState, StatsConnectorParams>;
+  };
+};
+
 export type StatsConnector = Connector<
-  StatsRendererOptions,
+  StatsWidgetDescription,
   StatsConnectorParams
 >;
 

--- a/src/connectors/toggle-refinement/__tests__/connectToggleRefinement-test.js
+++ b/src/connectors/toggle-refinement/__tests__/connectToggleRefinement-test.js
@@ -880,26 +880,27 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
       );
 
       expect(renderState.toggleRefinement).toEqual({
-        createURL: expect.any(Function),
-        canRefine: false,
-        refine: expect.any(Function),
-        sendEvent: expect.any(Function),
-        state: helper.state,
-        value: {
-          count: null,
-          isRefined: false,
-          name: 'isShippingFree',
-          offFacetValue: {
-            count: 0,
+        isShippingFree: {
+          createURL: expect.any(Function),
+          canRefine: false,
+          refine: expect.any(Function),
+          sendEvent: expect.any(Function),
+          value: {
+            count: null,
             isRefined: false,
+            name: 'isShippingFree',
+            offFacetValue: {
+              count: 0,
+              isRefined: false,
+            },
+            onFacetValue: {
+              count: 0,
+              isRefined: false,
+            },
           },
-          onFacetValue: {
-            count: 0,
-            isRefined: false,
+          widgetParams: {
+            attribute: 'isShippingFree',
           },
-        },
-        widgetParams: {
-          attribute: 'isShippingFree',
         },
       });
     });
@@ -927,26 +928,27 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
       );
 
       expect(renderState.toggleRefinement).toEqual({
-        createURL: expect.any(Function),
-        canRefine: true,
-        refine: expect.any(Function),
-        sendEvent: expect.any(Function),
-        state: helper.state,
-        value: {
-          count: 45,
-          isRefined: false,
-          name: 'isShippingFree',
-          offFacetValue: {
-            count: 85,
-            isRefined: false,
-          },
-          onFacetValue: {
+        isShippingFree: {
+          createURL: expect.any(Function),
+          canRefine: true,
+          refine: expect.any(Function),
+          sendEvent: expect.any(Function),
+          value: {
             count: 45,
             isRefined: false,
+            name: 'isShippingFree',
+            offFacetValue: {
+              count: 85,
+              isRefined: false,
+            },
+            onFacetValue: {
+              count: 45,
+              isRefined: false,
+            },
           },
-        },
-        widgetParams: {
-          attribute: 'isShippingFree',
+          widgetParams: {
+            attribute: 'isShippingFree',
+          },
         },
       });
     });
@@ -979,7 +981,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
         canRefine: false,
         refine: expect.any(Function),
         sendEvent: expect.any(Function),
-        state: helper.state,
         value: {
           count: null,
           isRefined: true,
@@ -1025,7 +1026,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
         canRefine: true,
         refine: expect.any(Function),
         sendEvent: expect.any(Function),
-        state: helper.state,
         value: {
           count: 345,
           isRefined: false,

--- a/src/connectors/toggle-refinement/connectToggleRefinement.js
+++ b/src/connectors/toggle-refinement/connectToggleRefinement.js
@@ -218,7 +218,10 @@ export default function connectToggleRefinement(renderFn, unmountFn = noop) {
       getRenderState(renderState, renderOptions) {
         return {
           ...renderState,
-          toggleRefinement: this.getWidgetRenderState(renderOptions),
+          toggleRefinement: {
+            ...renderState.toggleRefinement,
+            [attribute]: this.getWidgetRenderState(renderOptions),
+          },
         };
       },
 
@@ -303,7 +306,6 @@ export default function connectToggleRefinement(renderFn, unmountFn = noop) {
             onFacetValue,
             offFacetValue,
           },
-          state,
           createURL: connectorState.createURLFactory(isRefined, {
             state,
             createURL,

--- a/src/connectors/toggle-refinement/types.ts
+++ b/src/connectors/toggle-refinement/types.ts
@@ -1,0 +1,50 @@
+import { SendEventForFacet } from '../../lib/utils';
+import { Connector, CreateURL, WidgetRenderState } from '../../types';
+
+type ToggleRefinementConnectorParams = {
+  attribute: string;
+  on: string | string[];
+  off: string | string[];
+};
+
+type FacetValue = {
+  isRefined: boolean;
+  count: number;
+};
+
+type ToggleRefinementRenderState = {
+  value: {
+    name: string;
+    isRefined: boolean;
+    count: number | null;
+    onFacetValue: FacetValue;
+    offFacetValue: FacetValue;
+  };
+  createURL: CreateURL<string>;
+  sendEvent: SendEventForFacet;
+  canRefine: boolean;
+  refine: (value: string) => void;
+};
+
+export type ToggleRefinementWidgetDescription = {
+  $$type: 'ais.toggleRefinement';
+  renderState: ToggleRefinementRenderState;
+  indexRenderState: {
+    toggleRefinement: {
+      [attribute: string]: WidgetRenderState<
+        ToggleRefinementRenderState,
+        ToggleRefinementConnectorParams
+      >;
+    };
+  };
+  indexUiState: {
+    toggleRefinement: {
+      [attribute: string]: boolean;
+    };
+  };
+};
+
+export type ToggleRefinementConnector = Connector<
+  ToggleRefinementWidgetDescription,
+  ToggleRefinementConnectorParams
+>;

--- a/src/connectors/toggle-refinement/types.ts
+++ b/src/connectors/toggle-refinement/types.ts
@@ -38,7 +38,7 @@ export type ToggleRefinementWidgetDescription = {
     };
   };
   indexUiState: {
-    toggleRefinement: {
+    toggle: {
       [attribute: string]: boolean;
     };
   };

--- a/src/connectors/voice-search/connectVoiceSearch.ts
+++ b/src/connectors/voice-search/connectVoiceSearch.ts
@@ -4,7 +4,7 @@ import {
   createDocumentationMessageGenerator,
   noop,
 } from '../../lib/utils';
-import { Connector } from '../../types';
+import { Connector, WidgetRenderState } from '../../types';
 import builtInCreateVoiceSearchHelper from '../../lib/voiceSearchHelper';
 import {
   CreateVoiceSearchHelper,
@@ -25,15 +25,29 @@ export type VoiceSearchConnectorParams = {
   createVoiceSearchHelper?: CreateVoiceSearchHelper;
 };
 
-export type VoiceSearchRendererOptions = {
+export type VoiceSearchRenderState = {
   isBrowserSupported: boolean;
   isListening: boolean;
   toggleListening: () => void;
   voiceListeningState: VoiceListeningState;
 };
 
+export type VoiceSearchWidgetDescription = {
+  $$type: 'ais.voiceSearch';
+  renderState: VoiceSearchRenderState;
+  indexRenderState: {
+    voiceSearch: WidgetRenderState<
+      VoiceSearchRenderState,
+      VoiceSearchConnectorParams
+    >;
+  };
+  indexUiState: {
+    query: string;
+  };
+};
+
 export type VoiceSearchConnector = Connector<
-  VoiceSearchRendererOptions,
+  VoiceSearchWidgetDescription,
   VoiceSearchConnectorParams
 >;
 

--- a/src/types/connector.ts
+++ b/src/types/connector.ts
@@ -8,7 +8,7 @@ import { Widget, WidgetDescription } from './widget';
  * The base renderer options. All render functions receive
  * the options below plus the specific options per connector.
  */
-export type RenderState<TWidgetParams> = {
+export type RendererOptions<TWidgetParams> = {
   /**
    * The original widget params. Useful as you may
    * need them while using the render function.
@@ -44,7 +44,7 @@ export type Renderer<TRenderState, TWidgetParams> = (
   /**
    * The base render options plus the specific options of the widget.
    */
-  renderState: TRenderState & RenderState<TWidgetParams>,
+  renderState: TRenderState & RendererOptions<TWidgetParams>,
 
   /**
    * If is the first run.

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -155,7 +155,12 @@ type WidgetType<
   TWidgetDescription extends WidgetDescription
 > = TWidgetDescription extends RequiredKeys<WidgetDescription, '$$widgetType'>
   ? RequiredWidgetType<TWidgetDescription>
-  : Partial<RequiredWidgetType<TWidgetDescription>>;
+  : {
+      /**
+       * Identifier for widgets.
+       */
+      $$widgetType?: string;
+    };
 
 type RequiredUiStateLifeCycle<TWidgetDescription extends WidgetDescription> = {
   /**


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

migrates all the connectors to the new type from #4734 

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

fixes some smaller things in the tests, plus implementation of refinementList (removed dead code)

- connectToggleRefinement: nest `getRenderState` per attribute
- connectToggleRefinement: remove `state` state from getWidgetRenderState
- connectRefinementList: remove dead code in getWidgetRenderState
- connectRelevantSort: remove "relevantSort" nesting, since there's only one property

These are technically breaking changes, but small enough to just be listed in the changeling IMO

