### PR TITLE
chore(tests): hide console warnings in test output

### DIFF
--- a/scripts/jest/setupTests.ts
+++ b/scripts/jest/setupTests.ts
@@ -7,3 +7,7 @@ import { toWarnDev } from './matchers';
 Enzyme.configure({ adapter: new Adapter() });
 expect.addSnapshotSerializer(createSerializer({ mode: 'deep' }) as any);
 expect.extend(toWarnDev);
+
+// We hide console infos and warnings to not pollute the test logs.
+global.console.info = jest.fn();
+global.console.warn = jest.fn();


### PR DESCRIPTION
This hides the `console.info` and `console.warn` logs from the test output to reduce pollution. We do the same in React InstantSearch and in Autocomplete.

You can check the test output [before](https://app.circleci.com/pipelines/github/algolia/instantsearch.js/6931/workflows/16abe710-1872-4704-ad0d-15ece8aaafaa/jobs/33017/parallel-runs/0/steps/0-106) and [after](https://app.circleci.com/pipelines/github/algolia/instantsearch.js/6939/workflows/48a23291-e323-40f2-a38c-e183dc08bcde/jobs/33061/parallel-runs/0/steps/0-106).