### PR TITLE
feat(connectors): expose search results to `transformItems` when available

### DIFF
--- a/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.ts
+++ b/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.ts
@@ -798,12 +798,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
       uiState: {},
     });
     const helper = algoliasearchHelper(createSearchClient(), '', config);
+    const results = new SearchResults(helper.state, [
+      createSingleSearchResponse(),
+    ]);
+
     widget.init!(createInitOptions({ helper, state: helper.state }));
     widget.render!(
       createRenderOptions({
-        results: new SearchResults(helper.state, [
-          createSingleSearchResponse(),
-        ]),
+        results,
         state: helper.state,
         helper,
       })
@@ -811,9 +813,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
 
     expect(transformItems).lastCalledWith(
       expect.anything(),
-      expect.objectContaining({
-        results: expect.objectContaining({ _state: helper.state }),
-      })
+      expect.objectContaining({ results })
     );
   });
 

--- a/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.ts
+++ b/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.ts
@@ -786,6 +786,37 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
     ]);
   });
 
+  it('provides search results within transformItems', () => {
+    const transformItems = jest.fn((items) => items);
+    const makeWidget = connectBreadcrumb(() => {});
+    const widget = makeWidget({
+      attributes: ['category'],
+      transformItems,
+    });
+
+    const config = widget.getWidgetSearchParameters!(new SearchParameters(), {
+      uiState: {},
+    });
+    const helper = algoliasearchHelper(createSearchClient(), '', config);
+    widget.init!(createInitOptions({ helper, state: helper.state }));
+    widget.render!(
+      createRenderOptions({
+        results: new SearchResults(helper.state, [
+          createSingleSearchResponse(),
+        ]),
+        state: helper.state,
+        helper,
+      })
+    );
+
+    expect(transformItems).lastCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        results: expect.objectContaining({ _state: helper.state }),
+      })
+    );
+  });
+
   it('returns the correct URL', () => {
     const rendering = jest.fn();
     const makeWidget = connectBreadcrumb(rendering);

--- a/src/connectors/breadcrumb/connectBreadcrumb.ts
+++ b/src/connectors/breadcrumb/connectBreadcrumb.ts
@@ -112,8 +112,9 @@ const connectBreadcrumb: BreadcrumbConnector = function connectBreadcrumb(
       attributes,
       separator = ' > ',
       rootPath = null,
-      transformItems = ((items) =>
-        items) as TransformItems<BreadcrumbConnectorParamsItem>,
+      transformItems = ((items) => items) as NonNullable<
+        BreadcrumbConnectorParams['transformItems']
+      >,
     } = widgetParams || {};
 
     if (!attributes || !Array.isArray(attributes) || attributes.length === 0) {
@@ -198,7 +199,9 @@ const connectBreadcrumb: BreadcrumbConnector = function connectBreadcrumb(
             {}
           ) as SearchResults.HierarchicalFacet;
           const data = Array.isArray(facetValues.data) ? facetValues.data : [];
-          const items = transformItems(shiftItemsValues(prepareItems(data)));
+          const items = transformItems(shiftItemsValues(prepareItems(data)), {
+            results,
+          });
 
           return items;
         }

--- a/src/connectors/clear-refinements/__tests__/connectClearRefinements-test.ts
+++ b/src/connectors/clear-refinements/__tests__/connectClearRefinements-test.ts
@@ -827,21 +827,23 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/clear-refin
 
     it('provides search results within transformItems', () => {
       const transformItems = jest.fn((items) => items);
-      const helper = algoliasearchHelper(createSearchClient(), '', {
-        facets: ['facet1'],
-      });
       const makeWidget = connectClearRefinements(() => {});
       const widget = makeWidget({
         includedAttributes: ['facet1'],
         transformItems,
       });
 
+      const helper = algoliasearchHelper(createSearchClient(), '', {
+        facets: ['facet1'],
+      });
+      const results = new SearchResults(helper.state, [
+        createSingleSearchResponse(),
+      ]);
+
       widget.init!(createInitOptions({ helper, state: helper.state }));
       widget.render!(
         createRenderOptions({
-          results: new SearchResults(helper.state, [
-            createSingleSearchResponse(),
-          ]),
+          results,
           helper,
           state: helper.state,
         })
@@ -849,9 +851,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/clear-refin
 
       expect(transformItems).lastCalledWith(
         expect.anything(),
-        expect.objectContaining({
-          results: expect.objectContaining({ _state: helper.state }),
-        })
+        expect.objectContaining({ results })
       );
     });
 

--- a/src/connectors/clear-refinements/__tests__/connectClearRefinements-test.ts
+++ b/src/connectors/clear-refinements/__tests__/connectClearRefinements-test.ts
@@ -825,6 +825,36 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/clear-refin
       expect(rendering.mock.calls[2][0].canRefine).toBe(false);
     });
 
+    it('provides search results within transformItems', () => {
+      const transformItems = jest.fn((items) => items);
+      const helper = algoliasearchHelper(createSearchClient(), '', {
+        facets: ['facet1'],
+      });
+      const makeWidget = connectClearRefinements(() => {});
+      const widget = makeWidget({
+        includedAttributes: ['facet1'],
+        transformItems,
+      });
+
+      widget.init!(createInitOptions({ helper, state: helper.state }));
+      widget.render!(
+        createRenderOptions({
+          results: new SearchResults(helper.state, [
+            createSingleSearchResponse(),
+          ]),
+          helper,
+          state: helper.state,
+        })
+      );
+
+      expect(transformItems).lastCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          results: expect.objectContaining({ _state: helper.state }),
+        })
+      );
+    });
+
     describe('createURL', () => {
       it('consistent with the list of excludedAttributes', () => {
         const helper = algoliasearchHelper(createSearchClient(), 'indexName', {

--- a/src/connectors/current-refinements/__tests__/connectCurrentRefinements-test.ts
+++ b/src/connectors/current-refinements/__tests__/connectCurrentRefinements-test.ts
@@ -608,12 +608,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
         transformItems,
       });
 
+      const results = new SearchResults(helper.state, [
+        createSingleSearchResponse(),
+      ]);
+
       widget.init!(createInitOptions({ helper, state: helper.state }));
       widget.render!(
         createRenderOptions({
-          results: new SearchResults(helper.state, [
-            createSingleSearchResponse(),
-          ]),
+          results,
           state: helper.state,
           helper,
         })
@@ -621,9 +623,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
 
       expect(transformItems).lastCalledWith(
         expect.anything(),
-        expect.objectContaining({
-          results: expect.objectContaining({ _state: helper.state }),
-        })
+        expect.objectContaining({ results })
       );
     });
 

--- a/src/connectors/current-refinements/__tests__/connectCurrentRefinements-test.ts
+++ b/src/connectors/current-refinements/__tests__/connectCurrentRefinements-test.ts
@@ -601,6 +601,32 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
       );
     });
 
