### PR TITLE
fix(helpers): display warning if attribute is cannot be highlighted/snippeted

### DIFF
--- a/src/helpers/__tests__/highlight-test.ts
+++ b/src/helpers/__tests__/highlight-test.ts
@@ -145,4 +145,34 @@ describe('highlight', () => {
       })
     ).toMatchInlineSnapshot(`"Streaming Media Players"`);
   });
+
+  test('warns if attribute does not exist', () => {
+    const trigger = () => {
+      highlight({
+        attribute: 'does.not.exist',
+        hit,
+      });
+    };
+
+    expect(trigger)
+      .toWarnDev(`[InstantSearch.js]: Could not enable highlight for "does.not.exist", will display an empty string.
+Please check whether this attribute exists and is either searchable or specified in \`attributesToHighlight\`.
+
+See: https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/highlighting-snippeting/js/`);
+  });
+
+  test('warns if attribute does not have highlighting', () => {
+    const trigger = () => {
+      highlight({
+        attribute: 'link',
+        hit,
+      });
+    };
+
+    expect(trigger)
+      .toWarnDev(`[InstantSearch.js]: Could not enable highlight for "link", will display an empty string.
+Please check whether this attribute exists and is either searchable or specified in \`attributesToHighlight\`.
+
+See: https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/highlighting-snippeting/js/`);
+  });
 });

--- a/src/helpers/__tests__/highlight-test.ts
+++ b/src/helpers/__tests__/highlight-test.ts
@@ -158,7 +158,7 @@ describe('highlight', () => {
       .toWarnDev(`[InstantSearch.js]: Could not enable highlight for "does.not.exist", will display an empty string.
 Please check whether this attribute exists and is either searchable or specified in \`attributesToHighlight\`.
 
-See: https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/highlighting-snippeting/js/`);
+See: https://alg.li/highlighting`);
   });
 
   test('warns if attribute does not have highlighting', () => {
@@ -173,6 +173,6 @@ See: https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/hi
       .toWarnDev(`[InstantSearch.js]: Could not enable highlight for "link", will display an empty string.
 Please check whether this attribute exists and is either searchable or specified in \`attributesToHighlight\`.
 
-See: https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/highlighting-snippeting/js/`);
+See: https://alg.li/highlighting`);
   });
 });

--- a/src/helpers/__tests__/reverseHighlight-test.ts
+++ b/src/helpers/__tests__/reverseHighlight-test.ts
@@ -211,7 +211,7 @@ describe('reverseHighlight', () => {
       .toWarnDev(`[InstantSearch.js]: Could not enable reverse highlight for "does.not.exist", will display an empty string.
 Please check whether this attribute exists and is either searchable or specified in \`attributesToHighlight\`.
 
-See: https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/highlighting-snippeting/js/`);
+See: https://alg.li/highlighting`);
   });
 
   test('warns if attribute does not have highlighting', () => {
@@ -226,6 +226,6 @@ See: https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/hi
       .toWarnDev(`[InstantSearch.js]: Could not enable reverse highlight for "link", will display an empty string.
 Please check whether this attribute exists and is either searchable or specified in \`attributesToHighlight\`.
 
-See: https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/highlighting-snippeting/js/`);
+See: https://alg.li/highlighting`);
   });
 });

--- a/src/helpers/__tests__/reverseHighlight-test.ts
+++ b/src/helpers/__tests__/reverseHighlight-test.ts
@@ -198,4 +198,34 @@ describe('reverseHighlight', () => {
       `"<mark class=\\"ais-ReverseHighlight-highlighted\\">Streaming - (</mark>media<mark class=\\"ais-ReverseHighlight-highlighted\\"> plyr)</mark>"`
     );
   });
