### PR TITLE
fix(insights): handle multiple setUserToken call before search.start()

### DIFF
--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -152,7 +152,7 @@ class InstantSearch<
   public mainIndex: IndexWidget;
   public started: boolean;
   public templatesConfig: Record<string, unknown>;
-  public renderState: RenderState = {};
+  public renderState?: RenderState = {};
   public _stalledSearchDelay: number;
   public _searchStalledTimer: any;
   public _isSearchStalled: boolean;

--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -152,7 +152,7 @@ class InstantSearch<
   public mainIndex: IndexWidget;
   public started: boolean;
   public templatesConfig: Record<string, unknown>;
-  public renderState?: RenderState = {};
+  public renderState: RenderState = {};
   public _stalledSearchDelay: number;
   public _searchStalledTimer: any;
   public _isSearchStalled: boolean;

--- a/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -342,6 +342,37 @@ See documentation: https://www.algolia.com/doc/guides/building-search-ui/going-f
       expect(getUserToken()).toEqual('token-from-queue-before-init');
     });
 
+    it('applies the last userToken before search.start()', () => {
+      const { insightsClient } = createInsights();
+      const indexName = 'my-index';
+      const instantSearchInstance = instantsearch({
+        searchClient: createSearchClient({
+          // @ts-expect-error only available in search client v4
+          transporter: {
+            headers: {
+              'x-algolia-application-id': 'myAppId',
+              'x-algolia-api-key': 'myApiKey',
+            },
+          },
+        }),
+        indexName,
+      });
+
+      const middleware = createInsightsMiddleware({
+        insightsClient,
+      });
+      instantSearchInstance.use(middleware);
+
+      insightsClient('setUserToken', 'abc');
+      insightsClient('setUserToken', 'def');
+
+      instantSearchInstance.start();
+
+      const helper = instantSearchInstance.mainIndex.getHelper();
+      // @ts-expect-error `userToken` exists in only search client v4
+      expect(helper.state.userToken).toEqual('def');
+    });
+
     describe('umd', () => {
       it('applies userToken from queue if exists', () => {
         const {

--- a/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -342,7 +342,7 @@ See documentation: https://www.algolia.com/doc/guides/building-search-ui/going-f
       expect(getUserToken()).toEqual('token-from-queue-before-init');
     });
 
-    it('applies the last userToken before search.start()', () => {
+    it('handles multiple setUserToken calls before search.start()', () => {
       const { insightsClient } = createInsights();
       const indexName = 'my-index';
       const instantSearchInstance = instantsearch({

--- a/src/middlewares/createInsightsMiddleware.ts
+++ b/src/middlewares/createInsightsMiddleware.ts
@@ -103,17 +103,32 @@ export const createInsightsMiddleware: CreateInsightsMiddleware = (props) => {
         });
         instantSearchInstance.addWidgets([configureClickAnalytics]);
 
+        // const setUserTokenToSearch = (userToken?: string) => {
+        //   const refineFromRenderState =
+        //     instantSearchInstance.renderState?.[instantSearchInstance.indexName]
+        //       ?.configure?.refine;
+
+        //   if (configureUserToken && refineFromRenderState) {
+        //     refineFromRenderState({ userToken });
+        //   } else {
+        //     if (configureUserToken) {
+        //       instantSearchInstance.removeWidgets([configureUserToken]);
+        //     }
+        //     configureUserToken = createWidget({
+        //       searchParameters: { userToken },
+        //     });
+        //     instantSearchInstance.addWidgets([configureUserToken]);
+        //   }
+        // };
+
         const setUserTokenToSearch = (userToken?: string) => {
           if (configureUserToken) {
-            instantSearchInstance.renderState[
-              instantSearchInstance.indexName
-            ].configure!.refine({ userToken });
-          } else {
-            configureUserToken = createWidget({
-              searchParameters: { userToken },
-            });
-            instantSearchInstance.addWidgets([configureUserToken]);
+            instantSearchInstance.removeWidgets([configureUserToken]);
           }
+          configureUserToken = createWidget({
+            searchParameters: { userToken },
+          });
+          instantSearchInstance.addWidgets([configureUserToken]);
         };
 
         const anonymousUserToken = getInsightsAnonymousUserTokenInternal();

--- a/src/middlewares/createInsightsMiddleware.ts
+++ b/src/middlewares/createInsightsMiddleware.ts
@@ -103,24 +103,6 @@ export const createInsightsMiddleware: CreateInsightsMiddleware = (props) => {
         });
         instantSearchInstance.addWidgets([configureClickAnalytics]);
 
-        // const setUserTokenToSearch = (userToken?: string) => {
-        //   const refineFromRenderState =
-        //     instantSearchInstance.renderState?.[instantSearchInstance.indexName]
-        //       ?.configure?.refine;
-
-        //   if (configureUserToken && refineFromRenderState) {
-        //     refineFromRenderState({ userToken });
-        //   } else {
-        //     if (configureUserToken) {
-        //       instantSearchInstance.removeWidgets([configureUserToken]);
-        //     }
-        //     configureUserToken = createWidget({
-        //       searchParameters: { userToken },
-        //     });
-        //     instantSearchInstance.addWidgets([configureUserToken]);
-        //   }
-        // };
-
         const setUserTokenToSearch = (userToken?: string) => {
           if (configureUserToken) {
             instantSearchInstance.removeWidgets([configureUserToken]);


### PR DESCRIPTION
**Summary**

In #4849, we introduced a regression that insights middleware throws when `setUserToken` is called twice before `search.start()`.

In the revised implementation of the insights middleware either adds a configure widget with userToken or calls `refine` function of renderState. However when instantSearchInstance is not started yet, even though configure widget is added, there is no renderState. That's why it's failing.