### PR TITLE
fix(routing): prevent history.pushState on InstantSearch.dispose call

### DIFF
--- a/src/lib/routers/history.ts
+++ b/src/lib/routers/history.ts
@@ -119,7 +119,7 @@ class BrowserHistory implements Router {
   /**
    * Pushes a search state into the URL.
    */
-  public write(routeState: RouteState): void {
+  public write(routeState: RouteState, replace: boolean = false): void {
     const url = this.createURL(routeState);
     const title = this.windowTitle && this.windowTitle(routeState);
 
@@ -129,7 +129,13 @@ class BrowserHistory implements Router {
 
     this.writeTimer = window.setTimeout(() => {
       setWindowTitle(title);
-      window.history.pushState(routeState, title || '', url);
+
+      if (replace) {
+        window.history.replaceState(routeState, title || '', url);
+      } else {
+        window.history.pushState(routeState, title || '', url);
+      }
+
       this.writeTimer = undefined;
     }, this.writeDelay);
   }
@@ -187,7 +193,7 @@ class BrowserHistory implements Router {
       window.clearTimeout(this.writeTimer);
     }
 
-    this.write({});
+    this.write({}, true);
   }
 }
 

--- a/src/lib/routers/history.ts
+++ b/src/lib/routers/history.ts
@@ -84,6 +84,7 @@ class BrowserHistory implements Router {
   private readonly parseURL: Required<BrowserHistoryArgs>['parseURL'];
 
   private writeTimer?: number;
+  private _disposed: boolean = false;
   private _onPopState?(event: PopStateEvent): void;
 
   /**
@@ -120,6 +121,7 @@ class BrowserHistory implements Router {
    * Pushes a search state into the URL.
    */
   public write(routeState: RouteState, replace: boolean = false): void {
+    if (this._disposed) return;
     const url = this.createURL(routeState);
     const title = this.windowTitle && this.windowTitle(routeState);
 
@@ -194,6 +196,7 @@ class BrowserHistory implements Router {
     }
 
     this.write({}, true);
+    this._disposed = true;
   }
 }
 


### PR DESCRIPTION
**Summary**

This change is aiming a fixing an issue we've had with routing on [Angular IS](https://github.com/algolia/angular-instantsearch/issues?q=is%3Aissue+back+routing) and [Vue IS](https://github.com/algolia/vue-instantsearch/issues?q=is%3Aissue+back+button+routing+), and essentially in any context where [dispose](https://github.com/algolia/instantsearch.js/blob/master/src/lib/InstantSearch.ts#L506) is called. On Angular/Vue InstantSearch, dispose is casually called when we navigate from route A to B. During this transition, all the widgets of route A are unmounted -- InstantSearch included, hence the [dispose call](https://github.com/algolia/angular-instantsearch/blob/master/src/instantsearch/instantsearch.ts#L247).

In the [following Vanilla example](https://codesandbox.io/s/gallant-buck-mvcpv?file=/src/app.js), you can see that `window.history.pushState` is being when the InstantSearch instance is disposed. This is the result of 2 things `dispose` does:
1. it removes the widgets, which triggers the router middleware's [onStateChange](https://github.com/algolia/instantsearch.js/blob/master/src/middlewares/createRouterMiddleware.ts#L49), roughly:
  
   https://github.com/algolia/instantsearch.js/blob/ddf60adea7cf35f93338d6a70466ccfdbb71749e/src/lib/InstantSearch.ts#L511 
   ```
   InstantSearch.dispose() -> removeWidgets -> ... -> RouterMiddleware.onStateChange -> window.history.pushState
   ```
 
 
 

2. middleware unsubscribe -> triggers routers's dispose.
https://github.com/algolia/instantsearch.js/blob/ddf60adea7cf35f93338d6a70466ccfdbb71749e/src/lib/InstantSearch.ts#L526-L528

   ```
   InstantSearch.dispose() -> RouterMiddleware.unsubscribe() -> router.dipose()- -> window.history.pushState
   ```

**Result**

There are probably a few different ways to solve the issue, here are 2:

**Solution A**: (implemented in this PR)
   1. On the router level: neutralize `route.write` call after `router.dispose` was called 
   2. On the router level: enable `router.write` to use `window.history.replaceState` when called from dispose.

**Solution B** 
1. On the middleware level: prevent middleware's `onStateChange` to be called if middleware has been disposed. 
2. On the router level: enable `router.write` to use `window.history.replaceState` when called from dispose. (same as A)

