### PR TITLE
fix(insights): send view events after rendering

### DIFF
--- a/src/connectors/hits/__tests__/connectHits-test.ts
+++ b/src/connectors/hits/__tests__/connectHits-test.ts
@@ -781,6 +781,55 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
           });
         });
 
+        it('sends view event after hits are rendered', () => {
+          const renderFn = jest.fn();
+          const makeWidget = connectHits(renderFn);
+          const widget = makeWidget({});
+
+          const helper = algoliasearchHelper(createSearchClient(), '', {});
+          helper.search = jest.fn();
+
+          const initOptions = createInitOptions({
+            helper,
+            state: helper.state,
+          });
+          const instantSearchInstance = initOptions.instantSearchInstance;
+          instantSearchInstance.sendEventToInsights = jest.fn();
+          widget.init!(initOptions);
+
+          const hits = [
+            {
+              __position: 0,
+              __queryID: 'test-query-id',
+              fake: 'data',
+              objectID: '1',
+            },
+          ];
+
+          const results = new SearchResults(helper.state, [
+            createSingleSearchResponse({ hits }),
+          ]);
+
+          widget.render!(
+            createRenderOptions({
+              results,
+              state: helper.state,
+              helper,
+            })
+          );
+
+          const lastInvocationCallOrder = (mockFn: jest.Mock): number =>
+            mockFn.mock.invocationCallOrder[
+              mockFn.mock.invocationCallOrder.length - 1
+            ];
+
+          expect(lastInvocationCallOrder(renderFn)).toBeLessThan(
+            lastInvocationCallOrder(
+              instantSearchInstance.sendEventToInsights as jest.Mock
+            )
+          );
+        });
+
         it('sends click event', () => {
           const { instantSearchInstance, renderFn, hits } =
             createRenderedWidget();

--- a/src/connectors/hits/connectHits.ts
+++ b/src/connectors/hits/connectHits.ts
@@ -104,7 +104,6 @@ const connectHits: HitsConnector = function connectHits(
 
       render(renderOptions) {
         const renderState = this.getWidgetRenderState(renderOptions);
-        renderState.sendEvent('view', renderState.hits);
 
         renderFn(
           {
@@ -113,6 +112,8 @@ const connectHits: HitsConnector = function connectHits(
           },
           false
         );
+
+        renderState.sendEvent('view', renderState.hits);
       },
 
       getRenderState(renderState, renderOptions) {

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -274,8 +274,6 @@ const connectInfiniteHits: InfiniteHitsConnector = function connectInfiniteHits(
 
         const widgetRenderState = this.getWidgetRenderState(renderOptions);
 
-        sendEvent('view', widgetRenderState.currentPageHits);
-
         renderFn(
           {
             ...widgetRenderState,
@@ -283,6 +281,7 @@ const connectInfiniteHits: InfiniteHitsConnector = function connectInfiniteHits(
           },
           false
         );
+        sendEvent('view', widgetRenderState.currentPageHits);
       },
 
       getRenderState(renderState, renderOptions) {


### PR DESCRIPTION
**Summary**

This PR fixes the order of sending view events and rendering in connectors.

fixes #5013

**Result**

At the time of view events being sent, the DOM is already updated.