+    it('provides search results within transformItems', () => {
+      const transformItems = jest.fn((items) => items);
+      const customCurrentRefinements = connectCurrentRefinements(() => {});
+      const widget = customCurrentRefinements({
+        transformItems,
+      });
+
+      widget.init!(createInitOptions({ helper, state: helper.state }));
+      widget.render!(
+        createRenderOptions({
+          results: new SearchResults(helper.state, [
+            createSingleSearchResponse(),
+          ]),
+          state: helper.state,
+          helper,
+        })
+      );
+
+      expect(transformItems).lastCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          results: expect.objectContaining({ _state: helper.state }),
+        })
+      );
+    });
+
     it('sort numeric refinements by numeric value', () => {
       const rendering = jest.fn();
       const customCurrentRefinements = connectCurrentRefinements(rendering);

--- a/src/connectors/current-refinements/connectCurrentRefinements.ts
+++ b/src/connectors/current-refinements/connectCurrentRefinements.ts
@@ -173,8 +173,9 @@ const connectCurrentRefinements: CurrentRefinementsConnector =
       const {
         includedAttributes,
         excludedAttributes = ['query'],
-        transformItems = (items: CurrentRefinementsConnectorParamsItem[]) =>
-          items,
+        transformItems = ((items) => items) as NonNullable<
+          CurrentRefinementsConnectorParams['transformItems']
+        >,
       } = widgetParams || {};
 
       return {
@@ -224,7 +225,8 @@ const connectCurrentRefinements: CurrentRefinementsConnector =
                   helper,
                   includedAttributes,
                   excludedAttributes,
-                })
+                }),
+                { results }
               );
             }
 
@@ -238,7 +240,8 @@ const connectCurrentRefinements: CurrentRefinementsConnector =
                     helper: scopedResult.helper,
                     includedAttributes,
                     excludedAttributes,
-                  })
+                  }),
+                  { results }
                 )
               );
             }, []);

