### PR TITLE
fix(getUiState): support `initialUiState`

### DIFF
--- a/src/lib/__tests__/InstantSearch-test.tsx
+++ b/src/lib/__tests__/InstantSearch-test.tsx
@@ -2189,6 +2189,26 @@ describe('getUiState', () => {
     });
   });
 
+  test('retrieves the ui state from initialUiState on a started instance', () => {
+    const indexName = 'indexName';
+    const searchClient = createSearchClient();
+    const search = new InstantSearch({
+      indexName,
+      searchClient,
+      initialUiState: {
+        [indexName]: {
+          query: 'iphone',
+        },
+      },
+    });
+
+    search.start();
+
+    expect(search.getUiState()).toEqual({
+      [indexName]: { query: 'iphone' },
+    });
+  });
+
   test('retrieves the ui state without refinements (multi-index)', () => {
     const indexName = 'indexName';
     const secondIndexName = 'indexName2';
@@ -2209,6 +2229,32 @@ describe('getUiState', () => {
     expect(search.getUiState()).toEqual({
       [indexName]: {},
       [secondIndexName]: {},
+    });
+  });
+
+  test('retrieves the ui state from initialUiState on a started instance (multi-index)', () => {
+    const indexName = 'indexName';
+    const secondIndexName = 'indexName2';
+    const searchClient = createSearchClient();
+    const search = new InstantSearch({
+      indexName,
+      searchClient,
+      initialUiState: {
+        [indexName]: {
+          query: 'iphone 10',
+        },
+        [secondIndexName]: {
+          query: 'iphone 11',
+        },
+      },
+    });
+
+    search.start();
+    search.addWidgets([index({ indexName: secondIndexName })]);
+
+    expect(search.getUiState()).toEqual({
+      [indexName]: { query: 'iphone 10' },
+      [secondIndexName]: { query: 'iphone 11' },
     });
   });
 

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -708,10 +708,14 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
     },
 
     refreshUiState() {
-      localUiState = getLocalWidgetsUiState(localWidgets, {
-        searchParameters: this.getHelper()!.state,
-        helper: this.getHelper()!,
-      });
+      localUiState = getLocalWidgetsUiState(
+        localWidgets,
+        {
+          searchParameters: this.getHelper()!.state,
+          helper: this.getHelper()!,
+        },
+        localUiState
+      );
     },
   };
 };


### PR DESCRIPTION
This fixes an issue where you can get inconsistencies returned by `getUiState()` when you define an  `initialUiState`. I discovered this bug when implementing a `connectSearchState` connector and its `useSearchState` Hook in the new React InstantSearch.

## Problem

The problem came from the underlying `index.refreshUiState()` which ignored the previous index UI state. A "previous state" is a generalization of the "initial state" problem.

## Solution

We now pass the previous UI state to `getLocalWidgetsUiState()` called from `refreshUiState()`. This allows `getUiState()` to return the `initialUiState` initially.

## Impact

There's a slight behavior change with this update, which is that the initial UI state is not "verified" by our widget tree initially. As you can see in the tests, we don't need to mount a search box to get the `query` UI state param returned by `getUiState()`. A UI state param will get removed at the next widget tree pass if no widgets are responsible for this param.

