### PR TITLE
chore(insights): add user agent

### DIFF
--- a/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -177,23 +177,33 @@ describe('insights', () => {
 
     it('adds user agent', () => {
       const {
+        analytics,
         insightsClient,
         instantSearchInstance,
         searchClient,
       } = createTestEnvironment();
-      const addAlgoliaAgent = jest.fn();
       // @ts-ignore
-      searchClient.addAlgoliaAgent = addAlgoliaAgent;
+      searchClient.addAlgoliaAgent = jest.fn();
 
       const middleware = createInsightsMiddleware({
         insightsClient,
       })({ instantSearchInstance });
-      const times = addAlgoliaAgent.mock.calls.length;
+      const times = (searchClient.addAlgoliaAgent as jest.Mock).mock.calls
+        .length;
 
       middleware.subscribe();
 
-      expect(addAlgoliaAgent).toHaveBeenCalledTimes(times + 1);
-      expect(addAlgoliaAgent).toHaveBeenLastCalledWith('insights-middleware');
+      expect(searchClient.addAlgoliaAgent as jest.Mock).toHaveBeenCalledTimes(
+        times + 1
+      );
+      expect(
+        searchClient.addAlgoliaAgent as jest.Mock
+      ).toHaveBeenLastCalledWith('insights-middleware');
+
+      expect(analytics.addAlgoliaAgent).toHaveBeenCalledTimes(1);
+      expect(analytics.addAlgoliaAgent).toHaveBeenCalledWith(
+        'insights-middleware'
+      );
     });
   });
 

