### PR TITLE
chore(dynamicWidgets): use non-deprecated form in examples

### DIFF
--- a/src/connectors/dynamic-widgets/__tests__/connectDynamicWidgets-test.ts
+++ b/src/connectors/dynamic-widgets/__tests__/connectDynamicWidgets-test.ts
@@ -1,4 +1,4 @@
-import { connectMenu, EXPERIMENTAL_connectDynamicWidgets } from '../..';
+import { connectMenu, connectDynamicWidgets } from '../..';
 import { index } from '../../../widgets';
 import { widgetSnapshotSerializer } from '../../../../test/utils/widgetSnapshotSerializer';
 import {
@@ -23,7 +23,7 @@ describe('connectDynamicWidgets', () => {
     it('fails when no renderer is given', () => {
       expect(() =>
         // @ts-expect-error
-        EXPERIMENTAL_connectDynamicWidgets({})
+        connectDynamicWidgets({})
       ).toThrowErrorMatchingInlineSnapshot(`
         "The render function is not valid (received type Object).
 
@@ -33,7 +33,7 @@ describe('connectDynamicWidgets', () => {
 
     it('fails when no widgets are given', () => {
       expect(() =>
-        EXPERIMENTAL_connectDynamicWidgets(() => {})(
+        connectDynamicWidgets(() => {})(
           // @ts-expect-error
           {}
         )
@@ -46,7 +46,7 @@ describe('connectDynamicWidgets', () => {
 
     it('does not fail when empty widgets are given', () => {
       expect(() =>
-        EXPERIMENTAL_connectDynamicWidgets(() => {})({
+        connectDynamicWidgets(() => {})({
           widgets: [],
         })
       ).not.toThrow();
@@ -68,8 +68,7 @@ describe('connectDynamicWidgets', () => {
             }),
           ],
         };
-        const dynamicWidgets =
-          EXPERIMENTAL_connectDynamicWidgets(renderFn)(widgetParams);
+        const dynamicWidgets = connectDynamicWidgets(renderFn)(widgetParams);
 
         const parent = index({ indexName: 'test' }).addWidgets([
           dynamicWidgets,
@@ -90,7 +89,7 @@ describe('connectDynamicWidgets', () => {
 
     describe('widgets', () => {
       it('does not add widgets on init', () => {
-        const dynamicWidgets = EXPERIMENTAL_connectDynamicWidgets(() => {})({
+        const dynamicWidgets = connectDynamicWidgets(() => {})({
           transformItems() {
             return [];
           },
@@ -138,8 +137,7 @@ describe('connectDynamicWidgets', () => {
             }),
           ],
         };
-        const dynamicWidgets =
-          EXPERIMENTAL_connectDynamicWidgets(renderFn)(widgetParams);
+        const dynamicWidgets = connectDynamicWidgets(renderFn)(widgetParams);
 
         dynamicWidgets.render!(createRenderOptions());
 
@@ -166,8 +164,7 @@ describe('connectDynamicWidgets', () => {
             }),
           ],
         };
-        const dynamicWidgets =
-          EXPERIMENTAL_connectDynamicWidgets(renderFn)(widgetParams);
+        const dynamicWidgets = connectDynamicWidgets(renderFn)(widgetParams);
 
         dynamicWidgets.render!(createRenderOptions());
 
@@ -184,7 +181,7 @@ describe('connectDynamicWidgets', () => {
 
     describe('widgets', () => {
       it('keeps static widgets returned in transformItems', async () => {
-        const dynamicWidgets = EXPERIMENTAL_connectDynamicWidgets(() => {})({
+        const dynamicWidgets = connectDynamicWidgets(() => {})({
           transformItems() {
             return ['test1'];
           },
@@ -229,7 +226,7 @@ describe('connectDynamicWidgets', () => {
       });
 
       it('renders widgets returned by transformItems', async () => {
-        const dynamicWidgets = EXPERIMENTAL_connectDynamicWidgets(() => {})({
+        const dynamicWidgets = connectDynamicWidgets(() => {})({
           transformItems(_items, { results }) {
             return results.userData[0].MOCK_facetOrder;
           },
@@ -368,8 +365,7 @@ describe('connectDynamicWidgets', () => {
   describe('dispose', () => {
     it('calls unmount function', () => {
       const unmountFn = jest.fn();
-      const dynamicWidgets = EXPERIMENTAL_connectDynamicWidgets(() => {},
-      unmountFn)({
+      const dynamicWidgets = connectDynamicWidgets(() => {}, unmountFn)({
         transformItems() {
           return ['test1', 'test2'];
         },
@@ -386,7 +382,7 @@ describe('connectDynamicWidgets', () => {
     });
 
     it('removes all widgets', async () => {
-      const dynamicWidgets = EXPERIMENTAL_connectDynamicWidgets(() => {})({
+      const dynamicWidgets = connectDynamicWidgets(() => {})({
         transformItems() {
           return ['test1', 'test2'];
         },
@@ -445,9 +441,7 @@ describe('connectDynamicWidgets', () => {
           connectHierarchicalMenu(() => {})({ attributes: ['test2', 'test3'] }),
         ],
       };
-      const dynamicWidgets = EXPERIMENTAL_connectDynamicWidgets(() => {})(
-        widgetParams
-      );
+      const dynamicWidgets = connectDynamicWidgets(() => {})(widgetParams);
 
       expect(dynamicWidgets.getWidgetRenderState(createInitOptions())).toEqual({
         attributesToRender: [],
@@ -465,9 +459,7 @@ describe('connectDynamicWidgets', () => {
           connectHierarchicalMenu(() => {})({ attributes: ['test2', 'test3'] }),
         ],
       };
-      const dynamicWidgets = EXPERIMENTAL_connectDynamicWidgets(() => {})(
-        widgetParams
-      );
+      const dynamicWidgets = connectDynamicWidgets(() => {})(widgetParams);
 
       expect(dynamicWidgets.getWidgetRenderState(createInitOptions())).toEqual({
         attributesToRender: [],
@@ -485,9 +477,7 @@ describe('connectDynamicWidgets', () => {
           connectHierarchicalMenu(() => {})({ attributes: ['test2', 'test3'] }),
         ],
       };
-      const dynamicWidgets = EXPERIMENTAL_connectDynamicWidgets(() => {})(
-        widgetParams
-      );
+      const dynamicWidgets = connectDynamicWidgets(() => {})(widgetParams);
 
       expect(
         dynamicWidgets.getWidgetRenderState(createRenderOptions())
@@ -504,9 +494,7 @@ describe('connectDynamicWidgets', () => {
           connectHierarchicalMenu(() => {})({ attributes: ['test2', 'test3'] }),
         ],
       };
-      const dynamicWidgets = EXPERIMENTAL_connectDynamicWidgets(() => {})(
-        widgetParams
-      );
+      const dynamicWidgets = connectDynamicWidgets(() => {})(widgetParams);
 
       expect(
         dynamicWidgets.getWidgetRenderState(
@@ -538,9 +526,7 @@ describe('connectDynamicWidgets', () => {
           connectHierarchicalMenu(() => {})({ attributes: ['test2', 'test3'] }),
         ],
       };
-      const dynamicWidgets = EXPERIMENTAL_connectDynamicWidgets(() => {})(
-        widgetParams
-      );
+      const dynamicWidgets = connectDynamicWidgets(() => {})(widgetParams);
 
       expect(
         dynamicWidgets.getWidgetRenderState(createRenderOptions())
@@ -560,9 +546,7 @@ describe('connectDynamicWidgets', () => {
           connectHierarchicalMenu(() => {})({ attributes: ['test2', 'test3'] }),
         ],
       };
-      const dynamicWidgets = EXPERIMENTAL_connectDynamicWidgets(() => {})(
-        widgetParams
-      );
+      const dynamicWidgets = connectDynamicWidgets(() => {})(widgetParams);
 
       expect(
         dynamicWidgets.getWidgetRenderState(
@@ -599,8 +583,7 @@ describe('connectDynamicWidgets', () => {
           connectHierarchicalMenu(() => {})({ attributes: ['test2', 'test3'] }),
         ],
       };
-      const dynamicWidgets =
-        EXPERIMENTAL_connectDynamicWidgets(renderFn)(widgetParams);
+      const dynamicWidgets = connectDynamicWidgets(renderFn)(widgetParams);
 
       const existingRenderState = {};
 
@@ -625,8 +608,7 @@ describe('connectDynamicWidgets', () => {
           connectHierarchicalMenu(() => {})({ attributes: ['test2', 'test3'] }),
         ],
       };
-      const dynamicWidgets =
-        EXPERIMENTAL_connectDynamicWidgets(renderFn)(widgetParams);
+      const dynamicWidgets = connectDynamicWidgets(renderFn)(widgetParams);
 
       const existingRenderState = {};
 

--- a/src/widgets/dynamic-widgets/__tests__/dynamic-widgets-test.ts
+++ b/src/widgets/dynamic-widgets/__tests__/dynamic-widgets-test.ts
@@ -2,7 +2,7 @@ import {
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/mock/createWidget';
-import { index, searchBox, menu, EXPERIMENTAL_dynamicWidgets } from '../..';
+import { index, searchBox, menu, dynamicWidgets } from '../..';
 import { createInstantSearch } from '../../../../test/mock/createInstantSearch';
 import { SearchParameters, SearchResults } from 'algoliasearch-helper';
 import { createMultiSearchResponse } from '../../../../test/mock/createAPIResponse';
@@ -19,7 +19,7 @@ describe('dynamicWidgets()', () => {
     test('container is required', () => {
       expect(() =>
         // @ts-expect-error testing invalid input
-        EXPERIMENTAL_dynamicWidgets({})
+        dynamicWidgets({})
       ).toThrowErrorMatchingInlineSnapshot(`
         "The \`container\` option is required.
 
@@ -30,7 +30,7 @@ describe('dynamicWidgets()', () => {
     test('widgets is required', () => {
       expect(() =>
         // @ts-expect-error testing invalid input
-        EXPERIMENTAL_dynamicWidgets({
+        dynamicWidgets({
           container: document.createElement('div'),
         })
       ).toThrowErrorMatchingInlineSnapshot(`
@@ -42,7 +42,7 @@ describe('dynamicWidgets()', () => {
 
     test('widgets can be empty', () => {
       expect(() =>
-        EXPERIMENTAL_dynamicWidgets({
+        dynamicWidgets({
           container: document.createElement('div'),
           widgets: [],
         })
@@ -51,7 +51,7 @@ describe('dynamicWidgets()', () => {
 
     test('widgets is required to be callbacks', () => {
       expect(() =>
-        EXPERIMENTAL_dynamicWidgets({
+        dynamicWidgets({
           container: document.createElement('div'),
           // @ts-expect-error testing invalid input
           widgets: [searchBox({ container: document.createElement('div') })],
@@ -65,7 +65,7 @@ describe('dynamicWidgets()', () => {
 
     test('all options', () => {
       expect(() =>
-        EXPERIMENTAL_dynamicWidgets({
+        dynamicWidgets({
           container: document.createElement('div'),
           transformItems: (items) => items,
           widgets: [],
@@ -78,7 +78,7 @@ describe('dynamicWidgets()', () => {
     it('creates all containers on init', () => {
       const rootContainer = document.createElement('div');
 
-      const widget = EXPERIMENTAL_dynamicWidgets({
+      const widget = dynamicWidgets({
         container: rootContainer,
         transformItems: (items) => items,
         widgets: [
@@ -139,7 +139,7 @@ describe('dynamicWidgets()', () => {
       const rootContainer = document.createElement('div');
 
       const indexWidget = index({ indexName: 'test' }).addWidgets([
-        EXPERIMENTAL_dynamicWidgets({
+        dynamicWidgets({
           container: rootContainer,
           transformItems() {
             return [];
@@ -218,7 +218,7 @@ describe('dynamicWidgets()', () => {
       const rootContainer = document.createElement('div');
 
       instantSearchInstance.addWidgets([
-        EXPERIMENTAL_dynamicWidgets({
+        dynamicWidgets({
           container: rootContainer,
           transformItems() {
             return ['test1'];
@@ -293,7 +293,7 @@ describe('dynamicWidgets()', () => {
       let ordering = ['test1', 'test4'];
 
       instantSearchInstance.addWidgets([
-        EXPERIMENTAL_dynamicWidgets({
+        dynamicWidgets({
           container: rootContainer,
           transformItems() {
             return ordering;
@@ -398,7 +398,7 @@ describe('dynamicWidgets()', () => {
       const rootContainer = document.createElement('div');
 
       const indexWidget = index({ indexName: 'test' }).addWidgets([
-        EXPERIMENTAL_dynamicWidgets({
+        dynamicWidgets({
           container: rootContainer,
           transformItems(_items, { results }) {
             return results.userData[0].MOCK_facetOrder;
@@ -490,7 +490,7 @@ describe('dynamicWidgets()', () => {
       instantSearchInstance.start();
       const rootContainer = document.createElement('div');
 
-      const dynamicWidget = EXPERIMENTAL_dynamicWidgets({
+      const dynamicWidget = dynamicWidgets({
         container: rootContainer,
         transformItems() {
           return ['test1', 'test5', 'test4'];

--- a/stories/dynamic-widgets.stories.ts
+++ b/stories/dynamic-widgets.stories.ts
@@ -12,7 +12,7 @@ storiesOf('Basics/DynamicWidgets', module).add(
     rootContainer.appendChild(dynamicWidgetsContainer);
 
     search.addWidgets([
-      instantsearch.widgets.EXPERIMENTAL_dynamicWidgets({
+      instantsearch.widgets.dynamicWidgets({
         container: dynamicWidgetsContainer,
         fallbackWidget: ({ attribute, container }) =>
           instantsearch.widgets.panel<


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

in #4899 dynamic widgets became stable, but I forgot to update some of the tests and the stories to the new name

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

no more usage of `EXPERIMENTAL_(connect)dynamicWidgets` outside of the export

