### PR TITLE
fix(connectBreadcrumb): returns an empty array if no hierarchicalFacets exist

### DIFF
--- a/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.ts
+++ b/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.ts
@@ -180,7 +180,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
   });
 
   describe('getWidgetRenderState', () => {
-    test('returns the widget render state', () => {
+    it('returns the widget render state', () => {
       const renderFn = jest.fn();
       const unmountFn = jest.fn();
       const createBreadcrumb = connectBreadcrumb(renderFn, unmountFn);
@@ -244,6 +244,48 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
         canRefine: true,
         createURL: expect.any(Function),
         items: [{ label: 'Decoration', value: null }],
+        refine: expect.any(Function),
+        widgetParams: { attributes: ['category', 'subCategory'] },
+      });
+    });
+
+    it('returns an empty array of items if no hierarchicalFacets exist', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const createBreadcrumb = connectBreadcrumb(renderFn, unmountFn);
+      const breadcrumb = createBreadcrumb({
+        attributes: ['category', 'subCategory'],
+      });
+      const helper = algoliasearchHelper(createSearchClient(), 'indexName');
+
+      const results = new algoliasearchHelper.SearchResults(helper.state, [
+        {
+          query: helper.state.query ?? '',
+          page: helper.state.page ?? 0,
+          hitsPerPage: helper.state.hitsPerPage ?? 20,
+          hits: [],
+          nbHits: 0,
+          nbPages: 0,
+          params: '',
+          exhaustiveNbHits: true,
+          exhaustiveFacetsCount: true,
+          processingTimeMS: 0,
+          index: helper.state.index,
+        },
+      ]);
+
+      const renderState = breadcrumb.getWidgetRenderState(
+        createRenderOptions({
+          helper,
+          results,
+          state: results._state,
+        })
+      );
+
+      expect(renderState).toEqual({
+        canRefine: false,
+        createURL: expect.any(Function),
+        items: [],
         refine: expect.any(Function),
         widgetParams: { attributes: ['category', 'subCategory'] },
       });

--- a/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.ts
+++ b/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.ts
@@ -290,6 +290,35 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
         widgetParams: { attributes: ['category', 'subCategory'] },
       });
     });
+
+    const renderFn = jest.fn();
+    test('refine method called with null does not mutate the current helper state if no hierarchicalFacets exist', () => {
+      const unmountFn = jest.fn();
+      const createBreadcrumb = connectBreadcrumb(renderFn, unmountFn);
+      const breadcrumb = createBreadcrumb({
+        attributes: ['category', 'subCategory'],
+      });
+      const helper = algoliasearchHelper(createSearchClient(), 'indexName');
+
+      const renderState = breadcrumb.getWidgetRenderState(
+        createInitOptions({ helper })
+      );
+
+      renderState.refine(null);
+
+      expect(helper.state).toEqual({
+        facets: [],
+        disjunctiveFacets: [],
+        hierarchicalFacets: [],
+        facetsRefinements: {},
+        facetsExcludes: {},
+        disjunctiveFacetsRefinements: {},
+        numericRefinements: {},
+        tagRefinements: [],
+        hierarchicalFacetsRefinements: {},
+        index: 'indexName',
+      });
+    });
   });
 
   describe('getWidgetSearchParameters', () => {

--- a/src/connectors/breadcrumb/connectBreadcrumb.ts
+++ b/src/connectors/breadcrumb/connectBreadcrumb.ts
@@ -132,7 +132,9 @@ const connectBreadcrumb: BreadcrumbConnector = function connectBreadcrumb(
         const breadcrumb = state.getHierarchicalFacetBreadcrumb(
           hierarchicalFacetName
         );
-        if (breadcrumb.length > 0) {
+        if (breadcrumb.length === 0) {
+          return state;
+        } else {
           return state
             .resetPage()
             .toggleFacetRefinement(hierarchicalFacetName, breadcrumb[0]);

--- a/src/connectors/breadcrumb/connectBreadcrumb.ts
+++ b/src/connectors/breadcrumb/connectBreadcrumb.ts
@@ -182,7 +182,7 @@ const connectBreadcrumb: BreadcrumbConnector = function connectBreadcrumb(
 
       getWidgetRenderState({ helper, createURL, results, state }) {
         function getItems() {
-          if (!results) {
+          if (!results || state.hierarchicalFacets.length === 0) {
             return [];
           }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

- [x] returns an empty array of items if no `hierarchicalFacets` exist
- [x] refine to `null` throws an error if no `hierarchicalFacets` exist

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

This PR fixes an error we had implementing the hook `useBreadcrumb` in React InstantSearch Hooks.

It also fixes an error when refine to `null` is called (usually used when you click on the "Home" link to clear the current refinement) when no `hierarchicalFacets` exist.