### PR TITLE
fix(deps): force a lower version of qs

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,12 +54,13 @@
   "dependencies": {
     "@types/google.maps": "^3.45.3",
     "@types/hogan.js": "^3.0.0",
+    "@types/qs": "^6.5.3",
     "algoliasearch-helper": "^3.5.4",
     "classnames": "^2.2.5",
     "events": "^1.1.0",
     "hogan.js": "^3.0.2",
     "preact": "^10.0.0",
-    "qs": "^6.5.1"
+    "qs": "^6.5.1 < 6.10"
   },
   "devDependencies": {
     "@algolia/client-search": "4.10.3",
@@ -81,7 +82,6 @@
     "@types/enzyme": "^3.1.15",
     "@types/jest": "^26.0.22",
     "@types/jest-diff": "^24.3.0",
-    "@types/qs": "^6.5.3",
     "@types/storybook__addon-actions": "^3.4.2",
     "@typescript-eslint/eslint-plugin": "4.15.1",
     "@typescript-eslint/parser": "4.15.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11123,10 +11123,10 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
-qs@^6.5.1, qs@^6.6.0:
-  version "6.8.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.8.0.tgz#87b763f0d37ca54200334cd57bb2ef8f68a1d081"
-  integrity sha512-tPSkj8y92PfZVbinY1n84i1Qdx75lZjMQYx9WZhnkofyxzw2r7Ho39G3/aEvSUdebxpnnM4LZJCtvE/Aq3+s9w==
+qs@^6.6.0, "qs@^6.5.1 < 6.10":
+  version "6.9.6"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.6.tgz#26ed3c8243a431b2924aca84cc90471f35d5a0ee"
+  integrity sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==
 
 qs@~6.5.2:
   version "6.5.2"


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

In 6.10.1, qs became triple the size ((https://bundlephobia.com/package/qs@6.10.1 / https://github.com/ljharb/qs/issues/404)
), becoming a huge part of the bundlesize of InstantSearch.js. While we could fix this by not relying on a third-party anymore for this code, the least we can do is forcing the older version


**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

While this means it will be deduplicated less if people do use the later version of qs, it means a significant bundle size impact if we would have upgraded to 6.10+

