### PR TITLE
feat(widget): add access to "parent" in dispose

### DIFF
--- a/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.ts
+++ b/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.ts
@@ -7,6 +7,7 @@ import connectBreadcrumb from '../connectBreadcrumb';
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import { createSingleSearchResponse } from '../../../../test/mock/createAPIResponse';
 import {
+  createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/mock/createWidget';
@@ -1021,7 +1022,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
       const widget = makeWidget({ attributes: ['category'] });
 
       expect(() =>
-        widget.dispose!({ helper, state: helper.state })
+        widget.dispose!(createDisposeOptions({ helper, state: helper.state }))
       ).not.toThrow();
     });
 
@@ -1044,7 +1045,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
         })
       );
 
-      const newState = widget.dispose!({ helper, state: helper.state });
+      const newState = widget.dispose!(
+        createDisposeOptions({ helper, state: helper.state })
+      );
 
       expect(newState).toBeUndefined();
     });

--- a/src/connectors/clear-refinements/__tests__/connectClearRefinements-test.ts
+++ b/src/connectors/clear-refinements/__tests__/connectClearRefinements-test.ts
@@ -1,5 +1,6 @@
 import algoliasearchHelper, { SearchResults } from 'algoliasearch-helper';
 import {
+  createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/mock/createWidget';
@@ -122,7 +123,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/clear-refin
       const widget = makeWidget({});
 
       expect(() =>
-        widget.dispose!({ helper, state: helper.state })
+        widget.dispose!(createDisposeOptions({ helper, state: helper.state }))
       ).not.toThrow();
     });
 

--- a/src/connectors/current-refinements/__tests__/connectCurrentRefinements-test.ts
+++ b/src/connectors/current-refinements/__tests__/connectCurrentRefinements-test.ts
@@ -8,6 +8,7 @@ import connectCurrentRefinements, {
 } from '../connectCurrentRefinements';
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import {
+  createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/mock/createWidget';
@@ -119,7 +120,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
       const widget = customCurrentRefinements({});
 
       expect(() =>
-        widget.dispose!({ helper, state: helper.state })
+        widget.dispose!(createDisposeOptions({ helper, state: helper.state }))
       ).not.toThrow();
     });
 

--- a/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.ts
+++ b/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.ts
@@ -5,6 +5,7 @@ import algoliasearchHelper, {
 import { warning } from '../../../lib/utils';
 import connectHierarchicalMenu from '../connectHierarchicalMenu';
 import {
+  createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/mock/createWidget';
@@ -393,7 +394,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
         })
       );
       expect(() =>
-        widget.dispose!({ helper, state: helper.state })
+        widget.dispose!(createDisposeOptions({ helper, state: helper.state }))
       ).not.toThrow();
     });
 
@@ -412,9 +413,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
         })
       );
 
-      expect(widget.dispose!({ helper, state: helper.state })).toEqual(
-        new SearchParameters({ index: indexName })
-      );
+      expect(
+        widget.dispose!(createDisposeOptions({ helper, state: helper.state }))
+      ).toEqual(new SearchParameters({ index: indexName }));
     });
 
     it('unsets refinement', () => {
@@ -448,9 +449,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
         category: ['zombo.com'],
       });
 
-      expect(widget.dispose!({ helper, state: helper.state })).toEqual(
-        new SearchParameters({ index: indexName })
-      );
+      expect(
+        widget.dispose!(createDisposeOptions({ helper, state: helper.state }))
+      ).toEqual(new SearchParameters({ index: indexName }));
     });
   });
 

--- a/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.ts
+++ b/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.ts
@@ -5,6 +5,7 @@ import algoliasearchHelper, {
 import { connectHitsPerPage } from '../..';
 import { HitsPerPageConnectorParams } from '../connectHitsPerPage';
 import {
+  createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/mock/createWidget';
@@ -607,7 +608,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
 
       expect(unmountFn).toHaveBeenCalledTimes(0);
 
-      widget.dispose!({ helper, state: helper.state });
+      widget.dispose!(createDisposeOptions({ helper, state: helper.state }));
 
       expect(unmountFn).toHaveBeenCalledTimes(1);
     });
