### PR TITLE
fix(range): reset the page on refine

### DIFF
--- a/src/connectors/range/__tests__/connectRange-test.ts
+++ b/src/connectors/range/__tests__/connectRange-test.ts
@@ -667,6 +667,22 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       return helper;
     };
 
+    it('resets the page', () => {
+      const helper = createHelper();
+      helper.setPage(5);
+      const widget = connectRange(rendering)({
+        attribute,
+      });
+
+      const { refine } = widget.getWidgetRenderState(
+        createInitOptions({ helper })
+      );
+
+      refine([10, 490]);
+
+      expect(helper.state.page).toBe(0);
+    });
+
     it('expect to refine when range are not set', () => {
       const helper = createHelper();
       const widget = connectRange(rendering)({

--- a/src/connectors/range/connectRange.ts
+++ b/src/connectors/range/connectRange.ts
@@ -242,7 +242,7 @@ const connectRange: RangeConnector = function connectRange(
           );
         }
 
-        return resolvedState;
+        return resolvedState.resetPage();
       }
 
       return null;


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

when in #4446 the insights middleware was introduced, range was refactored from helper.addNumericRefinement to state.addNumericRefinement. The helper method resets the page and sets the state, while the state method does not do that. Therefore we need to manually reset the page.

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

1. Go to the [story](https://deploy-preview-4760--instantsearchjs.netlify.app/stories/?path=/story/refinements-rangeslider--default)
2. set the page to non-zero
3. refine the range slider

A similar test can be done for range input

fixes #4759
