### PR TITLE
fix: fix types of `sortBy` option

### DIFF
--- a/src/connectors/hierarchical-menu/connectHierarchicalMenu.ts
+++ b/src/connectors/hierarchical-menu/connectHierarchicalMenu.ts
@@ -84,7 +84,7 @@ export type HierarchicalMenuConnectorParams = {
    *
    * If a facetOrdering is set in the index settings, it is used when sortBy isn't passed
    */
-  sortBy?: SortBy<HierarchicalMenuItem>;
+  sortBy?: SortBy<SearchResults.HierarchicalFacet>;
   /**
    * Function to transform the items passed to the templates.
    */

--- a/src/connectors/menu/connectMenu.ts
+++ b/src/connectors/menu/connectMenu.ts
@@ -1,3 +1,4 @@
+import type { SearchResults } from 'algoliasearch-helper';
 import type { SendEventForFacet } from '../../lib/utils';
 import {
   checkRendering,
@@ -65,7 +66,7 @@ export type MenuConnectorParams = {
    *
    * If a facetOrdering is set in the index settings, it is used when sortBy isn't passed
    */
-  sortBy?: SortBy<MenuItem>;
+  sortBy?: SortBy<SearchResults.HierarchicalFacet>;
   /**
    * Function to transform the items passed to the templates.
    */

--- a/src/connectors/refinement-list/connectRefinementList.ts
+++ b/src/connectors/refinement-list/connectRefinementList.ts
@@ -81,7 +81,7 @@ export type RefinementListConnectorParams = {
    *
    * If a facetOrdering is set in the index settings, it is used when sortBy isn't passed
    */
-  sortBy?: SortBy<RefinementListItem>;
+  sortBy?: SortBy<SearchResults.FacetValue>;
   /**
    * Escapes the content of the facet values.
    */

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -279,22 +279,17 @@ export type TransformItems<TItem, TMetadata = TransformItemsMetadata> = (
   metadata: TMetadata
 ) => TItem[];
 
+type SortByDirection<TCriterion extends string> =
+  | TCriterion
+  | `${TCriterion}:asc`
+  | `${TCriterion}:desc`;
+
 /**
  * Transforms the given items.
  */
 export type SortBy<TItem> =
   | ((a: TItem, b: TItem) => number)
-  | Array<
-      | 'count'
-      | 'count:asc'
-      | 'count:desc'
-      | 'name'
-      | 'name:asc'
-      | 'name:desc'
-      | 'isRefined'
-      | 'isRefined:asc'
-      | 'isRefined:desc'
-    >;
+  | Array<SortByDirection<'count' | 'name' | 'isRefined'>>;
 
 /**
  * Creates the URL for the given value.

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -284,7 +284,17 @@ export type TransformItems<TItem, TMetadata = TransformItemsMetadata> = (
  */
 export type SortBy<TItem> =
   | ((a: TItem, b: TItem) => number)
-  | Array<'count' | 'isRefined' | 'name:asc' | 'name:desc'>;
+  | Array<
+      | 'count'
+      | 'count:asc'
+      | 'count:desc'
+      | 'name'
+      | 'name:asc'
+      | 'name:desc'
+      | 'isRefined'
+      | 'isRefined:asc'
+      | 'isRefined:desc'
+    >;
 
 /**
  * Creates the URL for the given value.


### PR DESCRIPTION
## Summary

This fixes type issues for the `sortBy` option which is exposed on `connectRefinementList`, `connectHierarchicalMenu`, and `connectMenu`.

The `SortBy` type takes more string-based options than specified in the type. Some of them are even [specified in the InstantSearch.js documentation](https://www.algolia.com/doc/api-reference/widgets/refinement-list/js/#widget-param-sortby), but were missing from the type.

The value passed to `sortBy` isn't the same one that's passed to `transformItems`. This is visible when passing a `sort` function (see console output in following examples).
- [`refinementList`](https://codesandbox.io/s/serene-bouman-01on2p?file=/src/app.js)
- [`hierarchicalMenu`](https://codesandbox.io/s/trusting-keldysh-vfjorp?file=/src/app.js)
- [`menu`](https://codesandbox.io/s/friendly-morse-t120rc?file=/src/app.js)

**Note:** it seems that the helper types aren't totally consistent with the actual types received by the function, which could come from the loose typing of the package.

## Changes

- The allowed string-based options are now all specified.
- The `sortBy` option is typed with the right generic type.
