### PR TITLE
fix(mainHelper): allow a mainHelper to be set before start

### DIFF
--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -425,7 +425,10 @@ See ${createDocumentationLink({
     // This Helper is used for the queries, we don't care about its state. The
     // states are managed at the `index` level. We use this Helper to create
     // DerivedHelper scoped into the `index` widgets.
-    const mainHelper = algoliasearchHelper(this.client, this.indexName);
+    // In Vue InstantSearch' hydrate, a main helper gets set before start, so
+    // we need to respect this helper as a way to keep all listeners correct.
+    const mainHelper =
+      this.mainHelper || algoliasearchHelper(this.client, this.indexName);
 
     mainHelper.search = () => {
       // This solution allows us to keep the exact same API for the users but

--- a/src/lib/__tests__/InstantSearch-test.tsx
+++ b/src/lib/__tests__/InstantSearch-test.tsx
@@ -850,6 +850,28 @@ describe('start', () => {
 See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/"
 `);
   });
+
+  it('keeps a mainHelper already set on the instance (Vue SSR)', () => {
+    const searchClient = createSearchClient();
+    const instance = new InstantSearch({
+      indexName: 'indexName',
+      searchClient,
+    });
+
+    const helper = algoliasearchHelper(searchClient, '');
+
+    // explicitly setting the mainHelper before start is used to force render to
+    // happen before the results of the first search are done. We need to make
+    // sure no extra helper is created, as that can cause certain things (like routing)
+    // to be listening to the wrong helper.
+    instance.mainHelper = helper;
+
+    expect(instance.mainHelper).toBe(helper);
+
+    instance.start();
+
+    expect(instance.mainHelper).toBe(helper);
+  });
 });
 
 describe('dispose', () => {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

In Vue InstantSearch server side rendering, we set a mainHelper https://github.com/algolia/vue-instantsearch/blob/118e0a39b8a047930520220da757ff0175cec12d/src/util/createServerRootMixin.js#L234-L235 before the instance is started.

This worked fine with existing fixes done, except for in routing, because every place that changes the state uses helper from the index, which is derived of the helper that's created before start. Routing and middleware however uses the helper which gets created in start, and thus don't trigger a search on the helper that actually searches.

To avoid these issues, we prevent recreation of the main helper if it's already set (by Vue InstantSearch for example). Whenever we will add the proper API for server side rendering in InstantSearch, we can rethink this part and probably remove it on a major.

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

mainHelper doesn't get recreated if there's already one present