### PR TITLE
fix(sendEvent): split > 20 objects in multiple calls

### DIFF
--- a/src/connectors/hits/__tests__/connectHits-test.ts
+++ b/src/connectors/hits/__tests__/connectHits-test.ts
@@ -846,26 +846,28 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
           expect(payload.startsWith('data-insights-event=')).toBe(true);
           expect(
             deserializePayload(payload.substr('data-insights-event='.length))
-          ).toEqual({
-            eventType: 'click',
-            hits: [
-              {
-                __position: 0,
-                __queryID: 'test-query-id',
-                fake: 'data',
-                objectID: '1',
+          ).toEqual([
+            {
+              eventType: 'click',
+              hits: [
+                {
+                  __position: 0,
+                  __queryID: 'test-query-id',
+                  fake: 'data',
+                  objectID: '1',
+                },
+              ],
+              insightsMethod: 'clickedObjectIDsAfterSearch',
+              payload: {
+                eventName: 'Product Added',
+                index: '',
+                objectIDs: ['1'],
+                positions: [0],
+                queryID: 'test-query-id',
               },
-            ],
-            insightsMethod: 'clickedObjectIDsAfterSearch',
-            payload: {
-              eventName: 'Product Added',
-              index: '',
-              objectIDs: ['1'],
-              positions: [0],
-              queryID: 'test-query-id',
+              widgetType: 'ais.hits',
             },
-            widgetType: 'ais.hits',
-          });
+          ]);
         });
 
         it('returns a payload for conversion event', () => {
@@ -876,25 +878,27 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
           expect(payload.startsWith('data-insights-event=')).toBe(true);
           expect(
             deserializePayload(payload.substr('data-insights-event='.length))
-          ).toEqual({
-            eventType: 'conversion',
-            hits: [
-              {
-                __position: 1,
-                __queryID: 'test-query-id',
-                objectID: '2',
-                sample: 'infos',
+          ).toEqual([
+            {
+              eventType: 'conversion',
+              hits: [
+                {
+                  __position: 1,
+                  __queryID: 'test-query-id',
+                  objectID: '2',
+                  sample: 'infos',
+                },
+              ],
+              insightsMethod: 'convertedObjectIDsAfterSearch',
+              payload: {
+                eventName: 'Product Ordered',
+                index: '',
+                objectIDs: ['2'],
+                queryID: 'test-query-id',
               },
-            ],
-            insightsMethod: 'convertedObjectIDsAfterSearch',
-            payload: {
-              eventName: 'Product Ordered',
-              index: '',
-              objectIDs: ['2'],
-              queryID: 'test-query-id',
+              widgetType: 'ais.hits',
             },
-            widgetType: 'ais.hits',
-          });
+          ]);
         });
       });
     });

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -1468,26 +1468,28 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
           expect(payload.startsWith('data-insights-event=')).toBe(true);
           expect(
             deserializePayload(payload.substr('data-insights-event='.length))
-          ).toEqual({
-            eventType: 'click',
-            hits: [
-              {
-                __position: 0,
-                __queryID: 'test-query-id',
-                fake: 'data',
-                objectID: '1',
+          ).toEqual([
+            {
+              eventType: 'click',
+              hits: [
+                {
+                  __position: 0,
+                  __queryID: 'test-query-id',
+                  fake: 'data',
+                  objectID: '1',
+                },
+              ],
+              insightsMethod: 'clickedObjectIDsAfterSearch',
+              payload: {
+                eventName: 'Product Added',
+                index: '',
+                objectIDs: ['1'],
+                positions: [0],
+                queryID: 'test-query-id',
               },
-            ],
-            insightsMethod: 'clickedObjectIDsAfterSearch',
-            payload: {
-              eventName: 'Product Added',
-              index: '',
-              objectIDs: ['1'],
-              positions: [0],
-              queryID: 'test-query-id',
+              widgetType: 'ais.infiniteHits',
             },
-            widgetType: 'ais.infiniteHits',
-          });
+          ]);
         });
 
         it('returns a payload for conversion event', () => {
@@ -1498,25 +1500,27 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
           expect(payload.startsWith('data-insights-event=')).toBe(true);
           expect(
             deserializePayload(payload.substr('data-insights-event='.length))
-          ).toEqual({
-            eventType: 'conversion',
-            hits: [
-              {
-                __position: 1,
-                __queryID: 'test-query-id',
-                objectID: '2',
-                sample: 'infos',
+          ).toEqual([
+            {
+              eventType: 'conversion',
+              hits: [
+                {
+                  __position: 1,
+                  __queryID: 'test-query-id',
+                  objectID: '2',
+                  sample: 'infos',
+                },
+              ],
+              insightsMethod: 'convertedObjectIDsAfterSearch',
+              payload: {
+                eventName: 'Product Ordered',
+                index: '',
+                objectIDs: ['2'],
+                queryID: 'test-query-id',
               },
-            ],
-            insightsMethod: 'convertedObjectIDsAfterSearch',
-            payload: {
-              eventName: 'Product Ordered',
-              index: '',
-              objectIDs: ['2'],
-              queryID: 'test-query-id',
+              widgetType: 'ais.infiniteHits',
             },
-            widgetType: 'ais.infiniteHits',
-          });
+          ]);
         });
       });
     });

