### PR TITLE
feat: rely on `state` in `getWidgetRenderState`

### DIFF
--- a/src/connectors/autocomplete/connectAutocomplete.ts
+++ b/src/connectors/autocomplete/connectAutocomplete.ts
@@ -159,7 +159,12 @@ search.addWidgets([
         };
       },
 
-      getWidgetRenderState({ helper, scopedResults, instantSearchInstance }) {
+      getWidgetRenderState({
+        helper,
+        state,
+        scopedResults,
+        instantSearchInstance,
+      }) {
         if (!connectorState.refine) {
           connectorState.refine = (query: string) => {
             helper.setQuery(query).search();
@@ -189,7 +194,7 @@ search.addWidgets([
         });
 
         return {
-          currentRefinement: helper.state.query || '',
+          currentRefinement: state.query || '',
           indices,
           refine: connectorState.refine,
           widgetParams,

--- a/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.ts
+++ b/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.ts
@@ -84,7 +84,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
         })
       );
 
-      helper.toggleRefinement('category', 'Decoration');
+      helper.toggleFacetRefinement('category', 'Decoration');
 
       const renderState1 = breadcrumb.getRenderState(
         {
@@ -195,7 +195,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
         })
       );
 
-      helper.toggleRefinement('category', 'Decoration');
+      helper.toggleFacetRefinement('category', 'Decoration');
 
       const renderState1 = breadcrumb.getWidgetRenderState(
         createInitOptions({ helper })
@@ -559,7 +559,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
     const helper = algoliasearchHelper(createSearchClient(), '', config);
     helper.search = jest.fn();
 
-    helper.toggleRefinement('category', 'Decoration');
+    helper.toggleFacetRefinement('category', 'Decoration');
 
     widget.init!(
       createInitOptions({
@@ -620,7 +620,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
 
     helper.search = jest.fn();
 
-    helper.toggleRefinement('category', 'Decoration');
+    helper.toggleFacetRefinement('category', 'Decoration');
 
     widget.init!(
       createInitOptions({
@@ -668,7 +668,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
     const helper = algoliasearchHelper(createSearchClient(), '', config);
     helper.search = jest.fn();
 
-    helper.toggleRefinement('category', 'Decoration');
+    helper.toggleFacetRefinement('category', 'Decoration');
 
     widget.init!(
       createInitOptions({
@@ -969,7 +969,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
     const firstRenderingOptions = rendering.mock.calls[0][0];
     expect(firstRenderingOptions.items).toEqual([]);
 
-    helper.toggleRefinement('category', 'Decoration');
+    helper.toggleFacetRefinement('category', 'Decoration');
 
     widget.render!(
       createRenderOptions({

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -303,8 +303,8 @@ const connectInfiniteHits: InfiniteHitsConnector = function connectInfiniteHits(
             widgetType: this.$$type,
           });
           isFirstPage =
-            helper.state.page === undefined ||
-            getFirstReceivedPage(helper.state, cachedHits) === 0;
+            state.page === undefined ||
+            getFirstReceivedPage(state, cachedHits) === 0;
         } else {
           const { page = 0 } = state;
 

--- a/src/connectors/pagination/connectPagination.ts
+++ b/src/connectors/pagination/connectPagination.ts
@@ -158,7 +158,7 @@ const connectPagination: PaginationConnector = function connectPagination(
         return searchParameters.setQueryParameter('page', page);
       },
 
-      getWidgetRenderState({ results, helper, createURL }) {
+      getWidgetRenderState({ results, helper, state, createURL }) {
         if (!connectorState.refine) {
           connectorState.refine = (page) => {
             helper.setPage(page);
@@ -167,11 +167,10 @@ const connectPagination: PaginationConnector = function connectPagination(
         }
 
         if (!connectorState.createURL) {
-          connectorState.createURL = (state) => (page) =>
-            createURL(state.setPage(page));
+          connectorState.createURL = (helperState) => (page) =>
+            createURL(helperState.setPage(page));
         }
 
-        const state = helper.state;
         const page = state.page || 0;
         const nbPages = getMaxPage(results || { nbPages: 0 });
         pager.currentPage = page;

--- a/src/connectors/search-box/connectSearchBox.ts
+++ b/src/connectors/search-box/connectSearchBox.ts
@@ -138,10 +138,10 @@ const connectSearchBox: SearchBoxConnector = function connectSearchBox(
         };
       },
 
-      getWidgetRenderState({ helper, searchMetadata }) {
+      getWidgetRenderState({ helper, searchMetadata, state }) {
         if (!_refine) {
           const setQueryAndSearch = (query: string) => {
-            if (query !== helper.state.query) {
+            if (query !== state.query) {
               helper.setQuery(query).search();
             }
           };
@@ -159,7 +159,7 @@ const connectSearchBox: SearchBoxConnector = function connectSearchBox(
         _clear = clear(helper);
 
         return {
-          query: helper.state.query || '',
+          query: state.query || '',
           refine: _refine,
           clear: _cachedClear,
           widgetParams,

--- a/src/connectors/sort-by/connectSortBy.ts
+++ b/src/connectors/sort-by/connectSortBy.ts
@@ -155,7 +155,7 @@ const connectSortBy: SortByConnector = function connectSortBy(
         };
       },
 
-      getWidgetRenderState({ results, helper, parent }) {
+      getWidgetRenderState({ results, helper, state, parent }) {
         if (!connectorState.initialIndex && parent) {
           connectorState.initialIndex = parent.getIndexName();
         }
@@ -166,7 +166,7 @@ const connectSortBy: SortByConnector = function connectSortBy(
         }
 
         return {
-          currentRefinement: helper.state.index,
+          currentRefinement: state.index,
           options: transformItems(items),
           refine: connectorState.setIndex,
           hasNoResults: results ? results.nbHits === 0 : true,

--- a/src/connectors/stats/connectStats.ts
+++ b/src/connectors/stats/connectStats.ts
@@ -109,17 +109,17 @@ const connectStats: StatsConnector = function connectStats(
       };
     },
 
-    getWidgetRenderState({ results, helper }) {
+    getWidgetRenderState({ results, state }) {
       if (!results) {
         return {
-          hitsPerPage: helper.state.hitsPerPage,
+          hitsPerPage: state.hitsPerPage,
           nbHits: 0,
           nbSortedHits: undefined,
           areHitsSorted: false,
           nbPages: 0,
-          page: helper.state.page || 0,
+          page: state.page || 0,
           processingTimeMS: -1,
-          query: helper.state.query || '',
+          query: state.query || '',
           widgetParams,
         };
       }

--- a/src/connectors/toggle-refinement/connectToggleRefinement.ts
+++ b/src/connectors/toggle-refinement/connectToggleRefinement.ts
@@ -285,9 +285,7 @@ const connectToggleRefinement: ToggleRefinementConnector =
           instantSearchInstance,
         }) {
           const isRefined = results
-            ? on.every((v) =>
-                helper.state.isDisjunctiveFacetRefined(attribute, v)
-              )
+            ? on.every((v) => state.isDisjunctiveFacetRefined(attribute, v))
             : on.every((v) => state.isDisjunctiveFacetRefined(attribute, v));
 
           let onFacetValue: ToggleRefinementValue = {

--- a/src/widgets/toggle-refinement/__tests__/__snapshots__/toggle-refinement-test.ts.snap
+++ b/src/widgets/toggle-refinement/__tests__/__snapshots__/toggle-refinement-test.ts.snap
@@ -26,7 +26,7 @@ exports[`toggleRefinement() Lifecycle render supports negative numeric off or on
     "templates": {
       "labelText": "{{name}}",
     },
-    "templatesConfig": undefined,
+    "templatesConfig": {},
     "useCustomCompileOptions": {
       "labelText": false,
     },
@@ -60,7 +60,7 @@ exports[`toggleRefinement() Lifecycle render supports negative numeric off or on
     "templates": {
       "labelText": "{{name}}",
     },
-    "templatesConfig": undefined,
+    "templatesConfig": {},
     "useCustomCompileOptions": {
       "labelText": false,
     },
@@ -94,7 +94,7 @@ exports[`toggleRefinement() Lifecycle render understands cssClasses 1`] = `
     "templates": {
       "labelText": "{{name}}",
     },
-    "templatesConfig": undefined,
+    "templatesConfig": {},
     "useCustomCompileOptions": {
       "labelText": false,
     },
@@ -128,7 +128,7 @@ exports[`toggleRefinement() Lifecycle render when refined 1`] = `
     "templates": {
       "labelText": "{{name}}",
     },
-    "templatesConfig": undefined,
+    "templatesConfig": {},
     "useCustomCompileOptions": {
       "labelText": false,
     },
@@ -162,7 +162,7 @@ exports[`toggleRefinement() Lifecycle render when refined 2`] = `
     "templates": {
       "labelText": "{{name}}",
     },
-    "templatesConfig": undefined,
+    "templatesConfig": {},
     "useCustomCompileOptions": {
       "labelText": false,
     },
@@ -196,7 +196,7 @@ exports[`toggleRefinement() Lifecycle render with facet values 1`] = `
     "templates": {
       "labelText": "{{name}}",
     },
-    "templatesConfig": undefined,
+    "templatesConfig": {},
     "useCustomCompileOptions": {
       "labelText": false,
     },
@@ -230,7 +230,7 @@ exports[`toggleRefinement() Lifecycle render with facet values 2`] = `
     "templates": {
       "labelText": "{{name}}",
     },
-    "templatesConfig": undefined,
+    "templatesConfig": {},
     "useCustomCompileOptions": {
       "labelText": false,
     },
@@ -264,7 +264,7 @@ exports[`toggleRefinement() Lifecycle render without facet values 1`] = `
     "templates": {
       "labelText": "{{name}}",
     },
-    "templatesConfig": undefined,
+    "templatesConfig": {},
     "useCustomCompileOptions": {
       "labelText": false,
     },
@@ -298,7 +298,7 @@ exports[`toggleRefinement() Lifecycle render without facet values 2`] = `
     "templates": {
       "labelText": "{{name}}",
     },
-    "templatesConfig": undefined,
+    "templatesConfig": {},
     "useCustomCompileOptions": {
       "labelText": false,
     },

--- a/src/widgets/toggle-refinement/__tests__/toggle-refinement-test.ts
+++ b/src/widgets/toggle-refinement/__tests__/toggle-refinement-test.ts
@@ -2,14 +2,12 @@ import { render as preactRender } from 'preact';
 import type { AlgoliaSearchHelper, SearchResults } from 'algoliasearch-helper';
 import jsHelper, { SearchParameters } from 'algoliasearch-helper';
 import toggleRefinement from '../toggle-refinement';
-import { createInstantSearch } from '../../../../test/mock/createInstantSearch';
 import { castToJestMock } from '../../../../test/utils/castToJestMock';
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import {
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/mock/createWidget';
-import type { InstantSearch } from '../../../types';
 
 const render = castToJestMock(preactRender);
 jest.mock('preact', () => {
@@ -38,7 +36,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
     let containerNode: HTMLElement;
     let widget: ReturnType<typeof toggleRefinement>;
     let attribute: string;
-    let instantSearchInstance: InstantSearch;
 
     beforeEach(() => {
       render.mockClear();
@@ -49,15 +46,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
         container: containerNode,
         attribute,
       });
-      instantSearchInstance = createInstantSearch({
-        templatesConfig: undefined,
-      });
     });
 
     describe('render', () => {
       let results: SearchResults;
       let helper: AlgoliaSearchHelper;
-      let state: SearchParameters;
       let createURL: () => string;
 
       beforeEach(() => {
@@ -68,15 +61,13 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
         helper.removeDisjunctiveFacetRefinement = jest.fn();
         helper.addDisjunctiveFacetRefinement = jest.fn();
         helper.search = jest.fn();
-        state = {
+        helper.state = {
           removeDisjunctiveFacetRefinement: jest.fn(),
           addDisjunctiveFacetRefinement: jest.fn(),
           isDisjunctiveFacetRefined: jest.fn().mockReturnValue(false),
         } as unknown as SearchParameters;
         createURL = () => '#';
-        widget.init!(
-          createInitOptions({ state, helper, createURL, instantSearchInstance })
-        );
+        widget.init!(createInitOptions({ helper, createURL }));
       });
 
       it('calls twice render', () => {
@@ -96,11 +87,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
         widget.getWidgetSearchParameters(new SearchParameters({}), {
           uiState: {},
         });
-        widget.init!(
-          createInitOptions({ helper, state, createURL, instantSearchInstance })
-        );
-        widget.render!(createRenderOptions({ results, helper, state }));
-        widget.render!(createRenderOptions({ results, helper, state }));
+        widget.init!(createInitOptions({ helper, createURL }));
+        widget.render!(createRenderOptions({ results, helper }));
+        widget.render!(createRenderOptions({ results, helper }));
 
         const [firstRender, secondRender] = render.mock.calls;
 
@@ -132,10 +121,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
         widget.getWidgetSearchParameters(new SearchParameters({}), {
           uiState: {},
         });
-        widget.init!(
-          createInitOptions({ state, helper, createURL, instantSearchInstance })
-        );
-        widget.render!(createRenderOptions({ results, helper, state }));
+        widget.init!(createInitOptions({ helper, createURL }));
+        widget.render!(createRenderOptions({ results, helper }));
 
         const [firstRender] = render.mock.calls;
 
@@ -160,11 +147,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
         widget.getWidgetSearchParameters(new SearchParameters({}), {
           uiState: {},
         });
-        widget.init!(
-          createInitOptions({ state, helper, createURL, instantSearchInstance })
-        );
-        widget.render!(createRenderOptions({ results, helper, state }));
-        widget.render!(createRenderOptions({ results, helper, state }));
+        widget.init!(createInitOptions({ helper, createURL }));
+        widget.render!(createRenderOptions({ results, helper }));
+        widget.render!(createRenderOptions({ results, helper }));
 
         const [firstRender, secondRender] = render.mock.calls;
 
@@ -197,20 +182,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
         );
         const altHelper = jsHelper(createSearchClient(), '', config);
 
-        widget.init!(
-          createInitOptions({
-            state: altHelper.state,
-            helper: altHelper,
-            createURL,
-            instantSearchInstance,
-          })
-        );
-        widget.render!(
-          createRenderOptions({ results, helper: altHelper, state })
-        );
-        widget.render!(
-          createRenderOptions({ results, helper: altHelper, state })
-        );
+        widget.init!(createInitOptions({ helper: altHelper, createURL }));
+        widget.render!(createRenderOptions({ results, helper: altHelper }));
+        widget.render!(createRenderOptions({ results, helper: altHelper }));
 
         const [firstRender, secondRender] = render.mock.calls;
 
@@ -222,12 +196,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
 
         widget
           .getWidgetRenderState(
-            createRenderOptions({
-              state: helper.state,
-              helper,
-              createURL,
-              results,
-            })
+            createRenderOptions({ helper, createURL, results })
           )
           .refine({ isRefined: true });
 
@@ -254,11 +223,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
         widget.getWidgetSearchParameters(new SearchParameters({}), {
           uiState: {},
         });
-        widget.init!(
-          createInitOptions({ state, helper, createURL, instantSearchInstance })
-        );
-        widget.render!(createRenderOptions({ results, helper, state }));
-        widget.render!(createRenderOptions({ results, helper, state }));
+        widget.init!(createInitOptions({ helper, createURL }));
+        widget.render!(createRenderOptions({ results, helper }));
+        widget.render!(createRenderOptions({ results, helper }));
 
         const [firstRender, secondRender] = render.mock.calls;
 
@@ -269,11 +236,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
       });
 
       it('when refined', () => {
-        helper = {
-          state: {
-            isDisjunctiveFacetRefined: jest.fn().mockReturnValue(true),
-          } as unknown as SearchParameters,
-        } as unknown as AlgoliaSearchHelper;
+        helper.state.isDisjunctiveFacetRefined = jest
+          .fn()
+          .mockReturnValue(true);
         results = {
           hits: [{ Hello: ', world!' }],
           nbHits: 1,
@@ -290,11 +255,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
         widget.getWidgetSearchParameters(new SearchParameters({}), {
           uiState: {},
         });
-        widget.init!(
-          createInitOptions({ state, helper, createURL, instantSearchInstance })
-        );
-        widget.render!(createRenderOptions({ results, helper, state }));
-        widget.render!(createRenderOptions({ results, helper, state }));
+        widget.init!(createInitOptions({ helper, createURL }));
+        widget.render!(createRenderOptions({ results, helper }));
+        widget.render!(createRenderOptions({ results, helper }));
 
         const [firstRender, secondRender] = render.mock.calls;
 
@@ -321,10 +284,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
         widget.getWidgetSearchParameters(new SearchParameters({}), {
           uiState: {},
         });
-        widget.init!(
-          createInitOptions({ state, helper, createURL, instantSearchInstance })
-        );
-        widget.render!(createRenderOptions({ results, helper, state }));
+        widget.init!(createInitOptions({ helper, createURL }));
+        widget.render!(createRenderOptions({ results, helper }));
 
         const [firstRender] = render.mock.calls;
         // @ts-expect-error
@@ -353,19 +314,13 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
       }) {
         widget
           .getWidgetRenderState(
-            createInitOptions({
-              state: altHelper.state,
-              helper: altHelper,
-              createURL,
-            })
+            createInitOptions({ helper: altHelper, createURL })
           )
           .refine({ isRefined: false });
       }
       function toggleOff({ createURL }: { createURL: () => string }) {
         widget
-          .getWidgetRenderState(
-            createInitOptions({ state: helper.state, helper, createURL })
-          )
+          .getWidgetRenderState(createInitOptions({ helper, createURL }))
           .refine({ isRefined: true });
       }
 
@@ -387,18 +342,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
           widget.getWidgetSearchParameters(new SearchParameters({}), {
             uiState: {},
           });
-          const state = {
-            isDisjunctiveFacetRefined: jest.fn().mockReturnValue(false),
-          } as unknown as SearchParameters;
+          helper.state.isDisjunctiveFacetRefined = jest
+            .fn()
+            .mockReturnValue(false);
           const createURL = () => '#';
-          widget.init!(
-            createInitOptions({
-              state,
-              helper,
-              createURL,
-              instantSearchInstance,
-            })
-          );
+          widget.init!(createInitOptions({ helper, createURL }));
 
           // When
           toggleOn({ createURL });
@@ -422,18 +370,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
           widget.getWidgetSearchParameters(new SearchParameters({}), {
             uiState: {},
           });
-          const state = {
-            isDisjunctiveFacetRefined: jest.fn().mockReturnValue(true),
-          } as unknown as SearchParameters;
+          helper.state.isDisjunctiveFacetRefined = jest
+            .fn()
+            .mockReturnValue(true);
           const createURL = () => '#';
-          widget.init!(
-            createInitOptions({
-              state,
-              helper,
-              createURL,
-              instantSearchInstance,
-            })
-          );
+          widget.init!(createInitOptions({ helper, createURL }));
 
           // When
           toggleOff({ createURL });
@@ -464,14 +405,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
 
           const createURL = () => '#';
 
-          widget.init!(
-            createInitOptions({
-              state: altHelper.state,
-              helper: altHelper,
-              createURL,
-              instantSearchInstance,
-            })
-          );
+          widget.init!(createInitOptions({ helper: altHelper, createURL }));
 
           // When
           toggleOn({ createURL, altHelper });
@@ -496,18 +430,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
           widget.getWidgetSearchParameters(new SearchParameters({}), {
             uiState: {},
           });
-          const state = {
-            isDisjunctiveFacetRefined: jest.fn().mockReturnValue(true),
-          } as unknown as SearchParameters;
+          helper.state.isDisjunctiveFacetRefined = jest
+            .fn()
+            .mockReturnValue(true);
           const createURL = () => '#';
-          widget.init!(
-            createInitOptions({
-              state,
-              helper,
-              createURL,
-              instantSearchInstance,
-            })
-          );
+          widget.init!(createInitOptions({ helper, createURL }));
 
           // When
           toggleOff({ createURL });
@@ -542,14 +469,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
         const helper = jsHelper(createSearchClient(), '', config);
 
         // When
-        widget.init!(
-          createInitOptions({
-            state: helper.state,
-            helper,
-            createURL,
-            instantSearchInstance,
-          })
-        );
+        widget.init!(createInitOptions({ helper, createURL }));
 
         // Then
         expect(helper.state.isDisjunctiveFacetRefined(attribute, 'off')).toBe(
@@ -568,17 +488,16 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
         widget.getWidgetSearchParameters(new SearchParameters({}), {
           uiState: {},
         });
-        const state = {
-          isDisjunctiveFacetRefined: jest.fn().mockReturnValue(true),
-        } as unknown as SearchParameters;
+
         const helper = {
           addDisjunctiveFacetRefinement: jest.fn(),
+          state: {
+            isDisjunctiveFacetRefined: jest.fn().mockReturnValue(true),
+          },
         } as unknown as AlgoliaSearchHelper;
 
         // When
-        widget.init!(
-          createInitOptions({ state, helper, createURL, instantSearchInstance })
-        );
+        widget.init!(createInitOptions({ helper, createURL }));
 
         // Then
         expect(helper.addDisjunctiveFacetRefinement).not.toHaveBeenCalled();
@@ -595,17 +514,16 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/toggle-refi
         widget.getWidgetSearchParameters(new SearchParameters({}), {
           uiState: {},
         });
-        const state = {
-          isDisjunctiveFacetRefined: () => false,
-        } as unknown as SearchParameters;
+
         const helper = {
           addDisjunctiveFacetRefinement: jest.fn(),
+          state: {
+            isDisjunctiveFacetRefined: () => false,
+          },
         } as unknown as AlgoliaSearchHelper;
 
         // When
-        widget.init!(
-          createInitOptions({ state, helper, createURL, instantSearchInstance })
-        );
+        widget.init!(createInitOptions({ helper, createURL }));
 
         // Then
         expect(helper.addDisjunctiveFacetRefinement).not.toHaveBeenCalled();

--- a/test/mock/createWidget.ts
+++ b/test/mock/createWidget.ts
@@ -12,14 +12,15 @@ export const createInitOptions = (
   args: Partial<InitOptions> = {}
 ): InitOptions => {
   const { instantSearchInstance = createInstantSearch(), ...rest } = args;
+  const helper = args.helper || instantSearchInstance.helper!;
 
   return {
     instantSearchInstance,
     parent: instantSearchInstance.mainIndex,
     uiState: instantSearchInstance._initialUiState,
     templatesConfig: instantSearchInstance.templatesConfig,
-    helper: instantSearchInstance.helper!,
-    state: instantSearchInstance.helper!.state,
+    helper,
+    state: helper.state,
     renderState: instantSearchInstance.renderState,
     scopedResults: [],
     createURL: jest.fn(() => '#'),
@@ -68,10 +69,11 @@ export const createDisposeOptions = (
   args: Partial<DisposeOptions> = {}
 ): DisposeOptions => {
   const instantSearchInstance = createInstantSearch();
+  const helper = args.helper || instantSearchInstance.helper!;
 
   return {
-    helper: instantSearchInstance.helper!,
-    state: instantSearchInstance.helper!.state,
+    helper,
+    state: helper.state,
     parent: instantSearchInstance.mainIndex,
     ...args,
   };


### PR DESCRIPTION
## Description

This changes how **we provide the widgets' render state from the helper state to the retrieved state** (`renderOptions.helper.state` vs. `renderOptions.state`).

This is required to support React InstantSearch Hooks SSR[^1] to avoid flashes between SSR and CSR[^2] when hydrating.

## Explanation

As opposed to Vue InstantSearch SSR, React InstantSearch Hooks SSR works in a single data flow pass. We rely on a single helper (the one created by InstantSearch.js), to provide the search state and the search results to the widgets.

By design, InstantSearch.js computes the search parameters from the mounted widgets (e.g., `searchBox` controls the `query` search parameter). As soon as you start setting a search parameter that is not yet controlled by a widget (this happens when a child index inherits from its parent index `searchBox` state), InstantSearch isn't able to take control back on that search parameter. This is for this reason that we cannot override the helper state (aka search parameters) before widgets are mounted, and _then_ rely on the widgets to update the helper state again.

Because of this constraint, once we override the initial helper state on SSR, any interactions on the browser won't update the search parameters, leaving the UI stuck.

This PR modifies the way we return the widgets' render state from `getWidgetRenderState` to rely directly on `state`, and not `helper.state`. This lets us provide a computed initial state from `results._state` without controlling the search parameters yet, and display the correct UI state on screen without messing with InstantSearch internals. And therefore lets InstantSearch correctly controls the search parameters after user interactions.

## Impact

This change is only internal and shouldn't impact any user implementations.

[^1]: SSR: Server-Side Rendering
[^2]: CSR: Client-Side Rendering