### PR TITLE
fix(metadata): ensure safe user agent detection

### DIFF
--- a/src/middlewares/__tests__/createMetadataMiddleware.ts
+++ b/src/middlewares/__tests__/createMetadataMiddleware.ts
@@ -15,9 +15,6 @@ declare global {
     interface Global {
       navigator?: {
         userAgent?: string;
-        // Deprecated property, but still used in React Native
-        // https://github.com/facebook/react-native/blob/8bd3edec88148d0ab1f225d2119435681fbbba33/Libraries/Core/setUpNavigator.js
-        product?: string;
       };
       window: Window;
     }
@@ -39,21 +36,6 @@ Object.defineProperty(
       value = newValue;
     },
   }))(window.navigator.userAgent)
-);
-
-Object.defineProperty(
-  window.navigator,
-  'product',
-  ((value) => ({
-    get() {
-      return value;
-    },
-    // TypeScript infers from the namespace, this isn't used.
-    // @ts-ignore
-    set(newValue) {
-      value = newValue;
-    },
-  }))(window.navigator.product)
 );
 
 const defaultUserAgent =
@@ -96,7 +78,6 @@ describe('createMetadataMiddleware', () => {
     });
 
     it("does not enable when navigator is different from browser's (React Native)", () => {
-      global.navigator!.product = 'ReactNative';
       global.navigator!.userAgent = undefined;
 
       createMetadataMiddleware();

--- a/src/middlewares/createMetadataMiddleware.ts
+++ b/src/middlewares/createMetadataMiddleware.ts
@@ -70,7 +70,8 @@ function extractPayload(
 
 export function isMetadataEnabled() {
   return safelyRunOnBrowser(
-    ({ window }) => window.navigator.userAgent.indexOf('Algolia Crawler') > -1,
+    ({ window }) =>
+      window.navigator?.userAgent?.indexOf('Algolia Crawler') > -1,
     { fallback: () => false }
   );
 }


### PR DESCRIPTION
## Summary

This ensures user agent detection doesn't break in non-browser environments.

In React Native, `window.navigator` is [polyfilled with a custom `product` property](https://github.com/facebook/react-native/blob/8bd3edec88148d0ab1f225d2119435681fbbba33/Libraries/Core/setUpNavigator.js), and doesn't have other properties traditionally exposed in the browser.

This change ensures this code path doesn't yield a runtime error regardless of the environment.