### PR TITLE
feat(ts): expose built files in umd

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,4 +1,4 @@
 {
   "sandboxes": ["instantsearchjs-es-template-pcw1k"],
-  "buildCommand": "build:es"
+  "buildCommand": "build"
 }

--- a/scripts/typescript/api-extractor.json
+++ b/scripts/typescript/api-extractor.json
@@ -6,7 +6,8 @@
   "mainEntryPointFilePath": "<projectFolder>/es/index.d.ts",
 
   "dtsRollup": {
-    "enabled": false
+    "enabled": true,
+    "untrimmedFilePath": "<projectFolder>/dist/instantsearch.production.d.ts"
   },
 
   "apiReport": {

--- a/scripts/typescript/extract.js
+++ b/scripts/typescript/extract.js
@@ -19,12 +19,6 @@ shell.sed(
   path.join(__dirname, '../../es/**/*.d.ts')
 );
 
-// expose only the es entry point, not the umd entry point
-shell.mv(
-  path.join(__dirname, '../../es/index.es.d.ts'),
-  path.join(__dirname, '../../es/index.d.ts')
-);
-
 console.log();
 console.log(`Validating definitions...`);
 
@@ -47,3 +41,24 @@ if (!result.succeeded) {
 
   process.exitCode = 1;
 }
+
+// move the right entry points
+// esm to override umd
+shell.mv(
+  path.join(__dirname, '../../es/index.es.d.ts'),
+  path.join(__dirname, '../../es/index.d.ts')
+);
+
+// production and development umd
+shell.cp(
+  path.join(__dirname, '../../dist/instantsearch.production.d.ts'),
+  path.join(__dirname, '../../dist/instantsearch.production.min.d.ts')
+);
+shell.cp(
+  path.join(__dirname, '../../dist/instantsearch.production.d.ts'),
+  path.join(__dirname, '../../dist/instantsearch.development.d.ts')
+);
+shell.cp(
+  path.join(__dirname, '../../dist/instantsearch.production.d.ts'),
+  path.join(__dirname, '../../dist/instantsearch.development.min.d.ts')
+);


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Exposes the entry point for umd for each of the umd entry points.

This is achieved using the dtsRollup feature of api-extractor, which isn't needed for the es build, as local files work perfectly fine in that case.

Make sure to check the generated files when reviewing this PR

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

A situation like https://github.com/algolia/create-instantsearch-app/pull/464 is done easier by simply declaring what's import from the umd