@@ -626,7 +627,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
       });
 
       expect(() =>
-        widget.dispose!({ helper, state: helper.state })
+        widget.dispose!(createDisposeOptions({ helper, state: helper.state }))
       ).not.toThrow();
     });
 
@@ -648,10 +649,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
 
       expect(helper.state.hitsPerPage).toBe(5);
 
-      const nextState = widget.dispose!({
-        helper,
-        state: helper.state,
-      }) as SearchParameters;
+      const nextState = widget.dispose!(
+        createDisposeOptions({
+          helper,
+          state: helper.state,
+        })
+      ) as SearchParameters;
 
       expect(nextState.hitsPerPage).toBeUndefined();
     });

--- a/src/connectors/hits/__tests__/connectHits-test.ts
+++ b/src/connectors/hits/__tests__/connectHits-test.ts
@@ -5,6 +5,7 @@ import algoliasearchHelper, {
 import { TAG_PLACEHOLDER, deserializePayload } from '../../../lib/utils';
 import connectHits from '../connectHits';
 import {
+  createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/mock/createWidget';
@@ -605,7 +606,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
 
       expect(unmountFn).toHaveBeenCalledTimes(0);
 
-      widget.dispose!({ helper, state: helper.state });
+      widget.dispose!(createDisposeOptions({ helper, state: helper.state }));
 
       expect(unmountFn).toHaveBeenCalledTimes(1);
     });
@@ -618,7 +619,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
       const widget = makeWidget({});
 
       expect(() =>
-        widget.dispose!({ helper, state: helper.state })
+        widget.dispose!(createDisposeOptions({ helper, state: helper.state }))
       ).not.toThrow();
     });
 
@@ -639,10 +640,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
         TAG_PLACEHOLDER.highlightPostTag
       );
 
-      const nextState = widget.dispose!({
-        helper,
-        state: helper.state,
-      }) as SearchParameters;
+      const nextState = widget.dispose!(
+        createDisposeOptions({
+          helper,
+          state: helper.state,
+        })
+      ) as SearchParameters;
 
       expect(nextState.highlightPreTag).toBeUndefined();
       expect(nextState.highlightPostTag).toBeUndefined();
@@ -663,10 +666,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
       expect(helper.state.highlightPreTag).toBe('<mark>');
       expect(helper.state.highlightPostTag).toBe('</mark>');
 
-      const nextState = widget.dispose!({
-        helper,
-        state: helper.state,
-      }) as SearchParameters;
+      const nextState = widget.dispose!(
+        createDisposeOptions({
+          helper,
+          state: helper.state,
+        })
+      ) as SearchParameters;
 
       expect(nextState.highlightPreTag).toBe('<mark>');
       expect(nextState.highlightPostTag).toBe('</mark>');

--- a/src/connectors/hits/__tests__/connectHitsWithInsights-test.ts
+++ b/src/connectors/hits/__tests__/connectHitsWithInsights-test.ts
@@ -2,6 +2,7 @@ import algoliasearchHelper, { SearchResults } from 'algoliasearch-helper';
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import { createInstantSearch } from '../../../../test/mock/createInstantSearch';
 import {
+  createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/mock/createWidget';
@@ -100,7 +101,7 @@ describe('connectHitsWithInsights', () => {
     const widget = makeWidget({});
     const helper = algoliasearchHelper(createSearchClient(), '', {});
     expect(() => {
-      widget.dispose!({ helper, state: helper.state });
+      widget.dispose!(createDisposeOptions({ helper, state: helper.state }));
     }).not.toThrow();
   });
 });

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -5,6 +5,7 @@ import algoliasearchHelper, {
 import { SearchClient, HitAttributeHighlightResult } from '../../../types';
 import { createInstantSearch } from '../../../../test/mock/createInstantSearch';
 import {
+  createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/mock/createWidget';
@@ -837,7 +838,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
 
       expect(unmountFn).toHaveBeenCalledTimes(0);
 
-      widget.dispose!({ helper, state: helper.state });
+      widget.dispose!(createDisposeOptions({ helper, state: helper.state }));
 
       expect(unmountFn).toHaveBeenCalledTimes(1);
     });
