### PR TITLE
fix(routing): prevent writing the same URL twice

### DIFF
--- a/src/lib/__tests__/routing/duplicate-url-test.ts
+++ b/src/lib/__tests__/routing/duplicate-url-test.ts
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { createSearchClient } from '../../../../test/mock/createSearchClient';
+import { wait } from '../../../../test/utils/wait';
+import historyRouter from '../../routers/history';
+import instantsearch from '../../..';
+import { connectPagination, connectSearchBox } from '../../../connectors';
+
+/* eslint no-lone-blocks: "off" */
+
+const writeDelay = 10;
+const writeWait = 1.5 * writeDelay;
+
+test('does not write the same URL twice', async () => {
+  // -- Flow
+  // 0. page is filtered out via stateMapping
+  // 1. Initial: '/'
+  // 2. Refine query: '/?indexName[query]=Apple' (writes)
+  // 3. Refine page: '/?indexName[query]=Apple' (does not write)
+
+  const pushState = jest.spyOn(window.history, 'pushState');
+
+  const search = instantsearch({
+    indexName: 'indexName',
+    searchClient: createSearchClient(),
+    routing: {
+      stateMapping: {
+        stateToRoute(uiState) {
+          return Object.fromEntries(
+            Object.entries(uiState).map(
+              ([indexId, { page, ...indexUiState }]) => [indexId, indexUiState]
+            )
+          );
+        },
+        routeToState(routeState) {
+          return routeState;
+        },
+      },
+      router: historyRouter({
+        writeDelay,
+      }),
+    },
+  });
+
+  // 1. Initial: '/'
+  {
+    search.addWidgets([
+      connectSearchBox(() => {})({}),
+      connectPagination(() => {})({}),
+    ]);
+    search.start();
+
+    await wait(writeWait);
+    expect(window.location.search).toEqual('');
+    expect(pushState).toHaveBeenCalledTimes(0);
+  }
+
+  // 2. Refine query: '/?indexName[query]=Apple'
+  {
+    search.renderState.indexName!.searchBox!.refine('Apple');
+
+    await wait(writeWait);
+    expect(window.location.search).toEqual(
+      `?${encodeURI('indexName[query]=Apple')}`
+    );
+    expect(pushState).toHaveBeenCalledTimes(1);
+  }
+
+  // 3. Refine page: '/?indexName[query]=Apple'
+  {
+    search.renderState.indexName!.pagination!.refine(2);
+
+    await wait(writeWait);
+    expect(window.location.search).toEqual(
+      `?${encodeURI('indexName[query]=Apple')}`
+    );
+    expect(pushState).toHaveBeenCalledTimes(1);
+  }
+});

