### PR TITLE
fix(events): emit error as typeof Error

### DIFF
--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -479,9 +479,14 @@ See ${createDocumentationLink({
     // Only the "main" Helper emits the `error` event vs the one for `search`
     // and `results` that are also emitted on the derived one.
     mainHelper.on('error', ({ error }) => {
-      this.emit('error', {
-        error,
-      });
+      // If an error is emitted, it is re-thrown by events. In previous versions
+      // we emitted {error}, which is thrown as:
+      // "Uncaught, unspecified \"error\" event. ([object Object])"
+      // To avoid breaking changes, we make the error available in both
+      // `error` and `error.error`
+      // @MAJOR emit only error
+      (error as any).error = error;
+      this.emit('error', error);
     });
 
     this.mainHelper = mainHelper;


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

If an uncaught error is thrown (eg. from the search engine) we want to throw that as is and not `Uncaught, unspecified \"error\" event. ([object Object])`

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

- uncaught error events are thrown as normal
- existing way of handling errors still works (`.on('error', ({ error }) => {})`)
