### PR TITLE
feat(dynamicWidgets): add fallbackWidget

### DIFF
--- a/src/connectors/dynamic-widgets/__tests__/connectDynamicWidgets-test.ts
+++ b/src/connectors/dynamic-widgets/__tests__/connectDynamicWidgets-test.ts
@@ -348,7 +348,7 @@ describe('connectDynamicWidgets', () => {
         await wait(0);
 
         expect(parent.getWidgets()).toMatchInlineSnapshot(`
-          Array [
+          [
             Widget(ais.dynamicWidgets),
             Widget(ais.menu) {
               attribute: test1

--- a/src/connectors/dynamic-widgets/__tests__/connectDynamicWidgets-test.ts
+++ b/src/connectors/dynamic-widgets/__tests__/connectDynamicWidgets-test.ts
@@ -14,6 +14,7 @@ import {
 } from '../../../../test/mock/createAPIResponse';
 import connectHierarchicalMenu from '../../hierarchical-menu/connectHierarchicalMenu';
 import type { DynamicWidgetsConnectorParams } from '../connectDynamicWidgets';
+import connectRefinementList from '../../refinement-list/connectRefinementList';
 
 expect.addSnapshotSerializer(widgetSnapshotSerializer);
 
@@ -41,6 +42,14 @@ describe('connectDynamicWidgets', () => {
 
         See documentation: https://www.algolia.com/doc/api-reference/widgets/dynamic-widgets/js/#connector"
       `);
+    });
+
+    it('does not fail when empty widgets are given', () => {
+      expect(() =>
+        EXPERIMENTAL_connectDynamicWidgets(() => {})({
+          widgets: [],
+        })
+      ).not.toThrow();
     });
   });
 
