### PR TITLE
chore: update google maps types

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "scripts/transforms"
   ],
   "dependencies": {
-    "@types/googlemaps": "^3.39.6",
     "@types/hogan.js": "^3.0.0",
     "algoliasearch-helper": "^3.4.5",
     "classnames": "^2.2.5",
@@ -80,6 +79,7 @@
     "@testing-library/preact": "1.0.2",
     "@types/classnames": "^2.2.7",
     "@types/enzyme": "^3.1.15",
+    "@types/google.maps": "^3.45.3",
     "@types/jest": "^26.0.22",
     "@types/jest-diff": "^24.3.0",
     "@types/qs": "^6.5.3",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "scripts/transforms"
   ],
   "dependencies": {
+    "@types/google.maps": "^3.45.3",
     "@types/hogan.js": "^3.0.0",
     "algoliasearch-helper": "^3.4.5",
     "classnames": "^2.2.5",
@@ -79,7 +80,6 @@
     "@testing-library/preact": "1.0.2",
     "@types/classnames": "^2.2.7",
     "@types/enzyme": "^3.1.15",
-    "@types/google.maps": "^3.45.3",
     "@types/jest": "^26.0.22",
     "@types/jest-diff": "^24.3.0",
     "@types/qs": "^6.5.3",

--- a/src/widgets/geo-search/createHTMLMarker.ts
+++ b/src/widgets/geo-search/createHTMLMarker.ts
@@ -65,7 +65,7 @@ const createHTMLMarker = (
 
     public onAdd() {
       // Append the element to the map
-      this.getPanes().overlayMouseTarget.appendChild(this.element);
+      this.getPanes()!.overlayMouseTarget.appendChild(this.element);
 
       // Compute the offset onAdd & cache it because afterwards
       // it won't retrieve the correct values, we also avoid
@@ -83,7 +83,7 @@ const createHTMLMarker = (
     }
 
     public draw() {
-      const position = this.getProjection().fromLatLngToDivPixel(this.latLng);
+      const position = this.getProjection().fromLatLngToDivPixel(this.latLng)!;
 
       this.element.style.left = `${Math.round(position.x - this.offset!.x)}px`;
       this.element.style.top = `${Math.round(position.y - this.offset!.y)}px`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2092,10 +2092,10 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/googlemaps@^3.39.6":
-  version "3.39.6"
-  resolved "https://registry.yarnpkg.com/@types/googlemaps/-/googlemaps-3.39.6.tgz#ca76df823fb4a8bd78bf47bd215fc70417a9ae51"
-  integrity sha512-O2joRmShgUcGBSyjp0pYFIP0Kv3y6jl8UXokEkcTI4D8FinTYsSt8OaHGQ/tI7WUF2eZTXKVJg6jQuEQS4d30w==
+"@types/google.maps@^3.45.3":
+  version "3.45.4"
+  resolved "https://registry.yarnpkg.com/@types/google.maps/-/google.maps-3.45.4.tgz#1b246e3bde97c541fd0cad4eeca9b0000f1d0ead"
+  integrity sha512-P7j+UsLXkDmPs4DkcSJlkkPBO+WDyFObnyfrIeoC8nTpGwskYcmBAiHK9qdwOoJCubKHdfgW4W6Qoart0HqQ9A==
 
 "@types/graceful-fs@^4.1.2":
   version "4.1.5"


### PR DESCRIPTION
https://www.npmjs.com/package/@types/googlemaps is deprecated in favor of https://www.npmjs.com/package/@types/google.maps
