### PR TITLE
feat(panel): render templates on init with render state

### DIFF
--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -6,7 +6,7 @@ import cx from 'classnames';
 import Template from '../Template/Template';
 import type {
   PanelCSSClasses,
-  PanelRenderOptions,
+  PanelSharedOptions,
   PanelTemplates,
 } from '../../widgets/panel/panel';
 import type { ComponentCSSClasses, UnknownWidgetFactory } from '../../types';
@@ -23,7 +23,7 @@ export type PanelProps<TWidget extends UnknownWidgetFactory> = {
   hidden: boolean;
   collapsible: boolean;
   isCollapsed: boolean;
-  data: PanelRenderOptions<TWidget>;
+  data: PanelSharedOptions<TWidget>;
   cssClasses: PanelComponentCSSClasses;
   templates: PanelComponentTemplates<TWidget>;
   bodyElement: HTMLElement;

--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -6,13 +6,10 @@ import cx from 'classnames';
 import Template from '../Template/Template';
 import type {
   PanelCSSClasses,
+  PanelRenderOptions,
   PanelTemplates,
 } from '../../widgets/panel/panel';
-import type {
-  ComponentCSSClasses,
-  RenderOptions,
-  UnknownWidgetFactory,
-} from '../../types';
+import type { ComponentCSSClasses, UnknownWidgetFactory } from '../../types';
 
 export type PanelComponentCSSClasses = ComponentCSSClasses<
   // `collapseIcon` is only used in the default templates of the widget
@@ -26,7 +23,7 @@ export type PanelProps<TWidget extends UnknownWidgetFactory> = {
   hidden: boolean;
   collapsible: boolean;
   isCollapsed: boolean;
-  data: RenderOptions | Record<string, never>;
+  data: PanelRenderOptions<TWidget>;
   cssClasses: PanelComponentCSSClasses;
   templates: PanelComponentTemplates<TWidget>;
   bodyElement: HTMLElement;

--- a/src/widgets/panel/panel.tsx
+++ b/src/widgets/panel/panel.tsx
@@ -103,7 +103,10 @@ type GetWidgetRenderState<TWidgetFactory extends AnyWidgetFactory> =
       : never
     : Record<string, unknown>;
 
-export type PanelRenderOptions<TWidgetFactory extends AnyWidgetFactory> = (
+export type PanelRenderOptions<TWidgetFactory extends AnyWidgetFactory> =
+  RenderOptions & GetWidgetRenderState<TWidgetFactory>;
+
+export type PanelSharedOptions<TWidgetFactory extends AnyWidgetFactory> = (
   | InitOptions
   | RenderOptions
 ) &
@@ -154,7 +157,7 @@ const renderer =
     collapsible,
     collapsed,
   }: {
-    options: PanelRenderOptions<TWidget>;
+    options: PanelSharedOptions<TWidget>;
     hidden: boolean;
     collapsible: boolean;
     collapsed: boolean;
@@ -316,9 +319,9 @@ const panel: PanelWidget = (panelWidgetParams) => {
         const [renderOptions] = args;
 
         const options = {
-          ...(widget.getWidgetRenderState
+          ...((widget.getWidgetRenderState
             ? widget.getWidgetRenderState(renderOptions)
-            : {}),
+            : {}) as GetWidgetRenderState<typeof widgetFactory>),
           ...renderOptions,
         };
 


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Before this PR the initial render happens *before* widget init. This doesn't have a huge effect, although it got rendered with just an empty object. This makes things needlessly dynamic (more than the types were saying even, because the Template isn't super strict), and would make a template like `header({ widgetParams }) { return widgetParams.attribute }` throw, even though with this PR it is possible without conditionals or flashing.

Under very strict conditions this could be construed as a breakign change, although it's closer to a fix, therefore I have classified it as a new feature.

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

panel's templates always get called with render state, but also with init options. Before this PR it got called with either results or an empty object