### PR TITLE
ci(ts): remove test for ts-in-js

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,18 +99,6 @@ jobs:
             yarn run website:build
             yarn run test:e2e:saucelabs
 
-  'type check js (optional)':
-    <<: *defaults
-    steps:
-      - checkout
-      - run: *install_yarn_version
-      - restore_cache: *restore_yarn_cache
-      - run: *run_yarn_install
-      - save_cache: *save_yarn_cache
-      - run:
-          name: Type Checking including JS files
-          command: yarn run type-check:js
-
   'release if needed':
     <<: *defaults
     steps:
@@ -147,7 +135,6 @@ workflows:
       - unit tests
       - lint
       - type check algoliasearch v3
-      - type check js (optional)
       - e2e tests
       - 'release if needed':
           filters:

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "lint:fix": "eslint --ext .js,.ts,.tsx --fix .",
     "type-check": "tsc",
     "type-check:v3": "tsc --project tsconfig.v3.json",
-    "type-check:js": "tsc --project tsconfig.checkjs.json",
     "type-check:watch": "yarn type-check --watch",
     "test": "jest",
     "test:watch": "jest --watch --bail",

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig",
-  "compilerOptions": {
-    "allowJs": true,
-    "checkJs": true
-  },
-  "include": ["src", "./global.d.ts"],
-  "exclude": ["**/__tests__"]
-}


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Since all output files are now TypeScript, we no longer need to allow JavaScript in our configuration!

(Before this PR the test still failed, but that was due to a small inconcistency in the geo search renderer, that we aren't migrating ATM)

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

One less test on CI, and no more configuration for checkJS, allowJS in typescript. This means CI is now finally fully green again