### PR TITLE
fix(types): export widget's types

### DIFF
--- a/src/widgets/dynamic-widgets/dynamic-widgets.ts
+++ b/src/widgets/dynamic-widgets/dynamic-widgets.ts
@@ -20,13 +20,13 @@ export type DynamicWidgetsWidgetParams = {
   widgets: Array<(container: HTMLElement) => Widget>;
 };
 
-export type DynamicWidgets = WidgetFactory<
+export type DynamicWidgetsWidget = WidgetFactory<
   DynamicWidgetsWidgetDescription & { $$widgetType: 'ais.dynamicWidgets' },
   Omit<DynamicWidgetsConnectorParams, 'widgets'>,
   DynamicWidgetsWidgetParams
 >;
 
-const dynamicWidgets: DynamicWidgets = function dynamicWidgets(widgetParams) {
+const dynamicWidgets: DynamicWidgetsWidget = function dynamicWidgets(widgetParams) {
   const { container: containerSelector, transformItems, widgets } =
     widgetParams || {};
 

--- a/src/widgets/dynamic-widgets/dynamic-widgets.ts
+++ b/src/widgets/dynamic-widgets/dynamic-widgets.ts
@@ -26,7 +26,9 @@ export type DynamicWidgetsWidget = WidgetFactory<
   DynamicWidgetsWidgetParams
 >;
 
-const dynamicWidgets: DynamicWidgetsWidget = function dynamicWidgets(widgetParams) {
+const dynamicWidgets: DynamicWidgetsWidget = function dynamicWidgets(
+  widgetParams
+) {
   const { container: containerSelector, transformItems, widgets } =
     widgetParams || {};
 

--- a/src/widgets/query-rule-context/query-rule-context.tsx
+++ b/src/widgets/query-rule-context/query-rule-context.tsx
@@ -7,12 +7,12 @@ import connectQueryRules, {
   QueryRulesWidgetDescription,
 } from '../../connectors/query-rules/connectQueryRules';
 
-type QueryRuleContextWidgetParams = {
+export type QueryRuleContextWidgetParams = {
   trackedFilters: ParamTrackedFilters;
   transformRuleContexts?: ParamTransformRuleContexts;
 };
 
-type QueryRuleContext = WidgetFactory<
+export type QueryRuleContextWidget = WidgetFactory<
   QueryRulesWidgetDescription & { $$widgetType: 'ais.queryRuleContext' },
   QueryRulesConnectorParams,
   QueryRuleContextWidgetParams
@@ -22,7 +22,7 @@ const withUsage = createDocumentationMessageGenerator({
   name: 'query-rule-context',
 });
 
-const queryRuleContext: QueryRuleContext = (
+const queryRuleContext: QueryRuleContextWidget = (
   widgetParams = {} as QueryRuleContextWidgetParams
 ) => {
   if (!widgetParams.trackedFilters) {

--- a/src/widgets/query-rule-custom-data/query-rule-custom-data.tsx
+++ b/src/widgets/query-rule-custom-data/query-rule-custom-data.tsx
@@ -27,13 +27,13 @@ export type QueryRuleCustomDataTemplates = Partial<{
   default: Template<{ items: any[] }>;
 }>;
 
-type QueryRuleCustomDataWidgetParams = {
+export type QueryRuleCustomDataWidgetParams = {
   container: string | HTMLElement;
   cssClasses?: QueryRuleCustomDataCSSClasses;
   templates?: QueryRuleCustomDataTemplates;
 };
 
-type QueryRuleCustomDataWidget = WidgetFactory<
+export type QueryRuleCustomDataWidget = WidgetFactory<
   QueryRulesWidgetDescription & { $$widgetType: 'ais.queryRuleCustomData' },
   QueryRulesConnectorParams,
   QueryRuleCustomDataWidgetParams

--- a/src/widgets/relevant-sort/relevant-sort.tsx
+++ b/src/widgets/relevant-sort/relevant-sort.tsx
@@ -37,7 +37,7 @@ export type RelevantSortWidgetParams = {
   templates?: RelevantSortTemplates;
 };
 
-type RelevantSortWidget = WidgetFactory<
+export type RelevantSortWidget = WidgetFactory<
   RelevantSortWidgetDescription & { $$widgetType: 'ais.relevantSort' },
   RelevantSortConnectorParams,
   RelevantSortWidgetParams

--- a/src/widgets/voice-search/voice-search.tsx
+++ b/src/widgets/voice-search/voice-search.tsx
@@ -56,7 +56,7 @@ export type VoiceSearchWidgetParams = {
   createVoiceSearchHelper?: CreateVoiceSearchHelper;
 };
 
-type VoiceSearch = WidgetFactory<
+export type VoiceSearchWidget = WidgetFactory<
   VoiceSearchWidgetDescription & { $$type: 'ais.voiceSearch' },
   VoiceSearchConnectorParams,
   VoiceSearchWidgetParams
@@ -89,7 +89,7 @@ const renderer = ({
   );
 };
 
-const voiceSearch: VoiceSearch = widgetParams => {
+const voiceSearch: VoiceSearchWidget = widgetParams => {
   const {
     container,
     cssClasses: userCssClasses = {},


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Not all widgets export their type correctly, which means it is harder to use

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

all types are exported from their respective file for widgets, not yet from the indexes

