### PR TITLE
feat: support initial results

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
   "bundlesize": [
     {
       "path": "./dist/instantsearch.production.min.js",
-      "maxSize": "69.25 kB"
+      "maxSize": "69.50 kB"
     },
     {
       "path": "./dist/instantsearch.development.js",

--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -1,4 +1,4 @@
-import type { SearchResults, AlgoliaSearchHelper } from 'algoliasearch-helper';
+import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
 import algoliasearchHelper from 'algoliasearch-helper';
 
 import EventEmitter from 'events';

--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -23,6 +23,7 @@ import type {
   Middleware,
   MiddlewareDefinition,
   RenderState,
+  InitialResults,
 } from '../types';
 import type { RouterProps } from '../middlewares/createRouterMiddleware';
 import { createRouterMiddleware } from '../middlewares/createRouterMiddleware';
@@ -158,7 +159,7 @@ class InstantSearch<
   public _searchStalledTimer: any;
   public _isSearchStalled: boolean;
   public _initialUiState: UiState;
-  public _initialResults: Record<string, SearchResults> | null;
+  public _initialResults: InitialResults | null;
   public _createURL: CreateURL<UiState>;
   public _searchFunction?: InstantSearchOptions['searchFunction'];
   public _mainHelperSearch?: AlgoliaSearchHelper['search'];

--- a/src/lib/__tests__/InstantSearch-test.tsx
+++ b/src/lib/__tests__/InstantSearch-test.tsx
@@ -540,6 +540,31 @@ describe('addWidget(s)', () => {
 
     expect(search.addWidgets([createWidget()])).toBe(search);
   });
+
+  it('does not trigger a search with initial results', async () => {
+    const searchClient = createSearchClient();
+    const search = new InstantSearch({
+      indexName: 'indexName',
+      searchClient,
+    });
+    // An empty object is a valid value for initial results
+    search._initialResults = {};
+
+    search.start();
+    search.addWidgets([createWidget()]);
+
+    expect(searchClient.search).toHaveBeenCalledTimes(0);
+
+    await wait(0);
+
+    expect(searchClient.search).toHaveBeenCalledTimes(0);
+
+    search.addWidgets([createWidget()]);
+
+    await wait(0);
+
+    expect(searchClient.search).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('removeWidget(s)', () => {
@@ -833,6 +858,24 @@ describe('start', () => {
       expect(event.error).toEqual(new Error('SERVER_ERROR'));
       done();
     });
+  });
+
+  it('does not trigger a search with initial results', async () => {
+    const searchClient = createSearchClient();
+    const search = new InstantSearch({
+      indexName: 'indexName',
+      searchClient,
+    });
+    // An empty object is a valid value for initial results
+    search._initialResults = {};
+
+    expect(searchClient.search).toHaveBeenCalledTimes(0);
+
+    search.start();
+
+    await wait(0);
+
+    expect(searchClient.search).toHaveBeenCalledTimes(0);
   });
 
   it('does start without widgets', () => {

--- a/src/types/results.ts
+++ b/src/types/results.ts
@@ -1,3 +1,8 @@
+import type {
+  PlainSearchParameters,
+  SearchResults,
+} from 'algoliasearch-helper';
+
 export type HitAttributeHighlightResult = {
   value: string;
   matchLevel: 'none' | 'partial' | 'full';
@@ -85,3 +90,9 @@ export type NumericRefinement = {
 };
 
 export type Refinement = FacetRefinement | NumericRefinement;
+
+type InitialResult = Pick<SearchResults, '_rawResults'> & {
+  _state: PlainSearchParameters;
+};
+
+export type InitialResults = Record<string, InitialResult>;

--- a/src/types/results.ts
+++ b/src/types/results.ts
@@ -91,8 +91,9 @@ export type NumericRefinement = {
 
 export type Refinement = FacetRefinement | NumericRefinement;
 
-type InitialResult = Pick<SearchResults, '_rawResults'> & {
-  _state: PlainSearchParameters;
+type InitialResult<THit> = {
+  state: PlainSearchParameters;
+  results: SearchResults<THit>['_rawResults'];
 };
 
-export type InitialResults = Record<string, InitialResult>;
+export type InitialResults<THit> = Record<string, InitialResult<THit>>;

--- a/src/types/results.ts
+++ b/src/types/results.ts
@@ -91,9 +91,9 @@ export type NumericRefinement = {
 
 export type Refinement = FacetRefinement | NumericRefinement;
 
-type InitialResult<THit> = {
+type InitialResult = {
   state: PlainSearchParameters;
-  results: SearchResults<THit>['_rawResults'];
+  results: SearchResults['_rawResults'];
 };
 
-export type InitialResults<THit> = Record<string, InitialResult<THit>>;
+export type InitialResults = Record<string, InitialResult>;

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -2896,12 +2896,15 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
         searchClient: createSearchClient(),
       });
       search._initialResults = {
-        indexName: new SearchResults(new SearchParameters(), [
-          createSingleSearchResponse({
-            query: 'iphone',
-            hits: [{ objectID: '1' }, { objectID: '2' }, { objectID: '3' }],
-          }),
-        ]),
+        indexName: {
+          state: new SearchParameters(),
+          results: [
+            createSingleSearchResponse({
+              query: 'iphone',
+              hits: [{ objectID: '1' }, { objectID: '2' }, { objectID: '3' }],
+            }),
+          ],
+        },
       };
 
       search.start();
@@ -2962,21 +2965,33 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
         searchClient: createSearchClient(),
       });
       search._initialResults = {
-        indexName: new SearchResults(new SearchParameters(), [
-          createSingleSearchResponse({
-            hits: [{ objectID: '1' }, { objectID: '2' }, { objectID: '3' }],
-          }),
-        ]),
-        indexName2: new SearchResults(new SearchParameters(), [
-          createSingleSearchResponse({
-            hits: [{ objectID: '4' }, { objectID: '5' }, { objectID: '6' }],
-          }),
-        ]),
-        indexName3: new SearchResults(new SearchParameters(), [
-          createSingleSearchResponse({
-            hits: [{ objectID: '7' }, { objectID: '8' }, { objectID: '9' }],
-          }),
-        ]),
+        indexName: {
+          state: new SearchParameters(),
+          results: [
+            createSingleSearchResponse({
+              query: 'iphone',
+              hits: [{ objectID: '1' }, { objectID: '2' }, { objectID: '3' }],
+            }),
+          ],
+        },
+        indexName2: {
+          state: new SearchParameters(),
+          results: [
+            createSingleSearchResponse({
+              query: 'iphone',
+              hits: [{ objectID: '4' }, { objectID: '5' }, { objectID: '6' }],
+            }),
+          ],
+        },
+        indexName3: {
+          state: new SearchParameters(),
+          results: [
+            createSingleSearchResponse({
+              query: 'iphone',
+              hits: [{ objectID: '7' }, { objectID: '8' }, { objectID: '9' }],
+            }),
+          ],
+        },
       };
 
       const nestedIndex1 = index({ indexName: 'indexName2' });
@@ -3031,17 +3046,25 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
         searchClient: createSearchClient(),
       });
       search._initialResults = {
-        indexName: new SearchResults(new SearchParameters(), [
-          createSingleSearchResponse({
-            hits: [{ objectID: '1' }, { objectID: '2' }, { objectID: '3' }],
-          }),
-        ]),
+        indexName: {
+          state: new SearchParameters(),
+          results: [
+            createSingleSearchResponse({
+              query: 'iphone',
+              hits: [{ objectID: '1' }, { objectID: '2' }, { objectID: '3' }],
+            }),
+          ],
+        },
         // Notice that `indexName2` is not provided
-        indexName3: new SearchResults(new SearchParameters(), [
-          createSingleSearchResponse({
-            hits: [{ objectID: '7' }, { objectID: '8' }, { objectID: '9' }],
-          }),
-        ]),
+        indexName3: {
+          state: new SearchParameters(),
+          results: [
+            createSingleSearchResponse({
+              query: 'iphone',
+              hits: [{ objectID: '7' }, { objectID: '8' }, { objectID: '9' }],
+            }),
+          ],
+        },
       };
 
       const nestedIndex1 = index({ indexName: 'indexName2' });
@@ -3089,11 +3112,15 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
         scheduleRender: jest.fn() as any,
       });
       instantSearchInstance._initialResults = {
-        indexName: new SearchResults(new SearchParameters(), [
-          createSingleSearchResponse({
-            hits: [{ objectID: '1' }, { objectID: '2' }, { objectID: '3' }],
-          }),
-        ]),
+        indexName: {
+          state: new SearchParameters(),
+          results: [
+            createSingleSearchResponse({
+              query: 'iphone',
+              hits: [{ objectID: '1' }, { objectID: '2' }, { objectID: '3' }],
+            }),
+          ],
+        },
       };
 
       instance.init(createInitOptions({ instantSearchInstance, parent: null }));
@@ -3107,11 +3134,15 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
         searchClient: createSearchClient(),
       });
       search._initialResults = {
-        indexName: new SearchResults(new SearchParameters(), [
-          createSingleSearchResponse({
-            hits: [{ objectID: '1' }, { objectID: '2' }, { objectID: '3' }],
-          }),
-        ]),
+        indexName: {
+          state: new SearchParameters(),
+          results: [
+            createSingleSearchResponse({
+              query: 'iphone',
+              hits: [{ objectID: '1' }, { objectID: '2' }, { objectID: '3' }],
+            }),
+          ],
+        },
       };
       const renderFn = jest.fn();
 

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -1,5 +1,9 @@
 import type { PlainSearchParameters } from 'algoliasearch-helper';
-import algoliasearchHelper, { SearchParameters } from 'algoliasearch-helper';
+import algoliasearchHelper, {
+  SearchResults,
+  SearchParameters,
+} from 'algoliasearch-helper';
+
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import { createInstantSearch } from '../../../../test/mock/createInstantSearch';
 import {
@@ -14,6 +18,8 @@ import InstantSearch from '../../../lib/InstantSearch';
 import index from '../index';
 import { warning } from '../../../lib/utils';
 import { refinementList } from '../..';
+import { createSingleSearchResponse } from '../../../../test/mock/createAPIResponse';
+import { connectHits } from '../../../connectors';
 
 describe('index', () => {
   const createSearchBox = (args: Partial<Widget> = {}): Widget =>
@@ -2880,6 +2886,247 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
       }).not.toWarnDev(
         '[InstantSearch.js]: The `getWidgetState` method is renamed `getWidgetUiState` and will no longer exist under that name in InstantSearch.js 5.x. Please use `getWidgetUiState` instead.'
       );
+    });
+  });
+
+  describe('with initial results', () => {
+    it('injects the results to the index helper', () => {
+      const search = new InstantSearch({
+        indexName: 'indexName',
+        searchClient: createSearchClient(),
+      });
+      search._initialResults = {
+        indexName: new SearchResults(new SearchParameters(), [
+          createSingleSearchResponse({
+            query: 'iphone',
+            hits: [{ objectID: '1' }, { objectID: '2' }, { objectID: '3' }],
+          }),
+        ]),
+      };
+
+      search.start();
+
+      const expectedResults = {
+        _rawResults: [
+          {
+            exhaustiveFacetsCount: true,
+            exhaustiveNbHits: true,
+            hits: [{ objectID: '1' }, { objectID: '2' }, { objectID: '3' }],
+            hitsPerPage: 20,
+            nbHits: 3,
+            nbPages: 1,
+            page: 0,
+            params: '',
+            processingTimeMS: 0,
+            query: 'iphone',
+          },
+        ],
+        _state: {
+          disjunctiveFacets: [],
+          disjunctiveFacetsRefinements: {},
+          facets: [],
+          facetsExcludes: {},
+          facetsRefinements: {},
+          hierarchicalFacets: [],
+          hierarchicalFacetsRefinements: {},
+          numericRefinements: {},
+          tagRefinements: [],
+        },
+        disjunctiveFacets: [],
+        exhaustiveFacetsCount: true,
+        exhaustiveNbHits: true,
+        facets: [],
+        hierarchicalFacets: [],
+        hits: [{ objectID: '1' }, { objectID: '2' }, { objectID: '3' }],
+        hitsPerPage: 20,
+        nbHits: 3,
+        nbPages: 1,
+        page: 0,
+        params: '',
+        processingTimeMS: 0,
+        query: 'iphone',
+      };
+
+      const helperResults = search.mainIndex.getHelper()!.lastResults;
+      const derivedHelperResults = search.mainIndex.getResults();
+
+      expect(derivedHelperResults).toEqual(expectedResults);
+      expect(derivedHelperResults).toBeInstanceOf(SearchResults);
+      expect(helperResults).toEqual(expectedResults);
+      expect(helperResults).toBeInstanceOf(SearchResults);
+    });
+
+    it('supports nested indices', () => {
+      const search = new InstantSearch({
+        indexName: 'indexName',
+        searchClient: createSearchClient(),
+      });
+      search._initialResults = {
+        indexName: new SearchResults(new SearchParameters(), [
+          createSingleSearchResponse({
+            hits: [{ objectID: '1' }, { objectID: '2' }, { objectID: '3' }],
+          }),
+        ]),
+        indexName2: new SearchResults(new SearchParameters(), [
+          createSingleSearchResponse({
+            hits: [{ objectID: '4' }, { objectID: '5' }, { objectID: '6' }],
+          }),
+        ]),
+        indexName3: new SearchResults(new SearchParameters(), [
+          createSingleSearchResponse({
+            hits: [{ objectID: '7' }, { objectID: '8' }, { objectID: '9' }],
+          }),
+        ]),
+      };
+
+      const nestedIndex1 = index({ indexName: 'indexName2' });
+      const nestedIndex2 = index({ indexName: 'indexName3' });
+
+      nestedIndex1.addWidgets([nestedIndex2]);
+      search.addWidgets([nestedIndex1]);
+      search.start();
+
+      const indexExpectedResults = expect.objectContaining({
+        _rawResults: [
+          expect.objectContaining({
+            hits: [{ objectID: '1' }, { objectID: '2' }, { objectID: '3' }],
+          }),
+        ],
+        hits: [{ objectID: '1' }, { objectID: '2' }, { objectID: '3' }],
+      });
+      const nestedIndex1ExpectedResults = expect.objectContaining({
+        _rawResults: [
+          expect.objectContaining({
+            hits: [{ objectID: '4' }, { objectID: '5' }, { objectID: '6' }],
+          }),
+        ],
+        hits: [{ objectID: '4' }, { objectID: '5' }, { objectID: '6' }],
+      });
+      const nestedIndex2ExpectedResults = expect.objectContaining({
+        _rawResults: [
+          expect.objectContaining({
+            hits: [{ objectID: '7' }, { objectID: '8' }, { objectID: '9' }],
+          }),
+        ],
+        hits: [{ objectID: '7' }, { objectID: '8' }, { objectID: '9' }],
+      });
+
+      expect(search.mainIndex.getHelper()!.lastResults).toEqual(
+        indexExpectedResults
+      );
+      expect(search.mainIndex.getResults()).toEqual(indexExpectedResults);
+      expect(nestedIndex1.getHelper()!.lastResults).toEqual(
+        nestedIndex1ExpectedResults
+      );
+      expect(nestedIndex1.getResults()).toEqual(nestedIndex1ExpectedResults);
+      expect(nestedIndex2.getHelper()!.lastResults).toEqual(
+        nestedIndex2ExpectedResults
+      );
+      expect(nestedIndex2.getResults()).toEqual(nestedIndex2ExpectedResults);
+    });
+
+    it('does not fail with non-provided index results', () => {
+      const search = new InstantSearch({
+        indexName: 'indexName',
+        searchClient: createSearchClient(),
+      });
+      search._initialResults = {
+        indexName: new SearchResults(new SearchParameters(), [
+          createSingleSearchResponse({
+            hits: [{ objectID: '1' }, { objectID: '2' }, { objectID: '3' }],
+          }),
+        ]),
+        // Notice that `indexName2` is not provided
+        indexName3: new SearchResults(new SearchParameters(), [
+          createSingleSearchResponse({
+            hits: [{ objectID: '7' }, { objectID: '8' }, { objectID: '9' }],
+          }),
+        ]),
+      };
+
+      const nestedIndex1 = index({ indexName: 'indexName2' });
+      const nestedIndex2 = index({ indexName: 'indexName3' });
+
+      nestedIndex1.addWidgets([nestedIndex2]);
+      search.addWidgets([nestedIndex1]);
+      search.start();
+
+      const indexExpectedResults = expect.objectContaining({
+        _rawResults: [
+          expect.objectContaining({
+            hits: [{ objectID: '1' }, { objectID: '2' }, { objectID: '3' }],
+          }),
+        ],
+        hits: [{ objectID: '1' }, { objectID: '2' }, { objectID: '3' }],
+      });
+      const nestedIndex1ExpectedResults = null;
+      const nestedIndex2ExpectedResults = expect.objectContaining({
+        _rawResults: [
+          expect.objectContaining({
+            hits: [{ objectID: '7' }, { objectID: '8' }, { objectID: '9' }],
+          }),
+        ],
+        hits: [{ objectID: '7' }, { objectID: '8' }, { objectID: '9' }],
+      });
+
+      expect(search.mainIndex.getHelper()!.lastResults).toEqual(
+        indexExpectedResults
+      );
+      expect(search.mainIndex.getResults()).toEqual(indexExpectedResults);
+      expect(nestedIndex1.getHelper()!.lastResults).toEqual(
+        nestedIndex1ExpectedResults
+      );
+      expect(nestedIndex1.getResults()).toEqual(nestedIndex1ExpectedResults);
+      expect(nestedIndex2.getHelper()!.lastResults).toEqual(
+        nestedIndex2ExpectedResults
+      );
+      expect(nestedIndex2.getResults()).toEqual(nestedIndex2ExpectedResults);
+    });
+
+    it('schedules a render after init', () => {
+      const instance = index({ indexName: 'indexName' });
+      const instantSearchInstance = createInstantSearch({
+        scheduleRender: jest.fn() as any,
+      });
+      instantSearchInstance._initialResults = {
+        indexName: new SearchResults(new SearchParameters(), [
+          createSingleSearchResponse({
+            hits: [{ objectID: '1' }, { objectID: '2' }, { objectID: '3' }],
+          }),
+        ]),
+      };
+
+      instance.init(createInitOptions({ instantSearchInstance, parent: null }));
+
+      expect(instantSearchInstance.scheduleRender).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders the hits coming from the initial results', async () => {
+      const search = new InstantSearch({
+        indexName: 'indexName',
+        searchClient: createSearchClient(),
+      });
+      search._initialResults = {
+        indexName: new SearchResults(new SearchParameters(), [
+          createSingleSearchResponse({
+            hits: [{ objectID: '1' }, { objectID: '2' }, { objectID: '3' }],
+          }),
+        ]),
+      };
+      const renderFn = jest.fn();
+
+      const customHits = connectHits(renderFn);
+
+      search.addWidgets([customHits({})]);
+      search.start();
+      await wait(0);
+
+      const receivedHits = renderFn.mock.calls[1][0].hits;
+      expect(receivedHits).toEqual([
+        expect.objectContaining({ objectID: '1' }),
+        expect.objectContaining({ objectID: '2' }),
+        expect.objectContaining({ objectID: '3' }),
+      ]);
     });
   });
 });

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -479,8 +479,8 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
         // We restore the shape of the results provided to the instance to respect
         // the helper's structure.
         const results = new algoliasearchHelper.SearchResults(
-          new algoliasearchHelper.SearchParameters(indexInitialResults._state),
-          indexInitialResults._rawResults
+          new algoliasearchHelper.SearchParameters(indexInitialResults.state),
+          indexInitialResults.results
         );
 
         derivedHelper.lastResults = results;