@@ -850,7 +851,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       const widget = makeWidget({});
 
       expect(() =>
-        widget.dispose!({ helper, state: helper.state })
+        widget.dispose!(createDisposeOptions({ helper, state: helper.state }))
       ).not.toThrow();
     });
 
@@ -871,10 +872,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
         TAG_PLACEHOLDER.highlightPostTag
       );
 
-      const nextState = widget.dispose!({
-        helper,
-        state: helper.state,
-      }) as SearchParameters;
+      const nextState = widget.dispose!(
+        createDisposeOptions({
+          helper,
+          state: helper.state,
+        })
+      ) as SearchParameters;
 
       expect(nextState.highlightPreTag).toBeUndefined();
       expect(nextState.highlightPostTag).toBeUndefined();
@@ -895,10 +898,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       expect(helper.state.highlightPreTag).toBe('<mark>');
       expect(helper.state.highlightPostTag).toBe('</mark>');
 
-      const nextState = widget.dispose!({
-        helper,
-        state: helper.state,
-      }) as SearchParameters;
+      const nextState = widget.dispose!(
+        createDisposeOptions({
+          helper,
+          state: helper.state,
+        })
+      ) as SearchParameters;
 
       expect(nextState.highlightPreTag).toBe('<mark>');
       expect(nextState.highlightPostTag).toBe('</mark>');
@@ -915,10 +920,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
 
       expect(helper.state.page).toBe(5);
 
-      const nextState = widget.dispose!({
-        helper,
-        state: helper.state,
-      }) as SearchParameters;
+      const nextState = widget.dispose!(
+        createDisposeOptions({
+          helper,
+          state: helper.state,
+        })
+      ) as SearchParameters;
 
       expect(nextState.page).toBeUndefined();
     });

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHitsWithInsights-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHitsWithInsights-test.ts
@@ -1,5 +1,6 @@
 import algoliasearchHelper, { SearchResults } from 'algoliasearch-helper';
 import {
+  createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/mock/createWidget';
@@ -116,7 +117,7 @@ describe('connectInfiniteHitsWithInsights', () => {
     const helper = algoliasearchHelper(createSearchClient(), '', {});
     const widget = makeWidget({});
     expect(() =>
-      widget.dispose!({ helper, state: helper.state })
+      widget.dispose!(createDisposeOptions({ helper, state: helper.state }))
     ).not.toThrow();
   });
 });

--- a/src/connectors/menu/__tests__/connectMenu-test.ts
+++ b/src/connectors/menu/__tests__/connectMenu-test.ts
@@ -6,6 +6,7 @@ import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import { createSingleSearchResponse } from '../../../../test/mock/createAPIResponse';
 import { createInstantSearch } from '../../../../test/mock/createInstantSearch';
 import {
+  createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/mock/createWidget';
@@ -475,7 +476,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
       })
     );
     expect(() =>
-      widget.dispose!!({ helper, state: helper.state })
+      widget.dispose!(createDisposeOptions({ helper, state: helper.state }))
     ).not.toThrow();
   });
 
@@ -1194,7 +1195,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
         })
       );
 
-      const newState = widget.dispose!({ state: helper.state, helper });
+      const newState = widget.dispose!(
+        createDisposeOptions({ state: helper.state, helper })
+      );
 
       expect(newState).toEqual(
         new SearchParameters({
@@ -1236,7 +1239,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
         })
       );
 
-      const newState = widget.dispose!({ state: helper.state, helper });
+      const newState = widget.dispose!(
+        createDisposeOptions({ state: helper.state, helper })
+      );
 
       expect(newState).toEqual(
         new SearchParameters({
@@ -1260,7 +1265,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
         })
       );
       helper.search = jest.fn();
