### PR TITLE
fix(clearRefinements): do not throw when widgetParams is not given

### DIFF
--- a/src/connectors/clear-refinements/__tests__/connectClearRefinements-test.ts
+++ b/src/connectors/clear-refinements/__tests__/connectClearRefinements-test.ts
@@ -21,6 +21,16 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/clear-refin
 `);
     });
 
+    it('does not throw when widgetParams is not given', () => {
+      const customClearRefinements = connectClearRefinements(() => {});
+
+      expect(() => {
+        // @ts-expect-error widgetParams could be undefined
+        // because it's supposed to work without any.
+        customClearRefinements();
+      }).not.toThrowError();
+    });
+
     it('throws with both `includedAttributes` and `excludedAttributes`', () => {
       const customClearRefinements = connectClearRefinements(() => {});
 

--- a/src/connectors/clear-refinements/connectClearRefinements.ts
+++ b/src/connectors/clear-refinements/connectClearRefinements.ts
@@ -95,8 +95,9 @@ const connectClearRefinements: ClearRefinementsConnector = function connectClear
     } = widgetParams || {};
 
     if (
-      (widgetParams || {}).includedAttributes &&
-      (widgetParams || {}).excludedAttributes
+      widgetParams &&
+      widgetParams.includedAttributes &&
+      widgetParams.excludedAttributes
     ) {
       throw new Error(
         withUsage(

--- a/src/connectors/clear-refinements/connectClearRefinements.ts
+++ b/src/connectors/clear-refinements/connectClearRefinements.ts
@@ -94,7 +94,10 @@ const connectClearRefinements: ClearRefinementsConnector = function connectClear
       transformItems = (items => items) as TransformItems<string>,
     } = widgetParams || {};
 
-    if (widgetParams.includedAttributes && widgetParams.excludedAttributes) {
+    if (
+      (widgetParams || {}).includedAttributes &&
+      (widgetParams || {}).excludedAttributes
+    ) {
       throw new Error(
         withUsage(
           'The options `includedAttributes` and `excludedAttributes` cannot be used together.'


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR prevents connectClearRefinement from throwing an error when widgetParams is not given.
When it's used with the official clearRefinement widget, then normally at least `container` is there, but if it's used in a custom widget or in Vue InstantSearch, there could be no widgetParams at all.
