### PR TITLE
fix(es): mark inner package.json as side-effect free

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build": "yarn run build:cjs && yarn run build:es && yarn run build:umd && yarn run build:types",
     "build:umd": "rm -rf dist && BABEL_ENV=umd rollup --config scripts/rollup/config.js",
     "build:cjs": "rm -rf cjs && BABEL_ENV=cjs babel src --extensions '.js,.ts,.tsx' --out-dir cjs/ --ignore 'src/index.es.ts','**/__tests__','**/__mocks__' --quiet",
-    "build:es": "rm -rf es && BABEL_ENV=es babel src --extensions '.js,.ts,.tsx' --out-dir es/ --ignore 'src/index.es.ts','**/__tests__','**/__mocks__' --quiet && BABEL_ENV=es babel src/index.es.ts --out-file es/index.js --quiet && echo '{\"type\":\"module\"}' > es/package.json",
+    "build:es": "rm -rf es && BABEL_ENV=es babel src --extensions '.js,.ts,.tsx' --out-dir es/ --ignore 'src/index.es.ts','**/__tests__','**/__mocks__' --quiet && BABEL_ENV=es babel src/index.es.ts --out-file es/index.js --quiet && echo '{\"type\":\"module\",\"sideEffects\":false}' > es/package.json",
     "build:types": "./scripts/typescript/extract.js",
     "doctoc": "doctoc --no-title --maxlevel 3 README.md CONTRIBUTING.md",
     "storybook": "start-storybook --quiet --port 6006 --ci --static-dir .storybook/static",


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

some (older) versions of rollup (like the one we use in react instantsearch) don't look at the root package.json, but only at the closest for sideEffects, and thus this change added in #4971 caused a regression in bundle size (notably from Hogan being included)

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

The package.json for /es now is marked as side-effect free

No new test was added, as I couldn't think of something, but maybe in the future we could run the React/Vue InstantSearch test suite based on every PR to InstantSearch? 