-      const newState = widget.dispose!({ state, helper });
+      const newState = widget.dispose!(createDisposeOptions({ state, helper }));
 
       expect(newState).toEqual(new SearchParameters());
     });

--- a/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.ts
+++ b/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.ts
@@ -9,6 +9,7 @@ import connectNumericMenu, {
 } from '../connectNumericMenu';
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import {
+  createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/mock/createWidget';
@@ -734,7 +735,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
     const helper = jsHelper(createSearchClient(), '');
 
     expect(() =>
-      widget.dispose!({ helper, state: helper.state })
+      widget.dispose!(createDisposeOptions({ helper, state: helper.state }))
     ).not.toThrow();
   });
 

--- a/src/connectors/pagination/__tests__/connectPagination-test.ts
+++ b/src/connectors/pagination/__tests__/connectPagination-test.ts
@@ -8,6 +8,7 @@ import connectPagination, {
   PaginationRenderState,
 } from '../connectPagination';
 import {
+  createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/mock/createWidget';
@@ -308,7 +309,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/pagination/
 
       expect(unmountFn).toHaveBeenCalledTimes(0);
 
-      widget.dispose!({ helper, state: helper.state });
+      widget.dispose!(createDisposeOptions({ helper, state: helper.state }));
 
       expect(unmountFn).toHaveBeenCalledTimes(1);
     });
@@ -321,7 +322,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/pagination/
       const widget = makeWidget({});
 
       expect(() =>
-        widget.dispose!({ helper, state: helper.state })
+        widget.dispose!(createDisposeOptions({ helper, state: helper.state }))
       ).not.toThrow();
     });
 
@@ -336,7 +337,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/pagination/
 
       expect(helper.state.page).toBe(5);
 
-      const nextState = widget.dispose!({ helper, state: helper.state });
+      const nextState = widget.dispose!(
+        createDisposeOptions({ helper, state: helper.state })
+      );
 
       // error used for typescript
       if (!nextState) {

--- a/src/connectors/powered-by/__tests__/connectPoweredBy-test.ts
+++ b/src/connectors/powered-by/__tests__/connectPoweredBy-test.ts
@@ -1,6 +1,7 @@
 import jsHelper from 'algoliasearch-helper';
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import {
+  createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/mock/createWidget';
@@ -119,7 +120,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/powered-by/
     const widget = makeWidget({});
     const helper = jsHelper(createSearchClient(), '');
     expect(() =>
-      widget.dispose!({ helper, state: helper.state })
+      widget.dispose!(createDisposeOptions({ helper, state: helper.state }))
     ).not.toThrow();
   });
 

--- a/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
+++ b/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
@@ -6,6 +6,7 @@ import algoliasearchHelper, {
 import { createInstantSearch } from '../../../../test/mock/createInstantSearch';
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import {
+  createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/mock/createWidget';
@@ -190,7 +191,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
         })
       );
 
-      widget.dispose!({ helper, state: helper.state });
+      widget.dispose!(createDisposeOptions({ helper, state: helper.state }));
 
       expect(unmountFn).toHaveBeenCalledTimes(1);
     });
@@ -209,7 +210,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
       );
 
       expect(() =>
-        widget.dispose!({ helper, state: helper.state })
+        widget.dispose!(createDisposeOptions({ helper, state: helper.state }))
       ).not.toThrow();
     });
   });
