### PR TITLE
fix(router): skip history push on browser back/forward [2]

### DIFF
--- a/src/lib/routers/history.ts
+++ b/src/lib/routers/history.ts
@@ -126,6 +126,7 @@ class BrowserHistory<TRouteState> implements Router<TRouteState> {
         if (this.shouldPushState) {
           window.history.pushState(routeState, title || '', url);
         }
+        this.shouldPushState = true;
         this.writeTimer = undefined;
       }, this.writeDelay);
     });


### PR DESCRIPTION
This is a follow up of a bad merge that happened in #4933.

I improved the tests to make sure that the regular history push flow works as expected before and after a "popstate" event.