### PR TITLE
fix(insightsMiddleware): throw an error when credentials can't be extracted

### DIFF
--- a/src/lib/utils/getAppIdAndApiKey.ts
+++ b/src/lib/utils/getAppIdAndApiKey.ts
@@ -1,7 +1,5 @@
 // typed as any, since it accepts the _real_ js clients, not the interface we otherwise expect
-export function getAppIdAndApiKey(
-  searchClient: any
-): [string | undefined, string | undefined] {
+export function getAppIdAndApiKey(searchClient: any) {
   if (searchClient.transporter) {
     // searchClient v4
     const { headers, queryParameters } = searchClient.transporter;

--- a/src/lib/utils/getAppIdAndApiKey.ts
+++ b/src/lib/utils/getAppIdAndApiKey.ts
@@ -1,5 +1,7 @@
 // typed as any, since it accepts the _real_ js clients, not the interface we otherwise expect
-export function getAppIdAndApiKey(searchClient: any) {
+export function getAppIdAndApiKey(
+  searchClient: any
+): [string | undefined, string | undefined] {
   if (searchClient.transporter) {
     // searchClient v4
     const { headers, queryParameters } = searchClient.transporter;

--- a/src/middlewares/createInsightsMiddleware.ts
+++ b/src/middlewares/createInsightsMiddleware.ts
@@ -59,6 +59,13 @@ export const createInsightsMiddleware: CreateInsightsMiddleware = (props) => {
 
   return ({ instantSearchInstance }) => {
     const [appId, apiKey] = getAppIdAndApiKey(instantSearchInstance.client);
+
+    if (!appId || !apiKey) {
+      throw new Error(
+        '[insights middleware]: could not extract Algolia credentials from searchClient'
+      );
+    }
+
     let queuedUserToken: string | undefined = undefined;
     let userTokenBeforeInit: string | undefined = undefined;
 

--- a/src/middlewares/createInsightsMiddleware.ts
+++ b/src/middlewares/createInsightsMiddleware.ts
@@ -60,7 +60,8 @@ export const createInsightsMiddleware: CreateInsightsMiddleware = (props) => {
   return ({ instantSearchInstance }) => {
     const [appId, apiKey] = getAppIdAndApiKey(instantSearchInstance.client);
 
-    if (!appId || !apiKey) {
+    // search-insights.js also throws an error so dev-only clarification is sufficient
+    if (__DEV__ && !(appId && apiKey)) {
       throw new Error(
         '[insights middleware]: could not extract Algolia credentials from searchClient'
       );

--- a/src/widgets/hits/__tests__/hits-integration-test.ts
+++ b/src/widgets/hits/__tests__/hits-integration-test.ts
@@ -31,6 +31,8 @@ const createSearchClient = ({
         ),
       })
     ),
+    applicationID: 'latency',
+    apiKey: '123',
   };
 };
 

--- a/src/widgets/infinite-hits/__tests__/infinite-hits-integration-test.ts
+++ b/src/widgets/infinite-hits/__tests__/infinite-hits-integration-test.ts
@@ -33,6 +33,8 @@ describe('infiniteHits', () => {
             ),
           }) as any
       ),
+      // credentials are stored like this in client v3, but not part of the SearchClient type
+      ...({ applicationID: 'latency', apiKey: '123' } as any),
     });
     const search = instantsearch({
       indexName: 'instant_search',


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

When api or appId is missing, an error gets thrown by search insights, but that doesn't explain *why* that error gets thrown.

Ideally this would also clarify what the next step is (usually making sure to spread the previous search client, or leaving all properties in place, but i'm not too sure how to word that.

This doesn't add a new error where there wasn't already one, as the search-insights library threw an error in this case already.


**Result**

An error that explains when the search client doesn't match insights' expectation

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

