### PR TITLE
fix(onStateChange): propagate change to middleware

### DIFF
--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -597,6 +597,7 @@ See ${createDocumentationLink({
     setIndexHelperState(this.mainIndex);
 
     this.scheduleSearch();
+    this.onInternalStateChange();
   }
 
   public getUiState(): UiState {

--- a/src/lib/__tests__/InstantSearch-integration-test.ts
+++ b/src/lib/__tests__/InstantSearch-integration-test.ts
@@ -1,8 +1,4 @@
-import {
-  getByText,
-  fireEvent,
-  getByPlaceholderText,
-} from '@testing-library/dom';
+import { getByText, fireEvent } from '@testing-library/dom';
 import instantsearch from '../../index.es';
 import { configure, searchBox } from '../../widgets';
 import { connectConfigure } from '../../connectors';
@@ -52,7 +48,7 @@ describe('configure', () => {
 });
 
 describe('middleware', () => {
-  it("runs middleware's onStateChange uiState has changed", async () => {
+  it("runs middlewares' onStateChange uiState has changed", async () => {
     const container = document.createElement('div');
     const search = instantsearch({
       indexName: 'instant_search',
@@ -76,7 +72,7 @@ describe('middleware', () => {
 
     search.start();
 
-    fireEvent.input(getByPlaceholderText(container, 'search'), {
+    fireEvent.input(container.querySelector('input')!, {
       target: { value: 'q' },
     });
 
@@ -84,7 +80,7 @@ describe('middleware', () => {
     expect(middlewareDefinition.onStateChange).toHaveBeenCalledTimes(1);
   });
 
-  it("runs middleware's onStateChange uiState has changed and onStateChange was provided", async () => {
+  it("runs middlewares' onStateChange uiState has changed and onStateChange was provided", async () => {
     const container = document.createElement('div');
     const search = instantsearch({
       indexName: 'instant_search',
@@ -111,7 +107,7 @@ describe('middleware', () => {
 
     search.start();
 
-    fireEvent.input(getByPlaceholderText(container, 'search'), {
+    fireEvent.input(container.querySelector('input')!, {
       target: { value: 'q' },
     });
 

--- a/src/lib/__tests__/InstantSearch-integration-test.ts
+++ b/src/lib/__tests__/InstantSearch-integration-test.ts
@@ -48,7 +48,7 @@ describe('configure', () => {
 });
 
 describe('middleware', () => {
-  it("runs middlewares' onStateChange uiState has changed", async () => {
+  it("runs middlewares' onStateChange when uiState changes", async () => {
     const container = document.createElement('div');
     const search = instantsearch({
       indexName: 'instant_search',
@@ -80,7 +80,7 @@ describe('middleware', () => {
     expect(middlewareDefinition.onStateChange).toHaveBeenCalledTimes(1);
   });
 
-  it("runs middlewares' onStateChange uiState has changed and onStateChange was provided", async () => {
+  it("runs middlewares' onStateChange when uiState changes with user-provided onStateChange param", async () => {
     const container = document.createElement('div');
     const search = instantsearch({
       indexName: 'instant_search',


### PR DESCRIPTION
This wrong behaviour was originally introduced in https://github.com/algolia/instantsearch.js/pull/4699 by removing onInternalStateChange, since I assumed the helper state change event would call the middleware, but it doesn't happen in all cases.

This means that now onInternalStateChange gets called one more time in certain situations, but that's not really an issue, as it's deferred anyway.

I've checked and the integration test written by @tkrugg indeed starts failing on #4699 

Fixes #4795 