### PR TITLE
fix(index): export `IndexWidgetParams` type

### DIFF
--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -28,7 +28,7 @@ const withUsage = createDocumentationMessageGenerator({
   name: 'index-widget',
 });
 
-type IndexWidgetParams = {
+export type IndexWidgetParams = {
   indexName: string;
   indexId?: string;
 };


### PR DESCRIPTION
This type cannot be imported from other projects, as opposed to other widgets.