### PR TITLE
test(jest): migrate to new defaults

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,8 @@
 
 module.exports = {
   rootDir: process.cwd(),
-  testEnvironment: 'jest-environment-jsdom-global',
+  testRunner: 'jest-circus',
+  testEnvironment: 'node',
   setupFilesAfterEnv: ['./scripts/jest/setupTests.ts'],
   testPathIgnorePatterns: [
     '<rootDir>/node_modules/',

--- a/src/components/Answers/__tests__/Answers-test.tsx
+++ b/src/components/Answers/__tests__/Answers-test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 /** @jsx h */
 
 import { h } from 'preact';

--- a/src/components/Breadcrumb/__tests__/Breadcrumb-test.tsx
+++ b/src/components/Breadcrumb/__tests__/Breadcrumb-test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 /** @jsx h */
 
 import { h } from 'preact';

--- a/src/components/ClearRefinements/__tests__/ClearRefinements-test.tsx
+++ b/src/components/ClearRefinements/__tests__/ClearRefinements-test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 /** @jsx h */
 
 import { h } from 'preact';

--- a/src/components/CurrentRefinements/__tests__/CurrentRefinements-test.tsx
+++ b/src/components/CurrentRefinements/__tests__/CurrentRefinements-test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 /** @jsx h */
 
 import { h } from 'preact';

--- a/src/components/GeoSearchControls/__tests__/GeoSearchButton-test.tsx
+++ b/src/components/GeoSearchControls/__tests__/GeoSearchButton-test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 /** @jsx h */
 
 import { h } from 'preact';

--- a/src/components/GeoSearchControls/__tests__/GeoSearchControls-test.tsx
+++ b/src/components/GeoSearchControls/__tests__/GeoSearchControls-test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 /** @jsx h */
 
 import { h } from 'preact';

--- a/src/components/GeoSearchControls/__tests__/GeoSearchToggle-test.tsx
+++ b/src/components/GeoSearchControls/__tests__/GeoSearchToggle-test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 /** @jsx h */
 
 import { h } from 'preact';

--- a/src/components/Hits/__tests__/Hits-test.tsx
+++ b/src/components/Hits/__tests__/Hits-test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 /** @jsx h */
 
 import { h } from 'preact';

--- a/src/components/InfiniteHits/__tests__/InfiniteHits-test.tsx
+++ b/src/components/InfiniteHits/__tests__/InfiniteHits-test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 /** @jsx h */
 
 import { h } from 'preact';

--- a/src/components/MenuSelect/__tests__/MenuSelect-test.tsx
+++ b/src/components/MenuSelect/__tests__/MenuSelect-test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 /** @jsx h */
 
 import { h } from 'preact';

--- a/src/components/Pagination/__tests__/Pagination-test.tsx
+++ b/src/components/Pagination/__tests__/Pagination-test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 /** @jsx h */
 
 import { h } from 'preact';

--- a/src/components/Panel/__tests__/Panel-test.tsx
+++ b/src/components/Panel/__tests__/Panel-test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 /** @jsx h */
 
 import { h } from 'preact';

--- a/src/components/PoweredBy/__tests__/PoweredBy-test.tsx
+++ b/src/components/PoweredBy/__tests__/PoweredBy-test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 /** @jsx h */
 
 import { h } from 'preact';

--- a/src/components/QueryRuleCustomData/__tests__/QueryRuleCustomData-test.tsx
+++ b/src/components/QueryRuleCustomData/__tests__/QueryRuleCustomData-test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 /** @jsx h */
 
 import { h } from 'preact';

--- a/src/components/RangeInput/__tests__/RangeInput-test.tsx
+++ b/src/components/RangeInput/__tests__/RangeInput-test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 /** @jsx h */
 
 import { h } from 'preact';

--- a/src/components/RefinementList/__tests__/RefinementList-test.tsx
+++ b/src/components/RefinementList/__tests__/RefinementList-test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 /** @jsx h */
 
 import { h } from 'preact';

--- a/src/components/RefinementList/__tests__/RefinementListItem-test.tsx
+++ b/src/components/RefinementList/__tests__/RefinementListItem-test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 /** @jsx h */
 
 import { h } from 'preact';

--- a/src/components/RelevantSort/__tests__/RelevantSort-test.tsx
+++ b/src/components/RelevantSort/__tests__/RelevantSort-test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 /** @jsx h */
 
 import { h } from 'preact';

--- a/src/components/SearchBox/__tests__/SearchBox-test.tsx
+++ b/src/components/SearchBox/__tests__/SearchBox-test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 /** @jsx h */
 
 import { h } from 'preact';

--- a/src/components/Selector/__tests__/Selector-test.tsx
+++ b/src/components/Selector/__tests__/Selector-test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 /** @jsx h */
 
 import { h } from 'preact';

--- a/src/components/Slider/__tests__/Slider-test.tsx
+++ b/src/components/Slider/__tests__/Slider-test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 /** @jsx h */
 
 import { h } from 'preact';

--- a/src/components/Stats/__tests__/Stats-test.tsx
+++ b/src/components/Stats/__tests__/Stats-test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 /** @jsx h */
 
 import { h } from 'preact';

--- a/src/components/Template/__tests__/Template-test.tsx
+++ b/src/components/Template/__tests__/Template-test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 /** @jsx h */
 
 import { h } from 'preact';

--- a/src/components/ToggleRefinement/ToggleRefinement.tsx
+++ b/src/components/ToggleRefinement/ToggleRefinement.tsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 /** @jsx h */
 
 import { h } from 'preact';

--- a/src/components/VoiceSearch/__tests__/VoiceSearch-test.tsx
+++ b/src/components/VoiceSearch/__tests__/VoiceSearch-test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 /** @jsx h */
 
 import { h } from 'preact';

--- a/src/connectors/hits/__tests__/connectHits-test.ts
+++ b/src/connectors/hits/__tests__/connectHits-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import algoliasearchHelper, {
   SearchParameters,
   SearchResults,

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import type { SearchParameters } from 'algoliasearch-helper';
 import algoliasearchHelper, { SearchResults } from 'algoliasearch-helper';
 import type {

--- a/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.ts
+++ b/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import jsHelper, {
   SearchResults,
   SearchParameters,

--- a/src/connectors/powered-by/__tests__/connectPoweredBy-test.ts
+++ b/src/connectors/powered-by/__tests__/connectPoweredBy-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import jsHelper from 'algoliasearch-helper';
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import {

--- a/src/helpers/__tests__/get-insights-anonymous-user-token-test.ts
+++ b/src/helpers/__tests__/get-insights-anonymous-user-token-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import getInsightsAnonymousUserToken, {
   ANONYMOUS_TOKEN_COOKIE_KEY,
 } from '../get-insights-anonymous-user-token';

--- a/src/helpers/__tests__/insights-test.ts
+++ b/src/helpers/__tests__/insights-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import insights, {
   writeDataAttributes,
   readDataAttributes,

--- a/src/lib/__tests__/InstantSearch-integration-test.ts
+++ b/src/lib/__tests__/InstantSearch-integration-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { getByText, fireEvent } from '@testing-library/dom';
 import instantsearch from '../../index.es';
 import { configure, searchBox } from '../../widgets';

--- a/src/lib/__tests__/InstantSearch-test.tsx
+++ b/src/lib/__tests__/InstantSearch-test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 /** @jsx h */
 
 import type preact from 'preact';

--- a/src/lib/__tests__/RoutingManager-test.ts
+++ b/src/lib/__tests__/RoutingManager-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom-global
+ */
+
 import qs from 'qs';
 import { createSearchClient } from '../../../test/mock/createSearchClient';
 import { createWidget } from '../../../test/mock/createWidget';

--- a/src/lib/__tests__/insights-listener-test.tsx
+++ b/src/lib/__tests__/insights-listener-test.tsx
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 /** @jsx h */
 
 import { h } from 'preact';

--- a/src/lib/__tests__/routing/dispose-start-test.ts
+++ b/src/lib/__tests__/routing/dispose-start-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import { wait } from '../../../../test/utils/wait';
 import historyRouter from '../../routers/history';

--- a/src/lib/__tests__/routing/external-influence-test.ts
+++ b/src/lib/__tests__/routing/external-influence-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import { wait } from '../../../../test/utils/wait';
 import historyRouter from '../../routers/history';

--- a/src/lib/__tests__/routing/modal-test.ts
+++ b/src/lib/__tests__/routing/modal-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import { wait } from '../../../../test/utils/wait';
 import historyRouter from '../../routers/history';

--- a/src/lib/__tests__/routing/spa-debounced-test.ts
+++ b/src/lib/__tests__/routing/spa-debounced-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import { wait } from '../../../../test/utils/wait';
 import historyRouter from '../../routers/history';

--- a/src/lib/__tests__/routing/spa-replace-state-test.ts
+++ b/src/lib/__tests__/routing/spa-replace-state-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import { wait } from '../../../../test/utils/wait';
 import historyRouter from '../../routers/history';

--- a/src/lib/__tests__/routing/spa-test.ts
+++ b/src/lib/__tests__/routing/spa-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { createSearchClient } from '../../../../test/mock/createSearchClient';
 import { wait } from '../../../../test/utils/wait';
 import historyRouter from '../../routers/history';

--- a/src/lib/infiniteHitsCache/__tests__/sessionStorage.ts
+++ b/src/lib/infiniteHitsCache/__tests__/sessionStorage.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import createInfiniteHitsSessionStorageCache from '../sessionStorage';
 
 const KEY = 'ais.infiniteHits';

--- a/src/lib/routers/__tests__/history.test.ts
+++ b/src/lib/routers/__tests__/history.test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import historyRouter from '../history';
 import type { UiState } from '../../../types';
 import { noop } from '../../utils';

--- a/src/lib/utils/__tests__/createHelpers-tests.ts
+++ b/src/lib/utils/__tests__/createHelpers-tests.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import renderTemplate from '../renderTemplate';
 import createHelpers from '../../createHelpers';
 import { insights } from '../../../helpers';

--- a/src/lib/utils/__tests__/createSendEventForHits-test.ts
+++ b/src/lib/utils/__tests__/createSendEventForHits-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { createInstantSearch } from '../../../../test/mock/createInstantSearch';
 import {
   createBindEventForHits,

--- a/src/lib/utils/__tests__/getContainerNode-test.ts
+++ b/src/lib/utils/__tests__/getContainerNode-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import getContainerNode from '../getContainerNode';
 
 describe('getContainerNode', () => {

--- a/src/lib/utils/__tests__/getWidgetAttribute-test.ts
+++ b/src/lib/utils/__tests__/getWidgetAttribute-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { getWidgetAttribute } from '..';
 import { createInitOptions } from '../../../../test/mock/createWidget';
 import { connectRefinementList } from '../../../connectors';

--- a/src/lib/utils/__tests__/isDomElement-test.ts
+++ b/src/lib/utils/__tests__/isDomElement-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import isDomElement from '../isDomElement';
 
 describe('isDomElement', () => {

--- a/src/lib/utils/__tests__/safelyRunOnBrowser-test.ts
+++ b/src/lib/utils/__tests__/safelyRunOnBrowser-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { safelyRunOnBrowser } from '../safelyRunOnBrowser';
 
 type CallbackReturn = {

--- a/src/lib/utils/createSendEventForHits.ts
+++ b/src/lib/utils/createSendEventForHits.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import type { InstantSearch, Hit, Hits, EscapedHits } from '../../types';
 import { serializePayload } from '../../lib/utils/serializer';
 import type { InsightsEvent } from '../../middlewares/createInsightsMiddleware';

--- a/src/lib/voiceSearchHelper/__tests__/index-test.ts
+++ b/src/lib/voiceSearchHelper/__tests__/index-test.ts
@@ -1,4 +1,8 @@
+/**
+ * @jest-environment jsdom
+ */
 /* global SpeechRecognition */
+
 import createVoiceSearchHelper from '..';
 
 type DummySpeechRecognition = () => void;

--- a/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import instantsearch from '../../index.es';
 import { createInsightsMiddleware } from '..';
 import {

--- a/src/middlewares/__tests__/createMetadataMiddleware.ts
+++ b/src/middlewares/__tests__/createMetadataMiddleware.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import algoliasearch from 'algoliasearch';
 // @ts-ignore (can't type a module that is imported with an alias?)
 import algoliasearchV3 from 'algoliasearch-v3';

--- a/src/middlewares/__tests__/createRouterMiddleware.ts
+++ b/src/middlewares/__tests__/createRouterMiddleware.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { createSearchClient } from '../../../test/mock/createSearchClient';
 import { wait } from '../../../test/utils/wait';
 import instantsearch from '../../index.es';

--- a/src/widgets/__tests__/index.test.ts
+++ b/src/widgets/__tests__/index.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 /* global google */
 import type { PlacesInstance } from 'places.js';
 import * as widgets from '..';

--- a/src/widgets/answers/__tests__/answers-test.ts
+++ b/src/widgets/answers/__tests__/answers-test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 /** @jsx h */
 
 import algoliasearchHelper from 'algoliasearch-helper';

--- a/src/widgets/breadcrumb/__tests__/breadcrumb-test.ts
+++ b/src/widgets/breadcrumb/__tests__/breadcrumb-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import type { VNode } from 'preact';
 import { render as preactRender } from 'preact';
 import breadcrumb from '../breadcrumb';

--- a/src/widgets/clear-refinements/__tests__/clear-refinements-test.ts
+++ b/src/widgets/clear-refinements/__tests__/clear-refinements-test.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
- import type { VNode } from 'preact';
+import type { VNode } from 'preact';
 import { render as preactRender } from 'preact';
 import algoliasearchHelper from 'algoliasearch-helper';
 import {

--- a/src/widgets/clear-refinements/__tests__/clear-refinements-test.ts
+++ b/src/widgets/clear-refinements/__tests__/clear-refinements-test.ts
@@ -1,4 +1,8 @@
-import type { VNode } from 'preact';
+/**
+ * @jest-environment jsdom
+ */
+
+ import type { VNode } from 'preact';
 import { render as preactRender } from 'preact';
 import algoliasearchHelper from 'algoliasearch-helper';
 import {

--- a/src/widgets/current-refinements/__tests__/current-refinements-test.ts
+++ b/src/widgets/current-refinements/__tests__/current-refinements-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import type { VNode } from 'preact';
 import { render as preactRender } from 'preact';
 import algoliasearchHelper, { SearchResults } from 'algoliasearch-helper';

--- a/src/widgets/dynamic-widgets/__tests__/dynamic-widgets-test.ts
+++ b/src/widgets/dynamic-widgets/__tests__/dynamic-widgets-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import {
   createInitOptions,
   createRenderOptions,

--- a/src/widgets/geo-search/__tests__/createHTMLMarker-test.ts
+++ b/src/widgets/geo-search/__tests__/createHTMLMarker-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 /* global google */
 import createHTMLMarker from '../createHTMLMarker';
 

--- a/src/widgets/geo-search/__tests__/geo-search-test.ts
+++ b/src/widgets/geo-search/__tests__/geo-search-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 /* global google */
 import { render as preactRender } from 'preact';
 import algoliasearchHelper, { SearchResults } from 'algoliasearch-helper';

--- a/src/widgets/hierarchical-menu/__tests__/hierarchical-menu-test.ts
+++ b/src/widgets/hierarchical-menu/__tests__/hierarchical-menu-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { render } from 'preact';
 import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
 import algoliasearchHelper, {

--- a/src/widgets/hits-per-page/__tests__/hits-per-page-test.ts
+++ b/src/widgets/hits-per-page/__tests__/hits-per-page-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import type { VNode, ComponentChildren } from 'preact';
 import { render as preactRender } from 'preact';
 import type { AlgoliaSearchHelper } from 'algoliasearch-helper';

--- a/src/widgets/hits/__tests__/hits-integration-test.ts
+++ b/src/widgets/hits/__tests__/hits-integration-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { getByText, fireEvent } from '@testing-library/dom';
 
 import instantsearch from '../../../index.es';

--- a/src/widgets/hits/__tests__/hits-test.ts
+++ b/src/widgets/hits/__tests__/hits-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import type { VNode } from 'preact';
 import { render as preactRender } from 'preact';
 import type { AlgoliaSearchHelper } from 'algoliasearch-helper';

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import type { PlainSearchParameters } from 'algoliasearch-helper';
 import algoliasearchHelper, {
   SearchResults,

--- a/src/widgets/infinite-hits/__tests__/infinite-hits-integration-test.ts
+++ b/src/widgets/infinite-hits/__tests__/infinite-hits-integration-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { getByText, waitFor, fireEvent } from '@testing-library/dom';
 
 import instantsearch from '../../../index.es';

--- a/src/widgets/infinite-hits/__tests__/infinite-hits-test.ts
+++ b/src/widgets/infinite-hits/__tests__/infinite-hits-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import type { VNode } from 'preact';
 import { render as preactRender } from 'preact';
 import type {

--- a/src/widgets/menu-select/__tests__/menu-select-test.ts
+++ b/src/widgets/menu-select/__tests__/menu-select-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import type { VNode } from 'preact';
 import { render as preactRender } from 'preact';
 import type { AlgoliaSearchHelper } from 'algoliasearch-helper';

--- a/src/widgets/menu/__tests__/menu-test.ts
+++ b/src/widgets/menu/__tests__/menu-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import jsHelper, {
   SearchParameters,
   SearchResults,

--- a/src/widgets/numeric-menu/__tests__/numeric-menu-test.ts
+++ b/src/widgets/numeric-menu/__tests__/numeric-menu-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import type { VNode } from 'preact';
 import { render as preactRender } from 'preact';
 import type defaultTemplates from '../defaultTemplates';

--- a/src/widgets/pagination/__tests__/pagination-test.ts
+++ b/src/widgets/pagination/__tests__/pagination-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { render as preactRender } from 'preact';
 import utilsGetContainerNode from '../../../lib/utils/getContainerNode';
 import type {

--- a/src/widgets/panel/__tests__/panel-test.ts
+++ b/src/widgets/panel/__tests__/panel-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import type { VNode } from 'preact';
 import { render as preactRender } from 'preact';
 import { castToJestMock } from '../../../../test/utils/castToJestMock';

--- a/src/widgets/places/__tests__/places-test.ts
+++ b/src/widgets/places/__tests__/places-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import algoliasearchHelper, { SearchParameters } from 'algoliasearch-helper';
 import algoliaPlaces from 'places.js';
 import places from '../places';

--- a/src/widgets/powered-by/__tests__/powered-by-test.ts
+++ b/src/widgets/powered-by/__tests__/powered-by-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
 import algoliasearchHelper from 'algoliasearch-helper';
 import type { VNode } from 'preact';

--- a/src/widgets/query-rule-custom-data/__tests__/query-rule-custom-data-test.ts
+++ b/src/widgets/query-rule-custom-data/__tests__/query-rule-custom-data-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import type { VNode } from 'preact';
 import { render as preactRender } from 'preact';
 import type { AlgoliaSearchHelper as Helper } from 'algoliasearch-helper';

--- a/src/widgets/range-input/__tests__/range-input-test.ts
+++ b/src/widgets/range-input/__tests__/range-input-test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 /** @jsx h */
 
 import type { VNode } from 'preact';

--- a/src/widgets/range-slider/__tests__/range-slider-test.ts
+++ b/src/widgets/range-slider/__tests__/range-slider-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import type { VNode } from 'preact';
 import { render as preactRender } from 'preact';
 import type { AlgoliaSearchHelper } from 'algoliasearch-helper';

--- a/src/widgets/rating-menu/__tests__/rating-menu-integration-test.ts
+++ b/src/widgets/rating-menu/__tests__/rating-menu-integration-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import jsHelper, {
   SearchResults,
   SearchParameters,

--- a/src/widgets/rating-menu/__tests__/rating-menu-test.ts
+++ b/src/widgets/rating-menu/__tests__/rating-menu-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import type { VNode } from 'preact';
 import { render as preactRender } from 'preact';
 import jsHelper, {

--- a/src/widgets/refinement-list/__tests__/refinement-list-test.ts
+++ b/src/widgets/refinement-list/__tests__/refinement-list-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import type { VNode } from 'preact';
 import { render as originalRender } from 'preact';
 import type { SearchResults } from 'algoliasearch-helper';

--- a/src/widgets/relevant-sort/__tests__/relevant-sort-test.ts
+++ b/src/widgets/relevant-sort/__tests__/relevant-sort-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { render } from 'preact';
 import type { RelevantSortTemplates } from '../relevant-sort';
 import relevantSort from '../relevant-sort';

--- a/src/widgets/search-box/__tests__/search-box-test.ts
+++ b/src/widgets/search-box/__tests__/search-box-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import type { VNode } from 'preact';
 import { render as preactRender } from 'preact';
 import searchBox from '../search-box';

--- a/src/widgets/sort-by/__tests__/sort-by-test.ts
+++ b/src/widgets/sort-by/__tests__/sort-by-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { render as preactRender } from 'preact';
 import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
 import algoliasearchHelper, { SearchResults } from 'algoliasearch-helper';

--- a/src/widgets/stats/__tests__/stats-test.ts
+++ b/src/widgets/stats/__tests__/stats-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { render as preactRender } from 'preact';
 import stats from '../stats';
 import { castToJestMock } from '../../../../test/utils/castToJestMock';

--- a/src/widgets/toggle-refinement/__tests__/toggle-refinement-test.ts
+++ b/src/widgets/toggle-refinement/__tests__/toggle-refinement-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { render as preactRender } from 'preact';
 import type { AlgoliaSearchHelper, SearchResults } from 'algoliasearch-helper';
 import jsHelper, { SearchParameters } from 'algoliasearch-helper';

--- a/src/widgets/voice-search/__tests__/voice-search-test.ts
+++ b/src/widgets/voice-search/__tests__/voice-search-test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import type { VNode } from 'preact';
 import { render as preactRender } from 'preact';
 import algoliasearch from 'algoliasearch';


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**


- use the jest-circus runner, which had no impact except slightly speeding up the build
- use the "node" test environment by default, and changing the tests that need it to jsdom


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

Both of these changes had an impact to make it so that the complete test run (cached) went from ~20 to ~15 seconds on my machine.

Read more on the motivation of these changes here: https://jestjs.io/blog/2021/05/25/jest-27