+
+  test('warns if attribute does not exist', () => {
+    const trigger = () => {
+      reverseHighlight({
+        attribute: 'does.not.exist',
+        hit,
+      });
+    };
+
+    expect(trigger)
+      .toWarnDev(`[InstantSearch.js]: Could not enable reverse highlight for "does.not.exist", will display an empty string.
+Please check whether this attribute exists and is either searchable or specified in \`attributesToHighlight\`.
+
+See: https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/highlighting-snippeting/js/`);
+  });
+
+  test('warns if attribute does not have highlighting', () => {
+    const trigger = () => {
+      reverseHighlight({
+        attribute: 'link',
+        hit,
+      });
+    };
+
+    expect(trigger)
+      .toWarnDev(`[InstantSearch.js]: Could not enable reverse highlight for "link", will display an empty string.
+Please check whether this attribute exists and is either searchable or specified in \`attributesToHighlight\`.
+
+See: https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/highlighting-snippeting/js/`);
+  });
 });

--- a/src/helpers/__tests__/reverseSnippet-test.ts
+++ b/src/helpers/__tests__/reverseSnippet-test.ts
@@ -208,7 +208,7 @@ describe('reverseSnippet', () => {
       .toWarnDev(`[InstantSearch.js]: Could not enable reverse snippet for "does.not.exist", will display an empty string.
 Please check whether this attribute exists and is specified in \`attributesToSnippet\`.
 
-See: https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/highlighting-snippeting/js/`);
+See: https://alg.li/highlighting`);
   });
 
   test('warns if attribute does not have snippeting', () => {
@@ -223,6 +223,6 @@ See: https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/hi
       .toWarnDev(`[InstantSearch.js]: Could not enable reverse snippet for "link", will display an empty string.
 Please check whether this attribute exists and is specified in \`attributesToSnippet\`.
 
-See: https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/highlighting-snippeting/js/`);
+See: https://alg.li/highlighting`);
   });
 });

--- a/src/helpers/__tests__/reverseSnippet-test.ts
+++ b/src/helpers/__tests__/reverseSnippet-test.ts
@@ -195,4 +195,34 @@ describe('reverseSnippet', () => {
       `"<mark class=\\"ais-ReverseSnippet-highlighted\\">Streaming - (</mark>media<mark class=\\"ais-ReverseSnippet-highlighted\\"> plyr)</mark>"`
     );
   });
+
+  test('warns if attribute does not exist', () => {
+    const trigger = () => {
+      reverseSnippet({
+        attribute: 'does.not.exist',
+        hit,
+      });
+    };
+
+    expect(trigger)
+      .toWarnDev(`[InstantSearch.js]: Could not enable reverse snippet for "does.not.exist", will display an empty string.
+Please check whether this attribute exists and is specified in \`attributesToSnippet\`.
+
+See: https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/highlighting-snippeting/js/`);
+  });
+
+  test('warns if attribute does not have snippeting', () => {
+    const trigger = () => {
+      reverseSnippet({
+        attribute: 'link',
+        hit,
+      });
+    };
+
+    expect(trigger)
+      .toWarnDev(`[InstantSearch.js]: Could not enable reverse snippet for "link", will display an empty string.
+Please check whether this attribute exists and is specified in \`attributesToSnippet\`.
+
+See: https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/highlighting-snippeting/js/`);
+  });
 });

--- a/src/helpers/__tests__/snippet-test.ts
+++ b/src/helpers/__tests__/snippet-test.ts
@@ -163,7 +163,7 @@ describe('snippet', () => {
       .toWarnDev(`[InstantSearch.js]: Could not enable snippet for "does.not.exist", will display an empty string.
 Please check whether this attribute exists and is specified in \`attributesToSnippet\`.
 
-See: https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/highlighting-snippeting/js/`);
+See: https://alg.li/highlighting`);
   });
 
   test('warns if attribute does not have snippeting', () => {
@@ -178,6 +178,6 @@ See: https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/hi
       .toWarnDev(`[InstantSearch.js]: Could not enable snippet for "link", will display an empty string.
 Please check whether this attribute exists and is specified in \`attributesToSnippet\`.
 
-See: https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/highlighting-snippeting/js/`);
+See: https://alg.li/highlighting`);
   });
 });

--- a/src/helpers/__tests__/snippet-test.ts
+++ b/src/helpers/__tests__/snippet-test.ts
@@ -150,4 +150,34 @@ describe('snippet', () => {
       })
     ).toMatchInlineSnapshot(`"Streaming Media Players"`);
   });