@@ -80,7 +89,7 @@ describe('connectDynamicWidgets', () => {
     });
 
     describe('widgets', () => {
-      it('adds all widgets to the parent', () => {
+      it('does not add widgets on init', () => {
         const dynamicWidgets = EXPERIMENTAL_connectDynamicWidgets(() => {})({
           transformItems() {
             return [];
@@ -108,12 +117,6 @@ describe('connectDynamicWidgets', () => {
         expect(parent.getWidgets()).toMatchInlineSnapshot(`
           [
             Widget(ais.dynamicWidgets),
-            Widget(ais.menu) {
-              attribute: test1
-            },
-            Widget(ais.hierarchicalMenu) {
-              attribute: test2
-            },
           ]
         `);
       });
@@ -180,54 +183,6 @@ describe('connectDynamicWidgets', () => {
     });
 
     describe('widgets', () => {
-      it('removes all widgets if transformItems says so', async () => {
-        const dynamicWidgets = EXPERIMENTAL_connectDynamicWidgets(() => {})({
-          transformItems() {
-            return [];
-          },
-          widgets: [
-            connectMenu(() => {})({ attribute: 'test1' }),
-            connectHierarchicalMenu(() => {})({
-              attributes: ['test2', 'test3'],
-            }),
-          ],
-        });
-
-        const parent = index({ indexName: 'test' }).addWidgets([
-          dynamicWidgets,
-        ]);
-
-        expect(parent.getWidgets()).toMatchInlineSnapshot(`
-          [
-            Widget(ais.dynamicWidgets),
-          ]
-        `);
-
-        dynamicWidgets.init!(createInitOptions({ parent }));
-
-        expect(parent.getWidgets()).toMatchInlineSnapshot(`
-          [
-            Widget(ais.dynamicWidgets),
-            Widget(ais.menu) {
-              attribute: test1
-            },
-            Widget(ais.hierarchicalMenu) {
-              attribute: test2
-            },
-          ]
-        `);
-
-        dynamicWidgets.render!(createRenderOptions({ parent }));
-
-        await wait(0);
-
-        expect(parent.getWidgets()).toMatchInlineSnapshot(`
-          [
-            Widget(ais.dynamicWidgets),
-          ]
-        `);
-      });
-
       it('keeps static widgets returned in transformItems', async () => {
         const dynamicWidgets = EXPERIMENTAL_connectDynamicWidgets(() => {})({
           transformItems() {
@@ -256,12 +211,6 @@ describe('connectDynamicWidgets', () => {
         expect(parent.getWidgets()).toMatchInlineSnapshot(`
           [
             Widget(ais.dynamicWidgets),
-            Widget(ais.menu) {
-              attribute: test1
-            },
-            Widget(ais.hierarchicalMenu) {
-              attribute: test2
-            },
           ]
         `);
 
@@ -284,6 +233,8 @@ describe('connectDynamicWidgets', () => {
           transformItems(_items, { results }) {
             return results.userData[0].MOCK_facetOrder;
           },
+          fallbackWidget: ({ attribute }) =>
+            connectRefinementList(() => {})({ attribute }),
           widgets: [
             connectMenu(() => {})({ attribute: 'test1' }),
             connectHierarchicalMenu(() => {})({
@@ -307,12 +258,6 @@ describe('connectDynamicWidgets', () => {
         expect(parent.getWidgets()).toMatchInlineSnapshot(`
           [
             Widget(ais.dynamicWidgets),
-            Widget(ais.menu) {
-              attribute: test1
-            },
-            Widget(ais.hierarchicalMenu) {
-              attribute: test2
-            },
           ]
         `);
 
@@ -387,6 +332,35 @@ describe('connectDynamicWidgets', () => {
             },
           ]
         `);
+
+        dynamicWidgets.render!(
+          createRenderOptions({
+            parent,
+            results: new SearchResults(
+              new SearchParameters(),
+              createMultiSearchResponse({
+                userData: [{ MOCK_facetOrder: ['test1', 'test4', 'test5'] }],
+              }).results
+            ),
+          })
+        );
+
+        await wait(0);
+
+        expect(parent.getWidgets()).toMatchInlineSnapshot(`
+          Array [
+            Widget(ais.dynamicWidgets),
+            Widget(ais.menu) {
+              attribute: test1
+            },
+            Widget(ais.refinementList) {
+              attribute: test4
+            },
+            Widget(ais.refinementList) {
+              attribute: test5
+            },
+          ]
+        `);
       });
     });
   });
@@ -435,12 +409,6 @@ describe('connectDynamicWidgets', () => {
       expect(parent.getWidgets()).toMatchInlineSnapshot(`
         [
           Widget(ais.dynamicWidgets),
-          Widget(ais.menu) {
-            attribute: test1
-          },
-          Widget(ais.hierarchicalMenu) {
-            attribute: test2
-          },
         ]
       `);
 

--- a/stories/dynamic-widgets.stories.ts
+++ b/stories/dynamic-widgets.stories.ts
@@ -14,20 +14,26 @@ storiesOf('Basics/DynamicWidgets', module).add(
     search.addWidgets([
       instantsearch.widgets.EXPERIMENTAL_dynamicWidgets({
         container: dynamicWidgetsContainer,
+        fallbackWidget: ({ attribute, container }) =>
+          instantsearch.widgets.panel<
+            typeof instantsearch.widgets.refinementList
+          >({
+            templates: {
+              header(stuff) {
+                return stuff.widgetParams.attribute;
+              },
+            },
+          })(instantsearch.widgets.refinementList)({ attribute, container }),
         widgets: [
           (container) =>
-            instantsearch.widgets.menu({ container, attribute: 'categories' }),
-          (container) =>
-            instantsearch.widgets.panel({ templates: { header: 'brand' } })(
-              instantsearch.widgets.refinementList
-            )({
+            instantsearch.widgets.menu({
               container,
-              attribute: 'brand',
+              attribute: 'categories',
             }),
           (container) =>
-            instantsearch.widgets.panel({ templates: { header: 'hierarchy' } })(
-              instantsearch.widgets.hierarchicalMenu
-            )({
+            instantsearch.widgets.panel({
+              templates: { header: 'hierarchy' },
+            })(instantsearch.widgets.hierarchicalMenu)({
               container,
               attributes: [
                 'hierarchicalCategories.lvl0',


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

adds a `fallbackWidget` key to dynamicWidgets to allow usage when you don't know in advance what the attributes will be

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

- new key: "fallbackWidget" that gets used and instantiated when the attribute is slated for mounting
- no longer automatically adding widgets on init


To investigate: does this break routing?
To do: update tests if it turns out the mounting wasn't needed
