### PR TITLE
fix(infinite/hits): stop saving the transformed results in cache

### DIFF
--- a/src/connectors/answers/__tests__/connectAnswers-test.ts
+++ b/src/connectors/answers/__tests__/connectAnswers-test.ts
@@ -240,7 +240,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/answers/js/
 
     // render with hits
     const expectedHits = [{ title: '', objectID: 'a', __position: 1 }];
-    (expectedHits as any).__escaped = true;
     expect(renderFn).toHaveBeenCalledTimes(3);
     expect(renderFn).toHaveBeenNthCalledWith(
       3,
@@ -303,7 +302,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/answers/js/
     // wait for debounce
     await wait(30);
     const expectedHits = [{ title: '', objectID: 'a', __position: 1 }];
-    (expectedHits as any).__escaped = true;
     expect(renderFn).toHaveBeenCalledTimes(4);
     expect(renderFn).toHaveBeenNthCalledWith(
       4,
@@ -425,7 +423,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/answers/js/
 
       await wait(30);
       const expectedHits = [{ title: '', objectID: 'a', __position: 1 }];
-      (expectedHits as any).__escaped = true;
       expect(
         widget.getWidgetRenderState(
           createRenderOptions({

--- a/src/connectors/hits/__tests__/connectHits-test.ts
+++ b/src/connectors/hits/__tests__/connectHits-test.ts
@@ -122,8 +122,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
       { objectID: '2', sample: 'infos' },
     ];
 
-    (hits as unknown as EscapedHits).__escaped = true;
-
     const results = new SearchResults(helper.state, [
       createSingleSearchResponse({ hits }),
     ]);
@@ -204,8 +202,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
       },
     ];
 
-    (expectedHits as unknown as EscapedHits).__escaped = true;
-
     expect(renderFn).toHaveBeenLastCalledWith(
       expect.objectContaining({
         hits: expectedHits,
@@ -259,7 +255,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
       { objectID: '1', name: 'transformed' },
       { objectID: '2', name: 'transformed' },
     ];
-    (expectedHits as unknown as EscapedHits).__escaped = true;
 
     expect(renderFn).toHaveBeenNthCalledWith(
       2,
@@ -306,8 +301,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
       { objectID: '1', name: 'name 1', __queryID: 'theQueryID' },
       { objectID: '2', name: 'name 2', __queryID: 'theQueryID' },
     ];
-
-    (expectedHits as unknown as EscapedHits).__escaped = true;
 
     expect(renderFn).toHaveBeenNthCalledWith(
       2,
@@ -414,8 +407,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
       },
     ];
 
-    (expectedHits as unknown as EscapedHits).__escaped = true;
-
     expect(renderFn).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
@@ -504,8 +495,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
         { objectID: '2', name: 'name 2', __queryID: 'theQueryID' },
       ];
 
-      (expectedHits as unknown as EscapedHits).__escaped = true;
-
       expect(renderState2.hits).toEqual({
         hits: expectedHits,
         sendEvent: renderState1.hits.sendEvent,
@@ -559,8 +548,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
         { objectID: '1', name: 'name 1', __queryID: 'theQueryID' },
         { objectID: '2', name: 'name 2', __queryID: 'theQueryID' },
       ];
-
-      (expectedHits as unknown as EscapedHits).__escaped = true;
 
       expect(renderState2).toEqual({
         hits: expectedHits,

--- a/src/connectors/hits/connectHits.ts
+++ b/src/connectors/hits/connectHits.ts
@@ -150,27 +150,23 @@ const connectHits: HitsConnector = function connectHits(
           results.hits = escapeHits(results.hits);
         }
 
-        const initialEscaped = (results.hits as ReturnType<typeof escapeHits>)
-          .__escaped;
-
-        results.hits = addAbsolutePosition(
+        const hitsWithAbsolutePosition = addAbsolutePosition(
           results.hits,
           results.page,
           results.hitsPerPage
         );
 
-        results.hits = addQueryID(results.hits, results.queryID);
+        const hitsWithAbsolutePositionAndQueryID = addQueryID(
+          hitsWithAbsolutePosition,
+          results.queryID
+        );
 
-        results.hits = transformItems(results.hits);
-
-        // Make sure the escaped tag stays, even after mapping over the hits.
-        // This prevents the hits from being double-escaped if there are multiple
-        // hits widgets mounted on the page.
-        (results.hits as ReturnType<typeof escapeHits>).__escaped =
-          initialEscaped;
+        const transformedHits = transformItems(
+          hitsWithAbsolutePositionAndQueryID
+        );
 
         return {
-          hits: results.hits,
+          hits: transformedHits,
           results,
           sendEvent,
           bindEvent,

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -1098,7 +1098,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
           objectID: '2',
         },
       ];
-      (expectedCurrentPageHits as any).__escaped = true;
 
       expect(renderState2.infiniteHits).toEqual({
         hits: expectedHits,
@@ -1191,7 +1190,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
           objectID: '2',
         },
       ];
-      (expectedCurrentPageHits as any).__escaped = true;
 
       expect(renderState2).toEqual({
         hits: expectedHits,

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -311,28 +311,27 @@ const connectInfiniteHits: InfiniteHitsConnector = function connectInfiniteHits(
           if (escapeHTML && results.hits.length > 0) {
             results.hits = escapeHits(results.hits);
           }
-          const initialEscaped = (results.hits as any).__escaped;
 
-          results.hits = addAbsolutePosition(
+          const hitsWithAbsolutePosition = addAbsolutePosition(
             results.hits,
             results.page,
             results.hitsPerPage
           );
 
-          results.hits = addQueryID(results.hits, results.queryID);
+          const hitsWithAbsolutePositionAndQueryID = addQueryID(
+            hitsWithAbsolutePosition,
+            results.queryID
+          );
 
-          results.hits = transformItems(results.hits);
-
-          // Make sure the escaped tag stays after mapping over the hits.
-          // This prevents the hits from being double-escaped if there are multiple
-          // hits widgets mounted on the page.
-          (results.hits as any).__escaped = initialEscaped;
+          const transformedHits = transformItems(
+            hitsWithAbsolutePositionAndQueryID
+          );
 
           if (cachedHits[page] === undefined) {
-            cachedHits[page] = results.hits;
+            cachedHits[page] = transformedHits;
             cache.write({ state, hits: cachedHits });
           }
-          currentPageHits = results.hits;
+          currentPageHits = transformedHits;
 
           isFirstPage = getFirstReceivedPage(state, cachedHits) === 0;
         }

--- a/src/widgets/hits/__tests__/hits-test.ts
+++ b/src/widgets/hits/__tests__/hits-test.ts
@@ -133,7 +133,6 @@ describe('hits()', () => {
           "hierarchicalFacets": [],
           "hits": [
             {
-              "__position": 9,
               "hit": "first",
               "objectID": "1",
             },
@@ -217,7 +216,6 @@ describe('hits()', () => {
           "hierarchicalFacets": [],
           "hits": [
             {
-              "__position": 9,
               "hit": "first",
               "objectID": "1",
             },
@@ -323,10 +321,8 @@ describe('hits()', () => {
           "hierarchicalFacets": [],
           "hits": [
             {
-              "__position": 9,
               "hit": "first",
               "objectID": "1",
-              "transformed": true,
             },
           ],
           "hitsPerPage": 4,
@@ -365,6 +361,10 @@ describe('hits()', () => {
 
     widget.render!(createRenderOptions({ results, state }));
 
-    expect(results.hits[0].__position).toEqual(41);
+    expect(render).toHaveBeenCalledTimes(1);
+    const firstRender = render.mock.calls[0][0] as VNode<HitsProps>;
+    const props = firstRender.props as HitsProps;
+
+    expect(props.hits[0].__position).toEqual(41);
   });
 });

--- a/src/widgets/infinite-hits/__tests__/__snapshots__/infinite-hits-test.ts.snap
+++ b/src/widgets/infinite-hits/__tests__/__snapshots__/infinite-hits-test.ts.snap
@@ -68,11 +68,9 @@ exports[`infiniteHits() calls twice render(<Hits props />, container) 1`] = `
     "hierarchicalFacets": [],
     "hits": [
       {
-        "__position": 3,
         "objectID": "1",
       },
       {
-        "__position": 4,
         "objectID": "2",
       },
     ],
@@ -173,11 +171,9 @@ exports[`infiniteHits() calls twice render(<Hits props />, container) 2`] = `
     "hierarchicalFacets": [],
     "hits": [
       {
-        "__position": 3,
         "objectID": "1",
       },
       {
-        "__position": 4,
         "objectID": "2",
       },
     ],
@@ -280,14 +276,10 @@ exports[`infiniteHits() renders transformed items 1`] = `
     "hierarchicalFacets": [],
     "hits": [
       {
-        "__position": 3,
         "objectID": "1",
-        "transformed": true,
       },
       {
-        "__position": 4,
         "objectID": "2",
-        "transformed": true,
       },
     ],
     "hitsPerPage": 2,

--- a/src/widgets/infinite-hits/__tests__/infinite-hits-test.ts
+++ b/src/widgets/infinite-hits/__tests__/infinite-hits-test.ts
@@ -182,7 +182,11 @@ describe('infiniteHits()', () => {
     widget.init!(createInitOptions({ helper }));
     widget.render!(createRenderOptions({ results, state }));
 
-    expect(results.hits[0].__position).toEqual(41);
+    expect(render).toHaveBeenCalledTimes(1);
+    const firstRender = render.mock.calls[0][0] as VNode<InfiniteHitsProps>;
+    const { hits } = firstRender.props as InfiniteHitsProps;
+
+    expect(hits[0].__position).toEqual(41);
   });
 
   it('if it is the first page, then the props should contain isFirstPage true', () => {


### PR DESCRIPTION




<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Since we introduced getWidgetRenderState, transformItems gets called two times. On its own this isn't problematic, however if the transformItems "mutates" a key, it will receive next the "mutated" hits instead of the ones that come from the results

One thing which is debatable about this PR is which parts should be saved to `results.hits`. I opted for just the escaped hits, but i wonder if there's any use cases for considering the query id and position as part of the hits directly.

However, I feel like if we want this behaviour, it shouldn't be hits and infiniteHits mutating results, but rather something global that gets called right after the results get returned. In fact, I also think it makes more sense to escape hits there than in hits.

I don't think removing the escapeHTML option is possible here without breaking change though, so if we want to do that, we should mark it as a possibility for a major in this PR

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

- transformItems only gets `hits` that come directly computed from a result, not from a previous transformItems
- the result of transformItems does not get stored on result.hits (could be considered a breaking change, but I don't think so)

FX-11
fixes #4819
