### PR TITLE
fix(build): ensure build fails when types building fails

### DIFF
--- a/scripts/release/build-experimental-typescript.js
+++ b/scripts/release/build-experimental-typescript.js
@@ -19,11 +19,11 @@ fs.writeFileSync(
   `export default '${newVersion}';\n`
 );
 
-if (
-  shell.exec(`NODE_ENV=production VERSION=${newVersion} yarn build`).code !== 0
-) {
-  shell.exit(1);
-}
-if (shell.exec('yarn build:types').code !== 0) {
+const results = [
+  shell.exec(`NODE_ENV=production VERSION=${newVersion} yarn build`),
+  shell.exec('yarn build:types'),
+];
+
+if (results.some(result.code !== 0)) {
   shell.exit(1);
 }

--- a/scripts/release/build-experimental-typescript.js
+++ b/scripts/release/build-experimental-typescript.js
@@ -24,6 +24,6 @@ const results = [
   shell.exec('yarn build:types'),
 ];
 
-if (results.some(result.code !== 0)) {
+if (results.some(({ code }) => code !== 0)) {
   shell.exit(1);
 }

--- a/scripts/release/build-experimental-typescript.js
+++ b/scripts/release/build-experimental-typescript.js
@@ -19,5 +19,11 @@ fs.writeFileSync(
   `export default '${newVersion}';\n`
 );
 
-shell.exec(`NODE_ENV=production VERSION=${newVersion} yarn build`);
-shell.exec('yarn build:types');
+if (
+  shell.exec(`NODE_ENV=production VERSION=${newVersion} yarn build`).code !== 0
+) {
+  shell.exit(1);
+}
+if (shell.exec('yarn build:types').code !== 0) {
+  shell.exit(1);
+}


### PR DESCRIPTION
**Summary**
At the moment failing build types are not being surfaced to circle ci. See for example this [build](https://app.circleci.com/pipelines/github/algolia/instantsearch.js/6416/workflows/3398a5d9-002b-4220-8263-6d45d98cf33d/jobs/30500), step `Trigger a release if the latest commit is a release commit` should have failed but it didn't.

This is because [`yarn built:types`  is run via `shell.exec`](https://github.com/algolia/instantsearch.js/blob/4ff0392767bfc7a2398b649b2f9362ddb9a8cc75/scripts/release/build-experimental-typescript.js#L23) and the return code of 1 is ignored, instead of passed to calling process.

Per [exec](https://www.npmjs.com/package/shelljs#examples) docs, it's the caller's reponsibility to read the exit code and exit or continue.

```js
// Run external tool synchronously
if (shell.exec('git commit -am "Auto-commit"').code !== 0) {
  shell.echo('Error: Git commit failed');
  shell.exit(1);
}
```

This change would effectively make sure that `scripts/release/build-experimental-typescript.js` return code 1 if any of the exec inside do.

NB: `exec` is also called [in other areas](https://github.com/algolia/instantsearch.js/blob/296e9c459a68f8bdfaf82973c6cf5cfcca874c06/ship.config.js#L27) but in this case, it's not from `shelljs` but the one in [shipjs-lib](https://github.com/algolia/shipjs/blob/main/packages/shipjs-lib/src/lib/shell/exec.js) which reads and throws when code is 1.


