### PR TITLE
fix(es): add warning to typescript declaration of keys to be imported from helpers

### DIFF
--- a/src/index.es.ts
+++ b/src/index.es.ts
@@ -20,19 +20,19 @@ type InstantSearchModule = {
   version: string;
 
   // @major remove these in favour of the exports
-  /** @deprecated */
+  /** @deprecated import { createInfiniteHitsSessionStorageCache } from 'instantsearch.js/es/helpers */
   createInfiniteHitsSessionStorageCache: typeof createInfiniteHitsSessionStorageCache;
-  /** @deprecated */
+  /** @deprecated import { highlight } from 'instantsearch.js/es/helpers */
   highlight: typeof highlight;
-  /** @deprecated */
+  /** @deprecated import { reverseHighlight } from 'instantsearch.js/es/helpers */
   reverseHighlight: typeof reverseHighlight;
-  /** @deprecated */
+  /** @deprecated import { snippet } from 'instantsearch.js/es/helpers */
   snippet: typeof snippet;
-  /** @deprecated */
+  /** @deprecated import { reverseSnippet } from 'instantsearch.js/es/helpers */
   reverseSnippet: typeof reverseSnippet;
-  /** @deprecated */
+  /** @deprecated use createInsightsMiddleware */
   insights: typeof insights;
-  /** @deprecated */
+  /** @deprecated use createInsightsMiddleware */
   getInsightsAnonymousUserToken: typeof getInsightsAnonymousUserToken;
 };
 

--- a/src/index.es.ts
+++ b/src/index.es.ts
@@ -20,19 +20,25 @@ type InstantSearchModule = {
   version: string;
 
   // @major remove these in favour of the exports
-  /** @deprecated import { createInfiniteHitsSessionStorageCache } from 'instantsearch.js/es/helpers */
+  /** @deprecated import { createInfiniteHitsSessionStorageCache } from 'instantsearch.js/es/helpers' */
   createInfiniteHitsSessionStorageCache: typeof createInfiniteHitsSessionStorageCache;
-  /** @deprecated import { highlight } from 'instantsearch.js/es/helpers */
+  /** @deprecated import { highlight } from 'instantsearch.js/es/helpers' */
   highlight: typeof highlight;
-  /** @deprecated import { reverseHighlight } from 'instantsearch.js/es/helpers */
+  /** @deprecated import { reverseHighlight } from 'instantsearch.js/es/helpers' */
   reverseHighlight: typeof reverseHighlight;
-  /** @deprecated import { snippet } from 'instantsearch.js/es/helpers */
+  /** @deprecated import { snippet } from 'instantsearch.js/es/helpers' */
   snippet: typeof snippet;
-  /** @deprecated import { reverseSnippet } from 'instantsearch.js/es/helpers */
+  /** @deprecated import { reverseSnippet } from 'instantsearch.js/es/helpers' */
   reverseSnippet: typeof reverseSnippet;
-  /** @deprecated use createInsightsMiddleware */
+  /**
+   * @deprecated use createInsightsMiddleware
+   * @link https://www.algolia.com/doc/api-reference/widgets/insights/js/
+   */
   insights: typeof insights;
-  /** @deprecated use createInsightsMiddleware */
+  /**
+   * @deprecated use createInsightsMiddleware
+   * @link https://www.algolia.com/doc/api-reference/widgets/insights/js/
+   */
   getInsightsAnonymousUserToken: typeof getInsightsAnonymousUserToken;
 };
 


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

We deprecated the properties added to instantsearch in #4814, but the deprecation does not mention the solution

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

The same solution as at runtime is given by typescript, importing from ./helpers