### PR TITLE
fix(routing): initialize uistate early

### DIFF
--- a/src/middlewares/__tests__/createRouterMiddleware.ts
+++ b/src/middlewares/__tests__/createRouterMiddleware.ts
@@ -4,7 +4,44 @@ import instantsearch from '../../index.es';
 import { searchBox } from '../../widgets';
 
 describe('router', () => {
-  it('sets initial ui state after reading URL', async () => {
+  it('sets initial ui state by reading URL before start', () => {
+    const searchClient = createSearchClient();
+    const search = instantsearch({
+      indexName: 'my-index',
+      searchClient,
+      initialUiState: {
+        'other-index': { query: 'dogs' },
+      },
+      routing: {
+        router: {
+          onUpdate: () => {},
+          read: () => {
+            return {
+              'my-index': {
+                query: 'iPhone',
+              },
+            };
+          },
+          write: () => {},
+          createURL: () => '',
+          dispose: () => {},
+        },
+      },
+    });
+
+    expect(search._initialUiState).toMatchInlineSnapshot(`
+      {
+        "my-index": {
+          "query": "iPhone",
+        },
+        "other-index": {
+          "query": "dogs",
+        },
+      }
+    `);
+  });
+
+  it('sets initial ui state by reading URL on subscribe', async () => {
     const searchClient = createSearchClient();
     const search = instantsearch({
       indexName: 'my-index',

--- a/src/middlewares/createRouterMiddleware.ts
+++ b/src/middlewares/createRouterMiddleware.ts
@@ -62,6 +62,11 @@ export const createRouterMiddleware = <
 
     const initialUiState = instantSearchInstance._initialUiState;
 
+    instantSearchInstance._initialUiState = {
+      ...initialUiState,
+      ...stateMapping.routeToState(router.read()),
+    };
+
     return {
       onStateChange({ uiState }) {
         const routeState = stateMapping.stateToRoute(uiState);


### PR DESCRIPTION
fixes https://github.com/algolia/vue-instantsearch/issues/1066
fixes https://github.com/algolia/vue-instantsearch/issues/1062
FX-349

see: https://github.com/algolia/instantsearch.js/pull/4849

I
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

n Vue InstantSearch SSR, the mainIndex gets init'ed *before* it does in regular InstantSearch (see https://codesandbox.io/s/beautiful-mestorf-ijc75?file), and at that point the ui state should already be initialized (before start).


**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

initial ui state gets set before subscribe of the middleware (before start), as was the case before #4849
