### PR TITLE
refactor(ts): avoid `as any`

### DIFF
--- a/src/connectors/autocomplete/__tests__/connectAutocomplete-test.ts
+++ b/src/connectors/autocomplete/__tests__/connectAutocomplete-test.ts
@@ -12,7 +12,7 @@ import { createSingleSearchResponse } from '../../../../test/mock/createAPIRespo
 import type { AutocompleteRenderState } from '../connectAutocomplete';
 import connectAutocomplete from '../connectAutocomplete';
 import { TAG_PLACEHOLDER } from '../../../lib/utils';
-import type { EscapedHits, Hit, SearchClient } from '../../../types';
+import type { SearchClient } from '../../../types';
 
 describe('connectAutocomplete', () => {
   const getInitializedWidget = (config = {}) => {
@@ -239,18 +239,19 @@ search.addWidgets([
       },
     ];
 
-    const escapedHits = [
-      {
-        _highlightResult: {
-          foobar: {
-            value: '&lt;script&gt;<mark>foobar</mark>&lt;/script&gt;',
+    const escapedHits = Object.assign(
+      [
+        {
+          _highlightResult: {
+            foobar: {
+              value: '&lt;script&gt;<mark>foobar</mark>&lt;/script&gt;',
+            },
           },
+          objectID: '1',
         },
-        objectID: '1',
-      },
-    ];
-
-    (escapedHits as any).__escaped = true;
+      ],
+      { __escaped: true }
+    );
 
     widget.init!(createInitOptions({ helper }));
 
@@ -533,8 +534,7 @@ search.addWidgets([
         createRenderOptions({ helper })
       );
 
-      const hits: Hit[] = [];
-      (hits as EscapedHits).__escaped = true;
+      const hits = Object.assign([], { __escaped: true });
 
       expect(renderState).toEqual({
         currentRefinement: 'query',

--- a/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -8,6 +8,7 @@ import type {
   SearchClient,
   HitAttributeHighlightResult,
   Hit,
+  EscapedHits,
 } from '../../../types';
 import { createInstantSearch } from '../../../../test/mock/createInstantSearch';
 import {
@@ -198,7 +199,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     const helper = algoliasearchHelper({} as SearchClient, '', {});
     helper.setPage(1);
     helper.search = jest.fn();
-    (helper as any).searchWithoutTriggeringOnStateChange = jest.fn();
+    helper.searchWithoutTriggeringOnStateChange = jest.fn();
     helper.emit = jest.fn();
 
     widget.init!(
@@ -236,9 +237,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     expect(helper.state.page).toBe(0);
     expect(helper.emit).not.toHaveBeenCalled();
     expect(helper.search).toHaveBeenCalledTimes(0);
-    expect(
-      (helper as any).searchWithoutTriggeringOnStateChange
-    ).toHaveBeenCalledTimes(1);
+    expect(helper.searchWithoutTriggeringOnStateChange).toHaveBeenCalledTimes(
+      1
+    );
 
     // the results should be prepended if there is an decrement in page
     const previousHits = [
@@ -857,7 +858,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       })
     );
 
-    expect((results.hits as any).__escaped).toBe(true);
+    expect((results.hits as unknown as EscapedHits).__escaped).toBe(true);
   });
 
   describe('dispose', () => {
@@ -1284,7 +1285,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       expect(actual.highlightPostTag).toBeUndefined();
     });
 
-    test('return Search Parameters with resetted page when `showPrevious` without `page` in the UI state', () => {
+    test('return Search Parameters with page reset when `showPrevious` without `page` in the UI state', () => {
       const render = jest.fn();
       const makeWidget = connectInfiniteHits(render);
       const helper = algoliasearchHelper(createSearchClient(), 'indexName');
@@ -1299,7 +1300,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       expect(actual.page).toEqual(0);
     });
 
-    test('return Search Parameters with resetted page when `showPrevious` and `page` is 0 in the UI state', () => {
+    test('return Search Parameters with page reset when `showPrevious` and `page` is 0 in the UI state', () => {
       const render = jest.fn();
       const makeWidget = connectInfiniteHits(render);
       const helper = algoliasearchHelper(createSearchClient(), 'indexName');

--- a/src/connectors/refinement-list/__tests__/connectRefinementList-test.ts
+++ b/src/connectors/refinement-list/__tests__/connectRefinementList-test.ts
@@ -30,8 +30,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
 
     expect(() =>
       connectRefinementList({
+        // @ts-expect-error we pass an object instead of renderer
         operator: 'and',
-      } as any)
+      })
     ).toThrowErrorMatchingInlineSnapshot(`
 "The render function is not valid (received type Object).
 

--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -192,7 +192,7 @@ class InstantSearch<
       throw new Error(withUsage('The `searchClient` option is required.'));
     }
 
-    if (typeof (searchClient as any).search !== 'function') {
+    if (typeof searchClient.search !== 'function') {
       throw new Error(
         `The \`searchClient\` must implement a \`search\` method.
 

--- a/src/lib/__tests__/RoutingManager-test.ts
+++ b/src/lib/__tests__/RoutingManager-test.ts
@@ -6,16 +6,11 @@ import qs from 'qs';
 import { createSearchClient } from '../../../test/mock/createSearchClient';
 import { createWidget } from '../../../test/mock/createWidget';
 import { wait } from '../../../test/utils/wait';
-import type {
-  Router,
-  Widget,
-  UiState,
-  StateMapping,
-  IndexUiState,
-} from '../../types';
+import type { Router, UiState, StateMapping, IndexUiState } from '../../types';
 import historyRouter from '../routers/history';
 import instantsearch from '../..';
 import type { JSDOM } from 'jsdom';
+import { connectHitsPerPage, connectSearchBox } from '../../connectors';
 
 declare const jsdom: JSDOM;
 
@@ -81,40 +76,6 @@ const createFakeHistory = <TEntry = Record<string, unknown>>(
     },
   };
 };
-
-const createFakeSearchBox = (): Widget =>
-  createWidget({
-    render({ helper }) {
-      (this as any).refine = (value: string) => {
-        helper.setQuery(value).search();
-      };
-    },
-    dispose({ state }) {
-      return state.setQuery('');
-    },
-    getWidgetSearchParameters(searchParameters, { uiState }) {
-      return searchParameters.setQuery(uiState.query || '');
-    },
-    getWidgetUiState(uiState, { searchParameters }) {
-      return {
-        ...uiState,
-        query: searchParameters.query,
-      };
-    },
-  });
-
-const createFakeHitsPerPage = (): Widget =>
-  createWidget({
-    dispose({ state }) {
-      return state;
-    },
-    getWidgetSearchParameters(parameters) {
-      return parameters;
-    },
-    getWidgetUiState(uiState) {
-      return uiState;
-    },
-  });
 
 describe('RoutingManager', () => {
   describe('within instantsearch', () => {
@@ -305,8 +266,10 @@ describe('RoutingManager', () => {
         },
       });
 
-      const fakeSearchBox: any = createFakeSearchBox();
-      const fakeHitsPerPage = createFakeHitsPerPage();
+      const fakeSearchBox = connectSearchBox(() => {})({});
+      const fakeHitsPerPage = connectHitsPerPage(() => {})({
+        items: [{ default: true, value: 1, label: 'one' }],
+      });
 
       search.addWidgets([fakeSearchBox, fakeHitsPerPage]);
 
@@ -315,7 +278,7 @@ describe('RoutingManager', () => {
       await wait(0);
 
       // Trigger an update - push a change
-      fakeSearchBox.refine('Apple');
+      search.renderState.indexName!.searchBox!.refine('Apple');
 
       await wait(0);
 
@@ -358,8 +321,10 @@ describe('RoutingManager', () => {
         },
       });
 
-      const fakeSearchBox = createFakeSearchBox();
-      const fakeHitsPerPage = createFakeHitsPerPage();
+      const fakeSearchBox = connectSearchBox(() => {})({});
+      const fakeHitsPerPage = connectHitsPerPage(() => {})({
+        items: [{ default: true, value: 1, label: 'one' }],
+      });
 
       search.addWidgets([fakeSearchBox, fakeHitsPerPage]);
 
@@ -409,8 +374,10 @@ describe('RoutingManager', () => {
         },
       });
 
-      const fakeSearchBox: any = createFakeSearchBox();
-      const fakeHitsPerPage = createFakeHitsPerPage();
+      const fakeSearchBox = connectSearchBox(() => {})({});
+      const fakeHitsPerPage = connectHitsPerPage(() => {})({
+        items: [{ default: true, value: 1, label: 'one' }],
+      });
 
       search.addWidgets([fakeSearchBox, fakeHitsPerPage]);
 
@@ -419,7 +386,7 @@ describe('RoutingManager', () => {
       await wait(0);
 
       // Trigger an update - push a change
-      fakeSearchBox.refine('Apple');
+      search.renderState.indexName!.searchBox!.refine('Apple');
 
       await wait(0);
 
@@ -431,7 +398,7 @@ describe('RoutingManager', () => {
       });
 
       // Trigger an update - push a change
-      fakeSearchBox.refine('Apple iPhone');
+      search.renderState.indexName!.searchBox!.refine('Apple iPhone');
 
       await wait(0);
 
@@ -501,9 +468,13 @@ describe('RoutingManager', () => {
         },
       });
 
-      const fakeSearchBox: any = createFakeSearchBox();
-      const fakeHitsPerPage1 = createFakeHitsPerPage();
-      const fakeHitsPerPage2 = createFakeHitsPerPage();
+      const fakeSearchBox = connectSearchBox(() => {})({});
+      const fakeHitsPerPage1 = connectHitsPerPage(() => {})({
+        items: [{ default: true, value: 1, label: 'one' }],
+      });
+      const fakeHitsPerPage2 = connectHitsPerPage(() => {})({
+        items: [{ default: true, value: 1, label: 'one' }],
+      });
 
       search.addWidgets([fakeSearchBox, fakeHitsPerPage1, fakeHitsPerPage2]);
 
@@ -512,7 +483,7 @@ describe('RoutingManager', () => {
       await wait(0);
 
       // Trigger an update - push a change
-      fakeSearchBox.refine('Apple');
+      search.renderState.indexName!.searchBox!.refine('Apple');
 
       await wait(0);
 
@@ -572,7 +543,7 @@ describe('RoutingManager', () => {
         },
       });
 
-      const fakeSearchBox = createFakeSearchBox();
+      const fakeSearchBox = connectSearchBox(() => {})({});
 
       search.addWidgets([fakeSearchBox]);
       search.start();

--- a/src/lib/utils/__tests__/createSendEventForHits-test.ts
+++ b/src/lib/utils/__tests__/createSendEventForHits-test.ts
@@ -65,7 +65,8 @@ describe('createSendEventForHits', () => {
     it('throw when eventName is missing for click or conversion event', () => {
       const { sendEvent } = createTestEnvironment();
       expect(() => {
-        sendEvent('click', {} as any);
+        // @ts-expect-error wrong input
+        sendEvent('click', {});
       }).toThrowErrorMatchingInlineSnapshot(`
 "You need to pass eventName as the third argument for 'click' or 'conversion' events like:
   sendEvent('click', hit, 'Product Purchased');
@@ -75,7 +76,8 @@ describe('createSendEventForHits', () => {
 `);
 
       expect(() => {
-        sendEvent('conversion', {} as any);
+        // @ts-expect-error wrong input
+        sendEvent('conversion', {});
       }).toThrowErrorMatchingInlineSnapshot(`
 "You need to pass eventName as the third argument for 'click' or 'conversion' events like:
   sendEvent('click', hit, 'Product Purchased');

--- a/src/lib/utils/__tests__/escape-highlight-test.ts
+++ b/src/lib/utils/__tests__/escape-highlight-test.ts
@@ -23,28 +23,30 @@ describe('escapeHits()', () => {
       },
     ];
 
-    const output = [
-      {
-        _highlightResult: {
-          foobar: {
-            value: '&lt;script&gt;<mark>foobar</mark>&lt;/script&gt;',
-            matchLevel: 'full' as const,
-            matchedWords: [],
+    const output = Object.assign(
+      [
+        {
+          _highlightResult: {
+            foobar: {
+              value: '&lt;script&gt;<mark>foobar</mark>&lt;/script&gt;',
+              matchLevel: 'full' as const,
+              matchedWords: [],
+            },
           },
-        },
-        _snippetResult: {
-          foobar: {
-            value: '&lt;script&gt;<mark>foobar</mark>&lt;/script&gt;',
-            matchLevel: 'full' as const,
-            matchedWords: [],
+          _snippetResult: {
+            foobar: {
+              value: '&lt;script&gt;<mark>foobar</mark>&lt;/script&gt;',
+              matchLevel: 'full' as const,
+              matchedWords: [],
+            },
           },
+          objectID: '1',
+          __position: 1,
         },
-        objectID: '1',
-        __position: 1,
-      },
-    ];
+      ],
+      { __escaped: true }
+    );
 
-    (output as any).__escaped = true;
     expect(escapeHits(hits)).toEqual(output);
   });
 
@@ -76,32 +78,34 @@ describe('escapeHits()', () => {
       },
     ];
 
-    const output = [
-      {
-        _highlightResult: {
-          foo: {
-            bar: {
-              value: '&lt;script&gt;<mark>foobar</mark>&lt;/script&gt;',
-              matchLevel: 'full' as const,
-              matchedWords: [],
+    const output = Object.assign(
+      [
+        {
+          _highlightResult: {
+            foo: {
+              bar: {
+                value: '&lt;script&gt;<mark>foobar</mark>&lt;/script&gt;',
+                matchLevel: 'full' as const,
+                matchedWords: [],
+              },
             },
           },
-        },
-        _snippetResult: {
-          foo: {
-            bar: {
-              value: '&lt;script&gt;<mark>foobar</mark>&lt;/script&gt;',
-              matchLevel: 'full' as const,
-              matchedWords: [],
+          _snippetResult: {
+            foo: {
+              bar: {
+                value: '&lt;script&gt;<mark>foobar</mark>&lt;/script&gt;',
+                matchLevel: 'full' as const,
+                matchedWords: [],
+              },
             },
           },
+          objectID: '1',
+          __position: 1,
         },
-        objectID: '1',
-        __position: 1,
-      },
-    ];
+      ],
+      { __escaped: true }
+    );
 
-    (output as any).__escaped = true;
     expect(escapeHits(hits)).toEqual(output);
   });
 
@@ -141,42 +145,44 @@ describe('escapeHits()', () => {
       },
     ];
 
-    const output = [
-      {
-        _highlightResult: {
-          foobar: [
-            {
-              value: '&lt;script&gt;<mark>bar</mark>&lt;/script&gt;',
-              matchLevel: 'full' as const,
-              matchedWords: [],
-            },
-            {
-              value: '&lt;script&gt;<mark>foo</mark>&lt;/script&gt;',
-              matchLevel: 'full' as const,
-              matchedWords: [],
-            },
-          ],
+    const output = Object.assign(
+      [
+        {
+          _highlightResult: {
+            foobar: [
+              {
+                value: '&lt;script&gt;<mark>bar</mark>&lt;/script&gt;',
+                matchLevel: 'full' as const,
+                matchedWords: [],
+              },
+              {
+                value: '&lt;script&gt;<mark>foo</mark>&lt;/script&gt;',
+                matchLevel: 'full' as const,
+                matchedWords: [],
+              },
+            ],
+          },
+          _snippetResult: {
+            foobar: [
+              {
+                value: '&lt;script&gt;<mark>bar</mark>&lt;/script&gt;',
+                matchLevel: 'full' as const,
+                matchedWords: [],
+              },
+              {
+                value: '&lt;script&gt;<mark>foo</mark>&lt;/script&gt;',
+                matchLevel: 'full' as const,
+                matchedWords: [],
+              },
+            ],
+          },
+          objectID: '1',
+          __position: 1,
         },
-        _snippetResult: {
-          foobar: [
-            {
-              value: '&lt;script&gt;<mark>bar</mark>&lt;/script&gt;',
-              matchLevel: 'full' as const,
-              matchedWords: [],
-            },
-            {
-              value: '&lt;script&gt;<mark>foo</mark>&lt;/script&gt;',
-              matchLevel: 'full' as const,
-              matchedWords: [],
-            },
-          ],
-        },
-        objectID: '1',
-        __position: 1,
-      },
-    ];
+      ],
+      { __escaped: true }
+    );
 
-    (output as any).__escaped = true;
     expect(escapeHits(hits)).toEqual(output);
   });
 
@@ -236,57 +242,60 @@ describe('escapeHits()', () => {
       },
     ];
 
-    const output = [
-      {
-        _highlightResult: {
-          foobar: [
-            {
-              foo: {
-                bar: {
-                  value: '&lt;script&gt;<mark>bar</mark>&lt;/script&gt;',
-                  matchLevel: 'full' as const,
-                  matchedWords: [],
+    const output = Object.assign(
+      [
+        {
+          _highlightResult: {
+            foobar: [
+              {
+                foo: {
+                  bar: {
+                    value: '&lt;script&gt;<mark>bar</mark>&lt;/script&gt;',
+                    matchLevel: 'full' as const,
+                    matchedWords: [],
+                  },
                 },
               },
-            },
-            {
-              foo: {
-                bar: {
-                  value: '&lt;script&gt;<mark>foo</mark>&lt;/script&gt;',
-                  matchLevel: 'full' as const,
-                  matchedWords: [],
+              {
+                foo: {
+                  bar: {
+                    value: '&lt;script&gt;<mark>foo</mark>&lt;/script&gt;',
+                    matchLevel: 'full' as const,
+                    matchedWords: [],
+                  },
                 },
               },
-            },
-          ],
+            ],
+          },
+          _snippetResult: {
+            foobar: [
+              {
+                foo: {
+                  bar: {
+                    value: '&lt;script&gt;<mark>bar</mark>&lt;/script&gt;',
+                    matchLevel: 'full' as const,
+                    matchedWords: [],
+                  },
+                },
+              },
+              {
+                foo: {
+                  bar: {
+                    value: '&lt;script&gt;<mark>foo</mark>&lt;/script&gt;',
+                    matchLevel: 'full' as const,
+                    matchedWords: [],
+                  },
+                },
+              },
+            ],
+          },
+          objectID: '1',
+          __position: 1,
         },
-        _snippetResult: {
-          foobar: [
-            {
-              foo: {
-                bar: {
-                  value: '&lt;script&gt;<mark>bar</mark>&lt;/script&gt;',
-                  matchLevel: 'full' as const,
-                  matchedWords: [],
-                },
-              },
-            },
-            {
-              foo: {
-                bar: {
-                  value: '&lt;script&gt;<mark>foo</mark>&lt;/script&gt;',
-                  matchLevel: 'full' as const,
-                  matchedWords: [],
-                },
-              },
-            },
-          ],
-        },
-        objectID: '1',
-        __position: 1,
-      },
-    ];
-    (output as any).__escaped = true;
+      ],
+      { __escaped: true }
+    );
+
     expect(escapeHits(hits)).toEqual(output);
   });
 
@@ -308,21 +317,22 @@ describe('escapeHits()', () => {
     hits = escapeHits(hits);
     hits = escapeHits(hits);
 
-    const output = [
-      {
-        _highlightResult: {
-          foobar: {
-            value: '&lt;script&gt;<mark>foo</mark>&lt;/script&gt;',
-            matchLevel: 'full' as const,
-            matchedWords: [],
+    const output = Object.assign(
+      [
+        {
+          _highlightResult: {
+            foobar: {
+              value: '&lt;script&gt;<mark>foo</mark>&lt;/script&gt;',
+              matchLevel: 'full' as const,
+              matchedWords: [],
+            },
           },
+          objectID: '1',
+          __position: 1,
         },
-        objectID: '1',
-        __position: 1,
-      },
-    ];
-
-    (output as any).__escaped = true;
+      ],
+      { __escaped: true }
+    );
 
     expect(hits).toEqual(output);
   });

--- a/src/lib/utils/escape-highlight.ts
+++ b/src/lib/utils/escape-highlight.ts
@@ -48,7 +48,7 @@ function recursiveEscape(input: any): any {
 export function escapeHits<THit extends Hit>(
   hits: THit[] | EscapedHits<THit>
 ): EscapedHits<THit> {
-  if ((hits as any).__escaped === undefined) {
+  if ((hits as EscapedHits).__escaped === undefined) {
     // We don't override the value on hit because it will mutate the raw results
     // instead we make a shallow copy and we assign the escaped values on it.
     hits = hits.map(({ ...hit }) => {
@@ -63,10 +63,10 @@ export function escapeHits<THit extends Hit>(
       return hit;
     });
 
-    (hits as any).__escaped = true;
+    (hits as EscapedHits).__escaped = true;
   }
 
-  return hits as unknown as EscapedHits<THit>;
+  return hits as EscapedHits<THit>;
 }
 
 export function escapeFacets(facetHits: FacetHit[]): FacetHit[] {

--- a/src/lib/utils/getAppIdAndApiKey.ts
+++ b/src/lib/utils/getAppIdAndApiKey.ts
@@ -1,5 +1,5 @@
 // typed as any, since it accepts the _real_ js clients, not the interface we otherwise expect
-export function getAppIdAndApiKey(searchClient: any) {
+export function getAppIdAndApiKey(searchClient: any): [string, string] {
   if (searchClient.transporter) {
     // searchClient v4
     const { headers, queryParameters } = searchClient.transporter;

--- a/src/lib/utils/safelyRunOnBrowser.ts
+++ b/src/lib/utils/safelyRunOnBrowser.ts
@@ -8,12 +8,12 @@ type SafelyRunOnBrowserOptions<TReturn> = {
 };
 
 /**
- * Runs code on browser enviromnents safely.
+ * Runs code on browser environments safely.
  */
 export function safelyRunOnBrowser<TReturn>(
   callback: BrowserCallback<TReturn>,
   { fallback }: SafelyRunOnBrowserOptions<TReturn> = {
-    fallback: () => undefined as any,
+    fallback: () => undefined as unknown as TReturn,
   }
 ): TReturn {
   // eslint-disable-next-line no-restricted-globals

--- a/src/widgets/hits-per-page/__tests__/hits-per-page-test.ts
+++ b/src/widgets/hits-per-page/__tests__/hits-per-page-test.ts
@@ -102,12 +102,12 @@ describe('hitsPerPage()', () => {
     widget.render!(createRenderOptions({ results, state }));
     widget.render!(createRenderOptions({ results, state }));
 
-    const firstRender = render.mock.calls[0][0] as VNode;
-    const { children, ...rootProps } = firstRender.props as any;
+    const firstRender = render.mock.calls[0][0] as VNode<SelectorProps>;
+    const { children, ...rootProps } = firstRender.props;
 
     expect(render).toHaveBeenCalledTimes(2);
     expect(rootProps).toMatchSnapshot();
-    expect(children.props).toMatchSnapshot();
+    expect((children! as VNode).props).toMatchSnapshot();
   });
 
   it('renders transformed items', () => {

--- a/src/widgets/index/__tests__/index-test.ts
+++ b/src/widgets/index/__tests__/index-test.ts
@@ -115,7 +115,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
 
   it('throws without `indexName` option', () => {
     expect(() => {
-      index({} as any);
+      // @ts-expect-error
+      index({});
     }).toThrowErrorMatchingInlineSnapshot(`
 "The \`indexName\` option is required.
 
@@ -190,7 +191,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
       const instance = index({ indexName: 'indexName' });
 
       expect(() => {
-        instance.addWidgets([{ dummy: true } as any]);
+        // @ts-expect-error
+        instance.addWidgets([{ dummy: true }]);
       }).toThrowErrorMatchingInlineSnapshot(`
 "The widget definition expects a \`render\` and/or an \`init\` method.
 

--- a/src/widgets/range-input/__tests__/range-input-test.ts
+++ b/src/widgets/range-input/__tests__/range-input-test.ts
@@ -17,6 +17,7 @@ import {
 } from '../../../../test/mock/createWidget';
 import { createInstantSearch } from '../../../../test/mock/createInstantSearch';
 import type { InstantSearch } from '../../../types';
+import type { RangeInputProps } from '../../../components/RangeInput/RangeInput';
 
 const render = castToJestMock(preactRender);
 jest.mock('preact', () => {
@@ -108,11 +109,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
     // @ts-expect-error SearchResults are missing properties that are not useful for this test
     widget.render!(createRenderOptions({ results, helper }));
 
-    const firstRender = render.mock.calls[0][0] as VNode;
+    const firstRender = render.mock.calls[0][0] as VNode<RangeInputProps>;
 
     expect(render).toHaveBeenCalledTimes(1);
-    expect((firstRender.props as any).min).toBe(10);
-    expect((firstRender.props as any).max).toBe(500);
+    expect(firstRender.props.min).toBe(10);
+    expect(firstRender.props.max).toBe(500);
     expect(firstRender.props).toMatchSnapshot();
   });
 
@@ -186,10 +187,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
     widget.init!(createInitOptions({ helper, instantSearchInstance }));
     widget.render!(createRenderOptions({ helper }));
 
-    const firstRender = render.mock.calls[0][0] as VNode;
+    const firstRender = render.mock.calls[0][0] as VNode<RangeInputProps>;
 
     expect(render).toHaveBeenCalledTimes(1);
-    expect((firstRender.props as any).min).toBe(20);
+    expect(firstRender.props.min).toBe(20);
   });
 
   it('expect to render with max', () => {
@@ -202,10 +203,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
     widget.init!(createInitOptions({ helper, instantSearchInstance }));
     widget.render!(createRenderOptions({ helper }));
 
-    const firstRender = render.mock.calls[0][0] as VNode;
+    const firstRender = render.mock.calls[0][0] as VNode<RangeInputProps>;
 
     expect(render).toHaveBeenCalledTimes(1);
-    expect((firstRender.props as any).max).toBe(480);
+    expect(firstRender.props.max).toBe(480);
   });
 
   it('expect to render with refinement', () => {
@@ -233,11 +234,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
     // @ts-expect-error SearchResults are missing properties that are not useful for this test
     widget.render!(createRenderOptions({ results, helper }));
 
-    const firstRender = render.mock.calls[0][0] as VNode;
+    const firstRender = render.mock.calls[0][0] as VNode<RangeInputProps>;
 
     expect(render).toHaveBeenCalledTimes(1);
     expect(firstRender.props).toMatchSnapshot();
-    expect((firstRender.props as any).values).toEqual({
+    expect(firstRender.props.values).toEqual({
       min: 25,
       max: 475,
     });
@@ -257,11 +258,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
     widget.init!(createInitOptions({ helper, instantSearchInstance }));
     widget.render!(createRenderOptions({ helper }));
 
-    const firstRender = render.mock.calls[0][0] as VNode;
+    const firstRender = render.mock.calls[0][0] as VNode<RangeInputProps>;
 
     expect(render).toHaveBeenCalledTimes(1);
     expect(firstRender.props).toMatchSnapshot();
-    expect((firstRender.props as any).values).toEqual({
+    expect(firstRender.props.values).toEqual({
       min: undefined,
       max: undefined,
     });
@@ -278,10 +279,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       widget.init!(createInitOptions({ helper, instantSearchInstance }));
       widget.render!(createRenderOptions({ helper }));
 
-      const firstRender = render.mock.calls[0][0] as VNode;
+      const firstRender = render.mock.calls[0][0] as VNode<RangeInputProps>;
 
       expect(render).toHaveBeenCalledTimes(1);
-      expect((firstRender.props as any).step).toBe(0.01);
+      expect(firstRender.props.step).toBe(0.01);
     });
 
     it('expect to render with precision of 0', () => {
@@ -294,10 +295,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       widget.init!(createInitOptions({ helper, instantSearchInstance }));
       widget.render!(createRenderOptions({ helper }));
 
-      const firstRender = render.mock.calls[0][0] as VNode;
+      const firstRender = render.mock.calls[0][0] as VNode<RangeInputProps>;
 
       expect(render).toHaveBeenCalledTimes(1);
-      expect((firstRender.props as any).step).toBe(1);
+      expect(firstRender.props.step).toBe(1);
     });
 
     it('expect to render with precision of 1', () => {
@@ -310,10 +311,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
       widget.init!(createInitOptions({ helper, instantSearchInstance }));
       widget.render!(createRenderOptions({ helper }));
 
-      const firstRender = render.mock.calls[0][0] as VNode;
+      const firstRender = render.mock.calls[0][0] as VNode<RangeInputProps>;
 
       expect(render).toHaveBeenCalledTimes(1);
-      expect((firstRender.props as any).step).toBe(0.1);
+      expect(firstRender.props.step).toBe(0.1);
     });
   });
 });


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

In a lot of cases, more sound patterns than casting into `any` are possible.

I didn't find an alternative for a remaining part of the code, so I'm not sure if I should find an eslint (or similar) rule to forbid "as any", or if it's good just being improved like this.

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

many `as any` instances are gone, but nothing is enforced
