### PR TITLE
feat(DynamicWidgets): throw when transformItems returns a non array

### DIFF
--- a/src/connectors/dynamic-widgets/__tests__/connectDynamicWidgets-test.ts
+++ b/src/connectors/dynamic-widgets/__tests__/connectDynamicWidgets-test.ts
@@ -182,11 +182,12 @@ describe('connectDynamicWidgets', () => {
         const renderFn = jest.fn();
         const widgetParams = {
           transformItems() {
-            // @ts-expect-error
             return null;
           },
           widgets: [],
         };
+
+        // @ts-expect-error
         const dynamicWidgets = connectDynamicWidgets(renderFn)(widgetParams);
 
         expect(() => {

--- a/src/connectors/dynamic-widgets/__tests__/connectDynamicWidgets-test.ts
+++ b/src/connectors/dynamic-widgets/__tests__/connectDynamicWidgets-test.ts
@@ -177,6 +177,27 @@ describe('connectDynamicWidgets', () => {
           false
         );
       });
+
+      it('fails when transformItems returns anything else than an array', () => {
+        const renderFn = jest.fn();
+        const widgetParams = {
+          transformItems() {
+            return null as any;
+          },
+          widgets: [],
+        };
+        const dynamicWidgets = connectDynamicWidgets(renderFn)(
+          widgetParams
+        );
+
+        expect(() => {
+          dynamicWidgets.render!(createRenderOptions());
+        }).toThrowErrorMatchingInlineSnapshot(`
+          "The \`transformItems\` option expects a function that returns an Array.
+
+          See documentation: https://www.algolia.com/doc/api-reference/widgets/dynamic-widgets/js/#connector"
+        `);
+      });
     });
 
     describe('widgets', () => {

--- a/src/connectors/dynamic-widgets/__tests__/connectDynamicWidgets-test.ts
+++ b/src/connectors/dynamic-widgets/__tests__/connectDynamicWidgets-test.ts
@@ -178,11 +178,12 @@ describe('connectDynamicWidgets', () => {
         );
       });
 
-      it('fails when transformItems returns anything else than an array', () => {
+      it('throws when transformItems returns anything else than an array', () => {
         const renderFn = jest.fn();
         const widgetParams = {
           transformItems() {
-            return null as any;
+            // @ts-expect-error
+            return null;
           },
           widgets: [],
         };

--- a/src/connectors/dynamic-widgets/__tests__/connectDynamicWidgets-test.ts
+++ b/src/connectors/dynamic-widgets/__tests__/connectDynamicWidgets-test.ts
@@ -186,9 +186,7 @@ describe('connectDynamicWidgets', () => {
           },
           widgets: [],
         };
-        const dynamicWidgets = connectDynamicWidgets(renderFn)(
-          widgetParams
-        );
+        const dynamicWidgets = connectDynamicWidgets(renderFn)(widgetParams);
 
         expect(() => {
           dynamicWidgets.render!(createRenderOptions());

--- a/src/connectors/dynamic-widgets/connectDynamicWidgets.ts
+++ b/src/connectors/dynamic-widgets/connectDynamicWidgets.ts
@@ -172,7 +172,7 @@ const connectDynamicWidgets: DynamicWidgetsConnector =
             { results }
           );
 
-          if (!Array.isArray(transformedAttributesToRender)) {
+          if (!Array.isArray(attributesToRender)) {
             throw new Error(
               withUsage(
                 'The `transformItems` option expects a function that returns an Array.'
@@ -181,7 +181,7 @@ const connectDynamicWidgets: DynamicWidgetsConnector =
           }
 
           return {
-            attributesToRender: transformedAttributesToRender,
+            attributesToRender,
             widgetParams,
           };
         },

--- a/src/connectors/dynamic-widgets/connectDynamicWidgets.ts
+++ b/src/connectors/dynamic-widgets/connectDynamicWidgets.ts
@@ -170,8 +170,21 @@ const connectDynamicWidgets: DynamicWidgetsConnector =
           const attributesToRender =
             results.renderingContent?.facetOrdering?.facets?.order ?? [];
 
+          const transformedAttributesToRender = transformItems(
+            attributesToRender,
+            { results }
+          );
+
+          if (!Array.isArray(transformedAttributesToRender)) {
+            throw new Error(
+              withUsage(
+                'The `transformItems` option expects a function that returns an Array.'
+              )
+            );
+          }
+
           return {
-            attributesToRender: transformItems(attributesToRender, { results }),
+            attributesToRender: transformedAttributesToRender,
             widgetParams,
           };
         },

--- a/src/connectors/dynamic-widgets/connectDynamicWidgets.ts
+++ b/src/connectors/dynamic-widgets/connectDynamicWidgets.ts
@@ -167,11 +167,8 @@ const connectDynamicWidgets: DynamicWidgetsConnector =
             return { attributesToRender: [], widgetParams };
           }
 
-          const attributesToRender =
-            results.renderingContent?.facetOrdering?.facets?.order ?? [];
-
-          const transformedAttributesToRender = transformItems(
-            attributesToRender,
+          const attributesToRender = transformItems(
+            results.renderingContent?.facetOrdering?.facets?.order ?? [],
             { results }
           );
 


### PR DESCRIPTION
`transformItems` implementations can get complicated and if you're not
cautious, it's very easy to have it return something other than an
array.

When this happens, the errors you get are not insightful on where the
mistake is.

```
TypeError: Cannot read property 'forEach' of undefined
```

This change helps the user identify this type of mistakes.
It adds a check on `transformItems` output to make sure it returns an
array.

closes FX-608

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->