### PR TITLE
Add missing peer dependency from algoliasearch-helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,6 +144,9 @@
     "typescript": "4.3.5",
     "webpack": "4.41.5"
   },
+  "peerDependencies": {
+    "algoliasearch": ">= 3.1 < 5"
+  },
   "resolutions": {
     "places.js/algoliasearch": "3.35.0"
   },


### PR DESCRIPTION
The dependency algoliasearch-helper [declares algoliasearch as a peer dependency](https://github.com/algolia/algoliasearch-helper-js/blob/develop/package.json#L103) [1], but instantsearch.js does not declare it as a dependency nor a peer dependency.
This can cause undefined issues during peer dependency resolution, and triggers warnings when using yarn v2+.

The commit adds algoliasearch as a peer dependency.