### PR TITLE
refactor(ts): migrate renderTemplate

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   ],
   "dependencies": {
     "@types/googlemaps": "^3.39.6",
+    "@types/hogan.js": "^3.0.0",
     "algoliasearch-helper": "^3.4.4",
     "classnames": "^2.2.5",
     "events": "^1.1.0",

--- a/src/lib/createHelpers.ts
+++ b/src/lib/createHelpers.ts
@@ -9,24 +9,27 @@ import {
   ReverseSnippetOptions,
   insights,
 } from '../helpers';
-import { Hit, InsightsClientMethod, InsightsClientPayload } from '../types';
+import {
+  Hit,
+  HoganHelpers,
+  InsightsClientMethod,
+  InsightsClientPayload,
+} from '../types';
 
-type HoganRenderer = (value: any) => string;
-
-type HoganHelpers = {
-  formatNumber: (value: number, render: HoganRenderer) => string;
-  highlight: (options: string, render: HoganRenderer) => string;
-  reverseHighlight: (options: string, render: HoganRenderer) => string;
-  snippet: (options: string, render: HoganRenderer) => string;
-  reverseSnippet: (options: string, render: HoganRenderer) => string;
-  insights: (options: string, render: HoganRenderer) => string;
-};
+type DefaultHoganHelpers = HoganHelpers<
+  | 'formatNumber'
+  | 'highlight'
+  | 'reverseHighlight'
+  | 'snippet'
+  | 'reverseSnippet'
+  | 'insights'
+>;
 
 export default function hoganHelpers({
   numberLocale,
 }: {
   numberLocale?: string;
-}): HoganHelpers {
+}): DefaultHoganHelpers {
   return {
     formatNumber(value, render) {
       return Number(render(value)).toLocaleString(numberLocale);

--- a/src/lib/utils/__tests__/renderTemplate-test.ts
+++ b/src/lib/utils/__tests__/renderTemplate-test.ts
@@ -73,12 +73,14 @@ describe('renderTemplate', () => {
     const actual1 = () =>
       renderTemplate({
         templateKey: 'test',
+        // @ts-expect-error wrong usage
         templates: { test: null },
       });
 
     const actual2 = () =>
       renderTemplate({
         templateKey: 'test',
+        // @ts-expect-error wrong usage
         templates: { test: 10 },
       });
 
@@ -118,8 +120,7 @@ describe('renderTemplate', () => {
       expect(actual).toBe(expectation);
     });
 
-    // eslint-disable-next-line jest/no-done-callback
-    it('expect to set the context (`this`) to the template `data`', done => {
+    it('expect to set the context (`this`) to the template `data`', () => {
       const templateKey = 'test';
       const templates = {
         test: '{{#helpers.emphasis}}{{feature}}{{/helpers.emphasis}}',
@@ -133,7 +134,7 @@ describe('renderTemplate', () => {
         emphasis() {
           // context will be different when using arrow function (lexical scope used)
           expect(this).toBe(data);
-          done();
+          return 'irrelevant return';
         },
       };
 
@@ -144,7 +145,7 @@ describe('renderTemplate', () => {
         helpers,
       });
 
-      const expectation = '';
+      const expectation = 'irrelevant return';
 
       expect(actual).toBe(expectation);
     });

--- a/src/lib/utils/prepareTemplateProps.ts
+++ b/src/lib/utils/prepareTemplateProps.ts
@@ -1,21 +1,10 @@
 import uniq from './uniq';
-import { Templates } from '../../types';
+import { HoganHelpers, Templates } from '../../types';
+import { HoganOptions } from 'hogan.js';
 
 type TemplatesConfig = {
-  helpers?: Record<
-    string,
-    (text: string, render: (value: any) => string) => string
-  >;
-  // https://github.com/twitter/hogan.js/#compilation-options
-  compileOptions?: {
-    asString?: boolean;
-    sectionTags?: Array<{
-      o?: string;
-      c?: string;
-    }>;
-    delimiters?: string;
-    disableLambda?: boolean;
-  };
+  helpers?: HoganHelpers;
+  compileOptions?: HoganOptions;
 };
 
 export type PreparedTemplateProps<TTemplates extends Templates> = {

--- a/src/lib/utils/renderTemplate.ts
+++ b/src/lib/utils/renderTemplate.ts
@@ -2,7 +2,7 @@ import hogan, { HoganOptions, Template } from 'hogan.js';
 import { Templates, HoganHelpers } from '../../types';
 import { BindEventForHits } from './createSendEventForHits';
 
-type ActualHoganHelpers = {
+type TransformedHoganHelpers = {
   [helper: string]: () => (text: string) => string;
 };
 

--- a/src/lib/utils/renderTemplate.ts
+++ b/src/lib/utils/renderTemplate.ts
@@ -15,7 +15,7 @@ function transformHelpersToHogan(
   compileOptions?: HoganOptions,
   data?: Record<string, any>
 ) {
-  return Object.keys(helpers).reduce<ActualHoganHelpers>(
+  return Object.keys(helpers).reduce< TransformedHoganHelpers>(
     (acc, helperKey) => ({
       ...acc,
       [helperKey]() {

--- a/src/lib/utils/renderTemplate.ts
+++ b/src/lib/utils/renderTemplate.ts
@@ -1,17 +1,27 @@
-import hogan from 'hogan.js';
+import hogan, { HoganOptions, Template } from 'hogan.js';
+import { Templates, HoganHelpers } from '../../types';
+import { BindEventForHits } from './createSendEventForHits';
+
+type ActualHoganHelpers = {
+  [helper: string]: () => (text: string) => string;
+};
 
 // We add all our template helper methods to the template as lambdas. Note
 // that lambdas in Mustache are supposed to accept a second argument of
 // `render` to get the rendered value, not the literal `{{value}}`. But
 // this is currently broken (see https://github.com/twitter/hogan.js/issues/222).
-function transformHelpersToHogan(helpers = {}, compileOptions, data) {
-  return Object.keys(helpers).reduce(
+function transformHelpersToHogan(
+  helpers: HoganHelpers = {},
+  compileOptions?: HoganOptions,
+  data?: Record<string, any>
+) {
+  return Object.keys(helpers).reduce<ActualHoganHelpers>(
     (acc, helperKey) => ({
       ...acc,
       [helperKey]() {
         return text => {
           const render = value =>
-            hogan.compile(value, compileOptions).render(this);
+            (hogan.compile(value, compileOptions) as Template).render(this);
 
           return helpers[helperKey].call(data, text, render);
         };
@@ -28,20 +38,24 @@ function renderTemplate({
   helpers,
   data,
   bindEvent,
+}: {
+  templates: Templates;
+  templateKey: string;
+  compileOptions?: HoganOptions;
+  helpers?: HoganHelpers;
+  data?: Record<string, any>;
+  bindEvent?: BindEventForHits;
 }) {
   const template = templates[templateKey];
-  const templateType = typeof template;
-  const isTemplateString = templateType === 'string';
-  const isTemplateFunction = templateType === 'function';
 
-  if (!isTemplateString && !isTemplateFunction) {
+  if (typeof template !== 'string' && typeof template !== 'function') {
     throw new Error(
-      `Template must be 'string' or 'function', was '${templateType}' (key: ${templateKey})`
+      `Template must be 'string' or 'function', was '${typeof template}' (key: ${templateKey})`
     );
   }
 
-  if (isTemplateFunction) {
-    return template(data, bindEvent);
+  if (typeof template === 'function') {
+    return template(data, bindEvent!);
   }
 
   const transformedHelpers = transformHelpersToHogan(
@@ -50,8 +64,7 @@ function renderTemplate({
     data
   );
 
-  return hogan
-    .compile(template, compileOptions)
+  return (hogan.compile(template, compileOptions) as Template)
     .render({
       ...data,
       helpers: transformedHelpers,

--- a/src/types/templates.ts
+++ b/src/types/templates.ts
@@ -11,3 +11,8 @@ export type TemplateWithBindEvent<TTemplateData = void> =
 export type Templates = {
   [key: string]: Template<any> | TemplateWithBindEvent<any> | undefined;
 };
+
+export type HoganHelpers<TKeys extends string = string> = Record<
+  TKeys,
+  (text: string, render: (value: string) => string) => string
+>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2771,6 +2771,11 @@
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.3.tgz#856c99cdc1551d22c22b18b5402719affec9839a"
   integrity sha512-cS5owqtwzLN5kY+l+KgKdRJ/Cee8tlmQoGQuIE9tWnSmS3JMKzmxo2HIAk2wODMifGwO20d62xZQLYz+RLfXmw==
 
+"@types/hogan.js@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/hogan.js/-/hogan.js-3.0.0.tgz#bf26560f39a38224ab6d0491b06f72c8fbe0953d"
+  integrity sha512-djkvb/AN43c3lIGCojNQ1FBS9VqqKhcTns5RQnHw4xBT/csy0jAssAsOiJ8NfaaioZaeKYE7XkVRxE5NeSZcaA==
+
 "@types/is-function@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/is-function/-/is-function-1.0.0.tgz#1b0b819b1636c7baf0d6785d030d12edf70c3e83"


### PR DESCRIPTION
DX-2017

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

converts the utility `renderTemplate` to TS (its test was already converted in #4769)

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

- adds @types/hogan to avoid any
- migrates that file
- update some usage to be simplified
