### PR TITLE
feat(infiniteHits): avoid caching artificial results

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@types/google.maps": "^3.45.3",
     "@types/hogan.js": "^3.0.0",
     "@types/qs": "^6.5.3",
-    "algoliasearch-helper": "^3.7.0",
+    "algoliasearch-helper": "^3.7.1",
     "classnames": "^2.2.5",
     "@algolia/events": "^4.0.1",
     "hogan.js": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@types/google.maps": "^3.45.3",
     "@types/hogan.js": "^3.0.0",
     "@types/qs": "^6.5.3",
-    "algoliasearch-helper": "^3.7.1",
+    "algoliasearch-helper": "^3.7.2",
     "classnames": "^2.2.5",
     "@algolia/events": "^4.0.1",
     "hogan.js": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@types/google.maps": "^3.45.3",
     "@types/hogan.js": "^3.0.0",
     "@types/qs": "^6.5.3",
-    "algoliasearch-helper": "^3.7.2",
+    "algoliasearch-helper": "^3.7.3",
     "classnames": "^2.2.5",
     "@algolia/events": "^4.0.1",
     "hogan.js": "^3.0.2",

--- a/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -334,7 +334,7 @@ const connectInfiniteHits: InfiniteHitsConnector = function connectInfiniteHits(
             { results }
           );
 
-          if (cachedHits[page] === undefined) {
+          if (cachedHits[page] === undefined && !results.__isArtificial) {
             cachedHits[page] = transformedHits;
             cache.write({ state, hits: cachedHits });
           }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3156,10 +3156,10 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@~6.12.6:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-algoliasearch-helper@^3.7.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.7.0.tgz#c0a0493df84d850360f664ad7a9d4fc78a94fd78"
-  integrity sha512-XJ3QfERBLfeVCyTVx80gon7r3/rgm/CE8Ha1H7cbablRe/X7SfYQ14g/eO+MhjVKIQp+gy9oC6G5ilmLwS1k6w==
+algoliasearch-helper@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.7.1.tgz#bbf154289e73ca4e89ae5cd311f8e532533256ab"
+  integrity sha512-IYJhVAzyyYaZ+wukguSo3PcRrbESldanPK2HZ3BqwSJ9hVX+GsV0VSKkbgGVZnIfI+LpuyI1ZRKJo8T0x7eBIg==
   dependencies:
     "@algolia/events" "^4.0.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3156,10 +3156,10 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@~6.12.6:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-algoliasearch-helper@^3.7.2:
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.7.2.tgz#fc91cfda38f0d039c308b4a898decb415ead3a01"
-  integrity sha512-RcJoZ0mx2kvIRIEHdM6ESY29ppcaN5wxt5lxhGZjHAldQNLKwIZs5t5kHLV+sgidkRE49U/dQTOGyMmlSrr+aw==
+algoliasearch-helper@^3.7.3:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.7.3.tgz#4da9e68591e02bf6accb6a77b0c2d2ecefab5c07"
+  integrity sha512-ra+SYf+R9bFdnBVMDYxjzdX246k4LtaeTPxww9EodnQcOSKn35TOb1/LOj1nIPZla/LjDr7wczVFqeH85O9kpg==
   dependencies:
     "@algolia/events" "^4.0.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3156,10 +3156,10 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@~6.12.6:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-algoliasearch-helper@^3.7.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.7.1.tgz#bbf154289e73ca4e89ae5cd311f8e532533256ab"
-  integrity sha512-IYJhVAzyyYaZ+wukguSo3PcRrbESldanPK2HZ3BqwSJ9hVX+GsV0VSKkbgGVZnIfI+LpuyI1ZRKJo8T0x7eBIg==
+algoliasearch-helper@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.7.2.tgz#fc91cfda38f0d039c308b4a898decb415ead3a01"
+  integrity sha512-RcJoZ0mx2kvIRIEHdM6ESY29ppcaN5wxt5lxhGZjHAldQNLKwIZs5t5kHLV+sgidkRE49U/dQTOGyMmlSrr+aw==
   dependencies:
     "@algolia/events" "^4.0.1"
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Only cache the hits in infiniteHits if it's a "real" set of results

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

in React InstantSearch Hooks, where we call getWidgetRenderState with fake results (empty hits), we need to ensure that those don't get cached.

> An alternative is to skip caching for `transformedHits.length === 0`, as those should not have an effect on the page, but this could have unintended effects