### PR TITLE
chore(ts): avoid more ts-ignores

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@types/google.maps": "^3.45.3",
     "@types/hogan.js": "^3.0.0",
     "@types/qs": "^6.5.3",
-    "algoliasearch-helper": "^3.5.4",
+    "algoliasearch-helper": "^3.5.5",
     "classnames": "^2.2.5",
     "events": "^1.1.0",
     "hogan.js": "^3.0.2",

--- a/src/connectors/answers/__tests__/connectAnswers-test.ts
+++ b/src/connectors/answers/__tests__/connectAnswers-test.ts
@@ -16,7 +16,7 @@ describe('connectAnswers', () => {
   describe('Usage', () => {
     it('throws without render function', () => {
       expect(() => {
-        // @ts-ignore: test connectAnswers with invalid parameters
+        // @ts-expect-error: test connectAnswers with invalid parameters
         connectAnswers()({});
       }).toThrowErrorMatchingInlineSnapshot(`
 "The render function is not valid (received type Undefined).
@@ -27,7 +27,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/answers/js/
 
     it('throws without `queryLanguages`', () => {
       expect(() => {
-        // @ts-ignore: test connectAnswers with invalid parameters
+        // @ts-expect-error: test connectAnswers with invalid parameters
         connectAnswers(() => {})({});
       }).toThrowErrorMatchingInlineSnapshot(`
 "The \`queryLanguages\` expects an array of strings.

--- a/src/connectors/answers/connectAnswers.ts
+++ b/src/connectors/answers/connectAnswers.ts
@@ -122,7 +122,7 @@ const connectAnswers: AnswersConnector = function connectAnswers(
       extraParameters = {},
     } = widgetParams || {};
 
-    // @ts-ignore checking for the wrong value
+    // @ts-expect-error checking for the wrong value
     if (!queryLanguages || queryLanguages.length === 0) {
       throw new Error(
         withUsage('The `queryLanguages` expects an array of strings.')

--- a/src/connectors/autocomplete/__tests__/connectAutocomplete-test.ts
+++ b/src/connectors/autocomplete/__tests__/connectAutocomplete-test.ts
@@ -13,7 +13,7 @@ import connectAutocomplete, {
   AutocompleteRenderState,
 } from '../connectAutocomplete';
 import { TAG_PLACEHOLDER } from '../../../lib/utils';
-import { Hit, SearchClient } from '../../../types';
+import { EscapedHits, Hit, SearchClient } from '../../../types';
 
 describe('connectAutocomplete', () => {
   const getInitializedWidget = (config = {}) => {
@@ -41,7 +41,7 @@ describe('connectAutocomplete', () => {
 
   it('throws without render function', () => {
     expect(() => {
-      // @ts-ignore
+      // @ts-expect-error
       connectAutocomplete();
     }).toThrowErrorMatchingInlineSnapshot(`
 "The render function is not valid (received type Undefined).
@@ -56,7 +56,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/autocomplet
 
     const trigger = () => {
       makeWidget({
-        // @ts-ignore outdated `indices` option
+        // @ts-expect-error outdated `indices` option
         indices: [
           { label: 'Products', value: 'products' },
           { label: 'Services', value: 'services' },
@@ -535,8 +535,7 @@ search.addWidgets([
       );
 
       const hits: Hit[] = [];
-      // @ts-ignore-next-line
-      hits.__escaped = true;
+      (hits as EscapedHits).__escaped = true;
 
       expect(renderState).toEqual({
         currentRefinement: 'query',

--- a/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.ts
+++ b/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.ts
@@ -16,7 +16,7 @@ describe('connectBreadcrumb', () => {
   describe('Usage', () => {
     it('throws without render function', () => {
       expect(() => {
-        // @ts-ignore
+        // @ts-expect-error
         connectBreadcrumb()({});
       }).toThrowErrorMatchingInlineSnapshot(`
 "The render function is not valid (received type Undefined).
@@ -28,7 +28,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
     it('throws with undefined `attributes`', () => {
       expect(() => {
         connectBreadcrumb(() => {})({
-          // @ts-ignore
+          // @ts-expect-error
           attributes: undefined,
         });
       }).toThrowErrorMatchingInlineSnapshot(`
@@ -368,8 +368,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
             name: 'category',
             attributes: ['category', 'sub_category'],
             separator: ' > ',
-            // @TODO Add missing type to js helper
-            // @ts-ignore
             rootPath: null,
           },
         ],
@@ -402,7 +400,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
             name: 'category',
             attributes: ['category', 'sub_category', 'sub_sub_category'],
             separator: ' > ',
-            // @ts-ignore
             rootPath: null,
           },
         ],
@@ -428,7 +425,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
             name: 'category',
             attributes: ['category', 'sub_category'],
             separator: ' > ',
-            // @ts-ignore
             rootPath: null,
           },
         ],
@@ -455,7 +451,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
             name: 'category',
             attributes: ['category', 'sub_category'],
             separator: ' > ',
-            // @ts-ignore
             rootPath: 'TopLevel > SubLevel',
           },
         ],
@@ -488,7 +483,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
           {
             attributes: ['category', 'sub_category'],
             name: 'category',
-            // @ts-ignore
             rootPath: null,
             separator: ' > ',
           },

--- a/src/connectors/clear-refinements/__tests__/connectClearRefinements-test.ts
+++ b/src/connectors/clear-refinements/__tests__/connectClearRefinements-test.ts
@@ -12,7 +12,7 @@ describe('connectClearRefinements', () => {
   describe('Usage', () => {
     it('throws without render function', () => {
       expect(() => {
-        // @ts-ignore
+        // @ts-expect-error
         connectClearRefinements()({});
       }).toThrowErrorMatchingInlineSnapshot(`
 "The render function is not valid (received type Undefined).

--- a/src/connectors/configure-related-items/__tests__/connectConfigureRelatedItems-test.ts
+++ b/src/connectors/configure-related-items/__tests__/connectConfigureRelatedItems-test.ts
@@ -41,7 +41,7 @@ describe('connectConfigureRelatedItems', () => {
       const configureRelatedItems = connectConfigureRelatedItems(noop);
 
       expect(() => {
-        // @ts-ignore missing options
+        // @ts-expect-error missing options
         configureRelatedItems();
       }).toThrowErrorMatchingInlineSnapshot(`
 "The \`hit\` option is required.
@@ -54,7 +54,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure-r
       const configureRelatedItems = connectConfigureRelatedItems(noop);
 
       expect(() => {
-        // @ts-ignore missing options
+        // @ts-expect-error missing options
         configureRelatedItems({
           hit,
         });

--- a/src/connectors/configure/__tests__/connectConfigure-test.ts
+++ b/src/connectors/configure/__tests__/connectConfigure-test.ts
@@ -21,7 +21,7 @@ describe('connectConfigure', () => {
 
   describe('Usage', () => {
     it('throws without searchParameters', () => {
-      // @ts-ignore wrong options
+      // @ts-expect-error wrong options
       expect(() => connectConfigure()()).toThrowErrorMatchingInlineSnapshot(`
 "The \`searchParameters\` option expects an object.
 
@@ -31,7 +31,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
 
     it('throws when you pass it a non-plain object', () => {
       expect(() => {
-        // @ts-ignore wrong options
+        // @ts-expect-error wrong options
         connectConfigure()(new Date());
       }).toThrowErrorMatchingInlineSnapshot(`
 "The \`searchParameters\` option expects an object.
@@ -40,7 +40,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
 `);
 
       expect(() => {
-        // @ts-ignore wrong options
+        // @ts-expect-error wrong options
         connectConfigure()(() => {});
       }).toThrowErrorMatchingInlineSnapshot(`
 "The \`searchParameters\` option expects an object.
@@ -54,12 +54,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
     });
 
     it('with a unmount function but no render function does not throw', () => {
-      // @ts-ignore wrong options
+      // @ts-expect-error wrong options
       expect(() => connectConfigure(undefined, jest.fn())).not.toThrow();
     });
 
     it('does not throw without render and unmount functions', () => {
-      // @ts-ignore wrong options
+      // @ts-expect-error wrong options
       expect(() => connectConfigure(undefined, undefined)).not.toThrow();
     });
   });

--- a/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.ts
+++ b/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.ts
@@ -99,7 +99,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
             name: 'category',
             rootPath: null,
             separator: ' > ',
-            // @ts-ignore `showParentLevel` is missing in the SearchParameters.HierarchicalFacet declaration
             showParentLevel: true,
           },
         ],
@@ -918,7 +917,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
             attributes: ['categoriesLvl0', 'categoriesLvl1'],
             separator: ' > ',
             rootPath: null,
-            // @ts-ignore `showParentLevel` is missing in the SearchParameters.HierarchicalFacet declaration
             showParentLevel: true,
           },
         ],
@@ -956,7 +954,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
             attributes: ['categoriesLvl0', 'categoriesLvl1'],
             separator: ' > ',
             rootPath: null,
-            // @ts-ignore `showParentLevel` is missing in the SearchParameters.HierarchicalFacet declaration
             showParentLevel: true,
           },
         ],
@@ -1182,7 +1179,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
         uiState: {},
       });
 
-      // @ts-ignore `showParentLevel` is missing in the SearchParameters.HierarchicalFacet declaration
       expect(actual.hierarchicalFacets[0].showParentLevel).toBe(true);
     });
 

--- a/src/connectors/hierarchical-menu/connectHierarchicalMenu.ts
+++ b/src/connectors/hierarchical-menu/connectHierarchicalMenu.ts
@@ -415,7 +415,6 @@ const connectHierarchicalMenu: HierarchicalMenuConnector = function connectHiera
             attributes,
             separator,
             rootPath,
-            // @ts-ignore `showParentLevel` is missing in the SearchParameters.HierarchicalFacet declaration
             showParentLevel,
           });
 

--- a/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.ts
+++ b/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.ts
@@ -17,7 +17,7 @@ describe('connectHitsPerPage', () => {
     it('throws without items', () => {
       expect(() => {
         connectHitsPerPage(() => {})({
-          // @ts-ignore
+          // @ts-expect-error
           items: undefined,
         });
       }).toThrowErrorMatchingInlineSnapshot(`

--- a/src/connectors/hits/__tests__/connectHits-test.ts
+++ b/src/connectors/hits/__tests__/connectHits-test.ts
@@ -23,7 +23,7 @@ jest.mock('../../../lib/utils/hits-absolute-position', () => ({
 describe('connectHits', () => {
   it('throws without render function', () => {
     expect(() => {
-      // @ts-ignore
+      // @ts-expect-error
       connectHits()({});
     }).toThrowErrorMatchingInlineSnapshot(`
 "The render function is not valid (received type Undefined).

--- a/src/connectors/hits/__tests__/connectHitsWithInsights-test.ts
+++ b/src/connectors/hits/__tests__/connectHitsWithInsights-test.ts
@@ -97,7 +97,6 @@ describe('connectHitsWithInsights', () => {
 
   it('does not throw without the unmount function', () => {
     const rendering = () => {};
-    // @ts-ignore:next-line
     const makeWidget = connectHitsWithInsights(rendering);
     const widget = makeWidget({});
     const helper = algoliasearchHelper(createSearchClient(), '', {});

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -24,7 +24,7 @@ jest.mock('../../../lib/utils/hits-absolute-position', () => ({
 describe('connectInfiniteHits', () => {
   it('throws without render function', () => {
     expect(() => {
-      // @ts-ignore: test connectInfiniteHits with invalid parameters
+      // @ts-expect-error: test connectInfiniteHits with invalid parameters
       connectInfiniteHits()({});
     }).toThrowErrorMatchingInlineSnapshot(`
 "The render function is not valid (received type Undefined).

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHitsWithInsights-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHitsWithInsights-test.ts
@@ -112,7 +112,6 @@ describe('connectInfiniteHitsWithInsights', () => {
 
   it('does not throw without the unmount function', () => {
     const rendering = () => {};
-    // @ts-ignore:next-line
     const makeWidget = connectInfiniteHitsWithInsights(rendering);
     const helper = algoliasearchHelper(createSearchClient(), '', {});
     const widget = makeWidget({});

--- a/src/connectors/menu/__tests__/connectMenu-test.ts
+++ b/src/connectors/menu/__tests__/connectMenu-test.ts
@@ -33,7 +33,7 @@ describe('connectMenu', () => {
   describe('Usage', () => {
     it('throws without render function', () => {
       expect(() => {
-        // @ts-ignore
+        // @ts-expect-error
         connectMenu()({});
       }).toThrowErrorMatchingInlineSnapshot(`
 "The render function is not valid (received type Undefined).

--- a/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.ts
+++ b/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.ts
@@ -58,7 +58,7 @@ describe('connectNumericMenu', () => {
   describe('Usage', () => {
     it('throws without render function', () => {
       expect(() => {
-        // @ts-ignore
+        // @ts-expect-error
         connectNumericMenu()({});
       }).toThrowErrorMatchingInlineSnapshot(`
 "The render function is not valid (received type Undefined).
@@ -69,7 +69,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
 
     it('throws without attribute', () => {
       expect(() => {
-        // @ts-ignore
+        // @ts-expect-error
         connectNumericMenu(() => {})({ attribute: undefined, items: [] });
       }).toThrowErrorMatchingInlineSnapshot(`
 "The \`attribute\` option is required.
@@ -82,7 +82,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
       expect(() => {
         connectNumericMenu(() => {})({
           attribute: 'attribute',
-          // @ts-ignore
+          // @ts-expect-error
           items: undefined,
         });
       }).toThrowErrorMatchingInlineSnapshot(`

--- a/src/connectors/pagination/__tests__/connectPagination-test.ts
+++ b/src/connectors/pagination/__tests__/connectPagination-test.ts
@@ -36,7 +36,7 @@ describe('connectPagination', () => {
   describe('Usage', () => {
     it('throws without render function', () => {
       expect(() => {
-        // @ts-ignore
+        // @ts-expect-error
         connectPagination()({});
       }).toThrowErrorMatchingInlineSnapshot(`
 "The render function is not valid (received type Undefined).
@@ -70,7 +70,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/pagination/
     const renderFn = jest.fn();
     const makeWidget = connectPagination(renderFn);
     const widget = makeWidget({
-      // @ts-ignore
+      // @ts-expect-error
       foo: 'bar',
     });
 
@@ -614,7 +614,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/pagination/
         widget.getRenderState(
           {
             hierarchicalMenu: {},
-            // @ts-ignore
+            // @ts-expect-error
             pagination: {},
           },
           createRenderOptions({

--- a/src/connectors/powered-by/__tests__/connectPoweredBy-test.ts
+++ b/src/connectors/powered-by/__tests__/connectPoweredBy-test.ts
@@ -10,7 +10,7 @@ import connectPoweredBy from '../connectPoweredBy';
 describe('connectPoweredBy', () => {
   it('throws without rendering function', () => {
     expect(() => {
-      // @ts-ignore
+      // @ts-expect-error
       connectPoweredBy();
     }).toThrowErrorMatchingInlineSnapshot(`
 "The render function is not valid (received type Undefined).

--- a/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
+++ b/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
@@ -36,7 +36,7 @@ describe('connectQueryRules', () => {
   describe('usage', () => {
     test('throws without render function', () => {
       expect(() => {
-        // @ts-ignore
+        // @ts-expect-error
         connectQueryRules()({});
       }).toThrowErrorMatchingInlineSnapshot(`
 "The render function is not valid (received type Undefined).
@@ -55,7 +55,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
       expect(() => {
         const { makeWidget } = createWidget();
         makeWidget({
-          // @ts-ignore
+          // @ts-expect-error
           trackedFilters: { brand: ['Samsung'] },
         });
       }).toThrowErrorMatchingInlineSnapshot(`

--- a/src/connectors/range/__tests__/connectRange-test.ts
+++ b/src/connectors/range/__tests__/connectRange-test.ts
@@ -44,7 +44,7 @@ describe('connectRange', () => {
   describe('Usage', () => {
     it('throws without render function', () => {
       expect(() => {
-        // @ts-ignore
+        // @ts-expect-error
         connectRange()({});
       }).toThrowErrorMatchingInlineSnapshot(`
 "The render function is not valid (received type Undefined).
@@ -55,7 +55,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
 
     it('throws without attribute', () => {
       expect(() => {
-        // @ts-ignore
+        // @ts-expect-error
         connectRange(() => {})({ attribute: undefined });
       }).toThrowErrorMatchingInlineSnapshot(`
 "The \`attribute\` option is required.
@@ -753,7 +753,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
         })
       );
 
-      // @ts-ignore
+      // @ts-expect-error
       refine(['10', '490']);
 
       expect(helper.getNumericRefinement(attribute, '>=')).toEqual([10]);
@@ -782,7 +782,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
         })
       );
 
-      // @ts-ignore
+      // @ts-expect-error
       refine(['10.50', '490.50']);
 
       // min is rounded down, max rounded up
@@ -945,7 +945,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
         })
       );
 
-      // @ts-ignore
+      // @ts-expect-error
       refine(['', 490]);
 
       expect(helper.getNumericRefinement(attribute, '>=')).toEqual([]);
@@ -979,7 +979,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
         })
       );
 
-      // @ts-ignore
+      // @ts-expect-error
       refine([10, '']);
 
       expect(helper.getNumericRefinement(attribute, '>=')).toEqual([10]);
@@ -1254,7 +1254,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
         })
       );
 
-      // @ts-ignore
+      // @ts-expect-error
       refine(['ADASA', 'FFDSFQS']);
 
       expect(helper.getNumericRefinement(attribute, '>=')).toEqual(undefined);

--- a/src/connectors/refinement-list/__tests__/connectRefinementList-test.ts
+++ b/src/connectors/refinement-list/__tests__/connectRefinementList-test.ts
@@ -38,7 +38,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
 See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-list/js/#connector"
 `);
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(() => connectRefinementList(() => {})())
       .toThrowErrorMatchingInlineSnapshot(`
 "The \`attribute\` option is required.
@@ -47,7 +47,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
 `);
 
     expect(() =>
-      // @ts-ignore
+      // @ts-expect-error
       connectRefinementList(() => {})({
         operator: 'and',
       })
@@ -60,7 +60,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
     expect(() =>
       connectRefinementList(() => {})({
         attribute: 'company',
-        // @ts-ignore
+        // @ts-expect-error
         operator: 'YUP',
       })
     ).toThrowErrorMatchingInlineSnapshot(`

--- a/src/connectors/voice-search/connectVoiceSearch.ts
+++ b/src/connectors/voice-search/connectVoiceSearch.ts
@@ -112,7 +112,7 @@ const connectVoiceSearch: VoiceSearchConnector = function connectVoiceSearch(
                   helper.state.setQueryParameters({
                     ignorePlurals: true,
                     removeStopWords: true,
-                    // @ts-ignore (optionalWords only allows array, while string is also valid)
+                    // @ts-ignore (optionalWords only allows array in v3, while string is also valid)
                     optionalWords: query,
                     ...additionalQueryParameters({ query }),
                   })
@@ -179,13 +179,13 @@ const connectVoiceSearch: VoiceSearchConnector = function connectVoiceSearch(
             ? (Object.keys(additional) as Array<
                 keyof PlainSearchParameters
               >).reduce<PlainSearchParameters>((acc, current) => {
-                // @ts-ignore search parameters is typed as readonly
+                // @ts-ignore search parameters is typed as readonly in v4
                 acc[current] = undefined;
                 return acc;
               }, {})
             : {};
           newState = state.setQueryParameters({
-            // @ts-ignore (queryLanguages is not yet added to algoliasearch)
+            // @ts-ignore (queryLanguages is not added to algoliasearch v3)
             queryLanguages: undefined,
             ignorePlurals: undefined,
             removeStopWords: undefined,

--- a/src/lib/__tests__/insights-client-test.ts
+++ b/src/lib/__tests__/insights-client-test.ts
@@ -1,5 +1,9 @@
 import { withInsights, inferInsightsPayload } from '../insights';
-import { Widget } from '../../types';
+import { SearchParameters, SearchResults } from 'algoliasearch-helper';
+import { InstantSearch, Widget } from '../../types';
+import { createInstantSearch } from '../../../test/mock/createInstantSearch';
+import { createSingleSearchResponse } from '../../../test/mock/createAPIResponse';
+import { castToJestMock } from '../../../test/utils/castToJestMock';
 
 const connectHits = (renderFn: any, unmountFn: any) => (
   widgetParams = {}
@@ -16,16 +20,17 @@ const connectHits = (renderFn: any, unmountFn: any) => (
 });
 
 const createWidgetWithInsights = ({
-  // @ts-ignore can not import types in this file?
   renderFn,
-  // @ts-ignore can not import types in this file?
   instantSearchInstance,
-  // @ts-ignore can not import types in this file?
   results,
+}: {
+  renderFn: any;
+  instantSearchInstance: InstantSearch;
+  results: SearchResults;
 }): Widget => {
   const connectHitsWithInsights = withInsights(connectHits as any);
   const widget = connectHitsWithInsights(renderFn, jest.fn())({});
-  (widget as any).render({ results, instantSearchInstance } as any);
+  widget.render({ results, instantSearchInstance } as any);
   return widget;
 };
 
@@ -33,16 +38,20 @@ describe('withInsights', () => {
   describe('when applied on connectHits', () => {
     it('should call the passed renderFn', () => {
       const renderFn = jest.fn();
-      const instantSearchInstance = { insightsClient: jest.fn() };
-      const results = {
-        index: 'theIndex',
-        hits: [
-          { objectID: '1', __queryID: 'theQueryID', __position: 9 },
-          { objectID: '2', __queryID: 'theQueryID', __position: 10 },
-          { objectID: '3', __queryID: 'theQueryID', __position: 11 },
-          { objectID: '4', __queryID: 'theQueryID', __position: 12 },
-        ],
-      };
+      const instantSearchInstance = createInstantSearch({
+        insightsClient: jest.fn(),
+      });
+      const results = new SearchResults(new SearchParameters(), [
+        createSingleSearchResponse({
+          index: 'theIndex',
+          hits: [
+            { objectID: '1', __queryID: 'theQueryID', __position: 9 },
+            { objectID: '2', __queryID: 'theQueryID', __position: 10 },
+            { objectID: '3', __queryID: 'theQueryID', __position: 11 },
+            { objectID: '4', __queryID: 'theQueryID', __position: 12 },
+          ],
+        }),
+      ]);
       createWidgetWithInsights({ renderFn, instantSearchInstance, results });
 
       expect(renderFn).toHaveBeenCalledTimes(1);
@@ -50,16 +59,20 @@ describe('withInsights', () => {
 
     it('should not remove any renderProps passed by connectHits', () => {
       const renderFn = jest.fn();
-      const instantSearchInstance = { insightsClient: jest.fn() };
-      const results = {
-        index: 'theIndex',
-        hits: [
-          { objectID: '1', __queryID: 'theQueryID', __position: 9 },
-          { objectID: '2', __queryID: 'theQueryID', __position: 10 },
-          { objectID: '3', __queryID: 'theQueryID', __position: 11 },
-          { objectID: '4', __queryID: 'theQueryID', __position: 12 },
-        ],
-      };
+      const instantSearchInstance = createInstantSearch({
+        insightsClient: jest.fn(),
+      });
+      const results = new SearchResults(new SearchParameters(), [
+        createSingleSearchResponse({
+          index: 'theIndex',
+          hits: [
+            { objectID: '1', __queryID: 'theQueryID', __position: 9 },
+            { objectID: '2', __queryID: 'theQueryID', __position: 10 },
+            { objectID: '3', __queryID: 'theQueryID', __position: 11 },
+            { objectID: '4', __queryID: 'theQueryID', __position: 12 },
+          ],
+        }),
+      ]);
       createWidgetWithInsights({ renderFn, instantSearchInstance, results });
 
       const [renderProps] = renderFn.mock.calls[0];
@@ -74,16 +87,20 @@ describe('withInsights', () => {
 
     it('should expose the insights client wrapper to renderOptions if passed to instantSearchInstance', () => {
       const renderFn = jest.fn();
-      const instantSearchInstance = { insightsClient: jest.fn() };
-      const results = {
-        index: 'theIndex',
-        hits: [
-          { objectID: '1', __queryID: 'theQueryID', __position: 9 },
-          { objectID: '2', __queryID: 'theQueryID', __position: 10 },
-          { objectID: '3', __queryID: 'theQueryID', __position: 11 },
-          { objectID: '4', __queryID: 'theQueryID', __position: 12 },
-        ],
-      };
+      const instantSearchInstance = createInstantSearch({
+        insightsClient: jest.fn(),
+      });
+      const results = new SearchResults(new SearchParameters(), [
+        createSingleSearchResponse({
+          index: 'theIndex',
+          hits: [
+            { objectID: '1', __queryID: 'theQueryID', __position: 9 },
+            { objectID: '2', __queryID: 'theQueryID', __position: 10 },
+            { objectID: '3', __queryID: 'theQueryID', __position: 11 },
+            { objectID: '4', __queryID: 'theQueryID', __position: 12 },
+          ],
+        }),
+      ]);
       createWidgetWithInsights({ renderFn, instantSearchInstance, results });
 
       const [renderProps] = renderFn.mock.calls[0];
@@ -92,18 +109,20 @@ describe('withInsights', () => {
     });
     it('should expose the insights client wrapper even when insightsClient was not provided', () => {
       const renderFn = jest.fn();
-      const instantSearchInstance = {
-        /* insightsClient was not passed */
-      };
-      const results = {
-        index: 'theIndex',
-        hits: [
-          { objectID: '1', __queryID: 'theQueryID', __position: 9 },
-          { objectID: '2', __queryID: 'theQueryID', __position: 10 },
-          { objectID: '3', __queryID: 'theQueryID', __position: 11 },
-          { objectID: '4', __queryID: 'theQueryID', __position: 12 },
-        ],
-      };
+      const instantSearchInstance = createInstantSearch({
+        insightsClient: null,
+      });
+      const results = new SearchResults(new SearchParameters(), [
+        createSingleSearchResponse({
+          index: 'theIndex',
+          hits: [
+            { objectID: '1', __queryID: 'theQueryID', __position: 9 },
+            { objectID: '2', __queryID: 'theQueryID', __position: 10 },
+            { objectID: '3', __queryID: 'theQueryID', __position: 11 },
+            { objectID: '4', __queryID: 'theQueryID', __position: 12 },
+          ],
+        }),
+      ]);
       createWidgetWithInsights({ renderFn, instantSearchInstance, results });
 
       const [renderProps] = renderFn.mock.calls[0];
@@ -112,18 +131,20 @@ describe('withInsights', () => {
     });
     it('should expose the insights client wrapper that throws when insightsClient was not provided', () => {
       const renderFn = jest.fn();
-      const instantSearchInstance = {
-        /* insightsClient was not passed */
-      };
-      const results = {
-        index: 'theIndex',
-        hits: [
-          { objectID: '1', __queryID: 'theQueryID', __position: 9 },
-          { objectID: '2', __queryID: 'theQueryID', __position: 10 },
-          { objectID: '3', __queryID: 'theQueryID', __position: 11 },
-          { objectID: '4', __queryID: 'theQueryID', __position: 12 },
-        ],
-      };
+      const instantSearchInstance = createInstantSearch({
+        insightsClient: null,
+      });
+      const results = new SearchResults(new SearchParameters(), [
+        createSingleSearchResponse({
+          index: 'theIndex',
+          hits: [
+            { objectID: '1', __queryID: 'theQueryID', __position: 9 },
+            { objectID: '2', __queryID: 'theQueryID', __position: 10 },
+            { objectID: '3', __queryID: 'theQueryID', __position: 11 },
+            { objectID: '4', __queryID: 'theQueryID', __position: 12 },
+          ],
+        }),
+      ]);
       createWidgetWithInsights({ renderFn, instantSearchInstance, results });
 
       const [renderProps] = renderFn.mock.calls[0];
@@ -143,16 +164,20 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
   describe('exposed insights client wrapper', () => {
     it('should call the insights client under the hood', () => {
       const renderFn = jest.fn();
-      const instantSearchInstance = { insightsClient: jest.fn() };
-      const results = {
-        index: 'theIndex',
-        hits: [
-          { objectID: '1', __queryID: 'theQueryID', __position: 9 },
-          { objectID: '2', __queryID: 'theQueryID', __position: 10 },
-          { objectID: '3', __queryID: 'theQueryID', __position: 11 },
-          { objectID: '4', __queryID: 'theQueryID', __position: 12 },
-        ],
-      };
+      const instantSearchInstance = createInstantSearch({
+        insightsClient: jest.fn(),
+      });
+      const results = new SearchResults(new SearchParameters(), [
+        createSingleSearchResponse({
+          index: 'theIndex',
+          hits: [
+            { objectID: '1', __queryID: 'theQueryID', __position: 9 },
+            { objectID: '2', __queryID: 'theQueryID', __position: 10 },
+            { objectID: '3', __queryID: 'theQueryID', __position: 11 },
+            { objectID: '4', __queryID: 'theQueryID', __position: 12 },
+          ],
+        }),
+      ]);
       createWidgetWithInsights({ renderFn, instantSearchInstance, results });
 
       const [renderProps] = renderFn.mock.calls[0];
@@ -165,16 +190,20 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
 
     it('should pass it the correct parameters', () => {
       const renderFn = jest.fn();
-      const instantSearchInstance = { insightsClient: jest.fn() };
-      const results = {
-        index: 'theIndex',
-        hits: [
-          { objectID: '1', __queryID: 'theQueryID', __position: 9 },
-          { objectID: '2', __queryID: 'theQueryID', __position: 10 },
-          { objectID: '3', __queryID: 'theQueryID', __position: 11 },
-          { objectID: '4', __queryID: 'theQueryID', __position: 12 },
-        ],
-      };
+      const instantSearchInstance = createInstantSearch({
+        insightsClient: jest.fn(),
+      });
+      const results = new SearchResults(new SearchParameters(), [
+        createSingleSearchResponse({
+          index: 'theIndex',
+          hits: [
+            { objectID: '1', __queryID: 'theQueryID', __position: 9 },
+            { objectID: '2', __queryID: 'theQueryID', __position: 10 },
+            { objectID: '3', __queryID: 'theQueryID', __position: 11 },
+            { objectID: '4', __queryID: 'theQueryID', __position: 12 },
+          ],
+        }),
+      ]);
       createWidgetWithInsights({ renderFn, instantSearchInstance, results });
 
       const [renderProps] = renderFn.mock.calls[0];
@@ -182,10 +211,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
         objectIDs: ['3'],
         eventName: 'Add to basket',
       });
-      const [
-        method,
-        payload,
-      ] = instantSearchInstance.insightsClient.mock.calls[0];
+      const [method, payload] = castToJestMock(
+        instantSearchInstance.insightsClient!
+      ).mock.calls[0];
       expect(method).toEqual('clickedObjectIDsAfterSearch');
       expect(payload).toEqual({
         eventName: 'Add to basket',
@@ -198,16 +226,20 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
 
     it('should not infer or pass the positions if method is `convertedObjectIDsAfterSearch`', () => {
       const renderFn = jest.fn();
-      const instantSearchInstance = { insightsClient: jest.fn() };
-      const results = {
-        index: 'theIndex',
-        hits: [
-          { objectID: '1', __queryID: 'theQueryID', __position: 9 },
-          { objectID: '2', __queryID: 'theQueryID', __position: 10 },
-          { objectID: '3', __queryID: 'theQueryID', __position: 11 },
-          { objectID: '4', __queryID: 'theQueryID', __position: 12 },
-        ],
-      };
+      const instantSearchInstance = createInstantSearch({
+        insightsClient: jest.fn(),
+      });
+      const results = new SearchResults(new SearchParameters(), [
+        createSingleSearchResponse({
+          index: 'theIndex',
+          hits: [
+            { objectID: '1', __queryID: 'theQueryID', __position: 9 },
+            { objectID: '2', __queryID: 'theQueryID', __position: 10 },
+            { objectID: '3', __queryID: 'theQueryID', __position: 11 },
+            { objectID: '4', __queryID: 'theQueryID', __position: 12 },
+          ],
+        }),
+      ]);
       createWidgetWithInsights({ renderFn, instantSearchInstance, results });
 
       const [renderProps] = renderFn.mock.calls[0];
@@ -215,10 +247,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
         objectIDs: ['1'],
         eventName: 'Add to basket',
       });
-      const [
-        method,
-        payload,
-      ] = instantSearchInstance.insightsClient.mock.calls[0];
+      const [method, payload] = castToJestMock(
+        instantSearchInstance.insightsClient!
+      ).mock.calls[0];
       expect(method).toEqual('convertedObjectIDsAfterSearch');
       expect(payload).toEqual({
         eventName: 'Add to basket',
@@ -230,16 +261,20 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
 
     it('should reject non-existing objectIDs', () => {
       const renderFn = jest.fn();
-      const instantSearchInstance = { insightsClient: jest.fn() };
-      const results = {
-        index: 'theIndex',
-        hits: [
-          { objectID: '1', __queryID: 'theQueryID', __position: 9 },
-          { objectID: '2', __queryID: 'theQueryID', __position: 10 },
-          { objectID: '3', __queryID: 'theQueryID', __position: 11 },
-          { objectID: '4', __queryID: 'theQueryID', __position: 12 },
-        ],
-      };
+      const instantSearchInstance = createInstantSearch({
+        insightsClient: jest.fn(),
+      });
+      const results = new SearchResults(new SearchParameters(), [
+        createSingleSearchResponse({
+          index: 'theIndex',
+          hits: [
+            { objectID: '1', __queryID: 'theQueryID', __position: 9 },
+            { objectID: '2', __queryID: 'theQueryID', __position: 10 },
+            { objectID: '3', __queryID: 'theQueryID', __position: 11 },
+            { objectID: '4', __queryID: 'theQueryID', __position: 12 },
+          ],
+        }),
+      ]);
       createWidgetWithInsights({ renderFn, instantSearchInstance, results });
 
       const [renderProps] = renderFn.mock.calls[0];
@@ -255,14 +290,18 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
 
     it('should reject if objectIDs provided have different queryIDs', () => {
       const renderFn = jest.fn();
-      const instantSearchInstance = { insightsClient: jest.fn() };
-      const results = {
-        index: 'theIndex',
-        hits: [
-          { objectID: '1', __position: 1, __queryID: 'theQueryID_1' },
-          { objectID: '2', __position: 2, __queryID: 'theQueryID_2' },
-        ],
-      };
+      const instantSearchInstance = createInstantSearch({
+        insightsClient: jest.fn(),
+      });
+      const results = new SearchResults(new SearchParameters(), [
+        createSingleSearchResponse({
+          index: 'theIndex',
+          hits: [
+            { objectID: '1', __position: 1, __queryID: 'theQueryID_1' },
+            { objectID: '2', __position: 2, __queryID: 'theQueryID_2' },
+          ],
+        }),
+      ]);
       createWidgetWithInsights({ renderFn, instantSearchInstance, results });
 
       const [renderProps] = renderFn.mock.calls[0];
@@ -278,14 +317,18 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
 
     it('should reject if no queryID found (clickAnalytics was not set to true)', () => {
       const renderFn = jest.fn();
-      const instantSearchInstance = { insightsClient: jest.fn() };
-      const results = {
-        index: 'theIndex',
-        hits: [
-          { objectID: '1', __position: 1 },
-          { objectID: '2', __position: 2 },
-        ],
-      };
+      const instantSearchInstance = createInstantSearch({
+        insightsClient: jest.fn(),
+      });
+      const results = new SearchResults(new SearchParameters(), [
+        createSingleSearchResponse({
+          index: 'theIndex',
+          hits: [
+            { objectID: '1', __position: 1 },
+            { objectID: '2', __position: 2 },
+          ],
+        }),
+      ]);
       createWidgetWithInsights({ renderFn, instantSearchInstance, results });
 
       const [renderProps] = renderFn.mock.calls[0];
@@ -303,42 +346,48 @@ See: https://alg.li/lNiZZ7"
 
     it('should reject unknown method name', () => {
       const renderFn = jest.fn();
-      const instantSearchInstance = { insightsClient: jest.fn() };
-      const results = {
-        index: 'theIndex',
-        hits: [
-          { objectID: '1', __queryID: 'theQueryID', __position: 9 },
-          { objectID: '2', __queryID: 'theQueryID', __position: 10 },
-          { objectID: '3', __queryID: 'theQueryID', __position: 11 },
-          { objectID: '4', __queryID: 'theQueryID', __position: 12 },
-        ],
-      };
+      const instantSearchInstance = createInstantSearch({
+        insightsClient: jest.fn(),
+      });
+      const results = new SearchResults(new SearchParameters(), [
+        createSingleSearchResponse({
+          index: 'theIndex',
+          hits: [
+            { objectID: '1', __queryID: 'theQueryID', __position: 9 },
+            { objectID: '2', __queryID: 'theQueryID', __position: 10 },
+            { objectID: '3', __queryID: 'theQueryID', __position: 11 },
+            { objectID: '4', __queryID: 'theQueryID', __position: 12 },
+          ],
+        }),
+      ]);
       createWidgetWithInsights({ renderFn, instantSearchInstance, results });
 
       const [renderProps] = renderFn.mock.calls[0];
       expect(() => {
-        renderProps.insights('unknow_method', {
+        renderProps.insights('unknown_method', {
           objectIDs: ['3'],
           eventName: 'Add to basket',
         });
       }).toThrowErrorMatchingInlineSnapshot(
-        `"Unsupported method passed to insights: \\"unknow_method\\"."`
+        `"Unsupported method passed to insights: \\"unknown_method\\"."`
       );
     });
   });
 });
 
 describe('inferInsightsPayload', () => {
-  const hits: any = [
+  const hits = [
     { objectID: '1', __queryID: 'theQueryID', __position: 9 },
     { objectID: '2', __queryID: 'theQueryID', __position: 10 },
     { objectID: '3', __queryID: 'theQueryID', __position: 11 },
     { objectID: '4', __queryID: 'theQueryID', __position: 12 },
   ];
-  const results: any = {
-    index: 'theIndex',
-    hits,
-  };
+  const results = new SearchResults(new SearchParameters(), [
+    createSingleSearchResponse({
+      index: 'theIndex',
+      hits,
+    }),
+  ]);
 
   describe('payload inferring', () => {
     it('should infer queryID from results', () => {

--- a/src/widgets/answers/__tests__/answers-test.ts
+++ b/src/widgets/answers/__tests__/answers-test.ts
@@ -8,12 +8,13 @@ import { runAllMicroTasks } from '../../../../test/utils/runAllMicroTasks';
 import { wait } from '../../../../test/utils/wait';
 import answers from '../answers';
 import searchBox from '../../search-box/search-box';
+import { createInitOptions } from '../../../../test/mock/createWidget';
 
 describe('answers', () => {
   describe('Usage', () => {
     it('throws without `container`', () => {
       expect(() => {
-        // @ts-ignore
+        // @ts-expect-error
         answers({});
       }).toThrowErrorMatchingInlineSnapshot(`
 "The \`container\` option is required.
@@ -25,7 +26,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/answers/js/
     it('throws without `queryLanguages`', () => {
       const container = document.createElement('div');
       expect(() => {
-        // @ts-ignore
+        // @ts-expect-error
         answers({ container });
       }).toThrowErrorMatchingInlineSnapshot(`
 "The \`queryLanguages\` expects an array of strings.
@@ -47,18 +48,20 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/answers/js/
         indexName: 'instant_search',
         searchClient,
       });
+      search.helper = helper;
       const widget = answers({
         container,
         queryLanguages: ['en'],
         attributesForPrediction: ['description'],
       });
       expect(() => {
-        // @ts-ignore-next-line
-        widget.init({
-          state: helper.state,
-          helper,
-          instantSearchInstance: search,
-        });
+        widget.init!(
+          createInitOptions({
+            state: helper.state,
+            helper,
+            instantSearchInstance: search,
+          })
+        );
       }).toThrowErrorMatchingInlineSnapshot(`
 "\`algoliasearch\` >= 4.8.0 required.
 

--- a/src/widgets/menu-select/__tests__/menu-select-test.ts
+++ b/src/widgets/menu-select/__tests__/menu-select-test.ts
@@ -27,7 +27,7 @@ describe('menuSelect', () => {
   describe('Usage', () => {
     it('throws without container', () => {
       expect(() => {
-        // @ts-ignore
+        // @ts-expect-error
         menuSelect({ container: undefined });
       }).toThrowErrorMatchingInlineSnapshot(`
 "The \`container\` option is required.

--- a/src/widgets/menu/__tests__/menu-test.ts
+++ b/src/widgets/menu/__tests__/menu-test.ts
@@ -24,7 +24,7 @@ jest.mock('preact', () => {
 describe('menu', () => {
   it('throws without container', () => {
     expect(() => {
-      // @ts-ignore
+      // @ts-expect-error
       menu({ attribute: undefined });
     }).toThrowErrorMatchingInlineSnapshot(`
 "The \`container\` option is required.

--- a/src/widgets/relevant-sort/__tests__/relevant-sort-test.ts
+++ b/src/widgets/relevant-sort/__tests__/relevant-sort-test.ts
@@ -31,7 +31,7 @@ describe('relevantSort', () => {
   describe('Usage', () => {
     it('throws without container', () => {
       expect(() => {
-        // @ts-ignore wrong options
+        // @ts-expect-error wrong options
         relevantSort({ container: undefined });
       }).toThrowErrorMatchingInlineSnapshot(`
 "The \`container\` option is required.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2902,10 +2902,10 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@~6.12.6:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-algoliasearch-helper@^3.5.4:
-  version "3.5.4"
-  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.5.4.tgz#21b20ab8a258daa9dde9aef2daa5e8994cd66077"
-  integrity sha512-t+FLhXYnPZiwjYe5ExyN962HQY8mi3KwRju3Lyf6OBgtRdx30d6mqvtClXf5NeBihH45Xzj6t4Y5YyvAI432XA==
+algoliasearch-helper@^3.5.5:
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.5.5.tgz#05263869d3c8a7292278d7e49630f52520f204d7"
+  integrity sha512-JDH14gMpSj8UzEaKwVkrqKOeAOyK0dDWsFlKvWhk0Xl5yw9FyafYf1xZPb4uSXaPBAFQtUouFlR1Zt68BCY0/w==
   dependencies:
     events "^1.1.1"
 


### PR DESCRIPTION
ts-expect-error will error if it's no longer needed, so it's better in almost all cases. There's some moments where we need to keep ts-ignore though:
- things that fail only with algoliasearch v3 or v4
- optional packages (places)
- code that doesn't always error

At the same time updated the algoliasearch-helper to a version that includes `showParentLevel` in the typings

part of DX-2299