### PR TITLE
fix(facetOrdering): prevent sparse array

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@types/google.maps": "^3.45.3",
     "@types/hogan.js": "^3.0.0",
     "@types/qs": "^6.5.3",
-    "algoliasearch-helper": "^3.5.5",
+    "algoliasearch-helper": "0.0.0-27d41bf",
     "classnames": "^2.2.5",
     "events": "^1.1.0",
     "hogan.js": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3151,10 +3151,10 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@~6.12.6:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-algoliasearch-helper@^3.5.5:
-  version "3.5.5"
-  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.5.5.tgz#05263869d3c8a7292278d7e49630f52520f204d7"
-  integrity sha512-JDH14gMpSj8UzEaKwVkrqKOeAOyK0dDWsFlKvWhk0Xl5yw9FyafYf1xZPb4uSXaPBAFQtUouFlR1Zt68BCY0/w==
+algoliasearch-helper@0.0.0-27d41bf:
+  version "0.0.0-27d41bf"
+  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-0.0.0-27d41bf.tgz#00761b0a4371033c6b4db92f727ae66f926af35b"
+  integrity sha512-fwHydK8n4PfHQBp0kXJGz5Vcbtyuz0CsHznZ3xKo8XabXQ3I0tyJuVBd/6QWYjEJBmKcofQHuUwbuZdOxH3gaQ==
   dependencies:
     events "^1.1.1"
 


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

This caused the number of items in limit to be lower than the possible returned results, as sparse elements in an array still "take up space"

https://github.com/algolia/algoliasearch-helper-js/pull/879

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

More items show up, as "missing" items in refinements (ordered, but not in results) no longer take up space


still to do:
- [ ] rely on non-prerelease helper version
