### PR TITLE
refactor(sendEventForHits): remove __escaped more efficiently

### DIFF
--- a/src/lib/utils/__tests__/createSendEventForHits-test.ts
+++ b/src/lib/utils/__tests__/createSendEventForHits-test.ts
@@ -4,6 +4,7 @@ import {
   createSendEventForHits,
 } from '../createSendEventForHits';
 import { deserializePayload } from '../../utils';
+import { EscapedHits } from '../../../types';
 
 const createTestEnvironment = () => {
   const instantSearchInstance = createInstantSearch();
@@ -221,6 +222,37 @@ describe('createSendEventForHits', () => {
     expect(instantSearchInstance.sendEventToInsights).toHaveBeenCalledWith({
       hello: 'world',
       custom: 'event',
+    });
+  });
+
+  it('removes __escaped marker', () => {
+    const { sendEvent, instantSearchInstance, hits } = createTestEnvironment();
+
+    (hits as EscapedHits).__escaped = true;
+
+    sendEvent('view', hits);
+    expect(instantSearchInstance.sendEventToInsights).toHaveBeenCalledTimes(1);
+    expect(instantSearchInstance.sendEventToInsights).toHaveBeenCalledWith({
+      eventType: 'view',
+      hits: [
+        {
+          __position: 0,
+          __queryID: 'test-query-id',
+          objectID: 'obj0',
+        },
+        {
+          __position: 1,
+          __queryID: 'test-query-id',
+          objectID: 'obj1',
+        },
+      ],
+      insightsMethod: 'viewedObjectIDs',
+      payload: {
+        eventName: 'Hits Viewed',
+        index: 'testIndex',
+        objectIDs: ['obj0', 'obj1'],
+      },
+      widgetType: 'ais.testWidget',
     });
   });
 });

--- a/src/lib/utils/__tests__/createSendEventForHits-test.ts
+++ b/src/lib/utils/__tests__/createSendEventForHits-test.ts
@@ -4,7 +4,7 @@ import {
   createSendEventForHits,
 } from '../createSendEventForHits';
 import { deserializePayload } from '../../utils';
-import { EscapedHits } from '../../../types';
+import type { EscapedHits } from '../../../types';
 
 const createTestEnvironment = () => {
   const instantSearchInstance = createInstantSearch();

--- a/src/lib/utils/createSendEventForHits.ts
+++ b/src/lib/utils/createSendEventForHits.ts
@@ -121,9 +121,8 @@ const buildPayload: BuildPayload = ({
 };
 
 function removeEscapedFromHits(hits: Hits | EscapedHits): Hits {
-  // this returns without `hits.__escaped`
-  // and this way it doesn't mutate the original `hits`
-  return hits.map((hit) => hit);
+  // remove `hits.__escaped` without mutating
+  return hits.slice();
 }
 
 export function createSendEventForHits({


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Mapping over the hits isn't heavy, but it's not required, as .slice also removes the __escaped key on hits


**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

replaced .map(identity) with .slice() to clone the hits

