### PR TITLE
fix(ts): correct entry point

### DIFF
--- a/scripts/build/api-extractor.json
+++ b/scripts/build/api-extractor.json
@@ -1,6 +1,12 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 
+  "projectFolder": "../../",
+  "mainEntryPointFilePath": "<projectFolder>/es/index.d.ts",
+  "dtsRollup": {
+    "enabled": false
+  },
+
   "apiReport": {
     "enabled": false
   },
@@ -40,9 +46,5 @@
         "logLevel": "none"
       }
     }
-  },
-  "mainEntryPointFilePath": "es/index.d.ts",
-  "dtsRollup": {
-    "enabled": false
   }
 }

--- a/scripts/build/tsconfig.declaration.json
+++ b/scripts/build/tsconfig.declaration.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./tsconfig",
+  "extends": "../../tsconfig",
   "compilerOptions": {
     "stripInternal": true,
     "noEmit": false,
@@ -7,6 +7,6 @@
     "emitDeclarationOnly": true,
     "allowJs": true
   },
-  "include": ["src", "./global.d.ts"],
-  "exclude": ["**/__tests__"]
+  "include": ["../../src", "../../global.d.ts"],
+  "exclude": ["../../**/__tests__"]
 }


### PR DESCRIPTION
The entry point used to be:

```ts
// this is wrong!!!
export { default } from './index.es';
export * from './connectors';
export * from './helpers';
export * from './types';
export * from './widgets';
export * from './lib/routers';
```

While really the entry point should be the same as index.es.ts, as otherwise the js bundle doesn't match the declaration.

This commit fixes that by no longer generating an entry point, and renaming index.es.d.ts to index.d.ts in the built files.

In the same commit I also move the declaration-related configuration files to the subfolder to make the root a little cleaner

