### PR TITLE
fix(sortBy): do not write the default state

### DIFF
--- a/src/connectors/sort-by/__tests__/connectSortBy-test.ts
+++ b/src/connectors/sort-by/__tests__/connectSortBy-test.ts
@@ -547,7 +547,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
         const [widget, helper] = getInitializedWidget();
 
         const uiStateBefore = {};
-        const uiStateAfter = widget.getWidgetUiState!(uiStateBefore, {
+        const uiStateAfter = widget.getWidgetUiState(uiStateBefore, {
           searchParameters: helper.state,
           helper,
         });
@@ -561,7 +561,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
         refine('priceASC');
 
         const uiStateBefore = {};
-        const uiStateAfter = widget.getWidgetUiState!(uiStateBefore, {
+        const uiStateAfter = widget.getWidgetUiState(uiStateBefore, {
           searchParameters: helper.state,
           helper,
         });
@@ -576,19 +576,39 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
 
         refine('priceASC');
 
-        const uiStateBefore = widget.getWidgetUiState!(
+        const uiStateBefore = widget.getWidgetUiState(
           {},
           {
             searchParameters: helper.state,
             helper,
           }
         );
-        const uiStateAfter = widget.getWidgetUiState!(uiStateBefore, {
+        const uiStateAfter = widget.getWidgetUiState(uiStateBefore, {
           searchParameters: helper.state,
           helper,
         });
 
         expect(uiStateAfter).toEqual(uiStateBefore);
+      });
+
+      test('should remove refinement if new refinement is the initial index', () => {
+        const [widget, helper] = getInitializedWidget();
+
+        expect(helper.state.index).toBe('relevance');
+
+        expect(
+          widget.getWidgetUiState(
+            {
+              sortBy: 'relevance',
+            },
+            {
+              searchParameters: helper.state,
+              helper,
+            }
+          )
+        ).toEqual({
+          sortBy: undefined,
+        });
       });
 
       test('should use the top-level `indexName` for the initial index', () => {
@@ -622,7 +642,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
           })
         );
 
-        const actual = widget.getWidgetUiState!(
+        const actual = widget.getWidgetUiState(
           {},
           {
             searchParameters: helper.state,
@@ -657,7 +677,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
           createSearchClient(),
           'indexNameParent'
         );
-        helper.search = jest.fn();
 
         widget.init!(
           createInitOptions({
@@ -668,7 +687,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
           })
         );
 
-        const actual = widget.getWidgetUiState!(
+        const actual = widget.getWidgetUiState(
           {},
           {
             searchParameters: helper.state,

--- a/src/connectors/sort-by/connectSortBy.ts
+++ b/src/connectors/sort-by/connectSortBy.ts
@@ -177,13 +177,12 @@ const connectSortBy: SortByConnector = function connectSortBy(
       getWidgetUiState(uiState, { searchParameters }) {
         const currentIndex = searchParameters.index;
 
-        if (currentIndex === connectorState.initialIndex) {
-          return uiState;
-        }
-
         return {
           ...uiState,
-          sortBy: currentIndex,
+          sortBy:
+            currentIndex !== connectorState.initialIndex
+              ? currentIndex
+              : undefined,
         };
       },
 


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Without this check, if a route state is read (eg. in ssr) with the default value, it will be persisted in the URL, as the refinement is the default refinement, and the ui state was kept as-is, instead of being cleared.



**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

fixes https://github.com/algolia/vue-instantsearch/issues/1005