--- a/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -12,9 +12,8 @@ import { SearchClient } from '../../types';
 describe('insights', () => {
   const createTestEnvironment = () => {
     const { analytics, insightsClient } = createInsights();
-    const searchClient = algoliasearch('myAppId', 'myApiKey');
     const instantSearchInstance = createInstantSearch({
-      client: searchClient,
+      client: algoliasearch('myAppId', 'myApiKey'),
     });
     const helper = algoliasearchHelper({} as SearchClient, '');
     const getUserToken = () => {
@@ -29,7 +28,6 @@ describe('insights', () => {
       analytics,
       insightsClient,
       instantSearchInstance,
-      searchClient,
       helper,
       getUserToken,
     };
@@ -179,25 +177,13 @@ describe('insights', () => {
         analytics,
         insightsClient,
         instantSearchInstance,
-        searchClient,
       } = createTestEnvironment();
-      // @ts-ignore
-      searchClient.addAlgoliaAgent = jest.fn();
 
       const middleware = createInsightsMiddleware({
         insightsClient,
       })({ instantSearchInstance });
-      const times = (searchClient.addAlgoliaAgent as jest.Mock).mock.calls
-        .length;
 
       middleware.subscribe();
-
-      expect(searchClient.addAlgoliaAgent as jest.Mock).toHaveBeenCalledTimes(
-        times + 1
-      );
-      expect(
-        searchClient.addAlgoliaAgent as jest.Mock
-      ).toHaveBeenLastCalledWith('insights-middleware');
 
       expect(analytics.addAlgoliaAgent).toHaveBeenCalledTimes(1);
       expect(analytics.addAlgoliaAgent).toHaveBeenCalledWith(

--- a/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -2,7 +2,6 @@ import algoliasearch from 'algoliasearch';
 import algoliasearchHelper from 'algoliasearch-helper';
 import { createInsightsMiddleware } from '../';
 import { createInstantSearch } from '../../../test/mock/createInstantSearch';
-import { createSearchClient } from '../../../test/mock/createSearchClient';
 import {
   createInsights,
   createInsightsUmdVersion,

--- a/src/middlewares/createInsightsMiddleware.ts
+++ b/src/middlewares/createInsightsMiddleware.ts
@@ -88,6 +88,12 @@ export const createInsightsMiddleware: CreateInsightsMiddleware = props => {
     return {
       onStateChange() {},
       subscribe() {
+        if (
+          typeof instantSearchInstance.client.addAlgoliaAgent === 'function'
+        ) {
+          instantSearchInstance.client.addAlgoliaAgent(`insights-middleware`);
+        }
+
         // At the time this middleware is subscribed, `mainIndex.init()` is already called.
         // It means `mainIndex.getHelper()` exists.
         const helper = instantSearchInstance.mainIndex.getHelper()!;

--- a/src/middlewares/createInsightsMiddleware.ts
+++ b/src/middlewares/createInsightsMiddleware.ts
@@ -88,11 +88,6 @@ export const createInsightsMiddleware: CreateInsightsMiddleware = props => {
     return {
       onStateChange() {},
       subscribe() {
-        if (
-          typeof instantSearchInstance.client.addAlgoliaAgent === 'function'
-        ) {
-          instantSearchInstance.client.addAlgoliaAgent(`insights-middleware`);
-        }
         insightsClient('addAlgoliaAgent', 'insights-middleware');
 
         // At the time this middleware is subscribed, `mainIndex.init()` is already called.

--- a/src/middlewares/createInsightsMiddleware.ts
+++ b/src/middlewares/createInsightsMiddleware.ts
@@ -93,6 +93,7 @@ export const createInsightsMiddleware: CreateInsightsMiddleware = props => {
         ) {
           instantSearchInstance.client.addAlgoliaAgent(`insights-middleware`);
         }
+        insightsClient('addAlgoliaAgent', 'insights-middleware');
 
         // At the time this middleware is subscribed, `mainIndex.init()` is already called.
         // It means `mainIndex.getHelper()` exists.

--- a/src/types/insights.ts
+++ b/src/types/insights.ts
@@ -42,7 +42,13 @@ export type InsightsInit = (
   }
 ) => void;
 
-export type InsightsClient = InsightsSendEvent &
+export type InsightsAddAlgoliaAgent = (
+  method: 'addAlgoliaAgent',
+  algoliaAgent: string
+) => void;
+
+export type InsightsClient = InsightsAddAlgoliaAgent &
+  InsightsSendEvent &
   InsightsOnUserTokenChange &
   InsightsGetUserToken &
   InsightsInit &

--- a/test/mock/createInsightsClient.ts
+++ b/test/mock/createInsightsClient.ts
@@ -3,7 +3,7 @@ import { processQueue } from 'search-insights/lib/_processQueue';
 import { getFunctionalInterface } from 'search-insights/lib/_getFunctionalInterface';
 
 export function createInsights() {
-  const analytics = mockSendingEvents(
+  const analytics = mockMethods(
     new AlgoliaAnalytics({
       requestFn: jest.fn(),
     })
@@ -23,7 +23,7 @@ export function createInsightsUmdVersion() {
     globalObject.aa.queue = globalObject.aa.queue || [];
     globalObject.aa.queue.push(args);
   };
-  const analytics = mockSendingEvents(
+  const analytics = mockMethods(
     new AlgoliaAnalytics({
       requestFn: jest.fn(),
     })
@@ -38,7 +38,9 @@ export function createInsightsUmdVersion() {
   };
 }
 
-function mockSendingEvents(analytics: AlgoliaAnalytics) {
+function mockMethods(analytics: AlgoliaAnalytics) {
+  analytics.addAlgoliaAgent = jest.fn(analytics.addAlgoliaAgent);
+
   analytics.viewedFilters = jest.fn(analytics.viewedFilters);
   analytics.viewedObjectIDs = jest.fn(analytics.viewedObjectIDs);
   analytics.clickedFilters = jest.fn(analytics.clickedFilters);


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR adds `insights-middleware` to the user agent in ~both **search call** and~ **insights call** when the `insights` middleware is subscribed.

There can be another way to check the usage of the `insights` middleware other than this, but this seems to be quick and harmless.

If we already had a dozen public middlewares and wanted to track which middlewares are used, this method wouldn't be appropriate. But it's not the case, so the user agent seems okay.