### PR TITLE
feat(ts): allow Hits related connectors to be generic

### DIFF
--- a/src/connectors/hits/connectHits.ts
+++ b/src/connectors/hits/connectHits.ts
@@ -15,6 +15,7 @@ import type {
   Connector,
   Hit,
   WidgetRenderState,
+  BaseHit,
 } from '../../types';
 import type { SearchResults } from 'algoliasearch-helper';
 
@@ -23,9 +24,7 @@ const withUsage = createDocumentationMessageGenerator({
   connector: true,
 });
 
-export type HitsRenderState<
-  THit extends Record<string, unknown> = Record<string, unknown>
-> = {
+export type HitsRenderState<THit extends BaseHit = BaseHit> = {
   /**
    * The matched hits from Algolia API.
    */
@@ -47,9 +46,7 @@ export type HitsRenderState<
   bindEvent: BindEventForHits;
 };
 
-export type HitsConnectorParams<
-  THit extends Record<string, unknown> = Record<string, unknown>
-> = {
+export type HitsConnectorParams<THit extends BaseHit = BaseHit> = {
   /**
    * Whether to escape HTML tags from hits string values.
    *
@@ -63,9 +60,7 @@ export type HitsConnectorParams<
   transformItems?: TransformItems<Hit<THit>>;
 };
 
-export type HitsWidgetDescription<
-  THit extends Record<string, unknown> = Record<string, unknown>
-> = {
+export type HitsWidgetDescription<THit extends BaseHit = BaseHit> = {
   $$type: 'ais.hits';
   renderState: HitsRenderState<THit>;
   indexRenderState: {
@@ -73,9 +68,10 @@ export type HitsWidgetDescription<
   };
 };
 
-export type HitsConnector<
-  THit extends Record<string, unknown> = Record<string, unknown>
-> = Connector<HitsWidgetDescription<THit>, HitsConnectorParams<THit>>;
+export type HitsConnector<THit extends BaseHit = BaseHit> = Connector<
+  HitsWidgetDescription<THit>,
+  HitsConnectorParams<THit>
+>;
 
 const connectHits: HitsConnector = function connectHits(
   renderFn,

--- a/src/connectors/hits/connectHits.ts
+++ b/src/connectors/hits/connectHits.ts
@@ -13,7 +13,6 @@ import {
 import type {
   TransformItems,
   Connector,
-  Hits,
   Hit,
   WidgetRenderState,
 } from '../../types';
@@ -24,16 +23,18 @@ const withUsage = createDocumentationMessageGenerator({
   connector: true,
 });
 
-export type HitsRenderState = {
+export type HitsRenderState<
+  THit extends Record<string, unknown> = Record<string, unknown>
+> = {
   /**
    * The matched hits from Algolia API.
    */
-  hits: Hits;
+  hits: Array<Hit<THit>>;
 
   /**
    * The response from the Algolia API.
    */
-  results?: SearchResults<Hit>;
+  results?: SearchResults<Hit<THit>>;
 
   /**
    * Sends an event to the Insights middleware.
@@ -46,7 +47,9 @@ export type HitsRenderState = {
   bindEvent: BindEventForHits;
 };
 
-export type HitsConnectorParams = {
+export type HitsConnectorParams<
+  THit extends Record<string, unknown> = Record<string, unknown>
+> = {
   /**
    * Whether to escape HTML tags from hits string values.
    *
@@ -57,21 +60,22 @@ export type HitsConnectorParams = {
   /**
    * Function to transform the items passed to the templates.
    */
-  transformItems?: TransformItems<Hit>;
+  transformItems?: TransformItems<Hit<THit>>;
 };
 
-export type HitsWidgetDescription = {
+export type HitsWidgetDescription<
+  THit extends Record<string, unknown> = Record<string, unknown>
+> = {
   $$type: 'ais.hits';
-  renderState: HitsRenderState;
+  renderState: HitsRenderState<THit>;
   indexRenderState: {
-    hits: WidgetRenderState<HitsRenderState, HitsConnectorParams>;
+    hits: WidgetRenderState<HitsRenderState<THit>, HitsConnectorParams<THit>>;
   };
 };
 
-export type HitsConnector = Connector<
-  HitsWidgetDescription,
-  HitsConnectorParams
->;
+export type HitsConnector<
+  THit extends Record<string, unknown> = Record<string, unknown>
+> = Connector<HitsWidgetDescription<THit>, HitsConnectorParams<THit>>;
 
 const connectHits: HitsConnector = function connectHits(
   renderFn,

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -9,6 +9,7 @@ import type {
   TransformItems,
   Hit,
   WidgetRenderState,
+  BaseHit,
 } from '../../types';
 import type { SendEventForHits, BindEventForHits } from '../../lib/utils';
 import {
@@ -24,17 +25,17 @@ import {
   createBindEventForHits,
 } from '../../lib/utils';
 
-export type InfiniteHitsCachedHits<THit extends Record<string, unknown>> = {
+export type InfiniteHitsCachedHits<THit extends BaseHit> = {
   [page: number]: Array<Hit<THit>>;
 };
 
-type Read<THit extends Record<string, unknown>> = ({
+type Read<THit extends BaseHit> = ({
   state,
 }: {
   state: PlainSearchParameters;
 }) => InfiniteHitsCachedHits<THit> | null;
 
-type Write<THit extends Record<string, unknown>> = ({
+type Write<THit extends BaseHit> = ({
   state,
   hits,
 }: {
@@ -42,16 +43,12 @@ type Write<THit extends Record<string, unknown>> = ({
   hits: InfiniteHitsCachedHits<THit>;
 }) => void;
 
-export type InfiniteHitsCache<
-  THit extends Record<string, unknown> = Record<string, unknown>
-> = {
+export type InfiniteHitsCache<THit extends BaseHit = BaseHit> = {
   read: Read<THit>;
   write: Write<THit>;
 };
 
-export type InfiniteHitsConnectorParams<
-  THit extends Record<string, unknown> = Record<string, unknown>
-> = {
+export type InfiniteHitsConnectorParams<THit extends BaseHit = BaseHit> = {
   /**
    * Escapes HTML entities from hits string values.
    *
@@ -80,9 +77,7 @@ export type InfiniteHitsConnectorParams<
   cache?: InfiniteHitsCache<THit>;
 };
 
-export type InfiniteHitsRenderState<
-  THit extends Record<string, unknown> = Record<string, unknown>
-> = {
+export type InfiniteHitsRenderState<THit extends BaseHit = BaseHit> = {
   /**
    * Loads the previous results.
    */
@@ -134,9 +129,7 @@ const withUsage = createDocumentationMessageGenerator({
   connector: true,
 });
 
-export type InfiniteHitsWidgetDescription<
-  THit extends Record<string, unknown> = Record<string, unknown>
-> = {
+export type InfiniteHitsWidgetDescription<THit extends BaseHit = BaseHit> = {
   $$type: 'ais.infiniteHits';
   renderState: InfiniteHitsRenderState<THit>;
   indexRenderState: {
@@ -150,9 +143,7 @@ export type InfiniteHitsWidgetDescription<
   };
 };
 
-export type InfiniteHitsConnector<
-  THit extends Record<string, unknown> = Record<string, unknown>
-> = Connector<
+export type InfiniteHitsConnector<THit extends BaseHit = BaseHit> = Connector<
   InfiniteHitsWidgetDescription<THit>,
   InfiniteHitsConnectorParams<THit>
 >;
@@ -162,9 +153,7 @@ function getStateWithoutPage(state: PlainSearchParameters) {
   return rest;
 }
 
-function getInMemoryCache<
-  THit extends Record<string, unknown>
->(): InfiniteHitsCache<THit> {
+function getInMemoryCache<THit extends BaseHit>(): InfiniteHitsCache<THit> {
   let cachedHits: InfiniteHitsCachedHits<THit> | null = null;
   let cachedState: PlainSearchParameters | null = null;
   return {
@@ -180,7 +169,7 @@ function getInMemoryCache<
   };
 }
 
-function extractHitsFromCachedHits<THit extends Record<string, unknown>>(
+function extractHitsFromCachedHits<THit extends BaseHit>(
   cachedHits: InfiniteHitsCachedHits<THit>
 ) {
   return Object.keys(cachedHits)
@@ -198,7 +187,7 @@ const connectInfiniteHits: InfiniteHitsConnector = function connectInfiniteHits(
   checkRendering(renderFn, withUsage());
 
   // @TODO: this should be a generic, but a Connector can not yet be generic itself
-  type THit = Record<string, unknown>;
+  type THit = BaseHit;
 
   return (widgetParams) => {
     const {

--- a/src/types/results.ts
+++ b/src/types/results.ts
@@ -63,7 +63,9 @@ export type AlgoliaHit<
   _geoLoc?: GeoLoc;
 } & THit;
 
-export type Hit<THit extends Record<string, unknown> = Record<string, any>> = {
+export type BaseHit = Record<string, unknown>;
+
+export type Hit<THit extends BaseHit = Record<string, any>> = {
   __position: number;
   __queryID?: string;
 } & AlgoliaHit<THit>;

--- a/src/types/results.ts
+++ b/src/types/results.ts
@@ -36,9 +36,7 @@ export type GeoLoc = {
   lng: number;
 };
 
-export type AlgoliaHit<
-  THit extends Record<string, unknown> = Record<string, any>
-> = {
+export type AlgoliaHit<THit extends BaseHit = Record<string, any>> = {
   objectID: string;
   _highlightResult?: HitHighlightResult;
   _snippetResult?: HitSnippetResult;

--- a/src/types/results.ts
+++ b/src/types/results.ts
@@ -36,8 +36,9 @@ export type GeoLoc = {
   lng: number;
 };
 
-export type AlgoliaHit = {
-  [attribute: string]: any;
+export type AlgoliaHit<
+  THit extends Record<string, unknown> = Record<string, any>
+> = {
   objectID: string;
   _highlightResult?: HitHighlightResult;
   _snippetResult?: HitSnippetResult;
@@ -60,13 +61,16 @@ export type AlgoliaHit = {
   };
   _distinctSeqID?: number;
   _geoLoc?: GeoLoc;
-};
+} & THit;
 
-export type Hit = {
+export type Hit<THit extends Record<string, unknown> = Record<string, any>> = {
   __position: number;
   __queryID?: string;
-} & AlgoliaHit;
+} & AlgoliaHit<THit>;
 
+/**
+ * @deprecated use Hit[] directly instead
+ */
 export type Hits = Hit[];
 
 export type EscapedHits<THit = Hit> = THit[] & { __escaped: boolean };

--- a/src/widgets/infinite-hits/__tests__/infinite-hits-integration-test.ts
+++ b/src/widgets/infinite-hits/__tests__/infinite-hits-integration-test.ts
@@ -68,7 +68,8 @@ describe('infiniteHits', () => {
       const isEqual = (a: any, b: any) =>
         JSON.stringify(a) === JSON.stringify(b);
       let cachedState: PlainSearchParameters | undefined = undefined;
-      let cachedHits: InfiniteHitsCachedHits | undefined = undefined;
+      let cachedHits: InfiniteHitsCachedHits<Record<string, any>> | undefined =
+        undefined;
 
       type Cache = InfiniteHitsCache & { clear(): void };
       type MockedCache = {


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Allows Hits and InfiniteHits connectors to be constructed with a generic Hit

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

It doesn't make the connectors themselves generic (yet), but allows you to cast the connector as one with this generic

