### PR TITLE
fix(insights): use getUserToken method instead of _get

### DIFF
--- a/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -86,25 +86,6 @@ describe('insights', () => {
   });
 
   describe('initialize', () => {
-    it('initialize insightsClient', () => {
-      const { insightsClient, instantSearchInstance } = createTestEnvironment();
-      expect.assertions(3);
-
-      insightsClient('setUserToken', 'abc');
-      createInsightsMiddleware({
-        insightsClient,
-      })({ instantSearchInstance });
-      insightsClient('_get', '_hasCredentials', hasCredentials => {
-        expect(hasCredentials).toBe(true);
-      });
-      insightsClient('_get', '_appId', appId => {
-        expect(appId).toBe('myAppId');
-      });
-      insightsClient('_get', '_apiKey', apiKey => {
-        expect(apiKey).toBe('myApiKey');
-      });
-    });
-
     it('passes initParams to insightsClient', () => {
       const { insightsClient, instantSearchInstance } = createTestEnvironment();
       createInsightsMiddleware({
@@ -299,7 +280,7 @@ describe('insights', () => {
         insightsClient('setUserToken', 'token-from-queue');
         libraryLoadedAndProcessQueue();
 
-        insightsClient('_get', '_userToken', userToken => {
+        insightsClient('getUserToken', null, (_error, userToken) => {
           expect(userToken).toEqual('token-from-queue');
         });
 
@@ -322,7 +303,7 @@ describe('insights', () => {
         insightsClient('init', { appId: 'myAppId', apiKey: 'myApiKey' });
         insightsClient('setUserToken', 'token-from-queue');
 
-        insightsClient('_get', '_userToken', userToken => {
+        insightsClient('getUserToken', null, (_error, userToken) => {
           expect(userToken).toEqual('token-from-queue');
         });
 

--- a/src/middlewares/createInsightsMiddleware.ts
+++ b/src/middlewares/createInsightsMiddleware.ts
@@ -75,7 +75,7 @@ export const createInsightsMiddleware: CreateInsightsMiddleware = props => {
           ([method]) => method === 'setUserToken'
         ) || [];
     }
-    insightsClient('_get', '_userToken', (userToken: string) => {
+    insightsClient('getUserToken', null, (userToken: string) => {
       // If user has called `aa('setUserToken', 'my-user-token')` before creating
       // the `insights` middleware, we store them temporarily and
       // set it later on.

--- a/src/middlewares/createInsightsMiddleware.ts
+++ b/src/middlewares/createInsightsMiddleware.ts
@@ -75,7 +75,7 @@ export const createInsightsMiddleware: CreateInsightsMiddleware = props => {
           ([method]) => method === 'setUserToken'
         ) || [];
     }
-    insightsClient('getUserToken', null, (userToken: string) => {
+    insightsClient('getUserToken', null, (_error: any, userToken: string) => {
       // If user has called `aa('setUserToken', 'my-user-token')` before creating
       // the `insights` middleware, we store them temporarily and
       // set it later on.

--- a/src/types/insights.ts
+++ b/src/types/insights.ts
@@ -31,7 +31,7 @@ export type InsightsOnUserTokenChange = (
 export type InsightsGetUserToken = (
   method: 'getUserToken',
   options?: any,
-  callback?: (userToken: string) => void
+  callback?: (error: any, userToken: string) => void
 ) => void;
 
 export type InsightsInit = (

--- a/src/types/insights.ts
+++ b/src/types/insights.ts
@@ -28,10 +28,10 @@ export type InsightsOnUserTokenChange = (
   options?: { immediate?: boolean }
 ) => void;
 
-export type InsightsGet = (
-  method: '_get',
-  key: string,
-  callback: (value: any) => void
+export type InsightsGetUserToken = (
+  method: 'getUserToken',
+  options?: any,
+  callback?: (userToken: string) => void
 ) => void;
 
 export type InsightsInit = (
@@ -44,7 +44,7 @@ export type InsightsInit = (
 
 export type InsightsClient = InsightsSendEvent &
   InsightsOnUserTokenChange &
-  InsightsGet &
+  InsightsGetUserToken &
   InsightsInit &
   InsightsSetUserToken & {
     queue?: Array<[string, any]>;

--- a/test/mock/createInsightsClient.ts
+++ b/test/mock/createInsightsClient.ts
@@ -3,7 +3,10 @@ export const ANONYMOUS_TOKEN = 'anonymous-user-id-1';
 export type AlgoliaAnalytics = {
   setUserToken(userToken: string): void;
   init({ appId, apiKey }): void;
-  _get(key: string, callback: (value: any) => void): void;
+  getUserToken(
+    options: any,
+    callback: (error: any, userToken: string) => void
+  ): void;
   onUserTokenChange(
     callback: (value: string) => void,
     options?: { immediate?: boolean }
@@ -30,7 +33,8 @@ export function createAlgoliaAnalytics(): AlgoliaAnalytics {
     setValues({ _hasCredentials: true, _appId: appId, _apiKey: apiKey });
     setUserToken(ANONYMOUS_TOKEN);
   };
-  const _get = (key, callback) => callback(values[key]);
+  const getUserToken = (_options, callback) =>
+    callback(null, values._userToken);
   const onUserTokenChange = (callback, { immediate = false } = {}) => {
     userTokenCallback = callback;
     if (immediate) {
@@ -42,7 +46,7 @@ export function createAlgoliaAnalytics(): AlgoliaAnalytics {
   return {
     setUserToken,
     init,
-    _get,
+    getUserToken,
     onUserTokenChange,
     viewedObjectIDs,
   };


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR replaces `_get` with `getUserToken`. At the time of writing the insights middleware, I wasn't aware of `getUserToken` method. 

**Result**

It works the same.