### PR TITLE
feat(InstantSearch): defer initial search

### DIFF
--- a/scripts/jest/matchers/__tests__/toWarnDev-test.ts
+++ b/scripts/jest/matchers/__tests__/toWarnDev-test.ts
@@ -1,5 +1,7 @@
 /* eslint-disable no-console */
 
+import { wait } from '../../../../test/utils/wait';
+
 // export is needed for TS isolatedModules
 // eslint-disable-next-line jest/no-export
 export {};
@@ -48,6 +50,26 @@ describe('toWarnDev', () => {
             console.warn('warning');
           }).toWarnDev('another warning');
         }).toThrow(/Unexpected warning recorded./);
+      });
+    });
+
+    describe('with async callback', () => {
+      test('does not fail with correct message', async () => {
+        await expect(async () => {
+          await expect(async () => {
+            console.warn('warning');
+            await wait(0);
+          }).toWarnDev('warning');
+        }).not.toThrow();
+      });
+
+      test('fails if a warning is not correct', async () => {
+        await expect(async () => {
+          await expect(async () => {
+            console.warn('warning');
+            await wait(0);
+          }).toWarnDev('another warning');
+        }).rejects.toThrow(/Unexpected warning recorded./);
       });
     });
   }

--- a/src/connectors/configure-related-items/__tests__/connectConfigureRelatedItems-test.ts
+++ b/src/connectors/configure-related-items/__tests__/connectConfigureRelatedItems-test.ts
@@ -3,6 +3,7 @@ import instantsearch from '../../..';
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import type { AlgoliaHit } from '../../../types';
 import { noop } from '../../../lib/utils';
