### PR TITLE
fix(types): fixing hits and results types in connectHits and connectInfiniteHits

### DIFF
--- a/src/connectors/hits/connectHits.ts
+++ b/src/connectors/hits/connectHits.ts
@@ -16,7 +16,6 @@ import {
   Connector,
   Hits,
   Hit,
-  AlgoliaHit,
   WidgetRenderState,
 } from '../../types';
 import { SearchResults } from 'algoliasearch-helper';
@@ -35,7 +34,7 @@ export type HitsRenderState = {
   /**
    * The response from the Algolia API.
    */
-  results?: SearchResults<AlgoliaHit>;
+  results?: SearchResults<Hit>;
 
   /**
    * Sends an event to the Insights middleware.

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -2,6 +2,7 @@ import {
   AlgoliaSearchHelper as Helper,
   PlainSearchParameters,
   SearchParameters,
+  SearchResults,
 } from 'algoliasearch-helper';
 import {
   Hits,
@@ -112,6 +113,16 @@ export type InfiniteHitsRenderState = {
    * Hits for the current page
    */
   currentPageHits: Hits;
+
+  /**
+   * Hits for current and cached pages
+   */
+  hits: Hits;
+
+  /**
+   * The response from the Algolia API.
+   */
+  results?: SearchResults<Hit>;
 };
 
 const withUsage = createDocumentationMessageGenerator({


### PR DESCRIPTION
####  `connectHits`


The types `Hit` and `AlgoliaHit` are mostly the same.

https://github.com/algolia/instantsearch.js/blob/21b6c53d4b1a3f3dd3a2375a5cfe0a31bef6ded6/src/types/results.ts#L60-L63

As of today, the hits exposed via results indeed [contain __position and __queryID](https://github.com/algolia/instantsearch.js/blob/21b6c53d4b1a3f3dd3a2375a5cfe0a31bef6ded6/src/connectors/hits/connectHits.ts#L158).


####  `connectInfiniteHits`

While trying use `InfiniteHitsRenderState` in Angular InstantSearch I noticed how `hits` and `results` while being [part of the state expored by`connectInfiniteHits`](https://github.com/algolia/instantsearch.js/blob/master/src/connectors/infinite-hits/connectInfiniteHits.ts#L331-L342) are not actually visible on the type.