--- a/src/connectors/dynamic-widgets/__tests__/connectDynamicWidgets-test.ts
+++ b/src/connectors/dynamic-widgets/__tests__/connectDynamicWidgets-test.ts
@@ -286,7 +286,7 @@ describe('connectDynamicWidgets', () => {
       it('renders widgets returned by transformItems', async () => {
         const dynamicWidgets = connectDynamicWidgets(() => {})({
           transformItems(_items, { results }) {
-            return results.userData[0].MOCK_facetOrder;
+            return results!.userData[0].MOCK_facetOrder;
           },
           fallbackWidget: ({ attribute }) =>
             connectRefinementList(() => {})({ attribute }),

--- a/src/connectors/dynamic-widgets/__tests__/connectDynamicWidgets-test.ts
+++ b/src/connectors/dynamic-widgets/__tests__/connectDynamicWidgets-test.ts
@@ -7,7 +7,10 @@ import {
   createRenderOptions,
 } from '../../../../test/mock/createWidget';
 import { wait } from '../../../../test/utils/wait';
-import { SearchParameters, SearchResults } from 'algoliasearch-helper';
+import algoliasearchHelper, {
+  SearchParameters,
+  SearchResults,
+} from 'algoliasearch-helper';
 import {
   createMultiSearchResponse,
   createSingleSearchResponse,
@@ -15,6 +18,7 @@ import {
 import connectHierarchicalMenu from '../../hierarchical-menu/connectHierarchicalMenu';
 import type { DynamicWidgetsConnectorParams } from '../connectDynamicWidgets';
 import connectRefinementList from '../../refinement-list/connectRefinementList';
+import { createSearchClient } from '../../../../test/mock/createSearchClient';
 
 expect.addSnapshotSerializer(widgetSnapshotSerializer);
 
@@ -626,6 +630,33 @@ describe('connectDynamicWidgets', () => {
         attributesToRender: ['test2', 'test1'],
         widgetParams,
       });
+    });
+
+    it('provides search results within transformItems', () => {
+      const transformItems = jest.fn((items) => items);
+      const dynamicWidgets = connectDynamicWidgets(() => {})({
+        transformItems,
+        widgets: [],
+      });
+
+      const helper = algoliasearchHelper(createSearchClient(), '');
+
+      dynamicWidgets.getWidgetRenderState(
+        createRenderOptions({
+          results: new SearchResults(helper.state, [
+            createSingleSearchResponse(),
+          ]),
+          state: helper.state,
+          helper,
+        })
+      );
+
+      expect(transformItems).lastCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          results: expect.objectContaining({ _state: helper.state }),
+        })
+      );
     });
 
     it('warns when facets is unset and more than 20 items are returned from attributesToDisplay', () => {

--- a/src/connectors/dynamic-widgets/__tests__/connectDynamicWidgets-test.ts
+++ b/src/connectors/dynamic-widgets/__tests__/connectDynamicWidgets-test.ts
@@ -640,12 +640,13 @@ describe('connectDynamicWidgets', () => {
       });
 
       const helper = algoliasearchHelper(createSearchClient(), '');
+      const results = new SearchResults(helper.state, [
+        createSingleSearchResponse(),
+      ]);
 
       dynamicWidgets.getWidgetRenderState(
         createRenderOptions({
-          results: new SearchResults(helper.state, [
-            createSingleSearchResponse(),
-          ]),
+          results,
           state: helper.state,
           helper,
         })
@@ -653,9 +654,7 @@ describe('connectDynamicWidgets', () => {
 
       expect(transformItems).lastCalledWith(
         expect.anything(),
-        expect.objectContaining({
-          results: expect.objectContaining({ _state: helper.state }),
-        })
+        expect.objectContaining({ results })
       );
     });
 

--- a/src/connectors/dynamic-widgets/__tests__/connectDynamicWidgets-test.ts
+++ b/src/connectors/dynamic-widgets/__tests__/connectDynamicWidgets-test.ts
@@ -290,7 +290,7 @@ describe('connectDynamicWidgets', () => {
       it('renders widgets returned by transformItems', async () => {
         const dynamicWidgets = connectDynamicWidgets(() => {})({
           transformItems(_items, { results }) {
-            return results!.userData[0].MOCK_facetOrder;
+            return results.userData[0].MOCK_facetOrder;
           },
           fallbackWidget: ({ attribute }) =>
             connectRefinementList(() => {})({ attribute }),

--- a/src/connectors/dynamic-widgets/connectDynamicWidgets.ts
+++ b/src/connectors/dynamic-widgets/connectDynamicWidgets.ts
@@ -1,3 +1,5 @@
+import type { SearchResults } from 'algoliasearch-helper';
+
 import {
   checkRendering,
   createDocumentationMessageGenerator,
@@ -35,7 +37,7 @@ export type DynamicWidgetsConnectorParams = {
    * Function to transform the items to render.
    * The function also exposes the full search response.
    */
-  transformItems?: TransformItems<string>;
+  transformItems?: TransformItems<string, { results: SearchResults }>;
 
   /**
    * To prevent unneeded extra network requests when widgets mount or unmount,

--- a/src/connectors/dynamic-widgets/connectDynamicWidgets.ts
+++ b/src/connectors/dynamic-widgets/connectDynamicWidgets.ts
@@ -1,5 +1,3 @@
-import type { SearchResults } from 'algoliasearch-helper';
-
 import {
   checkRendering,
   createDocumentationMessageGenerator,
@@ -7,7 +5,12 @@ import {
   noop,
   warning,
 } from '../../lib/utils';
-import type { Connector, TransformItems, Widget } from '../../types';
+import type {
+  Connector,
+  TransformItems,
+  TransformItemsMetadata,
+  Widget,
+} from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'dynamic-widgets',
@@ -37,7 +40,12 @@ export type DynamicWidgetsConnectorParams = {
    * Function to transform the items to render.
    * The function also exposes the full search response.
    */
-  transformItems?: TransformItems<string, { results: SearchResults }>;
+  transformItems?: TransformItems<
+    string,
+    Omit<TransformItemsMetadata, 'results'> & {
+      results: NonNullable<TransformItemsMetadata['results']>;
+    }
+  >;
 
   /**
    * To prevent unneeded extra network requests when widgets mount or unmount,

--- a/src/connectors/dynamic-widgets/connectDynamicWidgets.ts
+++ b/src/connectors/dynamic-widgets/connectDynamicWidgets.ts
@@ -1,4 +1,3 @@
-import type { SearchResults } from 'algoliasearch-helper';
 import {
   checkRendering,
   createDocumentationMessageGenerator,
@@ -6,7 +5,7 @@ import {
   noop,
   warning,
 } from '../../lib/utils';
-import type { Connector, Widget } from '../../types';
+import type { Connector, TransformItems, Widget } from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'dynamic-widgets',
@@ -36,10 +35,7 @@ export type DynamicWidgetsConnectorParams = {
    * Function to transform the items to render.
    * The function also exposes the full search response.
    */
-  transformItems?(
-    items: string[],
-    metadata: { results: SearchResults }
-  ): string[];
+  transformItems?: TransformItems<string>;
 
   /**
    * To prevent unneeded extra network requests when widgets mount or unmount,

--- a/src/connectors/geo-search/__tests__/connectGeoSearch-test.ts
+++ b/src/connectors/geo-search/__tests__/connectGeoSearch-test.ts
@@ -396,6 +396,33 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
     );
   });
 
+  it('expect to provide search results within transformItems', () => {
+    const transformItems = jest.fn((items) => items);
+    const customGeoSearch = connectGeoSearch(() => {});
+    const widget = customGeoSearch({
+      transformItems,
+    });
+
+    const helper = createFakeHelper();
+
+    widget.init!(createInitOptions({ helper, state: helper.state }));
+    widget.render!(
+      createRenderOptions({
+        results: new SearchResults(helper.state, [
+          createSingleSearchResponse(),
+        ]),
+        helper,
+      })
+    );
+
+    expect(transformItems).lastCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        results: expect.objectContaining({ _state: helper.state }),
+      })
+    );
+  });
+
   it('expect to reset the map state when position changed', () => {
     const render = jest.fn();
     const unmount = jest.fn();

--- a/src/connectors/geo-search/__tests__/connectGeoSearch-test.ts
+++ b/src/connectors/geo-search/__tests__/connectGeoSearch-test.ts
@@ -404,22 +404,21 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/geo-search/
     });
 
     const helper = createFakeHelper();
+    const results = new SearchResults(helper.state, [
+      createSingleSearchResponse(),
+    ]);
 
     widget.init!(createInitOptions({ helper, state: helper.state }));
     widget.render!(
       createRenderOptions({
-        results: new SearchResults(helper.state, [
-          createSingleSearchResponse(),
-        ]),
+        results,
         helper,
       })
     );
 
     expect(transformItems).lastCalledWith(
       expect.anything(),
-      expect.objectContaining({
-        results: expect.objectContaining({ _state: helper.state }),
-      })
+      expect.objectContaining({ results })
     );
   });
 

--- a/src/connectors/geo-search/connectGeoSearch.ts
+++ b/src/connectors/geo-search/connectGeoSearch.ts
@@ -159,7 +159,9 @@ const connectGeoSearch: GeoSearchConnector = (renderFn, unmountFn = noop) => {
   return (widgetParams) => {
     const {
       enableRefineOnMapMove = true,
-      transformItems = ((items) => items) as TransformItems<GeoHit>,
+      transformItems = ((items) => items) as NonNullable<
+        GeoSearchConnectorParams['transformItems']
+      >,
     } = widgetParams || {};
 
     const widgetState = {
@@ -325,7 +327,10 @@ const connectGeoSearch: GeoSearchConnector = (renderFn, unmountFn = noop) => {
         const state = helper.state;
 
         const items = results
-          ? transformItems(results.hits.filter((hit) => hit._geoloc))
+          ? transformItems(
+              results.hits.filter((hit) => hit._geoloc),
+              { results }
+            )
           : [];
 
         if (!sendEvent) {

--- a/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.ts
+++ b/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.ts
@@ -387,13 +387,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
     });
 
     const helper = algoliasearchHelper(createSearchClient(), '');
+    const results = new SearchResults(helper.state, [
+      createSingleSearchResponse(),
+    ]);
 
     widget.init!(createInitOptions({ helper, state: helper.state }));
     widget.render!(
       createRenderOptions({
-        results: new SearchResults(helper.state, [
-          createSingleSearchResponse(),
-        ]),
+        results,
         helper,
         state: helper.state,
       })
@@ -401,9 +402,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
 
     expect(transformItems).lastCalledWith(
       expect.anything(),
-      expect.objectContaining({
-        results: expect.objectContaining({ _state: helper.state }),
-      })
+      expect.objectContaining({ results })
     );
   });
 

--- a/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.ts
+++ b/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.ts
@@ -378,6 +378,35 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
     );
   });
 
+  it('provides search results within transformItems', () => {
+    const transformItems = jest.fn((items) => items);
+    const makeWidget = connectHierarchicalMenu(() => {});
+    const widget = makeWidget({
+      attributes: ['category', 'subCategory'],
+      transformItems,
+    });
+
+    const helper = algoliasearchHelper(createSearchClient(), '');
+
+    widget.init!(createInitOptions({ helper, state: helper.state }));
+    widget.render!(
+      createRenderOptions({
+        results: new SearchResults(helper.state, [
+          createSingleSearchResponse(),
+        ]),
+        helper,
+        state: helper.state,
+      })
+    );
+
+    expect(transformItems).lastCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        results: expect.objectContaining({ _state: helper.state }),
+      })
+    );
+  });
+
   describe('dispose', () => {
     it('does not throw without the unmount function', () => {
       const rendering = jest.fn();

--- a/src/connectors/hierarchical-menu/connectHierarchicalMenu.ts
+++ b/src/connectors/hierarchical-menu/connectHierarchicalMenu.ts
@@ -177,8 +177,9 @@ const connectHierarchicalMenu: HierarchicalMenuConnector =
         showMore = false,
         showMoreLimit = 20,
         sortBy = DEFAULT_SORT,
-        transformItems = ((items) =>
-          items) as TransformItems<HierarchicalMenuItem>,
+        transformItems = ((items) => items) as NonNullable<
+          HierarchicalMenuConnectorParams['transformItems']
+        >,
       } = widgetParams || {};
 
       if (
@@ -361,7 +362,9 @@ const connectHierarchicalMenu: HierarchicalMenuConnector =
             canToggleShowMore =
               showMore && (isShowingMore || !hasExhaustiveItems);
 
-            items = transformItems(_prepareFacetValues(facetItems));
+            items = transformItems(_prepareFacetValues(facetItems), {
+              results,
+            });
           }
 
           return {

--- a/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.ts
+++ b/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.ts
@@ -247,13 +247,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
     const helper = algoliasearchHelper(createSearchClient(), '', {
       hitsPerPage: 3,
     });
+    const results = new SearchResults(helper.state, [
+      createSingleSearchResponse(),
+    ]);
 
     widget.init!(createInitOptions({ helper, state: helper.state }));
     widget.render!(
       createRenderOptions({
-        results: new SearchResults(helper.state, [
-          createSingleSearchResponse(),
-        ]),
+        results,
         helper,
         state: helper.state,
       })
@@ -261,9 +262,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
 
     expect(transformItems).lastCalledWith(
       expect.anything(),
-      expect.objectContaining({
-        results: expect.objectContaining({ _state: helper.state }),
-      })
+      expect.objectContaining({ results })
     );
   });
 

--- a/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.ts
+++ b/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.ts
@@ -233,6 +233,40 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
     );
   });
 
+  it('Provides search results within transformItems', () => {
+    const transformItems = jest.fn((items) => items);
+    const makeWidget = connectHitsPerPage(() => {});
+    const widget = makeWidget({
+      items: [
+        { value: 3, label: '3 items per page', default: true },
+        { value: 10, label: '10 items per page' },
+      ],
+      transformItems,
+    });
+
+    const helper = algoliasearchHelper(createSearchClient(), '', {
+      hitsPerPage: 3,
+    });
+
+    widget.init!(createInitOptions({ helper, state: helper.state }));
+    widget.render!(
+      createRenderOptions({
+        results: new SearchResults(helper.state, [
+          createSingleSearchResponse(),
+        ]),
+        helper,
+        state: helper.state,
+      })
+    );
+
+    expect(transformItems).lastCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        results: expect.objectContaining({ _state: helper.state }),
+      })
+    );
+  });
+
   it('Configures the search with the default hitsPerPage provided', () => {
     const renderFn = jest.fn();
     const makeWidget = connectHitsPerPage(renderFn);

--- a/src/connectors/hits-per-page/connectHitsPerPage.ts
+++ b/src/connectors/hits-per-page/connectHitsPerPage.ts
@@ -123,8 +123,9 @@ const connectHitsPerPage: HitsPerPageConnector = function connectHitsPerPage(
   return (widgetParams) => {
     const {
       items: userItems,
-      transformItems = ((items) =>
-        items) as TransformItems<HitsPerPageRenderStateItem>,
+      transformItems = ((items) => items) as NonNullable<
+        HitsPerPageConnectorParams['transformItems']
+      >,
     } = widgetParams || {};
 
     if (!Array.isArray(userItems)) {
@@ -259,7 +260,7 @@ You may want to add another entry to the \`items\` option with this value.`
 
       getWidgetRenderState({ state, results, createURL, helper }) {
         return {
-          items: transformItems(normalizeItems(state)),
+          items: transformItems(normalizeItems(state), { results }),
           refine: connectorState.getRefine(helper),
           createURL: connectorState.createURLFactory({ state, createURL }),
           hasNoResults: results ? results.nbHits === 0 : true,

--- a/src/connectors/hits/__tests__/connectHits-test.ts
+++ b/src/connectors/hits/__tests__/connectHits-test.ts
@@ -274,13 +274,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
     });
 
     const helper = algoliasearchHelper(createSearchClient(), '');
+    const results = new SearchResults(helper.state, [
+      createSingleSearchResponse(),
+    ]);
 
     widget.init!(createInitOptions({ helper, state: helper.state }));
     widget.render!(
       createRenderOptions({
-        results: new SearchResults(helper.state, [
-          createSingleSearchResponse(),
-        ]),
+        results,
         helper,
         state: helper.state,
       })
@@ -288,9 +289,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
 
     expect(transformItems).lastCalledWith(
       expect.anything(),
-      expect.objectContaining({
-        results: expect.objectContaining({ _state: helper.state }),
-      })
+      expect.objectContaining({ results })
     );
   });
 

--- a/src/connectors/hits/__tests__/connectHits-test.ts
+++ b/src/connectors/hits/__tests__/connectHits-test.ts
@@ -266,6 +266,34 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
     );
   });
 
+  it('provides search results within transformItems', () => {
+    const transformItems = jest.fn((items) => items);
+    const makeWidget = connectHits(() => {});
+    const widget = makeWidget({
+      transformItems,
+    });
+
+    const helper = algoliasearchHelper(createSearchClient(), '');
+
+    widget.init!(createInitOptions({ helper, state: helper.state }));
+    widget.render!(
+      createRenderOptions({
+        results: new SearchResults(helper.state, [
+          createSingleSearchResponse(),
+        ]),
+        helper,
+        state: helper.state,
+      })
+    );
+
+    expect(transformItems).lastCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        results: expect.objectContaining({ _state: helper.state }),
+      })
+    );
+  });
+
   it('adds queryID if provided to results', () => {
     const renderFn = jest.fn();
     const makeWidget = connectHits(renderFn);

--- a/src/connectors/hits/connectHits.ts
+++ b/src/connectors/hits/connectHits.ts
@@ -82,7 +82,9 @@ const connectHits: HitsConnector = function connectHits(
   return (widgetParams) => {
     const {
       escapeHTML = true,
-      transformItems = ((items) => items) as TransformItems<Hit>,
+      transformItems = ((items) => items) as NonNullable<
+        HitsConnectorParams['transformItems']
+      >,
     } = widgetParams || {};
     let sendEvent: SendEventForHits;
     let bindEvent: BindEventForHits;
@@ -162,7 +164,8 @@ const connectHits: HitsConnector = function connectHits(
         );
 
         const transformedHits = transformItems(
-          hitsWithAbsolutePositionAndQueryID
+          hitsWithAbsolutePositionAndQueryID,
+          { results }
         );
 
         return {

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -565,6 +565,34 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     expect(secondRenderOptions.results).toEqual(results);
   });
 
+  it('provides search results within transformItems', () => {
+    const transformItems = jest.fn((items) => items);
+    const makeWidget = connectInfiniteHits(() => {});
+    const widget = makeWidget({
+      transformItems,
+    });
+
+    const helper = algoliasearchHelper(createSearchClient(), '');
+
+    widget.init!(createInitOptions({ helper, state: helper.state }));
+    widget.render!(
+      createRenderOptions({
+        results: new SearchResults(helper.state, [
+          createSingleSearchResponse(),
+        ]),
+        helper,
+        state: helper.state,
+      })
+    );
+
+    expect(transformItems).lastCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        results: expect.objectContaining({ _state: helper.state }),
+      })
+    );
+  });
+
   it('transform items after escaping', () => {
     const renderFn = jest.fn();
     const makeWidget = connectInfiniteHits(renderFn);

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -573,13 +573,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     });
 
     const helper = algoliasearchHelper(createSearchClient(), '');
+    const results = new SearchResults(helper.state, [
+      createSingleSearchResponse(),
+    ]);
 
     widget.init!(createInitOptions({ helper, state: helper.state }));
     widget.render!(
       createRenderOptions({
-        results: new SearchResults(helper.state, [
-          createSingleSearchResponse(),
-        ]),
+        results,
         helper,
         state: helper.state,
       })
@@ -587,9 +588,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
 
     expect(transformItems).lastCalledWith(
       expect.anything(),
-      expect.objectContaining({
-        results: expect.objectContaining({ _state: helper.state }),
-      })
+      expect.objectContaining({ results })
     );
   });
 

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -187,7 +187,9 @@ const connectInfiniteHits: InfiniteHitsConnector = function connectInfiniteHits(
   return (widgetParams) => {
     const {
       escapeHTML = true,
-      transformItems = ((items) => items) as TransformItems<Hit>,
+      transformItems = ((items) => items) as NonNullable<
+        InfiniteHitsConnectorParams['transformItems']
+      >,
       cache = getInMemoryCache(),
     } = widgetParams || {};
     let showPrevious: () => void;
@@ -324,7 +326,8 @@ const connectInfiniteHits: InfiniteHitsConnector = function connectInfiniteHits(
           );
 
           const transformedHits = transformItems(
-            hitsWithAbsolutePositionAndQueryID
+            hitsWithAbsolutePositionAndQueryID,
+            { results }
           );
 
           if (cachedHits[page] === undefined) {

--- a/src/connectors/menu/__tests__/connectMenu-test.ts
+++ b/src/connectors/menu/__tests__/connectMenu-test.ts
@@ -465,6 +465,34 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
     );
   });
 
+  it('provides search results within transformItems', () => {
+    const transformItems = jest.fn((items) => items);
+    const widget = makeWidget({
+      attribute: 'category',
+      transformItems,
+    });
+
+    const helper = jsHelper(createSearchClient(), '');
+
+    widget.init!(createInitOptions({ helper, state: helper.state }));
+    widget.render!(
+      createRenderOptions({
+        results: new SearchResults(helper.state, [
+          createSingleSearchResponse(),
+        ]),
+        helper,
+        state: helper.state,
+      })
+    );
+
+    expect(transformItems).lastCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        results: expect.objectContaining({ _state: helper.state }),
+      })
+    );
+  });
+
   it('does not throw without the unmount function', () => {
     const widget = connectMenu(() => {})({
       attribute: 'category',

--- a/src/connectors/menu/__tests__/connectMenu-test.ts
+++ b/src/connectors/menu/__tests__/connectMenu-test.ts
@@ -473,13 +473,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
     });
 
     const helper = jsHelper(createSearchClient(), '');
+    const results = new SearchResults(helper.state, [
+      createSingleSearchResponse(),
+    ]);
 
     widget.init!(createInitOptions({ helper, state: helper.state }));
     widget.render!(
       createRenderOptions({
-        results: new SearchResults(helper.state, [
-          createSingleSearchResponse(),
-        ]),
+        results,
         helper,
         state: helper.state,
       })
@@ -487,9 +488,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/menu/js/#co
 
     expect(transformItems).lastCalledWith(
       expect.anything(),
-      expect.objectContaining({
-        results: expect.objectContaining({ _state: helper.state }),
-      })
+      expect.objectContaining({ results })
     );
   });
 

--- a/src/connectors/menu/connectMenu.ts
+++ b/src/connectors/menu/connectMenu.ts
@@ -153,7 +153,9 @@ const connectMenu: MenuConnector = function connectMenu(
       showMore = false,
       showMoreLimit = 20,
       sortBy = DEFAULT_SORT,
-      transformItems = ((items) => items) as TransformItems<MenuItem>,
+      transformItems = ((items) => items) as NonNullable<
+        MenuConnectorParams['transformItems']
+      >,
     } = widgetParams || {};
 
     if (!attribute) {
@@ -303,7 +305,8 @@ const connectMenu: MenuConnector = function connectMenu(
                 ...item,
                 label,
                 value,
-              }))
+              })),
+            { results }
           );
         }
 

--- a/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.ts
+++ b/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.ts
@@ -235,6 +235,36 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
     );
   });
 
+  it('Provides search results within transformItems', () => {
+    const transformItems = jest.fn((items) => items);
+    const makeWidget = connectNumericMenu(() => {});
+    const widget = makeWidget({
+      attribute: 'numeric',
+      items: [{ label: 'below 20', end: 20 }],
+      transformItems,
+    });
+
+    const helper = jsHelper(createSearchClient(), '');
+
+    widget.init!(createInitOptions({ helper, state: helper.state }));
+    widget.render!(
+      createRenderOptions({
+        results: new SearchResults(helper.state, [
+          createSingleSearchResponse(),
+        ]),
+        helper,
+        state: helper.state,
+      })
+    );
+
+    expect(transformItems).lastCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        results: expect.objectContaining({ _state: helper.state }),
+      })
+    );
+  });
+
   it('Provide a function to update the refinements at each step', () => {
     const rendering = jest.fn();
     const makeWidget = connectNumericMenu(rendering);

--- a/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.ts
+++ b/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.ts
@@ -245,13 +245,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
     });
 
     const helper = jsHelper(createSearchClient(), '');
+    const results = new SearchResults(helper.state, [
+      createSingleSearchResponse(),
+    ]);
 
     widget.init!(createInitOptions({ helper, state: helper.state }));
     widget.render!(
       createRenderOptions({
-        results: new SearchResults(helper.state, [
-          createSingleSearchResponse(),
-        ]),
+        results,
         helper,
         state: helper.state,
       })
@@ -259,9 +260,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
 
     expect(transformItems).lastCalledWith(
       expect.anything(),
-      expect.objectContaining({
-        results: expect.objectContaining({ _state: helper.state }),
-      })
+      expect.objectContaining({ results })
     );
   });
 

--- a/src/connectors/numeric-menu/connectNumericMenu.ts
+++ b/src/connectors/numeric-menu/connectNumericMenu.ts
@@ -184,7 +184,9 @@ const connectNumericMenu: NumericMenuConnector = function connectNumericMenu(
     const {
       attribute = '',
       items = [],
-      transformItems = ((x) => x) as TransformItems<NumericMenuRenderStateItem>,
+      transformItems = ((item) => item) as NonNullable<
+        NumericMenuConnectorParams['transformItems']
+      >,
     } = widgetParams || {};
 
     if (attribute === '') {
@@ -355,7 +357,7 @@ const connectNumericMenu: NumericMenuConnector = function connectNumericMenu(
 
         return {
           createURL: connectorState.createURL(state),
-          items: transformItems(prepareItems(state)),
+          items: transformItems(prepareItems(state), { results }),
           hasNoResults: results ? results.nbHits === 0 : true,
           refine: connectorState.refine,
           sendEvent: connectorState.sendEvent,

--- a/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
+++ b/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
@@ -319,13 +319,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
       });
 
       const helper = createFakeHelper();
+      const results = new SearchResults(helper.state, [
+        createSingleSearchResponse(),
+      ]);
 
       widget.init!(createInitOptions({ helper, state: helper.state }));
       widget.render!(
         createRenderOptions({
-          results: new SearchResults(helper.state, [
-            createSingleSearchResponse(),
-          ]),
+          results,
           helper,
           state: helper.state,
         })
@@ -333,9 +334,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
 
       expect(transformItems).lastCalledWith(
         expect.anything(),
-        expect.objectContaining({
-          results: expect.objectContaining({ _state: helper.state }),
-        })
+        expect.objectContaining({ results })
       );
     });
   });

--- a/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
+++ b/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
@@ -310,6 +310,34 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/query-rules
         widgetParams: { transformItems },
       });
     });
+
+    it('provides search results within transformItems', () => {
+      const transformItems = jest.fn((items) => items);
+      const makeWidget = connectQueryRules(() => {});
+      const widget = makeWidget({
+        transformItems,
+      });
+
+      const helper = createFakeHelper();
+
+      widget.init!(createInitOptions({ helper, state: helper.state }));
+      widget.render!(
+        createRenderOptions({
+          results: new SearchResults(helper.state, [
+            createSingleSearchResponse(),
+          ]),
+          helper,
+          state: helper.state,
+        })
+      );
+
+      expect(transformItems).lastCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          results: expect.objectContaining({ _state: helper.state }),
+        })
+      );
+    });
   });
 
   describe('getRenderState', () => {

--- a/src/connectors/query-rules/connectQueryRules.ts
+++ b/src/connectors/query-rules/connectQueryRules.ts
@@ -24,12 +24,11 @@ export type ParamTrackedFilters = {
   ) => TrackedFilterRefinement[];
 };
 export type ParamTransformRuleContexts = (ruleContexts: string[]) => string[];
-type ParamTransformItems = TransformItems<any>;
 
 export type QueryRulesConnectorParams = {
   trackedFilters?: ParamTrackedFilters;
   transformRuleContexts?: ParamTransformRuleContexts;
-  transformItems?: ParamTransformItems;
+  transformItems?: TransformItems<any>;
 };
 
 export type QueryRulesRenderState = {
@@ -168,7 +167,9 @@ const connectQueryRules: QueryRulesConnector = function connectQueryRules(
     const {
       trackedFilters = {} as ParamTrackedFilters,
       transformRuleContexts = ((rules) => rules) as ParamTransformRuleContexts,
-      transformItems = ((items) => items) as ParamTransformItems,
+      transformItems = ((items) => items) as NonNullable<
+        QueryRulesConnectorParams['transformItems']
+      >,
     } = widgetParams || {};
 
     Object.keys(trackedFilters).forEach((facetName) => {
@@ -242,7 +243,7 @@ const connectQueryRules: QueryRulesConnector = function connectQueryRules(
 
       getWidgetRenderState({ results }) {
         const { userData = [] } = results || {};
-        const items = transformItems(userData);
+        const items = transformItems(userData, { results });
 
         return {
           items,

--- a/src/connectors/refinement-list/__tests__/connectRefinementList-test.ts
+++ b/src/connectors/refinement-list/__tests__/connectRefinementList-test.ts
@@ -529,13 +529,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
     });
 
     const helper = jsHelper(createSearchClient(), '');
+    const results = new SearchResults(helper.state, [
+      createSingleSearchResponse(),
+    ]);
 
     widget.init!(createInitOptions({ helper, state: helper.state }));
     widget.render!(
       createRenderOptions({
-        results: new SearchResults(helper.state, [
-          createSingleSearchResponse(),
-        ]),
+        results,
         helper,
         state: helper.state,
       })
@@ -543,9 +544,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
 
     expect(transformItems).lastCalledWith(
       expect.anything(),
-      expect.objectContaining({
-        results: expect.objectContaining({ _state: helper.state }),
-      })
+      expect.objectContaining({ results })
     );
   });
 

--- a/src/connectors/refinement-list/__tests__/connectRefinementList-test.ts
+++ b/src/connectors/refinement-list/__tests__/connectRefinementList-test.ts
@@ -520,6 +520,35 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
     ]);
   });
 
+  it('Provides search results within transformItems', () => {
+    const transformItems = jest.fn((items) => items);
+    const makeWidget = connectRefinementList(() => {});
+    const widget = makeWidget({
+      attribute: 'category',
+      transformItems,
+    });
+
+    const helper = jsHelper(createSearchClient(), '');
+
+    widget.init!(createInitOptions({ helper, state: helper.state }));
+    widget.render!(
+      createRenderOptions({
+        results: new SearchResults(helper.state, [
+          createSingleSearchResponse(),
+        ]),
+        helper,
+        state: helper.state,
+      })
+    );
+
+    expect(transformItems).lastCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        results: expect.objectContaining({ _state: helper.state }),
+      })
+    );
+  });
+
   it('Provide a function to clear the refinements at each step (or)', () => {
     const { makeWidget, rendering } = createWidgetFactory();
     const instantSearchInstance = createInstantSearch();

--- a/src/connectors/refinement-list/connectRefinementList.ts
+++ b/src/connectors/refinement-list/connectRefinementList.ts
@@ -1,8 +1,4 @@
-import type {
-  AlgoliaSearchHelper,
-  SearchForFacetValues,
-  SearchResults,
-} from 'algoliasearch-helper';
+import type { AlgoliaSearchHelper, SearchResults } from 'algoliasearch-helper';
 import type { SendEventForFacet } from '../../lib/utils';
 import {
   escapeFacets,
@@ -93,10 +89,7 @@ export type RefinementListConnectorParams = {
   /**
    * Function to transform the items passed to the templates.
    */
-  transformItems?: TransformItems<
-    RefinementListItem,
-    SearchResults | SearchForFacetValues.Result
-  >;
+  transformItems?: TransformItems<RefinementListItem>;
 };
 
 export type RefinementListRenderState = {
@@ -270,7 +263,8 @@ const connectRefinementList: RefinementListConnector =
       ) {
         return (renderOptions: RenderOptions | InitOptions) =>
           (query: string) => {
-            const { instantSearchInstance } = renderOptions;
+            const { instantSearchInstance, results: searchResults } =
+              renderOptions;
             if (query === '' && lastItemsFromMainSearch) {
               // render with previous data from the helper.
               renderFn(
@@ -314,7 +308,7 @@ const connectRefinementList: RefinementListConnector =
                       value,
                       label: value,
                     })),
-                    { results }
+                    { results: searchResults }
                   );
 
                   renderFn(

--- a/src/connectors/refinement-list/connectRefinementList.ts
+++ b/src/connectors/refinement-list/connectRefinementList.ts
@@ -1,4 +1,8 @@
-import type { AlgoliaSearchHelper, SearchResults } from 'algoliasearch-helper';
+import type {
+  AlgoliaSearchHelper,
+  SearchForFacetValues,
+  SearchResults,
+} from 'algoliasearch-helper';
 import type { SendEventForFacet } from '../../lib/utils';
 import {
   escapeFacets,
@@ -89,7 +93,10 @@ export type RefinementListConnectorParams = {
   /**
    * Function to transform the items passed to the templates.
    */
-  transformItems?: TransformItems<RefinementListItem>;
+  transformItems?: TransformItems<
+    RefinementListItem,
+    SearchResults | SearchForFacetValues.Result
+  >;
 };
 
 export type RefinementListRenderState = {
@@ -188,8 +195,9 @@ const connectRefinementList: RefinementListConnector =
         showMoreLimit = 20,
         sortBy = DEFAULT_SORT,
         escapeFacetValues = true,
-        transformItems = ((items) =>
-          items) as TransformItems<RefinementListItem>,
+        transformItems = ((items) => items) as NonNullable<
+          RefinementListConnectorParams['transformItems']
+        >,
       } = widgetParams || {};
 
       type ThisWidget = Widget<
@@ -305,7 +313,8 @@ const connectRefinementList: RefinementListConnector =
                       ...item,
                       value,
                       label: value,
-                    }))
+                    })),
+                    { results }
                   );
 
                   renderFn(
@@ -389,7 +398,8 @@ const connectRefinementList: RefinementListConnector =
             });
             facetValues = values && Array.isArray(values) ? values : [];
             items = transformItems(
-              facetValues.slice(0, getLimit()).map(formatItems)
+              facetValues.slice(0, getLimit()).map(formatItems),
+              { results }
             );
 
             const maxValuesPerFacetConfig = state.maxValuesPerFacet;

--- a/src/connectors/sort-by/__tests__/connectSortBy-test.ts
+++ b/src/connectors/sort-by/__tests__/connectSortBy-test.ts
@@ -219,13 +219,14 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
     });
 
     const helper = algoliasearchHelper(createSearchClient(), '');
+    const results = new SearchResults(helper.state, [
+      createSingleSearchResponse(),
+    ]);
 
     widget.init!(createInitOptions({ helper, state: helper.state }));
     widget.render!(
       createRenderOptions({
-        results: new SearchResults(helper.state, [
-          createSingleSearchResponse(),
-        ]),
+        results,
         helper,
         state: helper.state,
       })
@@ -233,9 +234,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
 
     expect(transformItems).lastCalledWith(
       expect.anything(),
-      expect.objectContaining({
-        results: expect.objectContaining({ _state: helper.state }),
-      })
+      expect.objectContaining({ results })
     );
   });
 

--- a/src/connectors/sort-by/__tests__/connectSortBy-test.ts
+++ b/src/connectors/sort-by/__tests__/connectSortBy-test.ts
@@ -210,6 +210,35 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
     );
   });
 
+  it('Provides search results within transformItems', () => {
+    const transformItems = jest.fn((items) => items);
+    const makeWidget = connectSortBy(() => {});
+    const widget = makeWidget({
+      items: [{ label: 'Sort products by relevance', value: 'relevance' }],
+      transformItems,
+    });
+
+    const helper = algoliasearchHelper(createSearchClient(), '');
+
+    widget.init!(createInitOptions({ helper, state: helper.state }));
+    widget.render!(
+      createRenderOptions({
+        results: new SearchResults(helper.state, [
+          createSingleSearchResponse(),
+        ]),
+        helper,
+        state: helper.state,
+      })
+    );
+
+    expect(transformItems).lastCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        results: expect.objectContaining({ _state: helper.state }),
+      })
+    );
+  });
+
   it('Provides a function to update the index at each step', () => {
     const rendering = jest.fn();
     const makeWidget = connectSortBy(rendering);

--- a/src/connectors/sort-by/connectSortBy.ts
+++ b/src/connectors/sort-by/connectSortBy.ts
@@ -93,8 +93,12 @@ const connectSortBy: SortByConnector = function connectSortBy(
   };
 
   return (widgetParams) => {
-    const { items, transformItems = ((x) => x) as TransformItems<SortByItem> } =
-      widgetParams || {};
+    const {
+      items,
+      transformItems = ((x) => x) as NonNullable<
+        SortByConnectorParams['transformItems']
+      >,
+    } = widgetParams || {};
 
     if (!Array.isArray(items)) {
       throw new Error(
@@ -167,7 +171,7 @@ const connectSortBy: SortByConnector = function connectSortBy(
 
         return {
           currentRefinement: state.index,
-          options: transformItems(items),
+          options: transformItems(items, { results }),
           refine: connectorState.setIndex,
           hasNoResults: results ? results.nbHits === 0 : true,
           widgetParams,

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -270,7 +270,12 @@ export type Widget<
 /**
  * Transforms the given items.
  */
-export type TransformItems<TItem> = (items: TItem[]) => TItem[];
+export type TransformItems<TItem, TResults = SearchResults<TItem>> = (
+  items: TItem[],
+  metadata: {
+    results: TResults | undefined;
+  }
+) => TItem[];
 
 /**
  * Transforms the given items.

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -270,12 +270,12 @@ export type Widget<
 /**
  * Transforms the given items.
  */
-export type TransformItems<TItem, TResults = SearchResults<TItem>> = (
-  items: TItem[],
-  metadata: {
-    results: TResults | undefined;
+export type TransformItems<
+  TItem,
+  TMetaData = {
+    results?: SearchResults;
   }
-) => TItem[];
+> = (items: TItem[], metadata: TMetadata) => TItem[];
 
 /**
  * Transforms the given items.

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -272,7 +272,7 @@ export type Widget<
  */
 export type TransformItems<
   TItem,
-  TMetaData = {
+  TMetadata = {
     results?: SearchResults;
   }
 > = (items: TItem[], metadata: TMetadata) => TItem[];

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -267,15 +267,17 @@ export type Widget<
     RenderStateLifeCycle<TWidgetDescription>
 >;
 
+export type TransformItemsMetadata = {
+  results?: SearchResults;
+};
+
 /**
  * Transforms the given items.
  */
-export type TransformItems<
-  TItem,
-  TMetadata = {
-    results?: SearchResults;
-  }
-> = (items: TItem[], metadata: TMetadata) => TItem[];
+export type TransformItems<TItem, TMetadata = TransformItemsMetadata> = (
+  items: TItem[],
+  metadata: TMetadata
+) => TItem[];
 
 /**
  * Transforms the given items.

--- a/src/widgets/dynamic-widgets/__tests__/dynamic-widgets-test.ts
+++ b/src/widgets/dynamic-widgets/__tests__/dynamic-widgets-test.ts
@@ -401,7 +401,7 @@ describe('dynamicWidgets()', () => {
         dynamicWidgets({
           container: rootContainer,
           transformItems(_items, { results }) {
-            return results!.userData[0].MOCK_facetOrder;
+            return results.userData[0].MOCK_facetOrder;
           },
           fallbackWidget: ({ container, attribute }) =>
             refinementList({

--- a/src/widgets/dynamic-widgets/__tests__/dynamic-widgets-test.ts
+++ b/src/widgets/dynamic-widgets/__tests__/dynamic-widgets-test.ts
@@ -401,7 +401,7 @@ describe('dynamicWidgets()', () => {
         dynamicWidgets({
           container: rootContainer,
           transformItems(_items, { results }) {
-            return results.userData[0].MOCK_facetOrder;
+            return results!.userData[0].MOCK_facetOrder;
           },
           fallbackWidget: ({ container, attribute }) =>
             refinementList({


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR adds a secondary parameter to `transformItems` on all connectors that support it. It currently exposes the search results from Algolia.

**Result**

Search results can now be used in transformItems for various applications. For example, you can show the number of hits in the last segment of a breadcrumb widget:

```js
// ...

instantsearch.widgets.breadcrumb({
  container: breadcrumbDiv,
  attributes: [
    'hierarchicalCategories.lvl0',
    'hierarchicalCategories.lvl1',
    'hierarchicalCategories.lvl2',
  ],
  transformItems: (items, { results }) => {
    const lastCrumb = items.pop();
    return [
      ...items,
      {
        ...lastCrumb,
        label: `${lastCrumb.label} (${results.nbHits} hits)`,
      },
    ];
  },
}),

// ...
```