+import { wait } from '../../../../test/utils/wait';
 
 const hit: AlgoliaHit = {
   objectID: '1',
@@ -97,7 +98,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure-r
   });
 
   describe('options', () => {
-    test('sets the optionalFilters search parameter based on matchingPatterns', () => {
+    test('sets the optionalFilters search parameter based on matchingPatterns', async () => {
       const searchClient = createSearchClient();
       const search = instantsearch({
         indexName: 'indexName',
@@ -115,6 +116,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure-r
         }),
       ]);
       search.start();
+
+      await wait(0);
 
       expect(searchClient.search).toHaveBeenCalledTimes(1);
       expect(searchClient.search).toHaveBeenCalledWith([
@@ -137,7 +140,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure-r
       ]);
     });
 
-    test('sets the optionalFilters search parameter based on matchingPatterns with nested attributes', () => {
+    test('sets the optionalFilters search parameter based on matchingPatterns with nested attributes', async () => {
       const searchClient = createSearchClient();
       const search = instantsearch({
         indexName: 'indexName',
@@ -155,6 +158,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure-r
         }),
       ]);
       search.start();
+
+      await wait(0);
 
       expect(searchClient.search).toHaveBeenCalledTimes(1);
       expect(searchClient.search).toHaveBeenCalledWith([
@@ -174,7 +179,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure-r
       ]);
     });
 
-    test('sets transformed search parameters based on transformSearchParameters', () => {
+    test('sets transformed search parameters based on transformSearchParameters', async () => {
       const searchClient = createSearchClient();
       const search = instantsearch({
         indexName: 'indexName',
@@ -198,6 +203,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure-r
         }),
       ]);
       search.start();
+
+      await wait(0);
 
       expect(searchClient.search).toHaveBeenCalledTimes(1);
       expect(searchClient.search).toHaveBeenCalledWith([
@@ -233,7 +240,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure-r
       ]);
     });
 
-    test('filter out and warns for incorrect optionalFilters value type', () => {
+    test('filter out and warns for incorrect optionalFilters value type', async () => {
       const searchClient = createSearchClient();
       const search = instantsearch({
         indexName: 'indexName',
@@ -259,6 +266,8 @@ You can remove the "rating" key from the \`matchingPatterns\` option.
 
 See https://www.algolia.com/doc/api-reference/api-parameters/optionalFilters/`);
       search.start();
+
+      await wait(0);
 
       expect(searchClient.search).toHaveBeenCalledTimes(1);
       expect(searchClient.search).toHaveBeenCalledWith([

--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -492,7 +492,7 @@ See ${createDocumentationLink({
       uiState: this._initialUiState,
     });
 
-    mainHelper.search();
+    this.scheduleSearch();
 
     // Keep the previous reference for legacy purpose, some pattern use
     // the direct Helper access `search.helper` (e.g multi-index).

--- a/src/lib/__tests__/InstantSearch-test.tsx
+++ b/src/lib/__tests__/InstantSearch-test.tsx
@@ -646,7 +646,7 @@ describe('start', () => {
     expect(algoliasearchHelper).toHaveBeenCalledWith(searchClient, indexName);
   });
 
-  it('replaces the regular `search` with `searchOnlyWithDerivedHelpers`', () => {
+  it('replaces the regular `search` with `searchOnlyWithDerivedHelpers`', async () => {
     const searchClient = createSearchClient();
     const search = new InstantSearch({
       indexName: 'indexName',
@@ -655,12 +655,14 @@ describe('start', () => {
 
     search.start();
 
+    await wait(0);
+
     expect(
       search.mainHelper!.searchOnlyWithDerivedHelpers
     ).toHaveBeenCalledTimes(1);
   });
 
-  it('calls the provided `searchFunction` with a single request', () => {
+  it('calls the provided `searchFunction` with a single request', async () => {
     const searchFunction = jest.fn((helper) =>
       helper.setQuery('test').search()
     );
@@ -675,6 +677,8 @@ describe('start', () => {
     expect(searchClient.search).toHaveBeenCalledTimes(0);
 
     search.start();
+
+    await wait(0);
 
     expect(searchFunction).toHaveBeenCalledTimes(1);
     expect(searchClient.search).toHaveBeenCalledTimes(1);
@@ -792,7 +796,7 @@ describe('start', () => {
     expect(searchClient.search).toHaveBeenCalledTimes(1);
   });
 
-  it('triggers a search without errors', () => {
+  it('triggers a search without errors', async () => {
     const searchClient = createSearchClient();
     const search = new InstantSearch({
       indexName: 'indexName',
@@ -802,6 +806,8 @@ describe('start', () => {
     expect(searchClient.search).toHaveBeenCalledTimes(0);
 
     search.start();
+
+    await wait(0);
 
     expect(searchClient.search).toHaveBeenCalledTimes(1);
   });
@@ -938,6 +944,8 @@ describe('dispose', () => {
     search.addWidgets([createWidget(), createWidget()]);
 
     search.start();
+
+    await wait(0);
 
     // Resolve the `search`
     searches[0].resolver();
@@ -1212,6 +1220,8 @@ describe('scheduleStalledRender', () => {
 
     search.start();
 
+    await wait(0);
+
     // Resolve the `search`
     searches[0].resolver();
 
@@ -1241,6 +1251,8 @@ describe('scheduleStalledRender', () => {
     search.addWidgets([widget]);
 
     search.start();
+
+    await wait(0);
 
     // Resolve the `search`
     searches[0].resolver();
@@ -1278,6 +1290,8 @@ describe('scheduleStalledRender', () => {
     search.start();
 
     expect(widget.render).toHaveBeenCalledTimes(0);
+
+    await wait(0);
 
     // Resolve the `search`
     searches[0].resolver();
@@ -1482,7 +1496,7 @@ describe('refresh', () => {
     expect(clearCache).toHaveBeenCalledTimes(1);
   });
 
-  it('triggers a `search` with the cache emptied', () => {
+  it('triggers a `search` with the cache emptied', async () => {
     const searchClient = createSearchClient();
     const search = new InstantSearch({
       indexName: 'indexName',
@@ -1490,6 +1504,8 @@ describe('refresh', () => {
     });
 
     search.start();
+
+    await wait(0);
 
     // it is called once with start
     expect(searchClient.search).toHaveBeenCalledTimes(1);
@@ -2302,7 +2318,7 @@ describe('onStateChange', () => {
     expect(middlewareOnStateChange).toHaveBeenCalledTimes(0);
   });
 
-  test('does not trigger a search', () => {
+  test('does not trigger a search', async () => {
     const searchClient = createSearchClient();
     const search = new InstantSearch({
       indexName: 'indexName',
@@ -2320,6 +2336,8 @@ describe('onStateChange', () => {
 
     search.addWidgets([searchBox({})]);
     search.start();
+
+    await wait(0);
 
     expect(searchClient.search).toHaveBeenCalledTimes(1);
 
@@ -2480,7 +2498,7 @@ describe('onStateChange', () => {
 });
 
 describe('initialUiState', () => {
-  it('warns if UI state contains unmounted widgets in development mode', () => {
+  it('warns if UI state contains unmounted widgets in development mode', async () => {
     const searchClient = createSearchClient();
     const search = new InstantSearch({
       indexName: 'indexName',
@@ -2520,8 +2538,9 @@ describe('initialUiState', () => {
 
     search.addWidgets([searchBox, customWidget]);
 
-    expect(() => {
+    await expect(async () => {
       search.start();
+      await wait(0);
     })
       .toWarnDev(`[InstantSearch.js]: The UI state for the index "indexName" is not consistent with the widgets mounted.
 


### PR DESCRIPTION
## Description

When InstantSearch.js starts, we directly call the helper `search` method. In framework-based InstantSearch flavors where we dynamically add widgets to the component tree, this is problematic because it directly triggers a network request on initial load, and then triggers another network request when widgets are added to InstantSearch.

In Vue InstantSearch, we solved this problem by relying on Vue's [`nextTick`](https://vuejs.org/v2/api/#Vue-nextTick) ([see code](https://github.com/algolia/vue-instantsearch/blob/03a5a358ba114925bafd241fa8c898e11a6d281a/src/util/createInstantSearchComponent.js#L65-L69)). However it's better to solve this at the InstantSearch.js level, so that the new React InstantSearch can also benefit from this solution without extra code.

This is fixed by deferring the initial search with the `scheduleSearch` function.

## Internal changes

- Some tests need to wait a micro tick before asserting
- The `toWarnDev` Jest matcher now also supports async callbacks