@@ -963,7 +964,9 @@ Consider using \`transformRuleContexts\` to minimize the number of rules sent to
           'ais-brand-Apple',
         ]);
 
-        const nextState = widget.dispose!({ helper, state: helper.state });
+        const nextState = widget.dispose!(
+          createDisposeOptions({ helper, state: helper.state })
+        );
 
         expect((nextState as SearchParameters).ruleContexts).toEqual([
           'initial-rule',
@@ -1002,7 +1005,7 @@ Consider using \`transformRuleContexts\` to minimize the number of rules sent to
         expect(brandFilterSpy).toHaveBeenCalledTimes(1);
         expect(brandFilterSpy).toHaveBeenCalledWith(['Samsung']);
 
-        widget.dispose!({ helper, state: helper.state });
+        widget.dispose!(createDisposeOptions({ helper, state: helper.state }));
 
         helper.setState({
           disjunctiveFacetsRefinements: {

--- a/src/connectors/range/__tests__/connectRange-test.ts
+++ b/src/connectors/range/__tests__/connectRange-test.ts
@@ -5,6 +5,7 @@ import jsHelper, {
 } from 'algoliasearch-helper';
 import connectRange from '../connectRange';
 import {
+  createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/mock/createWidget';
@@ -1261,7 +1262,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
         })
       );
       expect(() =>
-        widget.dispose!({ helper, state: helper.state })
+        widget.dispose!(createDisposeOptions({ helper, state: helper.state }))
       ).not.toThrow();
     });
 
@@ -1279,7 +1280,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
         })
       );
 
-      const newState = widget.dispose!({ helper, state: helper.state });
+      const newState = widget.dispose!(
+        createDisposeOptions({ helper, state: helper.state })
+      );
 
       expect(newState).toEqual(new SearchParameters({ index: indexName }));
     });
@@ -1323,7 +1326,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
         })
       );
 
-      const newState = widget.dispose!({ helper, state: helper.state });
+      const newState = widget.dispose!(
+        createDisposeOptions({ helper, state: helper.state })
+      );
 
       expect(newState).toEqual(new SearchParameters({ index: indexName }));
     });

--- a/src/connectors/rating-menu/__tests__/connectRatingMenu-test.ts
+++ b/src/connectors/rating-menu/__tests__/connectRatingMenu-test.ts
@@ -4,6 +4,7 @@ import jsHelper, {
 } from 'algoliasearch-helper';
 import connectRatingMenu from '../connectRatingMenu';
 import {
+  createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/mock/createWidget';
@@ -313,7 +314,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
       const { widget, helper } = getInitializedWidget();
 
       expect(() =>
-        widget.dispose!({ helper, state: helper.state })
+        widget.dispose!(createDisposeOptions({ helper, state: helper.state }))
       ).not.toThrow();
     });
 
@@ -321,7 +322,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
       const unmount = jest.fn();
       const { widget, helper } = getInitializedWidget({}, unmount);
 
-      widget.dispose!({ helper, state: helper.state });
+      widget.dispose!(createDisposeOptions({ helper, state: helper.state }));
 
       expect(unmount).toHaveBeenCalledTimes(1);
     });
@@ -357,7 +358,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
         })
       );
 
-      const nextState = widget.dispose!({ helper, state: helper.state });
+      const nextState = widget.dispose!(
+        createDisposeOptions({ helper, state: helper.state })
+      );
 
       expect(nextState).toEqual(
         new SearchParameters({

--- a/src/connectors/refinement-list/__tests__/connectRefinementList-test.ts
+++ b/src/connectors/refinement-list/__tests__/connectRefinementList-test.ts
@@ -6,6 +6,7 @@ import { TAG_PLACEHOLDER } from '../../../lib/utils';
 import connectRefinementList from '../connectRefinementList';
 import { createInstantSearch } from '../../../../test/mock/createInstantSearch';
 import {
+  createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/mock/createWidget';
@@ -2070,7 +2071,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
     );
 
     expect(() =>
-      widget.dispose!({ helper, state: helper.state })
+      widget.dispose!(createDisposeOptions({ helper, state: helper.state }))
     ).not.toThrow();
   });
 
@@ -2156,10 +2157,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
         })
       );
 
-      const newState = widget.dispose!({
-        state: helper.state,
-        helper,
-      });
+      const newState = widget.dispose!(
+        createDisposeOptions({
+          state: helper.state,
+          helper,
+        })
+      );
 
       expect(newState).toEqual(
         new SearchParameters({
@@ -2249,10 +2252,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
         })
       );
 
-      const newState = widget.dispose!({
-        state: helper.state,
-        helper,
-      });
+      const newState = widget.dispose!(
+        createDisposeOptions({
+          state: helper.state,
+          helper,
+        })
+      );
 
       expect(newState).toEqual(
         new SearchParameters({

--- a/src/connectors/search-box/__tests__/connectSearchBox-test.ts
+++ b/src/connectors/search-box/__tests__/connectSearchBox-test.ts
@@ -4,6 +4,7 @@ import algoliasearchHelper, {
 } from 'algoliasearch-helper';
 import connectSearchBox from '../connectSearchBox';
 import {
+  createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/mock/createWidget';
@@ -500,7 +501,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
 
       expect(unmountFn).toHaveBeenCalledTimes(0);
 
-      widget.dispose!({ helper, state: helper.state });
+      widget.dispose!(createDisposeOptions({ helper, state: helper.state }));
 
       expect(unmountFn).toHaveBeenCalledTimes(1);
     });
@@ -513,7 +514,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
       const widget = makeWidget({});
 
       expect(() =>
-        widget.dispose!({ helper, state: helper.state })
+        widget.dispose!(createDisposeOptions({ helper, state: helper.state }))
       ).not.toThrow();
     });
 
@@ -528,10 +529,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
 
       expect(helper.state.query).toBe('Apple');
 
-      const nextState = widget.dispose!({
-        helper,
-        state: helper.state,
-      }) as SearchParameters;
+      const nextState = widget.dispose!(
+        createDisposeOptions({
+          helper,
+          state: helper.state,
+        })
+      ) as SearchParameters;
 
       expect(nextState.query).toBeUndefined();
     });
@@ -561,7 +564,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
       });
     });
 
-    test('should give back the same instance if the value is alreay in the uiState', () => {
+    test('should give back the same instance if the value is already in the uiState', () => {
       const [widget, helper, refine] = getInitializedWidget();
       refine('query');
       const uiStateBefore = widget.getWidgetUiState(

--- a/src/connectors/sort-by/__tests__/connectSortBy-test.ts
+++ b/src/connectors/sort-by/__tests__/connectSortBy-test.ts
@@ -8,6 +8,7 @@ import index from '../../../widgets/index/index';
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import { createInstantSearch } from '../../../../test/mock/createInstantSearch';
 import {
+  createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/mock/createWidget';
@@ -144,7 +145,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
     const helper = algoliasearchHelper(createSearchClient(), items[0].value);
 
     expect(() =>
-      widget.dispose!({ helper, state: helper.state })
+      widget.dispose!(createDisposeOptions({ helper, state: helper.state }))
     ).not.toThrow();
   });
 

--- a/src/connectors/stats/__tests__/connectStats-test.ts
+++ b/src/connectors/stats/__tests__/connectStats-test.ts
@@ -3,6 +3,7 @@ const SearchResults = jsHelper.SearchResults;
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import { createSingleSearchResponse } from '../../../../test/mock/createAPIResponse';
 import {
+  createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/mock/createWidget';
@@ -427,7 +428,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/stats/js/#c
     const widget = makeWidget({});
     const helper = jsHelper(createSearchClient(), '');
     expect(() =>
-      widget.dispose!({ helper, state: helper.state })
+      widget.dispose!(createDisposeOptions({ helper, state: helper.state }))
     ).not.toThrow();
   });
 });

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -41,6 +41,7 @@ export type RenderOptions = SharedRenderOptions & {
 export type DisposeOptions = {
   helper: Helper;
   state: SearchParameters;
+  parent: IndexWidget;
 };
 
 export type BuiltinTypes =

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -574,6 +574,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
           expect(widget.dispose).toHaveBeenCalledWith({
             helper: instance.getHelper(),
             state: instance.getHelper()!.state,
+            parent: instance,
           });
         });
       });
@@ -2676,6 +2677,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
         expect(widget.dispose).toHaveBeenCalledWith({
           state: helper!.state,
           helper,
+          parent: instance,
         });
       });
     });

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -365,7 +365,11 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
       if (localInstantSearchInstance && Boolean(widgets.length)) {
         const nextState = widgets.reduce((state, widget) => {
           // the `dispose` method exists at this point we already assert it
-          const next = widget.dispose!({ helper: helper!, state });
+          const next = widget.dispose!({
+            helper: helper!,
+            state,
+            parent: this,
+          });
 
           return next || state;
         }, helper!.state);
@@ -655,7 +659,11 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
           // `dispose` because the index is removed. We can't call `removeWidgets`
           // because we want to keep the widgets on the instance, to allow idempotent
           // operations on `add` & `remove`.
-          widget.dispose({ helper: helper!, state: helper!.state });
+          widget.dispose({
+            helper: helper!,
+            state: helper!.state,
+            parent: this,
+          });
         }
       });
 

--- a/src/widgets/menu-select/__tests__/menu-select-test.ts
+++ b/src/widgets/menu-select/__tests__/menu-select-test.ts
@@ -3,6 +3,7 @@ import algoliasearchHelper, { SearchParameters } from 'algoliasearch-helper';
 import menuSelect from '../menu-select';
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import {
+  createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/mock/createWidget';
@@ -121,10 +122,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu-select
 
         expect(render).toHaveBeenCalledTimes(0);
 
-        const newState = widget.dispose!({
-          state: helper.state,
-          helper,
-        });
+        const newState = widget.dispose!(
+          createDisposeOptions({
+            state: helper.state,
+            helper,
+          })
+        );
 
         expect(render).toHaveBeenCalledTimes(1);
         expect(render).toHaveBeenLastCalledWith(null, container);

--- a/src/widgets/panel/__tests__/panel-test.ts
+++ b/src/widgets/panel/__tests__/panel-test.ts
@@ -199,7 +199,7 @@ describe('Lifecycle', () => {
 
     widgetWithPanel.init!(createInitOptions());
     widgetWithPanel.render!(createRenderOptions());
-    widgetWithPanel.dispose!(createRenderOptions());
+    widgetWithPanel.dispose!(createDisposeOptions());
 
     expect(widget.init).toHaveBeenCalledTimes(1);
     expect(widget.render).toHaveBeenCalledTimes(1);

--- a/src/widgets/query-rule-custom-data/__tests__/query-rule-custom-data-test.ts
+++ b/src/widgets/query-rule-custom-data/__tests__/query-rule-custom-data-test.ts
@@ -3,7 +3,10 @@ import algoliasearchHelper, {
   AlgoliaSearchHelper as Helper,
 } from 'algoliasearch-helper';
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
-import { createInitOptions } from '../../../../test/mock/createWidget';
+import {
+  createDisposeOptions,
+  createInitOptions,
+} from '../../../../test/mock/createWidget';
 import { castToJestMock } from '../../../../test/utils/castToJestMock';
 import queryRuleCustomData from '../query-rule-custom-data';
 import { QueryRuleCustomDataProps } from '../../../components/QueryRuleCustomData/QueryRuleCustomData';
@@ -203,10 +206,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rule-
 
         expect(render).toHaveBeenCalledTimes(1);
 
-        widget.dispose!({
-          helper,
-          state: helper.state,
-        });
+        widget.dispose!(
+          createDisposeOptions({
+            helper,
+            state: helper.state,
+          })
+        );
 
         expect(render).toHaveBeenCalledTimes(2);
         expect(render).toHaveBeenCalledWith(null, container);

--- a/test/mock/createWidget.ts
+++ b/test/mock/createWidget.ts
@@ -72,6 +72,7 @@ export const createDisposeOptions = (
   return {
     helper: instantSearchInstance.helper!,
     state: instantSearchInstance.helper!.state,
+    parent: instantSearchInstance.mainIndex,
     ...args,
   };
 };


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

If the widget is conditionally adding widgets to the parent in init & render, it needs to be able to remove those on dispose.


**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

`dispose` is called with `parent` too. Updated all tests to use the existing helper `createDisposeOptions`
