### PR TITLE
test(eslint): enable no-unnecessary-type-assertion

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -63,6 +63,25 @@ module.exports = {
       },
     },
     {
+      files: ['*.ts', '*.tsx'],
+      // this is the same files as ignored in tsconfig.json
+      excludedFiles: [
+        "examples/**/*",
+        "es",
+        // these two files are temporarily excluded because
+        // they import files from node_modules/search-insights directly
+        // and it causes the type-checking to fail.
+        "src/middlewares/__tests__/createInsightsMiddleware.ts",
+        "test/mock/createInsightsClient.ts"
+      ],
+      parserOptions: {
+        project: './tsconfig.json',
+      },
+      rules: {
+        '@typescript-eslint/no-unnecessary-type-assertion': 'error',
+      },
+    },
+    {
       files: ['*.js'],
       rules: {
         '@typescript-eslint/explicit-member-accessibility': 'off',

--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -40,14 +40,15 @@ function Panel<TWidget extends UnknownWidgetFactory>(
   const bodyRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
-    if (!bodyRef.current) {
+    const node = bodyRef.current;
+    if (!node) {
       return undefined;
     }
 
-    bodyRef.current.appendChild(props.bodyElement);
+    node.appendChild(props.bodyElement);
 
     return () => {
-      bodyRef!.current!.removeChild(props.bodyElement);
+      node.removeChild(props.bodyElement);
     };
   }, [bodyRef, props.bodyElement]);
 

--- a/src/components/Slider/Rheostat.tsx
+++ b/src/components/Slider/Rheostat.tsx
@@ -303,7 +303,7 @@ class Rheostat extends Component<Props, State> {
     if (!this.props.snapPoints!.length) return value;
 
     return this.props.snapPoints!.reduce((snapTo, snap) =>
-      Math.abs(snapTo! - value) < Math.abs(snap - value) ? snapTo : snap
+      Math.abs(snapTo - value) < Math.abs(snap - value) ? snapTo : snap
     );
   }
 

--- a/src/connectors/answers/connectAnswers.ts
+++ b/src/connectors/answers/connectAnswers.ts
@@ -146,7 +146,7 @@ const connectAnswers: AnswersConnector = function connectAnswers(
 
       init(initOptions) {
         const { state, instantSearchInstance } = initOptions;
-        const answersIndex = instantSearchInstance.client!.initIndex!(
+        const answersIndex = instantSearchInstance.client.initIndex!(
           state.index
         );
         if (!hasFindAnswersMethod(answersIndex)) {

--- a/src/connectors/autocomplete/__tests__/connectAutocomplete-test.ts
+++ b/src/connectors/autocomplete/__tests__/connectAutocomplete-test.ts
@@ -556,7 +556,7 @@ search.addWidgets([
     test('should give back the object unmodified if the default value is selected', () => {
       const [widget, helper] = getInitializedWidget();
       const uiStateBefore = {};
-      const uiStateAfter = widget.getWidgetUiState!(uiStateBefore, {
+      const uiStateAfter = widget.getWidgetUiState(uiStateBefore, {
         searchParameters: helper.state,
         helper,
       });
@@ -567,7 +567,7 @@ search.addWidgets([
       const [widget, helper, refine] = getInitializedWidget();
       refine('some query');
       const uiStateBefore = {};
-      const uiStateAfter = widget.getWidgetUiState!(uiStateBefore, {
+      const uiStateAfter = widget.getWidgetUiState(uiStateBefore, {
         searchParameters: helper.state,
         helper,
       });
@@ -579,14 +579,14 @@ search.addWidgets([
     test('should give back the same instance if the value is already in the uiState', () => {
       const [widget, helper, refine] = getInitializedWidget();
       refine('query');
-      const uiStateBefore = widget.getWidgetUiState!(
+      const uiStateBefore = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
           helper,
         }
       );
-      const uiStateAfter = widget.getWidgetUiState!(uiStateBefore, {
+      const uiStateAfter = widget.getWidgetUiState(uiStateBefore, {
         searchParameters: helper.state,
         helper,
       });
@@ -604,7 +604,7 @@ search.addWidgets([
         })
       );
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {
           query: 'Apple',
         },
@@ -628,7 +628,7 @@ search.addWidgets([
         })
       );
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {},
       });
 
@@ -652,7 +652,7 @@ search.addWidgets([
         })
       );
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {},
       });
 
@@ -676,7 +676,7 @@ search.addWidgets([
         })
       );
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {},
       });
 

--- a/src/connectors/autocomplete/connectAutocomplete.ts
+++ b/src/connectors/autocomplete/connectAutocomplete.ts
@@ -176,7 +176,7 @@ search.addWidgets([
           const sendEvent = createSendEventForHits({
             instantSearchInstance,
             index: scopedResult.results.index,
-            widgetType: this.$$type!,
+            widgetType: this.$$type,
           });
 
           return {
@@ -191,7 +191,7 @@ search.addWidgets([
         return {
           currentRefinement: helper.state.query || '',
           indices,
-          refine: connectorState.refine!,
+          refine: connectorState.refine,
           widgetParams,
         };
       },

--- a/src/connectors/configure/__tests__/connectConfigure-test.ts
+++ b/src/connectors/configure/__tests__/connectConfigure-test.ts
@@ -88,7 +88,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
     });
 
     expect(
-      widget.getWidgetSearchParameters!(new SearchParameters({}), {
+      widget.getWidgetSearchParameters(new SearchParameters({}), {
         uiState: {},
       })
     ).toEqual(
@@ -107,7 +107,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
     });
 
     expect(
-      widget.getWidgetSearchParameters!(
+      widget.getWidgetSearchParameters(
         new SearchParameters({
           analytics: false,
         }),
@@ -120,7 +120,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
     );
 
     expect(
-      widget.getWidgetSearchParameters!(
+      widget.getWidgetSearchParameters(
         new SearchParameters({
           analytics: false,
           clickAnalytics: true,
@@ -145,7 +145,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
     });
 
     helper.setState(
-      widget.getWidgetSearchParameters!(
+      widget.getWidgetSearchParameters(
         new SearchParameters({
           // This facet is added outside of the widget params
           // so it shouldn't be overridden when calling `refine`.
@@ -157,7 +157,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
     widget.init!(createInitOptions({ helper }));
 
     expect(
-      widget.getWidgetSearchParameters!(new SearchParameters({}), {
+      widget.getWidgetSearchParameters(new SearchParameters({}), {
         uiState: { configure: { analytics: true } },
       })
     ).toEqual(
@@ -177,7 +177,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
     refine({ hitsPerPage: 3, facets: ['rating'] });
 
     expect(
-      widget.getWidgetSearchParameters!(new SearchParameters({}), {
+      widget.getWidgetSearchParameters(new SearchParameters({}), {
         uiState: { configure: { hitsPerPage: 3, facets: ['rating'] } },
       })
     ).toEqual(
@@ -203,7 +203,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
     });
 
     helper.setState(
-      widget.getWidgetSearchParameters!(
+      widget.getWidgetSearchParameters(
         new SearchParameters({
           clickAnalytics: true,
         }),
@@ -213,7 +213,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
     widget.init!(createInitOptions({ helper }));
 
     expect(
-      widget.getWidgetSearchParameters!(new SearchParameters({}), {
+      widget.getWidgetSearchParameters(new SearchParameters({}), {
         uiState: { configure: { analytics: true } },
       })
     ).toEqual(
@@ -374,7 +374,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
       });
 
       expect(
-        widget.getWidgetUiState!({}, { helper, searchParameters: helper.state })
+        widget.getWidgetUiState({}, { helper, searchParameters: helper.state })
       ).toEqual({
         configure: { analytics: true },
       });
@@ -395,7 +395,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
       refine({ analytics: false });
 
       expect(
-        widget.getWidgetUiState!({}, { helper, searchParameters: helper.state })
+        widget.getWidgetUiState({}, { helper, searchParameters: helper.state })
       ).toEqual({
         configure: { analytics: false },
       });
@@ -416,7 +416,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
       refine({ query: 'unsafe toys' });
 
       expect(
-        widget.getWidgetUiState!({}, { helper, searchParameters: helper.state })
+        widget.getWidgetUiState({}, { helper, searchParameters: helper.state })
       ).toEqual({
         configure: { query: 'unsafe toys' },
       });
@@ -431,7 +431,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
       });
 
       expect(
-        widget.getWidgetUiState!(
+        widget.getWidgetUiState(
           { configure: { queryType: 'prefixAll' } },
           { helper, searchParameters: helper.state }
         )
@@ -449,7 +449,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
       });
 
       expect(
-        widget.getWidgetUiState!(
+        widget.getWidgetUiState(
           { configure: { analytics: false } },
           { helper, searchParameters: helper.state }
         )
@@ -468,7 +468,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
         },
       });
 
-      const sp = widget.getWidgetSearchParameters!(new SearchParameters(), {
+      const sp = widget.getWidgetSearchParameters(new SearchParameters(), {
         uiState: {},
       });
 
@@ -479,7 +479,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
       const makeWidget = connectConfigure(noop);
       const widget = makeWidget({ searchParameters: {} });
 
-      const sp = widget.getWidgetSearchParameters!(new SearchParameters(), {
+      const sp = widget.getWidgetSearchParameters(new SearchParameters(), {
         uiState: {
           configure: {
             analytics: false,
@@ -498,7 +498,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
         },
       });
 
-      const sp = widget.getWidgetSearchParameters!(new SearchParameters(), {
+      const sp = widget.getWidgetSearchParameters(new SearchParameters(), {
         uiState: {
           configure: {
             analytics: false,
@@ -517,7 +517,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
         },
       });
 
-      const sp = widget.getWidgetSearchParameters!(new SearchParameters(), {
+      const sp = widget.getWidgetSearchParameters(new SearchParameters(), {
         uiState: {
           configure: {
             analytics: false,
@@ -544,7 +544,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
         },
       });
 
-      const sp = widget.getWidgetSearchParameters!(
+      const sp = widget.getWidgetSearchParameters(
         new SearchParameters({
           disjunctiveFacets: ['categories'],
           disjunctiveFacetsRefinements: {
@@ -581,7 +581,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
 
       refine({ analyticsTags: ['worst-site-now'] });
 
-      const sp = widget.getWidgetSearchParameters!(new SearchParameters(), {
+      const sp = widget.getWidgetSearchParameters(new SearchParameters(), {
         uiState: {},
       });
 

--- a/src/connectors/dynamic-widgets/connectDynamicWidgets.ts
+++ b/src/connectors/dynamic-widgets/connectDynamicWidgets.ts
@@ -131,7 +131,7 @@ const connectDynamicWidgets: DynamicWidgetsConnector =
               toRemove.push(widget);
             }
           });
-          parent!.removeWidgets(toRemove);
+          parent.removeWidgets(toRemove);
 
           unmountFn();
         },

--- a/src/connectors/geo-search/__tests__/connectGeoSearch-test.ts
+++ b/src/connectors/geo-search/__tests__/connectGeoSearch-test.ts
@@ -74,7 +74,7 @@ describe('connectGeoSearch', () => {
       })
     );
 
-    const results = new SearchResults(helper!.state, [
+    const results = new SearchResults(helper.state, [
       createSingleSearchResponse({
         hits,
       }),

--- a/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.ts
+++ b/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.ts
@@ -88,7 +88,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
       attributes: ['category', 'sub_category'],
     });
 
-    const config = widget.getWidgetSearchParameters!(new SearchParameters(), {
+    const config = widget.getWidgetSearchParameters(new SearchParameters(), {
       uiState: {},
     });
     expect(config).toEqual(
@@ -162,7 +162,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
     const helper = algoliasearchHelper(
       createSearchClient(),
       '',
-      widget.getWidgetSearchParameters!(new SearchParameters(), { uiState: {} })
+      widget.getWidgetSearchParameters(new SearchParameters(), { uiState: {} })
     );
     helper.search = jest.fn();
 
@@ -211,7 +211,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
     const helper = algoliasearchHelper(
       createSearchClient(),
       '',
-      widget.getWidgetSearchParameters!(new SearchParameters(), { uiState: {} })
+      widget.getWidgetSearchParameters(new SearchParameters(), { uiState: {} })
     );
     helper.search = jest.fn();
 
@@ -320,7 +320,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
     const helper = algoliasearchHelper(
       createSearchClient(),
       '',
-      widget.getWidgetSearchParameters!(new SearchParameters(), { uiState: {} })
+      widget.getWidgetSearchParameters(new SearchParameters(), { uiState: {} })
     );
     helper.search = jest.fn();
 
@@ -388,7 +388,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
       const helper = algoliasearchHelper(
         createSearchClient(),
         '',
-        widget.getWidgetSearchParameters!(new SearchParameters(), {
+        widget.getWidgetSearchParameters(new SearchParameters(), {
           uiState: {},
         })
       );
@@ -407,7 +407,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
       const helper = algoliasearchHelper(
         createSearchClient(),
         indexName,
-        widget.getWidgetSearchParameters!(new SearchParameters(), {
+        widget.getWidgetSearchParameters(new SearchParameters(), {
           uiState: {},
         })
       );
@@ -427,7 +427,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
       const helper = algoliasearchHelper(
         createSearchClient(),
         indexName,
-        widget.getWidgetSearchParameters!(new SearchParameters(), {
+        widget.getWidgetSearchParameters(new SearchParameters(), {
           uiState: {},
         })
       );
@@ -468,7 +468,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
       const helper = algoliasearchHelper(
         createSearchClient(),
         'indexName',
-        hierarchicalMenu.getWidgetSearchParameters!(new SearchParameters(), {
+        hierarchicalMenu.getWidgetSearchParameters(new SearchParameters(), {
           uiState: {},
         })
       );
@@ -525,7 +525,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
       const helper = algoliasearchHelper(
         createSearchClient(),
         'indexName',
-        hierarchicalMenu.getWidgetSearchParameters!(new SearchParameters(), {
+        hierarchicalMenu.getWidgetSearchParameters(new SearchParameters(), {
           uiState: {},
         })
       );
@@ -560,7 +560,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
               }),
             ]),
           })
-        ).hierarchicalMenu!.category
+        ).hierarchicalMenu.category
       ).toEqual({
         items: [
           {
@@ -598,7 +598,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
       const helper = algoliasearchHelper(
         createSearchClient(),
         'indexName',
-        hierarchicalMenu.getWidgetSearchParameters!(new SearchParameters(), {
+        hierarchicalMenu.getWidgetSearchParameters(new SearchParameters(), {
           uiState: {},
         })
       );
@@ -634,7 +634,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
       const helper = algoliasearchHelper(
         createSearchClient(),
         'indexName',
-        hierarchicalMenu.getWidgetSearchParameters!(new SearchParameters(), {
+        hierarchicalMenu.getWidgetSearchParameters(new SearchParameters(), {
           uiState: {},
         })
       );
@@ -820,16 +820,13 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
           const helper = algoliasearchHelper(
             createSearchClient(),
             'indexName',
-            hierarchicalMenu.getWidgetSearchParameters!(
-              new SearchParameters(),
-              {
-                uiState: {
-                  hierarchicalMenu: {
-                    category: ['Decoration'],
-                  },
+            hierarchicalMenu.getWidgetSearchParameters(new SearchParameters(), {
+              uiState: {
+                hierarchicalMenu: {
+                  category: ['Decoration'],
                 },
-              }
-            )
+              },
+            })
           );
 
           hierarchicalMenu.init!(createInitOptions({ helper }));
@@ -896,7 +893,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
         attributes: ['categoriesLvl0', 'categoriesLvl1'],
       });
 
-      const actual = widget.getWidgetUiState!(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -929,7 +926,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
         attributes: ['categoriesLvl0', 'categoriesLvl1'],
       });
 
-      const actual = widget.getWidgetUiState!(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -966,7 +963,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
         attributes: ['categoriesLvl0', 'categoriesLvl1'],
       });
 
-      const actual = widget.getWidgetUiState!(
+      const actual = widget.getWidgetUiState(
         {
           hierarchicalMenu: {
             countryLvl0: ['TopLevelCountry', 'SubLevelCountry'],
@@ -1000,7 +997,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
         attributes: ['categoriesLvl0', 'categoriesLvl1'],
       });
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {},
       });
 
@@ -1040,7 +1037,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
         attributes: ['categoriesLvl0', 'categoriesLvl1'],
       });
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {},
       });
 
@@ -1067,7 +1064,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
         attributes: ['categoriesLvl0', 'categoriesLvl1'],
       });
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {
           hierarchicalMenu: {
             categoriesLvl0: ['TopLevel', 'SubLevel'],
@@ -1111,7 +1108,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
         attributes: ['categoriesLvl0', 'categoriesLvl1'],
       });
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {
           hierarchicalMenu: {
             categoriesLvl0: ['TopLevel', 'SubLevel'],
@@ -1143,7 +1140,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
         separator: ' / ',
       });
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {},
       });
 
@@ -1159,7 +1156,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
         rootPath: 'TopLevel > SubLevel',
       });
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {},
       });
 
@@ -1175,7 +1172,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
         showParentLevel: true,
       });
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {},
       });
 
@@ -1201,7 +1198,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
       });
 
       expect(() =>
-        widget.getWidgetSearchParameters!(helper.state, {
+        widget.getWidgetSearchParameters(helper.state, {
           uiState: {},
         })
       ).toWarnDev();
@@ -1227,7 +1224,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
       });
 
       expect(() =>
-        widget.getWidgetSearchParameters!(helper.state, {
+        widget.getWidgetSearchParameters(helper.state, {
           uiState: {},
         })
       ).toWarnDev();
@@ -1253,7 +1250,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
       });
 
       expect(() =>
-        widget.getWidgetSearchParameters!(helper.state, {
+        widget.getWidgetSearchParameters(helper.state, {
           uiState: {},
         })
       ).toWarnDev();
@@ -1268,7 +1265,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
           attributes: ['categoriesLvl0', 'categoriesLvl1'],
         });
 
-        const actual = widget.getWidgetSearchParameters!(helper.state, {
+        const actual = widget.getWidgetSearchParameters(helper.state, {
           uiState: {},
         });
 
@@ -1284,7 +1281,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
           limit: 5,
         });
 
-        const actual = widget.getWidgetSearchParameters!(helper.state, {
+        const actual = widget.getWidgetSearchParameters(helper.state, {
           uiState: {},
         });
 
@@ -1300,7 +1297,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
           showMore: true,
         });
 
-        const actual = widget.getWidgetSearchParameters!(helper.state, {
+        const actual = widget.getWidgetSearchParameters(helper.state, {
           uiState: {},
         });
 
@@ -1317,7 +1314,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
           showMoreLimit: 15,
         });
 
-        const actual = widget.getWidgetSearchParameters!(helper.state, {
+        const actual = widget.getWidgetSearchParameters(helper.state, {
           uiState: {},
         });
 
@@ -1335,7 +1332,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
           attributes: ['categoriesLvl0', 'categoriesLvl1'],
         });
 
-        const actual = widget.getWidgetSearchParameters!(helper.state, {
+        const actual = widget.getWidgetSearchParameters(helper.state, {
           uiState: {},
         });
 
@@ -1354,7 +1351,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
           limit: 110,
         });
 
-        const actual = widget.getWidgetSearchParameters!(helper.state, {
+        const actual = widget.getWidgetSearchParameters(helper.state, {
           uiState: {},
         });
 
@@ -1376,7 +1373,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
       const helper = algoliasearchHelper(
         createSearchClient(),
         '',
-        widget.getWidgetSearchParameters!(new SearchParameters(), {
+        widget.getWidgetSearchParameters(new SearchParameters(), {
           uiState: {},
         })
       );
@@ -1501,7 +1498,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
       const helper = algoliasearchHelper(
         createSearchClient(),
         '',
-        widget.getWidgetSearchParameters!(new SearchParameters(), {
+        widget.getWidgetSearchParameters(new SearchParameters(), {
           uiState: {},
         })
       );
@@ -1618,7 +1615,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
       const helper = algoliasearchHelper(
         createSearchClient(),
         '',
-        widget.getWidgetSearchParameters!(new SearchParameters(), {
+        widget.getWidgetSearchParameters(new SearchParameters(), {
           uiState: {},
         })
       );

--- a/src/connectors/hierarchical-menu/connectHierarchicalMenu.ts
+++ b/src/connectors/hierarchical-menu/connectHierarchicalMenu.ts
@@ -324,7 +324,7 @@ const connectHierarchicalMenu: HierarchicalMenuConnector =
               instantSearchInstance,
               helper,
               attribute: hierarchicalFacetName,
-              widgetType: this.$$type!,
+              widgetType: this.$$type,
             });
           }
 

--- a/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.ts
+++ b/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.ts
@@ -116,7 +116,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
     });
 
     expect(
-      widget.getWidgetSearchParameters!(new SearchParameters({}), {
+      widget.getWidgetSearchParameters(new SearchParameters({}), {
         uiState: {},
       })
     ).toEqual(
@@ -244,7 +244,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
     });
 
     expect(
-      widget.getWidgetSearchParameters!(new SearchParameters({}), {
+      widget.getWidgetSearchParameters(new SearchParameters({}), {
         uiState: {},
       })
     ).toEqual(
@@ -265,7 +265,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
     });
 
     expect(
-      widget.getWidgetSearchParameters!(
+      widget.getWidgetSearchParameters(
         new SearchParameters({ hitsPerPage: 20 }),
         { uiState: {} }
       )
@@ -952,7 +952,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
         ],
       });
 
-      const actual = widget.getWidgetUiState!(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -978,7 +978,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
         ],
       });
 
-      const actual = widget.getWidgetUiState!(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -1003,7 +1003,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
         ],
       });
 
-      const actual = widget.getWidgetUiState!(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -1030,7 +1030,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
         ],
       });
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {},
       });
 
@@ -1049,7 +1049,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
         ],
       });
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {
           hitsPerPage: 22,
         },
@@ -1072,7 +1072,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
         ],
       });
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {
           hitsPerPage: 33,
         },

--- a/src/connectors/hits/__tests__/connectHits-test.ts
+++ b/src/connectors/hits/__tests__/connectHits-test.ts
@@ -508,8 +508,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
 
       expect(renderState2.hits).toEqual({
         hits: expectedHits,
-        sendEvent: renderState1.hits!.sendEvent,
-        bindEvent: renderState1.hits!.bindEvent,
+        sendEvent: renderState1.hits.sendEvent,
+        bindEvent: renderState1.hits.bindEvent,
         results,
         widgetParams: {},
       });

--- a/src/connectors/hits/connectHits.ts
+++ b/src/connectors/hits/connectHits.ts
@@ -125,14 +125,14 @@ const connectHits: HitsConnector = function connectHits(
           sendEvent = createSendEventForHits({
             instantSearchInstance,
             index: helper.getIndex(),
-            widgetType: this.$$type!,
+            widgetType: this.$$type,
           });
         }
 
         if (!bindEvent) {
           bindEvent = createBindEventForHits({
             index: helper.getIndex(),
-            widgetType: this.$$type!,
+            widgetType: this.$$type,
           });
         }
 

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -942,7 +942,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       });
       const widget = makeWidget({});
 
-      const actual = widget.getWidgetUiState!(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -965,7 +965,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
         showPrevious: true,
       });
 
-      const actual = widget.getWidgetUiState!(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -986,7 +986,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
         showPrevious: true,
       });
 
-      const actual = widget.getWidgetUiState!(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -1009,7 +1009,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
         showPrevious: true,
       });
 
-      const actual = widget.getWidgetUiState!(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -1103,13 +1103,13 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       expect(renderState2.infiniteHits).toEqual({
         hits: expectedHits,
         currentPageHits: expectedCurrentPageHits,
-        sendEvent: renderState1.infiniteHits!.sendEvent,
-        bindEvent: renderState1.infiniteHits!.bindEvent,
+        sendEvent: renderState1.infiniteHits.sendEvent,
+        bindEvent: renderState1.infiniteHits.bindEvent,
         isFirstPage: true,
         isLastPage: true,
         results,
-        showMore: renderState1.infiniteHits!.showMore,
-        showPrevious: renderState1.infiniteHits!.showPrevious,
+        showMore: renderState1.infiniteHits.showMore,
+        showPrevious: renderState1.infiniteHits.showPrevious,
         widgetParams: {},
       });
     });
@@ -1215,7 +1215,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       const helper = algoliasearchHelper(createSearchClient(), 'indexName');
       const widget = makeWidget({});
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {},
       });
 
@@ -1231,7 +1231,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
         escapeHTML: true,
       });
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {},
       });
 
@@ -1247,7 +1247,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
         escapeHTML: false,
       });
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {},
       });
 
@@ -1263,7 +1263,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
         showPrevious: true,
       });
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {},
       });
 
@@ -1278,7 +1278,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
         showPrevious: true,
       });
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {
           page: 0,
         },
@@ -1295,7 +1295,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
         showPrevious: true,
       });
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {
           page: 3,
         },

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -296,11 +296,11 @@ const connectInfiniteHits: InfiniteHitsConnector = function connectInfiniteHits(
           sendEvent = createSendEventForHits({
             instantSearchInstance,
             index: helper.getIndex(),
-            widgetType: this.$$type!,
+            widgetType: this.$$type,
           });
           bindEvent = createBindEventForHits({
             index: helper.getIndex(),
-            widgetType: this.$$type!,
+            widgetType: this.$$type,
           });
           isFirstPage =
             helper.state.page === undefined ||

--- a/src/connectors/menu/__tests__/connectMenu-test.ts
+++ b/src/connectors/menu/__tests__/connectMenu-test.ts
@@ -101,7 +101,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
       });
 
       expect(
-        widget.getWidgetSearchParameters!(new SearchParameters(), {
+        widget.getWidgetSearchParameters(new SearchParameters(), {
           uiState: {},
         })
       ).toEqual(
@@ -127,7 +127,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
       });
 
       expect(
-        widget.getWidgetSearchParameters!(new SearchParameters(), {
+        widget.getWidgetSearchParameters(new SearchParameters(), {
           uiState: {},
         })
       ).toEqual(
@@ -155,7 +155,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
       limit: 9,
     });
 
-    const config = widget.getWidgetSearchParameters!(new SearchParameters(), {
+    const config = widget.getWidgetSearchParameters(new SearchParameters(), {
       uiState: {},
     });
     expect(config).toEqual(
@@ -233,7 +233,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
     const helper = jsHelper(
       createSearchClient(),
       '',
-      widget.getWidgetSearchParameters!(new SearchParameters(), { uiState: {} })
+      widget.getWidgetSearchParameters(new SearchParameters(), { uiState: {} })
     );
     helper.search = jest.fn();
 
@@ -283,7 +283,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
     const helper = jsHelper(
       createSearchClient(),
       '',
-      widget.getWidgetSearchParameters!(new SearchParameters(), { uiState: {} })
+      widget.getWidgetSearchParameters(new SearchParameters(), { uiState: {} })
     );
     helper.search = jest.fn();
 
@@ -409,7 +409,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
     const helper = jsHelper(
       createSearchClient(),
       '',
-      widget.getWidgetSearchParameters!(new SearchParameters(), { uiState: {} })
+      widget.getWidgetSearchParameters(new SearchParameters(), { uiState: {} })
     );
     helper.search = jest.fn();
 
@@ -472,7 +472,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
     const helper = jsHelper(
       createSearchClient(),
       '',
-      widget.getWidgetSearchParameters!!(new SearchParameters(), {
+      widget.getWidgetSearchParameters(new SearchParameters(), {
         uiState: {},
       })
     );
@@ -492,7 +492,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
       const helper = jsHelper(
         createSearchClient(),
         'indexName',
-        menu.getWidgetSearchParameters!(new SearchParameters(), { uiState: {} })
+        menu.getWidgetSearchParameters(new SearchParameters(), { uiState: {} })
       );
 
       const renderState1 = menu.getRenderState(
@@ -500,7 +500,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
         createInitOptions({ helper })
       );
 
-      expect(renderState1.menu!.brand).toEqual({
+      expect(renderState1.menu.brand).toEqual({
         items: [],
         createURL: expect.any(Function),
         refine: expect.any(Function),
@@ -523,7 +523,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
       const helper = jsHelper(
         createSearchClient(),
         'indexName',
-        menu.getWidgetSearchParameters!(new SearchParameters(), {
+        menu.getWidgetSearchParameters(new SearchParameters(), {
           uiState: {},
         })
       );
@@ -571,7 +571,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
       const helper = jsHelper(
         createSearchClient(),
         'indexName',
-        menu.getWidgetSearchParameters!(new SearchParameters(), { uiState: {} })
+        menu.getWidgetSearchParameters(new SearchParameters(), { uiState: {} })
       );
 
       const renderState1 = menu.getWidgetRenderState(
@@ -601,7 +601,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
       const helper = jsHelper(
         createSearchClient(),
         'indexName',
-        menu.getWidgetSearchParameters!(new SearchParameters(), { uiState: {} })
+        menu.getWidgetSearchParameters(new SearchParameters(), { uiState: {} })
       );
 
       const renderState1 = menu.getWidgetRenderState(
@@ -749,7 +749,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
           const helper = jsHelper(
             createSearchClient(),
             'indexName',
-            menu.getWidgetSearchParameters!(new SearchParameters(), {
+            menu.getWidgetSearchParameters(new SearchParameters(), {
               uiState: {},
             })
           );
@@ -800,7 +800,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
       });
 
       expect(
-        widget.getWidgetSearchParameters!(new SearchParameters(), {
+        widget.getWidgetSearchParameters(new SearchParameters(), {
           uiState: {},
         })
       ).toEqual(
@@ -828,7 +828,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
       });
 
       expect(
-        widget.getWidgetSearchParameters!(new SearchParameters(), {
+        widget.getWidgetSearchParameters(new SearchParameters(), {
           uiState: {},
         })
       ).toEqual(
@@ -857,7 +857,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
       });
 
       // When
-      const config = widget.getWidgetSearchParameters!(new SearchParameters(), {
+      const config = widget.getWidgetSearchParameters(new SearchParameters(), {
         uiState: {},
       });
       const helper = jsHelper(createSearchClient(), '', config);
@@ -889,7 +889,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
       });
 
       // When
-      const config = widget.getWidgetSearchParameters!(new SearchParameters(), {
+      const config = widget.getWidgetSearchParameters(new SearchParameters(), {
         uiState: {},
       });
       const helper = jsHelper(createSearchClient(), '', config);
@@ -959,7 +959,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
       });
 
       // When
-      const config = widget.getWidgetSearchParameters!(new SearchParameters(), {
+      const config = widget.getWidgetSearchParameters(new SearchParameters(), {
         uiState: {},
       });
       const helper = jsHelper(createSearchClient(), '', config);
@@ -1014,7 +1014,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
         attribute: 'brand',
       });
 
-      const actual = widget.getWidgetUiState!(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -1042,7 +1042,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
         attribute: 'brand',
       });
 
-      const actual = widget.getWidgetUiState!(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -1074,7 +1074,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
         attribute: 'brand',
       });
 
-      const actual = widget.getWidgetUiState!(
+      const actual = widget.getWidgetUiState(
         {
           menu: {
             categories: 'Phone',
@@ -1102,7 +1102,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
         attribute: 'brand',
       });
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {},
       });
 
@@ -1135,7 +1135,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
         attribute: 'brand',
       });
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {},
       });
 
@@ -1157,7 +1157,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
         attribute: 'brand',
       });
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {
           menu: {
             brand: 'Apple',
@@ -1194,7 +1194,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
         attribute: 'brand',
       });
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {
           menu: {
             brand: 'Apple',
@@ -1221,7 +1221,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
           attribute: 'brand',
         });
 
-        const actual = widget.getWidgetSearchParameters!(helper.state, {
+        const actual = widget.getWidgetSearchParameters(helper.state, {
           uiState: {},
         });
 
@@ -1235,7 +1235,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
           limit: 5,
         });
 
-        const actual = widget.getWidgetSearchParameters!(helper.state, {
+        const actual = widget.getWidgetSearchParameters(helper.state, {
           uiState: {},
         });
 
@@ -1249,7 +1249,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
           showMore: true,
         });
 
-        const actual = widget.getWidgetSearchParameters!(helper.state, {
+        const actual = widget.getWidgetSearchParameters(helper.state, {
           uiState: {},
         });
 
@@ -1264,7 +1264,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
           showMoreLimit: 15,
         });
 
-        const actual = widget.getWidgetSearchParameters!(helper.state, {
+        const actual = widget.getWidgetSearchParameters(helper.state, {
           uiState: {},
         });
 
@@ -1280,7 +1280,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
           attribute: 'brand',
         });
 
-        const actual = widget.getWidgetSearchParameters!(helper.state, {
+        const actual = widget.getWidgetSearchParameters(helper.state, {
           uiState: {},
         });
 
@@ -1297,7 +1297,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
           limit: 110,
         });
 
-        const actual = widget.getWidgetSearchParameters!(helper.state, {
+        const actual = widget.getWidgetSearchParameters(helper.state, {
           uiState: {},
         });
 
@@ -1318,7 +1318,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
       const helper = jsHelper(
         createSearchClient(),
         indexName,
-        widget.getWidgetSearchParameters!(new SearchParameters(), {
+        widget.getWidgetSearchParameters(new SearchParameters(), {
           uiState: {},
         })
       );
@@ -1417,7 +1417,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
       const helper = jsHelper(
         createSearchClient(),
         indexName,
-        widget.getWidgetSearchParameters!(new SearchParameters(), {
+        widget.getWidgetSearchParameters(new SearchParameters(), {
           uiState: {},
         })
       );
@@ -1460,7 +1460,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
       const helper = jsHelper(
         createSearchClient(),
         'test',
-        widget.getWidgetSearchParameters!(new SearchParameters(), {
+        widget.getWidgetSearchParameters(new SearchParameters(), {
           uiState: {},
         })
       );
@@ -1480,7 +1480,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
       const helper = jsHelper(
         createSearchClient(),
         '',
-        widget.getWidgetSearchParameters!(new SearchParameters(), {
+        widget.getWidgetSearchParameters(new SearchParameters(), {
           uiState: {},
         })
       );

--- a/src/connectors/menu/connectMenu.ts
+++ b/src/connectors/menu/connectMenu.ts
@@ -252,7 +252,7 @@ const connectMenu: MenuConnector = function connectMenu(
             instantSearchInstance,
             helper,
             attribute,
-            widgetType: this.$$type!,
+            widgetType: this.$$type,
           });
         }
 

--- a/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.ts
+++ b/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.ts
@@ -742,7 +742,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
     test('returns the `uiState` empty', () => {
       const [widget, helper] = getInitializedWidget();
 
-      const actual = widget.getWidgetUiState!(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -758,7 +758,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
 
       helper.addNumericRefinement('numerics', '=', 20);
 
-      const actual = widget.getWidgetUiState!(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -778,7 +778,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
 
       helper.addNumericRefinement('numerics', '>=', 10);
 
-      const actual = widget.getWidgetUiState!(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -798,7 +798,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
 
       helper.addNumericRefinement('numerics', '<=', 20);
 
-      const actual = widget.getWidgetUiState!(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -819,7 +819,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
       helper.addNumericRefinement('numerics', '>=', 10);
       helper.addNumericRefinement('numerics', '<=', 20);
 
-      const actual = widget.getWidgetUiState!(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -840,7 +840,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
       helper.addNumericRefinement('numerics', '>=', 10);
       helper.addNumericRefinement('numerics', '<=', 20);
 
-      const actual = widget.getWidgetUiState!(
+      const actual = widget.getWidgetUiState(
         {
           numericMenu: {
             numerics2: '27:36',
@@ -865,7 +865,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
     test('returns the `SearchParameters` with the default value', () => {
       const [widget, helper] = getInitializedWidget();
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {},
       });
 
@@ -884,7 +884,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
 
       helper.addNumericRefinement('numerics', '=', [5, 10]);
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {},
       });
 
@@ -905,7 +905,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
         .addNumericRefinement('numerics', '>=', [10])
         .addNumericRefinement('numerics', '<=', [20]);
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {
           numericMenu: {
             numerics: '10',
@@ -928,7 +928,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
     test('returns the `SearchParameters` with the value from `uiState` (only min)', () => {
       const [widget, helper] = getInitializedWidget();
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {
           numericMenu: {
             numerics: '10:',
@@ -951,7 +951,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
     test('returns the `SearchParameters` with the value from `uiState` (only max)', () => {
       const [widget, helper] = getInitializedWidget();
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {
           numericMenu: {
             numerics: ':20',
@@ -974,7 +974,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
     test('returns the `SearchParameters` with the value from `uiState` (range)', () => {
       const [widget, helper] = getInitializedWidget();
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {
           numericMenu: {
             numerics: '10:20',
@@ -998,7 +998,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
     test('returns the `SearchParameters` with the value from `uiState` (exact)', () => {
       const [widget, helper] = getInitializedWidget();
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {
           numericMenu: {
             numerics: '10',
@@ -1148,8 +1148,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
       expect(renderState2.numericMenu).toEqual({
         numerics: {
           createURL: expect.any(Function),
-          refine: renderState1.numericMenu!.numerics.refine,
-          sendEvent: renderState1.numericMenu!.numerics.sendEvent,
+          refine: renderState1.numericMenu.numerics.refine,
+          sendEvent: renderState1.numericMenu.numerics.sendEvent,
           hasNoResults: true,
           items: [
             {

--- a/src/connectors/numeric-menu/connectNumericMenu.ts
+++ b/src/connectors/numeric-menu/connectNumericMenu.ts
@@ -354,11 +354,11 @@ const connectNumericMenu: NumericMenuConnector = function connectNumericMenu(
         }
 
         return {
-          createURL: connectorState.createURL!(state),
+          createURL: connectorState.createURL(state),
           items: transformItems(prepareItems(state)),
           hasNoResults: results ? results.nbHits === 0 : true,
-          refine: connectorState.refine!,
-          sendEvent: connectorState.sendEvent!,
+          refine: connectorState.refine,
+          sendEvent: connectorState.sendEvent,
           widgetParams,
         };
       },
@@ -372,9 +372,7 @@ function isRefined(
   option: NumericMenuConnectorParamsItem
 ) {
   // @TODO: same as another spot, why is this mixing arrays & elements?
-  const currentRefinements = state.getNumericRefinements(
-    attribute
-  ) as SearchParameters.OperatorList;
+  const currentRefinements = state.getNumericRefinements(attribute);
 
   if (option.start !== undefined && option.end !== undefined) {
     if (option.start === option.end) {
@@ -409,9 +407,7 @@ function getRefinedState(
   const refinedOption = JSON.parse(decodeURI(facetValue));
 
   // @TODO: why is array / element mixed here & hasRefinements; seems wrong?
-  const currentRefinements = resolvedState.getNumericRefinements(
-    attribute
-  ) as SearchParameters.OperatorList;
+  const currentRefinements = resolvedState.getNumericRefinements(attribute);
 
   if (refinedOption.start === undefined && refinedOption.end === undefined) {
     return resolvedState.removeNumericRefinement(attribute);

--- a/src/connectors/pagination/__tests__/connectPagination-test.ts
+++ b/src/connectors/pagination/__tests__/connectPagination-test.ts
@@ -355,7 +355,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/pagination/
     test('returns the `uiState` empty', () => {
       const [widget, helper] = getInitializedWidget();
 
-      const actual = widget.getWidgetUiState!(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -371,7 +371,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/pagination/
 
       helper.setQueryParameter('page', 4);
 
-      const actual = widget.getWidgetUiState!(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -389,7 +389,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/pagination/
     test('returns the `SearchParameters` with the value from `uiState`', () => {
       const [widget, helper] = getInitializedWidget();
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {
           page: 5,
         },
@@ -406,7 +406,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/pagination/
     test('returns the `SearchParameters` with the default value', () => {
       const [widget, helper] = getInitializedWidget();
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {},
       });
 
@@ -424,7 +424,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/pagination/
       helper.setPage(200);
       expect(helper.state.page).toBe(200);
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {},
       });
 

--- a/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
+++ b/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
@@ -413,7 +413,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
 
         // Query parameters are initially set in the helper.
         // Therefore, `ruleContexts` should be set.
-        expect((helper.state as SearchParameters).ruleContexts).toEqual([
+        expect(helper.state.ruleContexts).toEqual([
           'ais-brand-Samsung',
           'ais-brand-Apple',
           'ais-price-500',
@@ -446,9 +446,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
           })
         );
 
-        expect((helper.state as SearchParameters).ruleContexts).toEqual([
-          'overriden-rule',
-        ]);
+        expect(helper.state.ruleContexts).toEqual(['overriden-rule']);
         expect(brandFilterSpy).toHaveBeenCalledTimes(1);
         expect(brandFilterSpy).toHaveBeenCalledWith([]);
       });
@@ -475,9 +473,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
         );
 
         // There's no results yet, so no `ruleContexts` should be set.
-        expect((helper.state as SearchParameters).ruleContexts).toEqual(
-          undefined
-        );
+        expect(helper.state.ruleContexts).toEqual(undefined);
         expect(brandFilterSpy).toHaveBeenCalledTimes(0);
         expect(priceFilterSpy).toHaveBeenCalledTimes(0);
 
@@ -502,9 +498,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
         // There are some results with the facets that we track in the
         // widget but the query parameters are not set in the helper.
         // Therefore, no `ruleContexts` should be set.
-        expect((helper.state as SearchParameters).ruleContexts).toEqual(
-          undefined
-        );
+        expect(helper.state.ruleContexts).toEqual(undefined);
         expect(brandFilterSpy).toHaveBeenCalledTimes(0);
         expect(priceFilterSpy).toHaveBeenCalledTimes(0);
 
@@ -542,7 +536,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
 
         // The search state contains the facets that we track,
         // therefore the `ruleContexts` should finally be set.
-        expect((helper.state as SearchParameters).ruleContexts).toEqual([
+        expect(helper.state.ruleContexts).toEqual([
           'ais-brand-Samsung',
           'ais-brand-Apple',
           'ais-price-500',
@@ -574,9 +568,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
           })
         );
 
-        expect((helper.state as SearchParameters).ruleContexts).toEqual(
-          undefined
-        );
+        expect(helper.state.ruleContexts).toEqual(undefined);
         expect(brandFilterSpy).toHaveBeenCalledTimes(0);
 
         widget.render!(
@@ -597,9 +589,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
           })
         );
 
-        expect((helper.state as SearchParameters).ruleContexts).toEqual(
-          undefined
-        );
+        expect(helper.state.ruleContexts).toEqual(undefined);
         expect(brandFilterSpy).toHaveBeenCalledTimes(0);
 
         helper.setState({
@@ -626,9 +616,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
           })
         );
 
-        expect((helper.state as SearchParameters).ruleContexts).toEqual([
-          'ais-brand-Samsung',
-        ]);
+        expect(helper.state.ruleContexts).toEqual(['ais-brand-Samsung']);
         expect(brandFilterSpy).toHaveBeenCalledTimes(1);
         expect(brandFilterSpy).toHaveBeenCalledWith(['Samsung', 'Apple']);
       });
@@ -650,9 +638,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
           })
         );
 
-        expect((helper.state as SearchParameters).ruleContexts).toEqual(
-          undefined
-        );
+        expect(helper.state.ruleContexts).toEqual(undefined);
         expect(priceFilterSpy).toHaveBeenCalledTimes(0);
 
         widget.render!(
@@ -666,9 +652,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
           })
         );
 
-        expect((helper.state as SearchParameters).ruleContexts).toEqual(
-          undefined
-        );
+        expect(helper.state.ruleContexts).toEqual(undefined);
         expect(priceFilterSpy).toHaveBeenCalledTimes(0);
 
         helper.setState({
@@ -691,9 +675,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
           })
         );
 
-        expect((helper.state as SearchParameters).ruleContexts).toEqual([
-          'ais-price-500',
-        ]);
+        expect(helper.state.ruleContexts).toEqual(['ais-price-500']);
         expect(priceFilterSpy).toHaveBeenCalledTimes(1);
         expect(priceFilterSpy).toHaveBeenCalledWith([500, 400, 100]);
       });
@@ -718,9 +700,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
           })
         );
 
-        expect((helper.state as SearchParameters).ruleContexts).toEqual(
-          undefined
-        );
+        expect(helper.state.ruleContexts).toEqual(undefined);
         expect(querySpy).toHaveBeenCalledTimes(0);
 
         widget.render!(
@@ -734,9 +714,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
           })
         );
 
-        expect((helper.state as SearchParameters).ruleContexts).toEqual(
-          undefined
-        );
+        expect(helper.state.ruleContexts).toEqual(undefined);
         expect(querySpy).toHaveBeenCalledTimes(0);
 
         helper.setState({
@@ -754,9 +732,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
           })
         );
 
-        expect((helper.state as SearchParameters).ruleContexts).toEqual([
-          'ais-query-cats_are_cool',
-        ]);
+        expect(helper.state.ruleContexts).toEqual(['ais-query-cats_are_cool']);
         expect(querySpy).toHaveBeenCalledTimes(1);
         expect(querySpy).toHaveBeenCalledWith(['cats are cool']);
 
@@ -775,7 +751,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
           })
         );
 
-        expect((helper.state as SearchParameters).ruleContexts).toBeUndefined();
+        expect(helper.state.ruleContexts).toBeUndefined();
         expect(querySpy).toHaveBeenCalledTimes(2);
         expect(querySpy).toHaveBeenCalledWith(['dogs are cool']);
       });
@@ -822,7 +798,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
           })
         );
 
-        expect((helper.state as SearchParameters).ruleContexts).toEqual([
+        expect(helper.state.ruleContexts).toEqual([
           'ais-brand-Insignia_',
           'ais-brand-_Apple',
         ]);
@@ -899,10 +875,8 @@ Consider using \`transformRuleContexts\` to minimize the number of rules sent to
           })
         );
 
-        expect((helper.state as SearchParameters).ruleContexts).toHaveLength(
-          10
-        );
-        expect((helper.state as SearchParameters).ruleContexts).toEqual([
+        expect(helper.state.ruleContexts).toHaveLength(10);
+        expect(helper.state.ruleContexts).toEqual([
           'ais-brand-Insignia',
           'ais-brand-Canon',
           'ais-brand-Dynex',
@@ -959,7 +933,7 @@ Consider using \`transformRuleContexts\` to minimize the number of rules sent to
           })
         );
 
-        expect((helper.state as SearchParameters).ruleContexts).toEqual([
+        expect(helper.state.ruleContexts).toEqual([
           'initial-rule',
           'ais-brand-Samsung',
           'ais-brand-Apple',
@@ -989,9 +963,7 @@ Consider using \`transformRuleContexts\` to minimize the number of rules sent to
           },
         });
 
-        expect((helper.state as SearchParameters).ruleContexts).toEqual(
-          undefined
-        );
+        expect(helper.state.ruleContexts).toEqual(undefined);
 
         widget.init!(
           createInitOptions({
@@ -1000,9 +972,7 @@ Consider using \`transformRuleContexts\` to minimize the number of rules sent to
           })
         );
 
-        expect((helper.state as SearchParameters).ruleContexts).toEqual([
-          'ais-brand-Samsung',
-        ]);
+        expect(helper.state.ruleContexts).toEqual(['ais-brand-Samsung']);
         expect(brandFilterSpy).toHaveBeenCalledTimes(1);
         expect(brandFilterSpy).toHaveBeenCalledWith(['Samsung']);
 
@@ -1014,9 +984,7 @@ Consider using \`transformRuleContexts\` to minimize the number of rules sent to
           },
         });
 
-        expect((helper.state as SearchParameters).ruleContexts).toEqual(
-          undefined
-        );
+        expect(helper.state.ruleContexts).toEqual(undefined);
         expect(brandFilterSpy).toHaveBeenCalledTimes(1);
       });
     });
@@ -1072,7 +1040,7 @@ Consider using \`transformRuleContexts\` to minimize the number of rules sent to
           'ais-brand-Samsung',
           'ais-brand-Apple',
         ]);
-        expect((helper.state as SearchParameters).ruleContexts).toEqual([
+        expect(helper.state.ruleContexts).toEqual([
           'initial-rule',
           'transformed-brand-Samsung',
           'transformed-brand-Apple',

--- a/src/connectors/range/__tests__/connectRange-test.ts
+++ b/src/connectors/range/__tests__/connectRange-test.ts
@@ -106,7 +106,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       attribute,
     });
 
-    const config = widget.getWidgetSearchParameters!(new SearchParameters(), {
+    const config = widget.getWidgetSearchParameters(new SearchParameters(), {
       uiState: {},
     });
     expect(config).toEqual(
@@ -179,7 +179,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       makeWidget({
         attribute,
         min: 0,
-      }).getWidgetSearchParameters!(new SearchParameters(), { uiState: {} })
+      }).getWidgetSearchParameters(new SearchParameters(), { uiState: {} })
     ).toEqual(
       new SearchParameters({
         disjunctiveFacets: [attribute],
@@ -193,7 +193,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       makeWidget({
         attribute,
         max: 100,
-      }).getWidgetSearchParameters!(new SearchParameters(), { uiState: {} })
+      }).getWidgetSearchParameters(new SearchParameters(), { uiState: {} })
     ).toEqual(
       new SearchParameters({
         disjunctiveFacets: [attribute],
@@ -208,7 +208,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
         attribute,
         min: 0,
         max: 100,
-      }).getWidgetSearchParameters!(new SearchParameters(), { uiState: {} })
+      }).getWidgetSearchParameters(new SearchParameters(), { uiState: {} })
     ).toEqual(
       new SearchParameters({
         disjunctiveFacets: [attribute],
@@ -234,7 +234,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
     const helper = jsHelper(
       createSearchClient(),
       '',
-      widget.getWidgetSearchParameters!(new SearchParameters(), { uiState: {} })
+      widget.getWidgetSearchParameters(new SearchParameters(), { uiState: {} })
     );
     helper.search = jest.fn();
 
@@ -295,7 +295,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
     const helper = jsHelper(
       createSearchClient(),
       '',
-      widget.getWidgetSearchParameters!(new SearchParameters(), { uiState: {} })
+      widget.getWidgetSearchParameters(new SearchParameters(), { uiState: {} })
     );
     helper.search = jest.fn();
 
@@ -327,7 +327,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
 
     const attribute = 'price';
     const widget = makeWidget({ attribute, min: 0, max: 500 });
-    const configuration = widget.getWidgetSearchParameters!(
+    const configuration = widget.getWidgetSearchParameters(
       new SearchParameters({
         index: 'movie',
       }),
@@ -375,7 +375,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
     const helper = jsHelper(
       createSearchClient(),
       '',
-      widget.getWidgetSearchParameters!(new SearchParameters(), { uiState: {} })
+      widget.getWidgetSearchParameters(new SearchParameters(), { uiState: {} })
     );
     helper.search = jest.fn();
 
@@ -434,7 +434,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       const helper = jsHelper(createSearchClient(), '');
 
       helper.setState(
-        widget.getWidgetSearchParameters!(helper.state, { uiState: {} })
+        widget.getWidgetSearchParameters(helper.state, { uiState: {} })
       );
 
       const { range } = widget.getWidgetRenderState(
@@ -459,7 +459,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       const helper = jsHelper(createSearchClient(), '');
 
       helper.setState(
-        widget.getWidgetSearchParameters!(helper.state, { uiState: {} })
+        widget.getWidgetSearchParameters(helper.state, { uiState: {} })
       );
 
       const { range } = widget.getWidgetRenderState(
@@ -484,7 +484,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       const helper = jsHelper(createSearchClient(), '');
 
       helper.setState(
-        widget.getWidgetSearchParameters!(helper.state, { uiState: {} })
+        widget.getWidgetSearchParameters(helper.state, { uiState: {} })
       );
 
       const { range } = widget.getWidgetRenderState(
@@ -509,7 +509,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       const helper = jsHelper(createSearchClient(), '');
 
       helper.setState(
-        widget.getWidgetSearchParameters!(helper.state, { uiState: {} })
+        widget.getWidgetSearchParameters(helper.state, { uiState: {} })
       );
 
       const { range } = widget.getWidgetRenderState(
@@ -534,7 +534,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       const helper = jsHelper(createSearchClient(), '');
 
       helper.setState(
-        widget.getWidgetSearchParameters!(helper.state, { uiState: {} })
+        widget.getWidgetSearchParameters(helper.state, { uiState: {} })
       );
 
       const { range } = widget.getWidgetRenderState(
@@ -559,7 +559,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       const helper = jsHelper(createSearchClient(), '');
 
       helper.setState(
-        widget.getWidgetSearchParameters!(helper.state, { uiState: {} })
+        widget.getWidgetSearchParameters(helper.state, { uiState: {} })
       );
 
       const { range } = widget.getWidgetRenderState(
@@ -587,7 +587,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       const helper = createHelper();
 
       helper.setState(
-        widget.getWidgetSearchParameters!(helper.state, { uiState: {} })
+        widget.getWidgetSearchParameters(helper.state, { uiState: {} })
       );
 
       const { start } = widget.getWidgetRenderState(
@@ -609,7 +609,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       const helper = createHelper();
 
       helper.setState(
-        widget.getWidgetSearchParameters!(helper.state, { uiState: {} })
+        widget.getWidgetSearchParameters(helper.state, { uiState: {} })
       );
       helper.addNumericRefinement(attribute, '>=', 10);
       helper.addNumericRefinement(attribute, '<=', 100);
@@ -634,7 +634,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       const helper = createHelper();
 
       helper.setState(
-        widget.getWidgetSearchParameters!(helper.state, { uiState: {} })
+        widget.getWidgetSearchParameters(helper.state, { uiState: {} })
       );
       helper.addNumericRefinement(attribute, '>=', 10.9);
       helper.addNumericRefinement(attribute, '<=', 99.1);
@@ -706,7 +706,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       const widget = connectRange(rendering)({ attribute });
 
       helper.setState(
-        widget.getWidgetSearchParameters!(helper.state, { uiState: {} })
+        widget.getWidgetSearchParameters(helper.state, { uiState: {} })
       );
 
       const { refine } = widget.getWidgetRenderState(
@@ -736,7 +736,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       const widget = connectRange(rendering)({ attribute });
 
       helper.setState(
-        widget.getWidgetSearchParameters!(helper.state, { uiState: {} })
+        widget.getWidgetSearchParameters(helper.state, { uiState: {} })
       );
 
       const { refine } = widget.getWidgetRenderState(
@@ -765,7 +765,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       const widget = connectRange(rendering)({ attribute });
 
       helper.setState(
-        widget.getWidgetSearchParameters!(helper.state, { uiState: {} })
+        widget.getWidgetSearchParameters(helper.state, { uiState: {} })
       );
 
       const { refine } = widget.getWidgetRenderState(
@@ -795,7 +795,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       const widget = connectRange(rendering)({ attribute, min: 10 });
 
       helper.setState(
-        widget.getWidgetSearchParameters!(helper.state, { uiState: {} })
+        widget.getWidgetSearchParameters(helper.state, { uiState: {} })
       );
 
       const { refine } = widget.getWidgetRenderState(
@@ -826,7 +826,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       });
 
       helper.setState(
-        widget.getWidgetSearchParameters!(helper.state, { uiState: {} })
+        widget.getWidgetSearchParameters(helper.state, { uiState: {} })
       );
 
       const { refine } = widget.getWidgetRenderState(
@@ -859,7 +859,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       const widget = connectRange(rendering)({ attribute });
 
       helper.setState(
-        widget.getWidgetSearchParameters!(helper.state, { uiState: {} })
+        widget.getWidgetSearchParameters(helper.state, { uiState: {} })
       );
 
       helper.addNumericRefinement(attribute, '>=', 10);
@@ -892,7 +892,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       const widget = connectRange(rendering)({ attribute });
 
       helper.setState(
-        widget.getWidgetSearchParameters!(helper.state, { uiState: {} })
+        widget.getWidgetSearchParameters(helper.state, { uiState: {} })
       );
 
       helper.addNumericRefinement(attribute, '>=', 10);
@@ -925,7 +925,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       const widget = connectRange(rendering)({ attribute });
 
       helper.setState(
-        widget.getWidgetSearchParameters!(helper.state, { uiState: {} })
+        widget.getWidgetSearchParameters(helper.state, { uiState: {} })
       );
 
       helper.addNumericRefinement(attribute, '>=', 10);
@@ -959,7 +959,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       const widget = connectRange(rendering)({ attribute });
 
       helper.setState(
-        widget.getWidgetSearchParameters!(helper.state, { uiState: {} })
+        widget.getWidgetSearchParameters(helper.state, { uiState: {} })
       );
 
       helper.addNumericRefinement(attribute, '>=', 10);
@@ -993,7 +993,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       const widget = connectRange(rendering)({ attribute });
 
       helper.setState(
-        widget.getWidgetSearchParameters!(helper.state, { uiState: {} })
+        widget.getWidgetSearchParameters(helper.state, { uiState: {} })
       );
 
       helper.addNumericRefinement(attribute, '>=', 10);
@@ -1025,7 +1025,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       const widget = connectRange(rendering)({ attribute });
 
       helper.setState(
-        widget.getWidgetSearchParameters!(helper.state, { uiState: {} })
+        widget.getWidgetSearchParameters(helper.state, { uiState: {} })
       );
 
       helper.addNumericRefinement(attribute, '<=', 490);
@@ -1060,7 +1060,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       });
 
       helper.setState(
-        widget.getWidgetSearchParameters!(helper.state, { uiState: {} })
+        widget.getWidgetSearchParameters(helper.state, { uiState: {} })
       );
 
       helper.addNumericRefinement(attribute, '>=', 20);
@@ -1093,7 +1093,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       });
 
       helper.setState(
-        widget.getWidgetSearchParameters!(helper.state, { uiState: {} })
+        widget.getWidgetSearchParameters(helper.state, { uiState: {} })
       );
 
       helper.addNumericRefinement(attribute, '>=', 240);
@@ -1123,7 +1123,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       const widget = connectRange(rendering)({ attribute });
 
       helper.setState(
-        widget.getWidgetSearchParameters!(helper.state, { uiState: {} })
+        widget.getWidgetSearchParameters(helper.state, { uiState: {} })
       );
 
       const { refine } = widget.getWidgetRenderState(
@@ -1151,7 +1151,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       const widget = connectRange(rendering)({ attribute });
 
       helper.setState(
-        widget.getWidgetSearchParameters!(helper.state, { uiState: {} })
+        widget.getWidgetSearchParameters(helper.state, { uiState: {} })
       );
 
       const { refine } = widget.getWidgetRenderState(
@@ -1179,7 +1179,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       const widget = connectRange(rendering)({ attribute });
 
       helper.setState(
-        widget.getWidgetSearchParameters!(helper.state, { uiState: {} })
+        widget.getWidgetSearchParameters(helper.state, { uiState: {} })
       );
 
       const { refine } = widget.getWidgetRenderState(
@@ -1207,7 +1207,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       const widget = connectRange(rendering)({ attribute });
 
       helper.setState(
-        widget.getWidgetSearchParameters!(helper.state, { uiState: {} })
+        widget.getWidgetSearchParameters(helper.state, { uiState: {} })
       );
 
       helper.addNumericRefinement(attribute, '>=', 10);
@@ -1237,7 +1237,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       const helper = createHelper();
       const widget = connectRange(rendering)({ attribute });
       helper.setState(
-        widget.getWidgetSearchParameters!(helper.state, { uiState: {} })
+        widget.getWidgetSearchParameters(helper.state, { uiState: {} })
       );
 
       const { refine } = widget.getWidgetRenderState(
@@ -1271,7 +1271,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       const helper = jsHelper(
         createSearchClient(),
         '',
-        widget.getWidgetSearchParameters!(new SearchParameters(), {
+        widget.getWidgetSearchParameters(new SearchParameters(), {
           uiState: {},
         })
       );
@@ -1289,7 +1289,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       const helper = jsHelper(
         createSearchClient(),
         indexName,
-        widget.getWidgetSearchParameters!(new SearchParameters(), {
+        widget.getWidgetSearchParameters(new SearchParameters(), {
           uiState: {},
         })
       );
@@ -1310,7 +1310,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       const helper = jsHelper(
         createSearchClient(),
         indexName,
-        widget.getWidgetSearchParameters!(new SearchParameters(), {
+        widget.getWidgetSearchParameters(new SearchParameters(), {
           uiState: {},
         })
       );
@@ -1357,7 +1357,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
         attribute: 'price',
       });
 
-      const actual = widget.getWidgetUiState!(
+      const actual = widget.getWidgetUiState(
         {},
         {
           helper,
@@ -1384,7 +1384,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
         attribute: 'price',
       });
 
-      const actual = widget.getWidgetUiState!(
+      const actual = widget.getWidgetUiState(
         {},
         {
           helper,
@@ -1410,7 +1410,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
         attribute: 'price',
       });
 
-      const actual = widget.getWidgetUiState!(
+      const actual = widget.getWidgetUiState(
         {},
         {
           helper,
@@ -1440,7 +1440,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
         attribute: 'price',
       });
 
-      const actual = widget.getWidgetUiState!(
+      const actual = widget.getWidgetUiState(
         {},
         {
           helper,
@@ -1471,7 +1471,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
         attribute: 'price',
       });
 
-      const actual = widget.getWidgetUiState!(
+      const actual = widget.getWidgetUiState(
         {},
         {
           helper,
@@ -1502,7 +1502,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
         attribute: 'price',
       });
 
-      const actual = widget.getWidgetUiState!(
+      const actual = widget.getWidgetUiState(
         {},
         {
           helper,
@@ -1533,7 +1533,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
         attribute: 'price',
       });
 
-      const actual = widget.getWidgetUiState!(
+      const actual = widget.getWidgetUiState(
         {},
         {
           helper,
@@ -1564,7 +1564,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
         attribute: 'price',
       });
 
-      const actual = widget.getWidgetUiState!(
+      const actual = widget.getWidgetUiState(
         {
           range: {
             age: '16:',
@@ -1802,7 +1802,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
         attribute: 'price',
       });
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {},
       });
 
@@ -1828,7 +1828,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
         attribute: 'price',
       });
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {},
       });
 
@@ -1846,7 +1846,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
         attribute: 'price',
       });
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {
           range: {
             price: '100:1000',
@@ -1871,7 +1871,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
         attribute: 'price',
       });
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {
           range: {
             price: '100:',
@@ -1895,7 +1895,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
         attribute: 'price',
       });
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {
           range: {
             price: ':1000',
@@ -1919,7 +1919,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
         attribute: 'price',
       });
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {
           range: {},
         },
@@ -1939,7 +1939,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
         attribute: 'price',
       });
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {
           range: {
             price: 'min:max',
@@ -1961,7 +1961,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
         attribute: 'price',
       });
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {
           range: {
             price: 'wrong-format',
@@ -1989,7 +1989,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
         attribute: 'price',
       });
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {
           range: {
             price: '100:1000',
@@ -2021,7 +2021,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
         max: 500,
       });
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {
           range: {
             price: '0:400',
@@ -2045,7 +2045,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
         max: 500,
       });
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {
           range: {
             price: '-20:600',
@@ -2065,7 +2065,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
         attribute,
       });
 
-      const actual = widget.getWidgetSearchParameters!(new SearchParameters(), {
+      const actual = widget.getWidgetSearchParameters(new SearchParameters(), {
         uiState: {},
       });
 
@@ -2086,7 +2086,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
         max: 500,
       });
 
-      const actual = widget.getWidgetSearchParameters!(
+      const actual = widget.getWidgetSearchParameters(
         new SearchParameters({
           numericRefinements: {
             price: {
@@ -2125,7 +2125,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
         },
       });
 
-      const actual = widget.getWidgetSearchParameters!(new SearchParameters(), {
+      const actual = widget.getWidgetSearchParameters(new SearchParameters(), {
         uiState: {},
       });
 
@@ -2148,7 +2148,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
         },
       });
 
-      const actual = widget.getWidgetSearchParameters!(new SearchParameters(), {
+      const actual = widget.getWidgetSearchParameters(new SearchParameters(), {
         uiState: {},
       });
 
@@ -2173,7 +2173,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
         },
       });
 
-      const actual = widget.getWidgetSearchParameters!(new SearchParameters(), {
+      const actual = widget.getWidgetSearchParameters(new SearchParameters(), {
         uiState: {},
       });
 
@@ -2228,7 +2228,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       const helper = jsHelper(
         createSearchClient(),
         '',
-        widget.getWidgetSearchParameters!(new SearchParameters(), {
+        widget.getWidgetSearchParameters(new SearchParameters(), {
           uiState: {},
         })
       );

--- a/src/connectors/rating-menu/__tests__/connectRatingMenu-test.ts
+++ b/src/connectors/rating-menu/__tests__/connectRatingMenu-test.ts
@@ -24,7 +24,7 @@ describe('connectRatingMenu', () => {
       ...config,
     });
 
-    const initialConfig = widget.getWidgetSearchParameters!(
+    const initialConfig = widget.getWidgetSearchParameters(
       new SearchParameters({}),
       { uiState: {} }
     );
@@ -383,7 +383,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
         attribute: 'grade',
       });
 
-      const actual = widget.getWidgetUiState!(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -410,7 +410,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
         attribute: 'grade',
       });
 
-      const actual = widget.getWidgetUiState!(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -441,7 +441,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
         attribute: 'grade',
       });
 
-      const actual = widget.getWidgetUiState!(
+      const actual = widget.getWidgetUiState(
         {
           ratingMenu: {
             rating: 4,
@@ -573,7 +573,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
           createURL: expect.any(Function),
           canRefine: true,
           refine: expect.any(Function),
-          sendEvent: renderState1.ratingMenu!.grade.sendEvent,
+          sendEvent: renderState1.ratingMenu.grade.sendEvent,
           hasNoResults: true,
           widgetParams: {
             attribute: 'grade',
@@ -709,7 +709,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
         attribute: 'grade',
       });
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {},
       });
 
@@ -739,7 +739,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
         attribute: 'grade',
       });
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {},
       });
 
@@ -762,7 +762,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
         attribute: 'grade',
       });
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {
           ratingMenu: {
             grade: 3,
@@ -800,7 +800,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
         attribute: 'grade',
       });
 
-      const actual = widget.getWidgetSearchParameters!(helper.state, {
+      const actual = widget.getWidgetSearchParameters(helper.state, {
         uiState: {
           ratingMenu: {
             grade: 3,

--- a/src/connectors/rating-menu/connectRatingMenu.ts
+++ b/src/connectors/rating-menu/connectRatingMenu.ts
@@ -247,12 +247,12 @@ const connectRatingMenu: RatingMenuConnector = function connectRatingMenu(
     function getRefinedState(state: SearchParameters, facetValue: string) {
       const isRefined = getRefinedStar(state) === Number(facetValue);
 
-      const emptyState = state.resetPage().removeNumericRefinement(attribute!);
+      const emptyState = state.resetPage().removeNumericRefinement(attribute);
 
       if (!isRefined) {
         return emptyState
-          .addNumericRefinement(attribute!, '<=', max)
-          .addNumericRefinement(attribute!, '>=', Number(facetValue));
+          .addNumericRefinement(attribute, '<=', max)
+          .addNumericRefinement(attribute, '>=', Number(facetValue));
       }
       return emptyState;
     }

--- a/src/connectors/refinement-list/__tests__/connectRefinementList-test.ts
+++ b/src/connectors/refinement-list/__tests__/connectRefinementList-test.ts
@@ -124,7 +124,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       });
 
       expect(
-        widget.getWidgetSearchParameters!(new SearchParameters(), {
+        widget.getWidgetSearchParameters(new SearchParameters(), {
           uiState: {},
         })
       ).toEqual(
@@ -144,7 +144,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       });
 
       expect(
-        widget.getWidgetSearchParameters!(new SearchParameters(), {
+        widget.getWidgetSearchParameters(new SearchParameters(), {
           uiState: {},
         })
       ).toEqual(
@@ -156,7 +156,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       );
 
       expect(
-        widget.getWidgetSearchParameters!(
+        widget.getWidgetSearchParameters(
           new SearchParameters({ maxValuesPerFacet: 100 }),
           { uiState: {} }
         )
@@ -181,7 +181,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       const helper = jsHelper(
         createSearchClient(),
         '',
-        widget.getWidgetSearchParameters!(new SearchParameters({}), {
+        widget.getWidgetSearchParameters(new SearchParameters({}), {
           uiState: {},
         })
       );
@@ -230,7 +230,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       secondRenderingOptions.toggleShowMore();
 
       expect(
-        widget.getWidgetSearchParameters!(new SearchParameters({}), {
+        widget.getWidgetSearchParameters(new SearchParameters({}), {
           uiState: {},
         })
       ).toEqual(
@@ -242,7 +242,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       );
 
       expect(
-        widget.getWidgetSearchParameters!(
+        widget.getWidgetSearchParameters(
           new SearchParameters({ maxValuesPerFacet: 100 }),
           { uiState: {} }
         )
@@ -266,7 +266,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       const helper = jsHelper(
         createSearchClient(),
         '',
-        widget.getWidgetSearchParameters!(new SearchParameters({}), {
+        widget.getWidgetSearchParameters(new SearchParameters({}), {
           uiState: {},
         })
       );
@@ -315,7 +315,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       secondRenderingOptions.toggleShowMore();
 
       expect(
-        widget.getWidgetSearchParameters!(new SearchParameters({}), {
+        widget.getWidgetSearchParameters(new SearchParameters({}), {
           uiState: {},
         })
       ).toEqual(
@@ -335,7 +335,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       });
 
       expect(
-        widget.getWidgetSearchParameters!(new SearchParameters({}), {
+        widget.getWidgetSearchParameters(new SearchParameters({}), {
           uiState: {},
         })
       ).toEqual(
@@ -357,7 +357,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       limit: 9,
     });
 
-    const config = widget.getWidgetSearchParameters!(new SearchParameters({}), {
+    const config = widget.getWidgetSearchParameters(new SearchParameters({}), {
       uiState: {},
     });
     expect(config).toEqual(
@@ -462,7 +462,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
     const helper = jsHelper(
       createSearchClient(),
       '',
-      widget.getWidgetSearchParameters!(new SearchParameters({}), {
+      widget.getWidgetSearchParameters(new SearchParameters({}), {
         uiState: {},
       })
     );
@@ -529,7 +529,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
     const helper = jsHelper(
       createSearchClient(),
       '',
-      widget.getWidgetSearchParameters!(new SearchParameters({}), {
+      widget.getWidgetSearchParameters(new SearchParameters({}), {
         uiState: {},
       })
     );
@@ -584,7 +584,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
     const helper = jsHelper(
       createSearchClient(),
       '',
-      widget.getWidgetSearchParameters!(new SearchParameters({}), {
+      widget.getWidgetSearchParameters(new SearchParameters({}), {
         uiState: {},
       })
     );
@@ -640,7 +640,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
     const helper = jsHelper(
       createSearchClient(),
       '',
-      widget.getWidgetSearchParameters!(new SearchParameters({}), {
+      widget.getWidgetSearchParameters(new SearchParameters({}), {
         uiState: {},
       })
     );
@@ -695,7 +695,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
     const helper = jsHelper(
       createSearchClient(),
       '',
-      widget.getWidgetSearchParameters!(new SearchParameters({}), {
+      widget.getWidgetSearchParameters(new SearchParameters({}), {
         uiState: {},
       })
     );
@@ -756,7 +756,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
     const helper = jsHelper(
       createSearchClient(),
       '',
-      widget.getWidgetSearchParameters!(new SearchParameters({}), {
+      widget.getWidgetSearchParameters(new SearchParameters({}), {
         uiState: {},
       })
     );
@@ -817,7 +817,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
     const helper = jsHelper(
       createSearchClient(),
       '',
-      widget.getWidgetSearchParameters!(new SearchParameters({}), {
+      widget.getWidgetSearchParameters(new SearchParameters({}), {
         uiState: {},
       })
     );
@@ -881,7 +881,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
     const helper = jsHelper(
       createSearchClient(),
       '',
-      widget.getWidgetSearchParameters!(new SearchParameters({}), {
+      widget.getWidgetSearchParameters(new SearchParameters({}), {
         uiState: {},
       })
     );
@@ -986,7 +986,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
     const helper = jsHelper(
       createSearchClient(),
       '',
-      widget.getWidgetSearchParameters!(new SearchParameters({}), {
+      widget.getWidgetSearchParameters(new SearchParameters({}), {
         uiState: {},
       })
     );
@@ -1195,7 +1195,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
     });
 
     const helper = jsHelper(createSearchClient(), '', {
-      ...widget.getWidgetSearchParameters!(new SearchParameters({}), {
+      ...widget.getWidgetSearchParameters(new SearchParameters({}), {
         uiState: {},
       }),
       maxValuesPerFacet: 10,
@@ -1293,7 +1293,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
     });
 
     const helper = jsHelper(createSearchClient(), '', {
-      ...widget.getWidgetSearchParameters!(new SearchParameters({}), {
+      ...widget.getWidgetSearchParameters(new SearchParameters({}), {
         uiState: {},
       }),
       maxValuesPerFacet: 10,
@@ -1389,7 +1389,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
     const helper = jsHelper(
       createSearchClient(),
       '',
-      widget.getWidgetSearchParameters!(new SearchParameters({}), {
+      widget.getWidgetSearchParameters(new SearchParameters({}), {
         uiState: {},
       })
     );
@@ -1475,7 +1475,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
     });
 
     const helper = jsHelper(createSearchClient(), '', {
-      ...widget.getWidgetSearchParameters!(new SearchParameters({}), {
+      ...widget.getWidgetSearchParameters(new SearchParameters({}), {
         uiState: {},
       }),
       maxValuesPerFacet: 3,
@@ -1566,7 +1566,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
     const helper = jsHelper(
       createSearchClient(),
       '',
-      widget.getWidgetSearchParameters!(new SearchParameters({}), {
+      widget.getWidgetSearchParameters(new SearchParameters({}), {
         uiState: {},
       })
     );
@@ -1678,7 +1678,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
     const helper = jsHelper(
       createSearchClient(),
       '',
-      widget.getWidgetSearchParameters!(new SearchParameters({}), {
+      widget.getWidgetSearchParameters(new SearchParameters({}), {
         uiState: {},
       })
     );
@@ -1754,7 +1754,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
     const helper = jsHelper(
       createSearchClient(),
       '',
-      widget.getWidgetSearchParameters!(new SearchParameters({}), {
+      widget.getWidgetSearchParameters(new SearchParameters({}), {
         uiState: {},
       })
     );
@@ -1856,7 +1856,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
     });
 
     const helper = jsHelper(createSearchClient(), '', {
-      ...widget.getWidgetSearchParameters!(new SearchParameters({}), {
+      ...widget.getWidgetSearchParameters(new SearchParameters({}), {
         uiState: {},
       }),
       // Here we simulate that another widget has set some highlight tags
@@ -1962,7 +1962,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
     });
 
     const helper = jsHelper(createSearchClient(), '', {
-      ...widget.getWidgetSearchParameters!(new SearchParameters({}), {
+      ...widget.getWidgetSearchParameters(new SearchParameters({}), {
         uiState: {},
       }),
       // Here we simulate that another widget has set some highlight tags
@@ -2065,7 +2065,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
     const helper = jsHelper(
       createSearchClient(),
       '',
-      widget.getWidgetSearchParameters!(new SearchParameters({}), {
+      widget.getWidgetSearchParameters(new SearchParameters({}), {
         uiState: {},
       })
     );
@@ -2090,7 +2090,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       const helper = jsHelper(
         createSearchClient(),
         indexName,
-        widget.getWidgetSearchParameters!(new SearchParameters({}), {
+        widget.getWidgetSearchParameters(new SearchParameters({}), {
           uiState: {},
         })
       );
@@ -2185,7 +2185,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       const helper = jsHelper(
         createSearchClient(),
         indexName,
-        widget.getWidgetSearchParameters!(new SearchParameters({}), {
+        widget.getWidgetSearchParameters(new SearchParameters({}), {
           uiState: {},
         })
       );
@@ -2276,7 +2276,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
         attribute: 'brand',
       });
 
-      const actual = widget.getWidgetUiState!(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -2301,7 +2301,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
         attribute: 'brand',
       });
 
-      const actual = widget.getWidgetUiState!(
+      const actual = widget.getWidgetUiState(
         {},
         {
           searchParameters: helper.state,
@@ -2330,7 +2330,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
         attribute: 'brand',
       });
 
-      const actual = widget.getWidgetUiState!(
+      const actual = widget.getWidgetUiState(
         {
           refinementList: {
             categories: ['Phone', 'Tablet'],
@@ -2459,10 +2459,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
               value: 'Samsung',
             },
           ],
-          refine: renderState1.refinementList!.brand.refine,
+          refine: renderState1.refinementList.brand.refine,
           searchForItems: expect.any(Function),
           sendEvent: expect.any(Function),
-          toggleShowMore: renderState1.refinementList!.brand.toggleShowMore,
+          toggleShowMore: renderState1.refinementList.brand.toggleShowMore,
           widgetParams: {
             attribute: 'brand',
           },
@@ -2680,7 +2680,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
           const helper = jsHelper(
             createSearchClient(),
             'indexName',
-            refinementList.getWidgetSearchParameters!(new SearchParameters(), {
+            refinementList.getWidgetSearchParameters(new SearchParameters(), {
               uiState: {
                 refinementList: { brand: ['Apple', 'Samsung'] },
               },
@@ -2734,7 +2734,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
           attribute: 'brand',
         });
 
-        const actual = widget.getWidgetSearchParameters!(helper.state, {
+        const actual = widget.getWidgetSearchParameters(helper.state, {
           uiState: {},
         });
 
@@ -2750,7 +2750,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
           limit: 5,
         });
 
-        const actual = widget.getWidgetSearchParameters!(helper.state, {
+        const actual = widget.getWidgetSearchParameters(helper.state, {
           uiState: {},
         });
 
@@ -2766,7 +2766,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
           showMore: true,
         });
 
-        const actual = widget.getWidgetSearchParameters!(helper.state, {
+        const actual = widget.getWidgetSearchParameters(helper.state, {
           uiState: {},
         });
 
@@ -2783,7 +2783,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
           showMoreLimit: 15,
         });
 
-        const actual = widget.getWidgetSearchParameters!(helper.state, {
+        const actual = widget.getWidgetSearchParameters(helper.state, {
           uiState: {},
         });
 
@@ -2801,7 +2801,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
           attribute: 'brand',
         });
 
-        const actual = widget.getWidgetSearchParameters!(helper.state, {
+        const actual = widget.getWidgetSearchParameters(helper.state, {
           uiState: {},
         });
 
@@ -2820,7 +2820,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
           limit: 110,
         });
 
-        const actual = widget.getWidgetSearchParameters!(helper.state, {
+        const actual = widget.getWidgetSearchParameters(helper.state, {
           uiState: {},
         });
 
@@ -2838,7 +2838,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
           operator: 'and',
         });
 
-        const actual = widget.getWidgetSearchParameters!(helper.state, {
+        const actual = widget.getWidgetSearchParameters(helper.state, {
           uiState: {},
         });
 
@@ -2863,7 +2863,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
           operator: 'and',
         });
 
-        const actual = widget.getWidgetSearchParameters!(helper.state, {
+        const actual = widget.getWidgetSearchParameters(helper.state, {
           uiState: {},
         });
 
@@ -2882,7 +2882,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
           operator: 'and',
         });
 
-        const actual = widget.getWidgetSearchParameters!(helper.state, {
+        const actual = widget.getWidgetSearchParameters(helper.state, {
           uiState: {
             refinementList: {
               brand: ['Apple', 'Samsung'],
@@ -2911,7 +2911,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
           operator: 'and',
         });
 
-        const actual = widget.getWidgetSearchParameters!(helper.state, {
+        const actual = widget.getWidgetSearchParameters(helper.state, {
           uiState: {
             refinementList: {
               brand: ['Apple', 'Samsung'],
@@ -2935,7 +2935,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
           attribute: 'brand',
         });
 
-        const actual = widget.getWidgetSearchParameters!(helper.state, {
+        const actual = widget.getWidgetSearchParameters(helper.state, {
           uiState: {},
         });
 
@@ -2959,7 +2959,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
           attribute: 'brand',
         });
 
-        const actual = widget.getWidgetSearchParameters!(helper.state, {
+        const actual = widget.getWidgetSearchParameters(helper.state, {
           uiState: {},
         });
 
@@ -2977,7 +2977,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
           attribute: 'brand',
         });
 
-        const actual = widget.getWidgetSearchParameters!(helper.state, {
+        const actual = widget.getWidgetSearchParameters(helper.state, {
           uiState: {
             refinementList: {
               brand: ['Apple', 'Samsung'],
@@ -3005,7 +3005,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
           attribute: 'brand',
         });
 
-        const actual = widget.getWidgetSearchParameters!(helper.state, {
+        const actual = widget.getWidgetSearchParameters(helper.state, {
           uiState: {
             refinementList: {
               brand: ['Apple', 'Samsung'],
@@ -3034,7 +3034,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       const helper = jsHelper(
         createSearchClient(),
         '',
-        widget.getWidgetSearchParameters!(new SearchParameters({}), {
+        widget.getWidgetSearchParameters(new SearchParameters({}), {
           uiState: {},
         })
       );

--- a/src/connectors/refinement-list/connectRefinementList.ts
+++ b/src/connectors/refinement-list/connectRefinementList.ts
@@ -371,7 +371,7 @@ const connectRefinementList: RefinementListConnector =
               instantSearchInstance,
               helper,
               attribute,
-              widgetType: this.$$type!,
+              widgetType: this.$$type,
             });
 
             triggerRefine = (facetValue) => {

--- a/src/connectors/relevant-sort/__tests__/connectRelevantSort-test.ts
+++ b/src/connectors/relevant-sort/__tests__/connectRelevantSort-test.ts
@@ -46,7 +46,7 @@ describe('connectRelevantSort', () => {
     );
     refine(10);
     expect(
-      widget.getWidgetSearchParameters!(helper.state, {
+      widget.getWidgetSearchParameters(helper.state, {
         uiState: {},
       }).relevancyStrictness
     ).toEqual(10);
@@ -245,7 +245,7 @@ describe('connectRelevantSort', () => {
       const makeWidget = connectRelevantSort(noop);
       const widget = makeWidget({});
 
-      const widgetUiState = widget.getWidgetUiState!(
+      const widgetUiState = widget.getWidgetUiState(
         {},
         { helper, searchParameters: helper.state }
       );
@@ -264,7 +264,7 @@ describe('connectRelevantSort', () => {
       refine(25);
 
       expect(
-        widget.getWidgetUiState!({}, { helper, searchParameters: helper.state })
+        widget.getWidgetUiState({}, { helper, searchParameters: helper.state })
       ).toEqual({
         relevantSort: 25,
       });
@@ -276,7 +276,7 @@ describe('connectRelevantSort', () => {
       const widget = makeWidget({});
 
       expect(
-        widget.getWidgetUiState!(
+        widget.getWidgetUiState(
           { relevantSort: 25 },
           { helper, searchParameters: helper.state }
         )
@@ -291,7 +291,7 @@ describe('connectRelevantSort', () => {
 
       // applies 30 from searchParameters
       expect(
-        widget.getWidgetUiState!(
+        widget.getWidgetUiState(
           { relevantSort: 25 },
           { helper, searchParameters: helper.state }
         )
@@ -306,7 +306,7 @@ describe('connectRelevantSort', () => {
       const makeWidget = connectRelevantSort(noop);
       const widget = makeWidget({});
 
-      const searchParameters = widget.getWidgetSearchParameters!(
+      const searchParameters = widget.getWidgetSearchParameters(
         new SearchParameters(),
         {
           uiState: {},
@@ -319,7 +319,7 @@ describe('connectRelevantSort', () => {
       const makeWidget = connectRelevantSort(noop);
       const widget = makeWidget({});
 
-      const searchParameters = widget.getWidgetSearchParameters!(
+      const searchParameters = widget.getWidgetSearchParameters(
         new SearchParameters(),
         {
           uiState: {
@@ -342,7 +342,7 @@ describe('connectRelevantSort', () => {
       );
       refine(25);
 
-      const searchParameters = widget.getWidgetSearchParameters!(helper.state, {
+      const searchParameters = widget.getWidgetSearchParameters(helper.state, {
         uiState: {},
       });
       expect(searchParameters.relevancyStrictness).toEqual(25);
@@ -358,7 +358,7 @@ describe('connectRelevantSort', () => {
       );
       refine(25);
 
-      const searchParameters = widget.getWidgetSearchParameters!(
+      const searchParameters = widget.getWidgetSearchParameters(
         new SearchParameters(),
         {
           uiState: {

--- a/src/connectors/search-box/__tests__/connectSearchBox-test.ts
+++ b/src/connectors/search-box/__tests__/connectSearchBox-test.ts
@@ -348,10 +348,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
       const renderState2 = searchBox.getRenderState({}, createRenderOptions());
 
       expect(renderState2.searchBox).toEqual({
-        clear: renderState1.searchBox!.clear,
+        clear: renderState1.searchBox.clear,
         isSearchStalled: false,
         query: '',
-        refine: renderState1.searchBox!.refine,
+        refine: renderState1.searchBox.refine,
         widgetParams: {
           queryHook,
         },

--- a/src/connectors/sort-by/__tests__/connectSortBy-test.ts
+++ b/src/connectors/sort-by/__tests__/connectSortBy-test.ts
@@ -706,7 +706,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
 
         const uiState = {};
         const searchParametersBefore = SearchParameters.make(helper.state);
-        const searchParametersAfter = widget.getWidgetSearchParameters!(
+        const searchParametersAfter = widget.getWidgetSearchParameters(
           searchParametersBefore,
           { uiState }
         );
@@ -722,7 +722,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
         };
 
         const searchParametersBefore = SearchParameters.make(helper.state);
-        const searchParametersAfter = widget.getWidgetSearchParameters!(
+        const searchParametersAfter = widget.getWidgetSearchParameters(
           searchParametersBefore,
           { uiState }
         );
@@ -741,7 +741,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
 
         const uiState = {};
         const searchParametersBefore = new SearchParameters(helper.state);
-        const searchParametersAfter = widget.getWidgetSearchParameters!(
+        const searchParametersAfter = widget.getWidgetSearchParameters(
           searchParametersBefore,
           { uiState }
         );
@@ -764,7 +764,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
           ],
         });
 
-        const actual = widget.getWidgetSearchParameters!(
+        const actual = widget.getWidgetSearchParameters(
           new SearchParameters({
             index: 'relevance',
           }),

--- a/src/lib/utils/checkIndexUiState.ts
+++ b/src/lib/utils/checkIndexUiState.ts
@@ -156,7 +156,7 @@ ${missingWidgets
     return `- \`${stateParameter}\` needs one of these widgets: ${(
       [] as string[]
     )
-      .concat(...widgets.map((name) => getWidgetNames(name!)))
+      .concat(...widgets.map((name) => getWidgetNames(name)))
       .map((name: string) => `"${name}"`)
       .join(', ')}`;
   })

--- a/src/lib/utils/mergeSearchParameters.ts
+++ b/src/lib/utils/mergeSearchParameters.ts
@@ -30,7 +30,7 @@ const mergeFacets: Merger = (left, right) =>
   right.facets!.reduce((_, name) => _.addFacet(name), left);
 
 const mergeDisjunctiveFacets: Merger = (left, right) =>
-  right.disjunctiveFacets!.reduce(
+  right.disjunctiveFacets.reduce(
     (_, name) => _.addDisjunctiveFacet(name),
     left
   );
@@ -53,7 +53,7 @@ const mergeHierarchicalFacets: Merger = (left, right) =>
 
 // Merge facet refinements
 const mergeTagRefinements: Merger = (left, right) =>
-  right.tagRefinements!.reduce((_, value) => _.addTagRefinement(value), left);
+  right.tagRefinements.reduce((_, value) => _.addTagRefinement(value), left);
 
 const mergeFacetRefinements: Merger = (left, right) =>
   left.setQueryParameters({

--- a/src/widgets/__tests__/index.test.ts
+++ b/src/widgets/__tests__/index.test.ts
@@ -165,7 +165,7 @@ describe('widgets', () => {
       const widgetInstances = initiateAllWidgets();
 
       widgetInstances.forEach(([name, widget]) =>
-        expect([name, widget.$$type!.substr(0, 4)]).toEqual([name, 'ais.'])
+        expect([name, widget.$$type.substr(0, 4)]).toEqual([name, 'ais.'])
       );
     });
   });

--- a/src/widgets/dynamic-widgets/__tests__/dynamic-widgets-test.ts
+++ b/src/widgets/dynamic-widgets/__tests__/dynamic-widgets-test.ts
@@ -161,7 +161,7 @@ describe('dynamicWidgets()', () => {
         }),
       ]);
 
-      indexWidget.init!(createInitOptions({ instantSearchInstance }));
+      indexWidget.init(createInitOptions({ instantSearchInstance }));
 
       // set results to the relevant index, so it renders all children
       instantSearchInstance.mainHelper!.derivedHelpers[0].lastResults =
@@ -172,7 +172,7 @@ describe('dynamicWidgets()', () => {
           createMultiSearchResponse({}).results
         );
 
-      indexWidget.render!(createRenderOptions({ instantSearchInstance }));
+      indexWidget.render(createRenderOptions({ instantSearchInstance }));
 
       await wait(0);
 
@@ -237,7 +237,7 @@ describe('dynamicWidgets()', () => {
         }),
       ]);
 
-      indexWidget.init!(createInitOptions({ instantSearchInstance }));
+      indexWidget.init(createInitOptions({ instantSearchInstance }));
 
       // set results to the relevant index, so it renders all children
       instantSearchInstance.mainHelper!.derivedHelpers[0].lastResults =
@@ -248,7 +248,7 @@ describe('dynamicWidgets()', () => {
           createMultiSearchResponse({}).results
         );
 
-      indexWidget.render!(createRenderOptions({ instantSearchInstance }));
+      indexWidget.render(createRenderOptions({ instantSearchInstance }));
 
       await wait(0);
 
@@ -317,7 +317,7 @@ describe('dynamicWidgets()', () => {
         }),
       ]);
 
-      indexWidget.init!(createInitOptions({ instantSearchInstance }));
+      indexWidget.init(createInitOptions({ instantSearchInstance }));
 
       // set results to the relevant index, so it renders all children
       instantSearchInstance.mainHelper!.derivedHelpers[0].lastResults =
@@ -330,7 +330,7 @@ describe('dynamicWidgets()', () => {
           }).results
         );
 
-      indexWidget.render!(createRenderOptions({ instantSearchInstance }));
+      indexWidget.render(createRenderOptions({ instantSearchInstance }));
 
       await wait(0);
 
@@ -374,7 +374,7 @@ describe('dynamicWidgets()', () => {
           }).results
         );
 
-      indexWidget.render!(createRenderOptions({ instantSearchInstance }));
+      indexWidget.render(createRenderOptions({ instantSearchInstance }));
 
       expect(rootContainer).toMatchInlineSnapshot(`
         <div>
@@ -445,7 +445,7 @@ describe('dynamicWidgets()', () => {
         }),
       ]);
 
-      indexWidget.init!(createInitOptions({ instantSearchInstance }));
+      indexWidget.init(createInitOptions({ instantSearchInstance }));
 
       // set results to the relevant index, so it renders all children
       instantSearchInstance.mainHelper!.derivedHelpers[0].lastResults =
@@ -458,7 +458,7 @@ describe('dynamicWidgets()', () => {
           }).results
         );
 
-      indexWidget.render!(createRenderOptions({ instantSearchInstance }));
+      indexWidget.render(createRenderOptions({ instantSearchInstance }));
 
       await wait(0);
 
@@ -524,7 +524,7 @@ describe('dynamicWidgets()', () => {
         }),
       ]);
 
-      indexWidget.init!(createInitOptions({ instantSearchInstance }));
+      indexWidget.init(createInitOptions({ instantSearchInstance }));
 
       // set results to the relevant index, so it renders all children
       instantSearchInstance.mainHelper!.derivedHelpers[0].lastResults =
@@ -537,7 +537,7 @@ describe('dynamicWidgets()', () => {
           }).results
         );
 
-      indexWidget.render!(createRenderOptions({ instantSearchInstance }));
+      indexWidget.render(createRenderOptions({ instantSearchInstance }));
 
       await wait(0);
 

--- a/src/widgets/hits-per-page/__tests__/hits-per-page-test.ts
+++ b/src/widgets/hits-per-page/__tests__/hits-per-page-test.ts
@@ -83,7 +83,7 @@ describe('hitsPerPage()', () => {
     });
 
     expect(
-      widgetWithDefaults.getWidgetSearchParameters!(new SearchParameters({}), {
+      widgetWithDefaults.getWidgetSearchParameters(new SearchParameters({}), {
         uiState: {},
       })
     ).toEqual(

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -167,7 +167,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
       }).toThrow();
 
       expect(() => {
-        instance.addWidgets(createWidget() as any);
+        instance.addWidgets(createWidget());
       }).toThrowErrorMatchingInlineSnapshot(`
 "The \`addWidgets\` method expects an array of widgets.
 
@@ -434,7 +434,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
       }).toThrow();
 
       expect(() => {
-        instance.removeWidgets(createWidget() as any);
+        instance.removeWidgets(createWidget());
       }).toThrowErrorMatchingInlineSnapshot(`
 "The \`removeWidgets\` method expects an array of widgets.
 

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -167,6 +167,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
       }).toThrow();
 
       expect(() => {
+        // @ts-expect-error
         instance.addWidgets(createWidget());
       }).toThrowErrorMatchingInlineSnapshot(`
 "The \`addWidgets\` method expects an array of widgets.
@@ -434,6 +435,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
       }).toThrow();
 
       expect(() => {
+        // @ts-expect-error
         instance.removeWidgets(createWidget());
       }).toThrowErrorMatchingInlineSnapshot(`
 "The \`removeWidgets\` method expects an array of widgets.

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -247,7 +247,7 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
     },
 
     createURL(nextState: SearchParameters) {
-      return localInstantSearchInstance!._createURL!({
+      return localInstantSearchInstance!._createURL({
         [indexId]: getLocalWidgetsUiState(localWidgets, {
           searchParameters: nextState,
           helper: helper!,
@@ -432,7 +432,7 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
       // aware of the `searchClient`).
       helper.search = () => {
         if (instantSearchInstance.onStateChange) {
-          instantSearchInstance.onStateChange!({
+          instantSearchInstance.onStateChange({
             uiState: instantSearchInstance.mainIndex.getWidgetUiState({}),
             setUiState: instantSearchInstance.setUiState.bind(
               instantSearchInstance

--- a/src/widgets/menu-select/__tests__/menu-select-test.ts
+++ b/src/widgets/menu-select/__tests__/menu-select-test.ts
@@ -111,7 +111,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu-select
         });
 
         helper.setState(
-          widget.getWidgetSearchParameters!(new SearchParameters({}), {
+          widget.getWidgetSearchParameters(new SearchParameters({}), {
             uiState: {
               menu: {
                 amazingBrand: 'algolia',

--- a/src/widgets/menu/__tests__/menu-test.ts
+++ b/src/widgets/menu/__tests__/menu-test.ts
@@ -48,7 +48,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/"
       const helper = jsHelper(createSearchClient(), '');
 
       helper.setState(
-        widget.getWidgetSearchParameters!(new SearchParameters({}), {
+        widget.getWidgetSearchParameters(new SearchParameters({}), {
           uiState: {},
         })
       );
@@ -95,7 +95,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/"
       const helper = jsHelper(createSearchClient(), '');
 
       helper.setState(
-        widget.getWidgetSearchParameters!(new SearchParameters({}), {
+        widget.getWidgetSearchParameters(new SearchParameters({}), {
           uiState: {},
         })
       );

--- a/src/widgets/numeric-menu/__tests__/numeric-menu-test.ts
+++ b/src/widgets/numeric-menu/__tests__/numeric-menu-test.ts
@@ -71,7 +71,7 @@ describe('numericMenu()', () => {
     helper = algoliasearchHelper(
       createSearchClient(),
       '',
-      widget.getWidgetSearchParameters!(new SearchParameters(), { uiState: {} })
+      widget.getWidgetSearchParameters(new SearchParameters(), { uiState: {} })
     );
 
     jest.spyOn(helper, 'search');

--- a/src/widgets/places/__tests__/places-test.ts
+++ b/src/widgets/places/__tests__/places-test.ts
@@ -155,7 +155,7 @@ describe('places', () => {
 
         widget.init!(createInitOptions({ helper }));
         // Trigger the initialization of `aroundLatLngViaIP`.
-        widget.getWidgetSearchParameters!(helper.state, { uiState: {} });
+        widget.getWidgetSearchParameters(helper.state, { uiState: {} });
 
         expect(helper.state.aroundLatLngViaIP).toBe(true);
 
@@ -198,7 +198,7 @@ describe('places', () => {
 
         widget.init!(createInitOptions({ helper }));
 
-        const nextSearchParameters = widget.getWidgetSearchParameters!(
+        const nextSearchParameters = widget.getWidgetSearchParameters(
           helper.state,
           {
             uiState: {},
@@ -222,7 +222,7 @@ describe('places', () => {
 
         widget.init!(createInitOptions({ helper }));
 
-        const nextSearchParameters = widget.getWidgetSearchParameters!(
+        const nextSearchParameters = widget.getWidgetSearchParameters(
           helper.state,
           {
             uiState: {
@@ -253,7 +253,7 @@ describe('places', () => {
 
         widget.init!(createInitOptions({ helper }));
 
-        const nextSearchParameters = widget.getWidgetSearchParameters!(
+        const nextSearchParameters = widget.getWidgetSearchParameters(
           helper.state,
           {
             uiState: {
@@ -284,7 +284,7 @@ describe('places', () => {
 
         widget.init!(createInitOptions({ helper }));
 
-        const nextSearchParameters = widget.getWidgetSearchParameters!(
+        const nextSearchParameters = widget.getWidgetSearchParameters(
           helper.state,
           {
             uiState: {},
@@ -318,7 +318,7 @@ describe('places', () => {
           },
         };
 
-        widget.getWidgetSearchParameters!(previousSearchParameters, {
+        widget.getWidgetSearchParameters(previousSearchParameters, {
           uiState,
         });
 
@@ -348,7 +348,7 @@ describe('places', () => {
           0
         );
 
-        widget.getWidgetSearchParameters!(helper.state, {
+        widget.getWidgetSearchParameters(helper.state, {
           uiState: {
             places: {
               query: 'Paris, Île-de-France, France',
@@ -372,7 +372,7 @@ describe('places', () => {
         });
 
         const previousUiState = {};
-        const nextUiState = widget.getWidgetUiState!(previousUiState, {
+        const nextUiState = widget.getWidgetUiState(previousUiState, {
           helper,
           searchParameters: helper.state,
         });
@@ -389,7 +389,7 @@ describe('places', () => {
         });
 
         const previousUiState = {};
-        const nextUiState = widget.getWidgetUiState!(previousUiState, {
+        const nextUiState = widget.getWidgetUiState(previousUiState, {
           helper,
           searchParameters: helper.state,
         });
@@ -422,7 +422,7 @@ describe('places', () => {
         });
 
         const previousUiState = {};
-        const nextUiState = widget.getWidgetUiState!(previousUiState, {
+        const nextUiState = widget.getWidgetUiState(previousUiState, {
           helper,
           searchParameters: helper.state,
         });
@@ -452,7 +452,7 @@ describe('places', () => {
         clearEventListener();
 
         const previousUiState = {};
-        const nextUiState = widget.getWidgetUiState!(previousUiState, {
+        const nextUiState = widget.getWidgetUiState(previousUiState, {
           helper,
           searchParameters: helper.state,
         });
@@ -478,7 +478,7 @@ describe('places', () => {
         clearEventListener();
 
         const previousUiState = {};
-        const nextUiState = widget.getWidgetUiState!(previousUiState, {
+        const nextUiState = widget.getWidgetUiState(previousUiState, {
           helper,
           searchParameters: helper.state,
         });

--- a/src/widgets/query-rule-custom-data/query-rule-custom-data.tsx
+++ b/src/widgets/query-rule-custom-data/query-rule-custom-data.tsx
@@ -67,7 +67,7 @@ const renderer =
   ({ items }: QueryRulesRenderState) => {
     render(
       <CustomData
-        cssClasses={cssClasses as QueryRuleCustomDataComponentCSSClasses}
+        cssClasses={cssClasses}
         templates={templates}
         items={items}
       />,

--- a/src/widgets/rating-menu/__tests__/rating-menu-integration-test.ts
+++ b/src/widgets/rating-menu/__tests__/rating-menu-integration-test.ts
@@ -21,7 +21,7 @@ function getInitializedWidget() {
   const helper = jsHelper(
     createSearchClient(),
     '',
-    widget.getWidgetSearchParameters!(new SearchParameters({}), {
+    widget.getWidgetSearchParameters(new SearchParameters({}), {
       uiState: {},
     })
   );

--- a/src/widgets/rating-menu/__tests__/rating-menu-test.ts
+++ b/src/widgets/rating-menu/__tests__/rating-menu-test.ts
@@ -55,7 +55,7 @@ describe('ratingMenu()', () => {
     helper = jsHelper(
       createSearchClient(),
       '',
-      widget.getWidgetSearchParameters!(new SearchParameters({}), {
+      widget.getWidgetSearchParameters(new SearchParameters({}), {
         uiState: {},
       })
     );
@@ -80,7 +80,7 @@ describe('ratingMenu()', () => {
 
   it('configures the underlying disjunctive facet', () => {
     expect(
-      widget.getWidgetSearchParameters!(new SearchParameters(), { uiState: {} })
+      widget.getWidgetSearchParameters(new SearchParameters(), { uiState: {} })
     ).toEqual(
       new SearchParameters({
         disjunctiveFacets: ['anAttrName'],
@@ -231,7 +231,7 @@ describe('ratingMenu()', () => {
     const _helper = jsHelper(
       createSearchClient(),
       '',
-      _widget.getWidgetSearchParameters!(new SearchParameters({}), {
+      _widget.getWidgetSearchParameters(new SearchParameters({}), {
         uiState: {},
       })
     );


### PR DESCRIPTION
There's a lot of assertions in our code base that were once necessary, but that's no longer the case.

This rule requires typescript, so files that are ignored in typescript also need to be ignored for these rules