--- a/src/widgets/index/index.ts
+++ b/src/widgets/index/index.ts
@@ -472,6 +472,21 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
         mergeSearchParameters(...resolveSearchParameters(this))
       );
 
+      const indexInitialResults =
+        instantSearchInstance._initialResults?.[this.getIndexId()];
+
+      if (indexInitialResults) {
+        // We restore the shape of the results provided to the instance to respect
+        // the helper's structure.
+        const results = new algoliasearchHelper.SearchResults(
+          new algoliasearchHelper.SearchParameters(indexInitialResults._state),
+          indexInitialResults._rawResults
+        );
+
+        derivedHelper.lastResults = results;
+        helper.lastResults = results;
+      }
+
       // Subscribe to the Helper state changes for the page before widgets
       // are initialized. This behavior mimics the original one of the Helper.
       // It makes sense to replicate it at the `init` step. We have another
@@ -590,6 +605,13 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
           instantSearchInstance.onInternalStateChange();
         }
       });
+
+      if (indexInitialResults) {
+        // If there are initial results, we're not notified of the next results
+        // because we don't trigger an initial search. We therefore need to directly
+        // schedule a render that will render the results injected on the helper.
+        instantSearchInstance.scheduleRender();
+      }
     },
 
     render({ instantSearchInstance }: IndexRenderOptions) {

--- a/test/mock/createInstantSearch.ts
+++ b/test/mock/createInstantSearch.ts
@@ -36,6 +36,7 @@ export const createInstantSearch = (
     _stalledSearchDelay: 200,
     _searchStalledTimer: null,
     _initialUiState: {},
+    _initialResults: null,
     _createURL: jest.fn(() => '#'),
     onStateChange: null,
     setUiState: jest.fn(),


### PR DESCRIPTION
## Description

This adds supports for initial results in InstantSearch.js. This API is required to implement the React InstantSearch Hooks SSR API (see [RFC](https://github.com/algolia/instantsearch-rfcs/blob/843996b214aee8dcb389bcad46135f90dd51ebda/accepted/react-instantsearch-ssr/react-instantsearch-ssr.md)).

This private API is released silently at first. It doesn't expose a public API as an option, but support the private `_initialResults` field attached to the search instance. We'll silently release it to keep room for changes before introducing the official InstantSearch.js SSR API.

When initial results are provided, we don't trigger an initial search (which skips the initial network request on the browser), but directly inject the results to each index' helper and render. We're able to skip this initial request by assigning a noop to `scheduleSearch` until widgets are added (this supports both statically and dynamically added widgets).

## Private usage

In React InstantSearch Hooks (and in the future, in Vue InstantSearch), we're able to use the API as follows:

```js
const search = instantsearch(props);
search._initialResults = {
  indexName: {
    state: {
      query: 'iphone',
    },
    results: [
      createSingleSearchResponse({
        query: 'iphone',
        hits: [{ objectID: '1' }, { objectID: '2' }, { objectID: '3' }],
      }),
    ],
  },
};
search.start();
```