### PR TITLE
docs(examples): Add README to the tourism example

### DIFF
--- a/examples/tourism/README.md
+++ b/examples/tourism/README.md
@@ -1,0 +1,20 @@
+# Instantsearch tourism demo
+
+This demo shows how to leverage [Algolia Geo Location](https://www.algolia.com/doc/guides/managing-results/refine-results/geolocation/) with [InstantSearch's geoSearch widget](https://www.algolia.com/doc/api-reference/widgets/geo-search/js/#widget-param-googlereference) with [Google Maps](https://developers.google.com/maps).
+
+<img src="examples/tourism/capture.png?raw=true" alt="A capture of the Algolia InstantSearch tourism demo" align="center">
+
+## Features
+
+This demo showcase the following features:
+
+- 🗺️ InstantSearch [geoSearch widget](https://www.algolia.com/doc/api-reference/widgets/geo-search/js/#widget-param-googlereference).
+- 📍 Algolia [aroundLatLngViaIP](https://www.algolia.com/doc/api-reference/api-parameters/aroundLatLngViaIP/) API parameter.
+
+## How to run this demo locally
+
+### 1. Clone this repository
+
+```
+git clone git@github.com:algolia/instantsearch.js.git
+```


### PR DESCRIPTION
**Summary**

Short documentation for the geoSearch / tourism example.

Not sure about the next points in the `How to run this demo locally` section though.
Is this demos are still used for the integration tests as stated in the `e-commerce` README one? Would it be possible to replace the `start` / `build` scripts in the `package.json`? Thanks!