+
+  test('warns if attribute does not exist', () => {
+    const trigger = () => {
+      snippet({
+        attribute: 'does.not.exist',
+        hit,
+      });
+    };
+
+    expect(trigger)
+      .toWarnDev(`[InstantSearch.js]: Could not enable snippet for "does.not.exist", will display an empty string.
+Please check whether this attribute exists and is specified in \`attributesToSnippet\`.
+
+See: https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/highlighting-snippeting/js/`);
+  });
+
+  test('warns if attribute does not have snippeting', () => {
+    const trigger = () => {
+      snippet({
+        attribute: 'link',
+        hit,
+      });
+    };
+
+    expect(trigger)
+      .toWarnDev(`[InstantSearch.js]: Could not enable snippet for "link", will display an empty string.
+Please check whether this attribute exists and is specified in \`attributesToSnippet\`.
+
+See: https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/highlighting-snippeting/js/`);
+  });
 });

--- a/src/helpers/highlight.ts
+++ b/src/helpers/highlight.ts
@@ -1,6 +1,6 @@
 import type { Hit } from '../types';
 import { component } from '../lib/suit';
-import { getPropertyByPath, TAG_REPLACEMENT } from '../lib/utils';
+import { getPropertyByPath, TAG_REPLACEMENT, warning } from '../lib/utils';
 
 export type HighlightOptions = {
   // @MAJOR string should no longer be allowed to be a path, only array can be a path
@@ -20,8 +20,22 @@ export default function highlight({
   hit,
   cssClasses = {},
 }: HighlightOptions): string {
-  const { value: attributeValue = '' } =
-    getPropertyByPath(hit._highlightResult, attribute) || {};
+  const highlightAttributeResult = getPropertyByPath(
+    hit._highlightResult,
+    attribute
+  );
+
+  // @MAJOR fallback to attribute value if highlight is not found
+  warning(
+    highlightAttributeResult,
+    `Could not enable highlight for "${attribute}", will display an empty string.
+Please check whether this attribute exists and is either searchable or specified in \`attributesToHighlight\`.
+
+See: https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/highlighting-snippeting/js/
+`
+  );
+
+  const { value: attributeValue = '' } = highlightAttributeResult || {};
 
   // cx is not used, since it would be bundled as a dependency for Vue & Angular
   const className =

--- a/src/helpers/highlight.ts
+++ b/src/helpers/highlight.ts
@@ -31,7 +31,7 @@ export default function highlight({
     `Could not enable highlight for "${attribute}", will display an empty string.
 Please check whether this attribute exists and is either searchable or specified in \`attributesToHighlight\`.
 
-See: https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/highlighting-snippeting/js/
+See: https://alg.li/highlighting
 `
   );
 

--- a/src/helpers/reverseHighlight.ts
+++ b/src/helpers/reverseHighlight.ts
@@ -5,6 +5,7 @@ import {
   getHighlightedParts,
   reverseHighlightedParts,
   concatHighlightedParts,
+  warning,
 } from '../lib/utils';
 import { component } from '../lib/suit';
 
@@ -26,8 +27,22 @@ export default function reverseHighlight({
   hit,
   cssClasses = {},
 }: ReverseHighlightOptions): string {
-  const { value: attributeValue = '' } =
-    getPropertyByPath(hit._highlightResult, attribute) || {};
+  const highlightAttributeResult = getPropertyByPath(
+    hit._highlightResult,
+    attribute
+  );
+
+  // @MAJOR fallback to attribute value if highlight is not found
+  warning(
+    highlightAttributeResult,
+    `Could not enable reverse highlight for "${attribute}", will display an empty string.
+Please check whether this attribute exists and is either searchable or specified in \`attributesToHighlight\`.
+
+See: https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/highlighting-snippeting/js/
+`
+  );
+
+  const { value: attributeValue = '' } = highlightAttributeResult || {};
 
   // cx is not used, since it would be bundled as a dependency for Vue & Angular
   const className =

--- a/src/helpers/reverseHighlight.ts
+++ b/src/helpers/reverseHighlight.ts
@@ -38,7 +38,7 @@ export default function reverseHighlight({
     `Could not enable reverse highlight for "${attribute}", will display an empty string.
 Please check whether this attribute exists and is either searchable or specified in \`attributesToHighlight\`.
 
-See: https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/highlighting-snippeting/js/
+See: https://alg.li/highlighting
 `
   );
 

--- a/src/helpers/reverseSnippet.ts
+++ b/src/helpers/reverseSnippet.ts
@@ -5,6 +5,7 @@ import {
   getHighlightedParts,
   reverseHighlightedParts,
   concatHighlightedParts,
+  warning,
 } from '../lib/utils';
 import { component } from '../lib/suit';
 
@@ -26,8 +27,22 @@ export default function reverseSnippet({
   hit,
   cssClasses = {},
 }: ReverseSnippetOptions): string {
-  const { value: attributeValue = '' } =
-    getPropertyByPath(hit._snippetResult, attribute) || {};
+  const snippetAttributeResult = getPropertyByPath(
+    hit._snippetResult,
+    attribute
+  );
+
+  // @MAJOR fallback to attribute value if snippet is not found
+  warning(
+    snippetAttributeResult,
+    `Could not enable reverse snippet for "${attribute}", will display an empty string.
+Please check whether this attribute exists and is specified in \`attributesToSnippet\`.
+
+See: https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/highlighting-snippeting/js/
+`
+  );
+
+  const { value: attributeValue = '' } = snippetAttributeResult || {};
 
   // cx is not used, since it would be bundled as a dependency for Vue & Angular
   const className =

--- a/src/helpers/reverseSnippet.ts
+++ b/src/helpers/reverseSnippet.ts
@@ -38,7 +38,7 @@ export default function reverseSnippet({
     `Could not enable reverse snippet for "${attribute}", will display an empty string.
 Please check whether this attribute exists and is specified in \`attributesToSnippet\`.
 
-See: https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/highlighting-snippeting/js/
+See: https://alg.li/highlighting
 `
   );
 

--- a/src/helpers/snippet.ts
+++ b/src/helpers/snippet.ts
@@ -31,7 +31,7 @@ export default function snippet({
     `Could not enable snippet for "${attribute}", will display an empty string.
 Please check whether this attribute exists and is specified in \`attributesToSnippet\`.
 
-See: https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/highlighting-snippeting/js/
+See: https://alg.li/highlighting
 `
   );
 

--- a/src/helpers/snippet.ts
+++ b/src/helpers/snippet.ts
@@ -1,6 +1,6 @@
 import type { Hit } from '../types';
 import { component } from '../lib/suit';
-import { TAG_REPLACEMENT, getPropertyByPath } from '../lib/utils';
+import { TAG_REPLACEMENT, getPropertyByPath, warning } from '../lib/utils';
 
 export type SnippetOptions = {
   // @MAJOR string should no longer be allowed to be a path, only array can be a path
@@ -20,8 +20,22 @@ export default function snippet({
   hit,
   cssClasses = {},
 }: SnippetOptions): string {
-  const { value: attributeValue = '' } =
-    getPropertyByPath(hit._snippetResult, attribute) || {};
+  const snippetAttributeResult = getPropertyByPath(
+    hit._snippetResult,
+    attribute
+  );
+
+  // @MAJOR fallback to attribute value if snippet is not found
+  warning(
+    snippetAttributeResult,
+    `Could not enable snippet for "${attribute}", will display an empty string.
+Please check whether this attribute exists and is specified in \`attributesToSnippet\`.
+
+See: https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/highlighting-snippeting/js/
+`
+  );
+
+  const { value: attributeValue = '' } = snippetAttributeResult || {};
 
   // cx is not used, since it would be bundled as a dependency for Vue & Angular
   const className =


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR shows a helpful warning in dev environment when an attribute cannot be highlighted or snippeted.
It's an adaptation from a similar message in the custom highlight implementation in Angular.

**Result**

![image](https://user-images.githubusercontent.com/154633/150797199-d3eabb06-ee76-4be9-802e-9fb59d3aeff7.png)
