### PR TITLE
fix(toggleRefinement): don't set off value in getWidgetRenderState

### DIFF
--- a/src/connectors/toggle-refinement/connectToggleRefinement.ts
+++ b/src/connectors/toggle-refinement/connectToggleRefinement.ts
@@ -340,14 +340,6 @@ const connectToggleRefinement: ToggleRefinementConnector =
                 offData.reduce((acc, v) => acc + v.count, 0) ||
                 allFacetValues.reduce((total, { count }) => total + count, 0),
             };
-          } else if (hasAnOffValue && !isRefined) {
-            if (off) {
-              off.forEach((v) =>
-                helper.addDisjunctiveFacetRefinement(attribute, v)
-              );
-            }
-
-            helper.setPage(helper.state.page!);
           }
 
           if (!sendEvent) {

--- a/src/lib/utils/__tests__/getWidgetAttribute-test.ts
+++ b/src/lib/utils/__tests__/getWidgetAttribute-test.ts
@@ -6,6 +6,7 @@ import {
   hits,
   panel,
   refinementList,
+  toggleRefinement,
 } from '../../../widgets';
 
 describe('getWidgetAttribute', () => {
@@ -40,6 +41,20 @@ describe('getWidgetAttribute', () => {
         createInitOptions()
       )
     ).toBe('test1');
+  });
+
+  it('reads the attribute from a toggleRefinement', () => {
+    expect(
+      getWidgetAttribute(
+        toggleRefinement({
+          container: document.createElement('div'),
+          attribute: 'test',
+          on: 'yes',
+          off: 'no',
+        }),
+        createInitOptions()
+      )
+    ).toBe('test');
   });
 
   it('reads the attribute from a panel', () => {


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

This was added in the migration from render to getWidgetRenderState, but actually getWidgetSearchParameters already takes this in account, and i can't find any situations where "off" gets erased.

Added a test to make sure getWidgetAttribute works when "off" is given, but it's straightforward now

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

Nothing really changes, except toggle with an off works in dynamic widgets works now and a little bit less code