--- a/src/helpers/insights.ts
+++ b/src/helpers/insights.ts
@@ -18,8 +18,8 @@ export function readDataAttributes(domElement: HTMLElement): {
   }
 
   try {
-    const payload: Partial<InsightsClientPayload> =
-      deserializePayload(serializedPayload);
+    const payload =
+      deserializePayload<Partial<InsightsClientPayload>>(serializedPayload);
     return { method, payload };
   } catch (error) {
     throw new Error(

--- a/src/lib/insights/listener.tsx
+++ b/src/lib/insights/listener.tsx
@@ -27,9 +27,7 @@ const findInsightsTarget = (
   return element;
 };
 
-type ParseInsightsEvent = (element: HTMLElement) => InsightsEvent;
-
-const parseInsightsEvent: ParseInsightsEvent = (element) => {
+const parseInsightsEvent = (element: HTMLElement): InsightsEvent[] => {
   const serializedPayload = element.getAttribute('data-insights-event');
 
   if (typeof serializedPayload !== 'string') {
@@ -39,7 +37,7 @@ const parseInsightsEvent: ParseInsightsEvent = (element) => {
   }
 
   try {
-    return deserializePayload(serializedPayload) as InsightsEvent;
+    return deserializePayload(serializedPayload);
   } catch (error) {
     throw new Error(
       'The insights middleware was unable to parse `data-insights-event`.'
@@ -59,7 +57,8 @@ const insightsListener = (BaseComponent: any) => {
         );
         if (targetWithEvent) {
           const payload = parseInsightsEvent(targetWithEvent);
-          props.sendEvent(payload);
+
+          payload.forEach((single) => props.sendEvent!(single));
         }
       }
 

--- a/src/lib/utils/__tests__/createSendEventForHits-test.ts
+++ b/src/lib/utils/__tests__/createSendEventForHits-test.ts
@@ -218,6 +218,52 @@ describe('createSendEventForHits', () => {
     });
   });
 
+  it('sends click event with more than 20 hits', () => {
+    const { sendEvent, instantSearchInstance, hits } = createTestEnvironment({
+      nbHits: 21,
+    });
+    sendEvent('click', hits, 'Product Clicked');
+    expect(instantSearchInstance.sendEventToInsights).toHaveBeenCalledTimes(2);
+    expect(instantSearchInstance.sendEventToInsights).toHaveBeenCalledWith({
+      eventType: 'click',
+      hits: Array.from({ length: 20 }, (_, i) => {
+        return {
+          __position: i,
+          __queryID: 'test-query-id',
+          objectID: `obj${i}`,
+        };
+      }),
+      insightsMethod: 'clickedObjectIDsAfterSearch',
+      payload: {
+        eventName: 'Product Clicked',
+        index: 'testIndex',
+        objectIDs: Array.from({ length: 20 }, (_, i) => `obj${i}`),
+        positions: Array.from({ length: 20 }, (_, i) => i),
+        queryID: 'test-query-id',
+      },
+      widgetType: 'ais.testWidget',
+    });
+    expect(instantSearchInstance.sendEventToInsights).toHaveBeenCalledWith({
+      eventType: 'click',
+      hits: [
+        {
+          __position: 20,
+          __queryID: 'test-query-id',
+          objectID: 'obj20',
+        },
+      ],
+      insightsMethod: 'clickedObjectIDsAfterSearch',
+      payload: {
+        eventName: 'Product Clicked',
+        index: 'testIndex',
+        objectIDs: ['obj20'],
+        positions: [20],
+        queryID: 'test-query-id',
+      },
+      widgetType: 'ais.testWidget',
+    });
+  });
+
   it('sends conversion event', () => {
     const { sendEvent, instantSearchInstance, hits } = createTestEnvironment();
     sendEvent('conversion', hits[0], 'Product Ordered');
@@ -236,6 +282,50 @@ describe('createSendEventForHits', () => {
         eventName: 'Product Ordered',
         index: 'testIndex',
         objectIDs: ['obj0'],
+        queryID: 'test-query-id',
+      },
+      widgetType: 'ais.testWidget',
+    });
+  });
+
+  it('sends conversion event with more than 20 hits', () => {
+    const { sendEvent, instantSearchInstance, hits } = createTestEnvironment({
+      nbHits: 21,
+    });
+    sendEvent('conversion', hits, 'Product Ordered');
+    expect(instantSearchInstance.sendEventToInsights).toHaveBeenCalledTimes(2);
+    expect(instantSearchInstance.sendEventToInsights).toHaveBeenCalledWith({
+      eventType: 'conversion',
+      hits: Array.from({ length: 20 }, (_, i) => {
+        return {
+          __position: i,
+          __queryID: 'test-query-id',
+          objectID: `obj${i}`,
+        };
+      }),
+      insightsMethod: 'convertedObjectIDsAfterSearch',
+      payload: {
+        eventName: 'Product Ordered',
+        index: 'testIndex',
+        objectIDs: Array.from({ length: 20 }, (_, i) => `obj${i}`),
+        queryID: 'test-query-id',
+      },
+      widgetType: 'ais.testWidget',
+    });
+    expect(instantSearchInstance.sendEventToInsights).toHaveBeenCalledWith({
+      eventType: 'conversion',
+      hits: [
+        {
+          __position: 20,
+          __queryID: 'test-query-id',
+          objectID: 'obj20',
+        },
+      ],
+      insightsMethod: 'convertedObjectIDsAfterSearch',
+      payload: {
+        eventName: 'Product Ordered',
+        index: 'testIndex',
+        objectIDs: ['obj20'],
         queryID: 'test-query-id',
       },
       widgetType: 'ais.testWidget',
@@ -267,25 +357,27 @@ describe('createBindEventForHits', () => {
     const parsedPayload = parsePayload(
       bindEvent('click', hits[0], 'Product Clicked')
     );
-    expect(parsedPayload).toEqual({
-      eventType: 'click',
-      hits: [
-        {
-          __position: 0,
-          __queryID: 'test-query-id',
-          objectID: 'obj0',
+    expect(parsedPayload).toEqual([
+      {
+        eventType: 'click',
+        hits: [
+          {
+            __position: 0,
+            __queryID: 'test-query-id',
+            objectID: 'obj0',
+          },
+        ],
+        insightsMethod: 'clickedObjectIDsAfterSearch',
+        payload: {
+          eventName: 'Product Clicked',
+          index: 'testIndex',
+          objectIDs: ['obj0'],
+          positions: [0],
+          queryID: 'test-query-id',
         },
-      ],
-      insightsMethod: 'clickedObjectIDsAfterSearch',
-      payload: {
-        eventName: 'Product Clicked',
-        index: 'testIndex',
-        objectIDs: ['obj0'],
-        positions: [0],
-        queryID: 'test-query-id',
+        widgetType: 'ais.testWidget',
       },
-      widgetType: 'ais.testWidget',
-    });
+    ]);
   });
 
   it('returns a payload for conversion event', () => {
@@ -293,23 +385,70 @@ describe('createBindEventForHits', () => {
     const parsedPayload = parsePayload(
       bindEvent('conversion', hits[0], 'Product Ordered')
     );
-    expect(parsedPayload).toEqual({
-      eventType: 'conversion',
-      hits: [
-        {
-          __position: 0,
-          __queryID: 'test-query-id',
-          objectID: 'obj0',
+    expect(parsedPayload).toEqual([
+      {
+        eventType: 'conversion',
+        hits: [
+          {
+            __position: 0,
+            __queryID: 'test-query-id',
+            objectID: 'obj0',
+          },
+        ],
+        insightsMethod: 'convertedObjectIDsAfterSearch',
+        payload: {
+          eventName: 'Product Ordered',
+          index: 'testIndex',
+          objectIDs: ['obj0'],
+          queryID: 'test-query-id',
         },
-      ],
-      insightsMethod: 'convertedObjectIDsAfterSearch',
-      payload: {
-        eventName: 'Product Ordered',
-        index: 'testIndex',
-        objectIDs: ['obj0'],
-        queryID: 'test-query-id',
+        widgetType: 'ais.testWidget',
       },
-      widgetType: 'ais.testWidget',
-    });
+    ]);
+  });
+
+  it('splits a payload for > 20 hits', () => {
+    const { bindEvent, hits } = createTestEnvironment({ nbHits: 21 });
+    const parsedPayload = parsePayload(
+      bindEvent('click', hits, 'Product Clicked')
+    );
+    expect(parsedPayload).toEqual([
+      {
+        eventType: 'click',
+        hits: Array.from({ length: 20 }, (_, i) => ({
+          __position: i,
+          __queryID: 'test-query-id',
+          objectID: `obj${i}`,
+        })),
+        insightsMethod: 'clickedObjectIDsAfterSearch',
+        payload: {
+          eventName: 'Product Clicked',
+          index: 'testIndex',
+          objectIDs: Array.from({ length: 20 }, (_, i) => `obj${i}`),
+          positions: Array.from({ length: 20 }, (_, i) => i),
+          queryID: 'test-query-id',
+        },
+        widgetType: 'ais.testWidget',
+      },
+      {
+        eventType: 'click',
+        hits: [
+          {
+            __position: 20,
+            __queryID: 'test-query-id',
+            objectID: 'obj20',
+          },
+        ],
+        insightsMethod: 'clickedObjectIDsAfterSearch',
+        payload: {
+          eventName: 'Product Clicked',
+          index: 'testIndex',
+          objectIDs: ['obj20'],
+          positions: [20],
+          queryID: 'test-query-id',
+        },
+        widgetType: 'ais.testWidget',
+      },
+    ]);
   });
 });

--- a/src/lib/utils/createSendEventForHits.ts
+++ b/src/lib/utils/createSendEventForHits.ts
@@ -183,9 +183,8 @@ export function createBindEventForHits({
       args,
     });
 
-    // TODO: deal with longer payloads in bind
     return payloads.length
-      ? `data-insights-event=${serializePayload(payloads[0])}`
+      ? `data-insights-event=${serializePayload(payloads)}`
       : '';
   };
   return bindEventForHits;

--- a/src/lib/utils/serializer.ts
+++ b/src/lib/utils/serializer.ts
@@ -1,7 +1,7 @@
-export function serializePayload(payload: Record<string, unknown>): string {
+export function serializePayload<TPayload>(payload: TPayload): string {
   return btoa(encodeURIComponent(JSON.stringify(payload)));
 }
 
-export function deserializePayload(payload: string): Record<string, unknown> {
-  return JSON.parse(decodeURIComponent(atob(payload)));
+export function deserializePayload<TPayload>(serialized: string): TPayload {
+  return JSON.parse(decodeURIComponent(atob(serialized)));
 }


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

the backend api doesn't allow > 20 hits per event, so we split the sendEvent calls up into multiple if > 20 DX-2379


**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

edited sendEvent and bindEvent to both split up the vents in arrays where it makes sense, and calling sendEvent multiple times.

We choose to split at this level and not inside the events listener, as you can't know what method is used, and you'd need a lot of conditional code to handle all chunking

