### PR TITLE
fix(relevantSort): export `RelevantSortWidgetParams` type

### DIFF
--- a/src/widgets/relevant-sort/relevant-sort.tsx
+++ b/src/widgets/relevant-sort/relevant-sort.tsx
@@ -30,7 +30,7 @@ export type RelevantSortTemplates = Partial<{
   button: Template<{ isRelevantSorted: boolean }>;
 }>;
 
-type RelevantSortWidgetParams = {
+export type RelevantSortWidgetParams = {
   container: string | HTMLElement;
   cssClasses?: RelevantSortCSSClasses;
   templates?: RelevantSortTemplates;


### PR DESCRIPTION
This type cannot be imported from other projects, as opposed to other widgets.