### PR TITLE
test(snapshots): automatically register widget serializer

### DIFF
--- a/scripts/jest/serializers/widgetSnapshotSerializer.ts
+++ b/scripts/jest/serializers/widgetSnapshotSerializer.ts
@@ -1,7 +1,7 @@
-import type { Widget } from '../../src/types';
-import type { IndexWidget } from '../../src/widgets/index/index';
-import { getWidgetAttribute } from '../../src/lib/utils';
-import { createInitOptions } from '../mock/createWidget';
+import type { Widget } from '../../../src/types';
+import type { IndexWidget } from '../../../src/widgets/index/index';
+import { getWidgetAttribute } from '../../../src/lib/utils';
+import { createInitOptions } from '../../../test/mock/createWidget';
 
 function getAttribute(widget: Widget | IndexWidget) {
   try {

--- a/scripts/jest/setupTests.ts
+++ b/scripts/jest/setupTests.ts
@@ -3,9 +3,11 @@ import Adapter from 'enzyme-adapter-preact-pure';
 import { createSerializer } from 'enzyme-to-json';
 import '@testing-library/jest-dom/extend-expect';
 import { toWarnDev } from './matchers';
+import { widgetSnapshotSerializer } from './serializers/widgetSnapshotSerializer';
 
 Enzyme.configure({ adapter: new Adapter() });
 expect.addSnapshotSerializer(createSerializer({ mode: 'deep' }) as any);
+expect.addSnapshotSerializer(widgetSnapshotSerializer);
 expect.extend(toWarnDev);
 
 // We hide console infos and warnings to not pollute the test logs.

--- a/src/connectors/dynamic-widgets/__tests__/connectDynamicWidgets-test.ts
+++ b/src/connectors/dynamic-widgets/__tests__/connectDynamicWidgets-test.ts
@@ -1,6 +1,5 @@
 import { connectMenu, connectDynamicWidgets } from '../..';
 import { index } from '../../../widgets';
-import { widgetSnapshotSerializer } from '../../../../test/utils/widgetSnapshotSerializer';
 import {
   createDisposeOptions,
   createInitOptions,
@@ -15,8 +14,6 @@ import {
 import connectHierarchicalMenu from '../../hierarchical-menu/connectHierarchicalMenu';
 import type { DynamicWidgetsConnectorParams } from '../connectDynamicWidgets';
 import connectRefinementList from '../../refinement-list/connectRefinementList';
-
-expect.addSnapshotSerializer(widgetSnapshotSerializer);
 
 describe('connectDynamicWidgets', () => {
   describe('Usage', () => {

--- a/src/widgets/dynamic-widgets/__tests__/dynamic-widgets-test.ts
+++ b/src/widgets/dynamic-widgets/__tests__/dynamic-widgets-test.ts
@@ -7,12 +7,9 @@ import { createInstantSearch } from '../../../../test/mock/createInstantSearch';
 import { SearchParameters, SearchResults } from 'algoliasearch-helper';
 import { createMultiSearchResponse } from '../../../../test/mock/createAPIResponse';
 import { wait } from '../../../../test/utils/wait';
-import { widgetSnapshotSerializer } from '../../../../test/utils/widgetSnapshotSerializer';
 import refinementList from '../../refinement-list/refinement-list';
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import instantsearch from '../../..';
-
-expect.addSnapshotSerializer(widgetSnapshotSerializer);
 
 describe('dynamicWidgets()', () => {
   describe('usage', () => {


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
This makes it so that we can add any test that snapshots a widget and have the readable output.

No actual tests are changed, as all previous locations that used the widgetSnapshotSerializer manually set up the serializer


**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

all tests can snapshot widgets