--- a/src/lib/__tests__/routing/spa-replace-state-test.ts
+++ b/src/lib/__tests__/routing/spa-replace-state-test.ts
@@ -22,8 +22,8 @@ describe('routing using `replaceState`', () => {
     // 2. Refine: '/?indexName[query]=Apple'
     // 3. Dispose: does not yet write
     // 4. Route change (with `replaceState`): '/about?external=true', replaces state 2
-    // 3. Dispose: writes '/about' (this is a bug, and should be fixed when we have a way to prevent it)
-    // 5. Back: '/about?external=true'
+    // 5. Dispose: writes '/about' (this is a bug, and should be fixed when we have a way to prevent it)
+    // 6. Back: '/about?external=true'
 
     const pushState = jest.spyOn(window.history, 'pushState');
 

--- a/src/lib/__tests__/routing/spa-replace-state-test.ts
+++ b/src/lib/__tests__/routing/spa-replace-state-test.ts
@@ -20,9 +20,10 @@ describe('routing using `replaceState`', () => {
     // -- Flow
     // 1. Initial: '/'
     // 2. Refine: '/?indexName[query]=Apple'
-    // 3. Dispose: '/about'
-    // 4. Route change (with `replaceState`): '/about'
-    // 5. Back: '/about'
+    // 3. Dispose: does not yet write
+    // 4. Route change (with `replaceState`): '/about?external=true', replaces state 2
+    // 3. Dispose: writes '/about' (this is a bug, and should be fixed when we have a way to prevent it)
+    // 5. Back: '/about?external=true'
 
     const pushState = jest.spyOn(window.history, 'pushState');
 
@@ -61,11 +62,11 @@ describe('routing using `replaceState`', () => {
     // 4. Route change (with `replaceState`): '/about'
     {
       search.dispose();
-      window.history.replaceState({}, '', '/about');
+      window.history.replaceState({}, '', '/about?external=true');
 
       // Asserting `replaceState` call
       expect(window.location.pathname).toEqual('/about');
-      expect(window.location.search).toEqual('');
+      expect(window.location.search).toEqual('?external=true');
       expect(pushState).toHaveBeenCalledTimes(1);
 
       // Asserting `dispose` calling `pushState`
@@ -81,7 +82,7 @@ describe('routing using `replaceState`', () => {
 
       await wait(writeWait);
       expect(window.location.pathname).toEqual('/about');
-      expect(window.location.search).toEqual('');
+      expect(window.location.search).toEqual('?external=true');
     }
   });
 });

--- a/src/lib/routers/history.ts
+++ b/src/lib/routers/history.ts
@@ -224,7 +224,7 @@ class BrowserHistory<TRouteState> implements Router<TRouteState> {
       );
 
       return (
-        // When the the last state change was through popstate, the IS.js state changes,
+        // When the last state change was through popstate, the IS.js state changes,
         // but that should not write the URL.
         !this.inPopState &&
         // When the previous pushState after dispose was by IS.js, we want to write the URL.

--- a/src/lib/routers/history.ts
+++ b/src/lib/routers/history.ts
@@ -73,10 +73,9 @@ class BrowserHistory<TRouteState> implements Router<TRouteState> {
   private _onPopState?(event: PopStateEvent): void;
 
   /**
-   * Indicates if history.pushState should be executed.
-   * It needs to avoid pushing state to history in case of back/forward in browser
+   * Indicates if last action was back/forward in the browser.
    */
-  private shouldPushState: boolean = true;
+  private inPopState: boolean = false;
 
   /**
    * Indicates whether the history router is disposed or not.
@@ -139,20 +138,11 @@ class BrowserHistory<TRouteState> implements Router<TRouteState> {
       this.writeTimer = setTimeout(() => {
         setWindowTitle(title);
 
-        // We do want to `pushState` if:
-        // - the router is not disposed, IS.js needs to update the URL
-        // OR
-        // - the last write was from InstantSearch.js
-        // (unlike a SPA, where it would have last written)
-        const lastPushWasByISAfterDispose =
-          !this.isDisposed ||
-          this.latestAcknowledgedHistory === window.history.length;
-
-        if (this.shouldPushState && lastPushWasByISAfterDispose) {
+        if (this.shouldWrite(url)) {
           window.history.pushState(routeState, title || '', url);
           this.latestAcknowledgedHistory = window.history.length;
         }
-        this.shouldPushState = true;
+        this.inPopState = false;
         this.writeTimer = undefined;
       }, this.writeDelay);
     });
@@ -169,7 +159,7 @@ class BrowserHistory<TRouteState> implements Router<TRouteState> {
         this.writeTimer = undefined;
       }
 
-      this.shouldPushState = false;
+      this.inPopState = true;
       const routeState = event.state;
 
       // At initial load, the state is read from the URL without update.
@@ -219,6 +209,30 @@ class BrowserHistory<TRouteState> implements Router<TRouteState> {
     }
 
     this.write({} as TRouteState);
+  }
+
+  private shouldWrite(url: string): boolean {
+    return safelyRunOnBrowser(({ window }) => {
+      // We do want to `pushState` if:
+      // - the router is not disposed, IS.js needs to update the URL
+      // OR
+      // - the last write was from InstantSearch.js
+      // (unlike a SPA, where it would have last written)
+      const lastPushWasByISAfterDispose = !(
+        this.isDisposed &&
+        this.latestAcknowledgedHistory !== window.history.length
+      );
+
+      return (
+        // When the the last state change was through popstate, the IS.js state changes,
+        // but that should not write the URL.
+        !this.inPopState &&
+        // When the previous pushState after dispose was by IS.js, we want to write the URL.
+        lastPushWasByISAfterDispose &&
+        // When the URL is the same as the current one, we do not want to write it.
+        url !== window.location.href
+      );
+    });
   }
 }
 


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

We've given this from time to time as workarounds for customer issues, where due to state desync or other external influence the URL is already changed to the one InstantSearch would navigate to.

The specific state I test and am fixing here however is with `stateMapping` (described in https://github.com/algolia/instantsearch.js/discussions/5044) removing a piece of the state that still changes, and thus would cause duplicate writes of the same URL before this PR.

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

The same URL will not be written twice subsequently

I had to change the test for replaceState a bit, as the cleaned URL being the same as the replaceState navigated URL being the same was hiding the issue we have that test for.

