### PR TITLE
Use arrow functions in connector types to fix `@typescript-eslint/no-unbound-method` errors

### DIFF
--- a/src/connectors/current-refinements/connectCurrentRefinements.ts
+++ b/src/connectors/current-refinements/connectCurrentRefinements.ts
@@ -90,7 +90,7 @@ export type CurrentRefinementsConnectorParamsItem = {
   /**
    * Removes the given refinement and triggers a new search.
    */
-  refine(refinement: CurrentRefinementsConnectorParamsRefinement): void;
+  refine: (refinement: CurrentRefinementsConnectorParamsRefinement) => void;
 };
 
 export type CurrentRefinementsConnectorParams = {
@@ -130,7 +130,7 @@ export type CurrentRefinementsRenderState = {
   /**
    * Removes the given refinement and triggers a new search.
    */
-  refine(refinement: CurrentRefinementsConnectorParamsRefinement): void;
+  refine: (refinement: CurrentRefinementsConnectorParamsRefinement) => void;
 
   /**
    * Generates a URL for the next state.

--- a/src/connectors/geo-search/connectGeoSearch.ts
+++ b/src/connectors/geo-search/connectGeoSearch.ts
@@ -56,7 +56,7 @@ export type GeoSearchRenderState = {
   /**
    * Reset the current bounding box refinement.
    */
-  clearMapRefinement(): void;
+  clearMapRefinement: () => void;
   /**
    * The current bounding box of the search.
    */
@@ -64,15 +64,15 @@ export type GeoSearchRenderState = {
   /**
    * Return true if the map has move since the last refinement.
    */
-  hasMapMoveSinceLastRefine(): boolean;
+  hasMapMoveSinceLastRefine: () => boolean;
   /**
    * Return true if the current refinement is set with the map bounds.
    */
-  isRefinedWithMap(): boolean;
+  isRefinedWithMap: () => boolean;
   /**
    * Return true if the user is able to refine on map move.
    */
-  isRefineOnMapMove(): boolean;
+  isRefineOnMapMove: () => boolean;
   /**
    * The matched hits from Algolia API.
    */
@@ -84,7 +84,7 @@ export type GeoSearchRenderState = {
   /**
    * Sets a bounding box to filter the results from the given map bounds.
    */
-  refine(bounds: Bounds): void;
+  refine: (bounds: Bounds) => void;
   /**
    * Send event to insights middleware
    */
@@ -94,11 +94,11 @@ export type GeoSearchRenderState = {
    * called on each map move. The call to the function triggers a new rendering
    * only when the value change.
    */
-  setMapMoveSinceLastRefine(): void;
+  setMapMoveSinceLastRefine: () => void;
   /**
    * Toggle the fact that the user is able to refine on map move.
    */
-  toggleRefineOnMapMove(): void;
+  toggleRefineOnMapMove: () => void;
 };
 
 export type GeoSearchConnectorParams = {

--- a/src/connectors/menu/connectMenu.ts
+++ b/src/connectors/menu/connectMenu.ts
@@ -85,7 +85,7 @@ export type MenuRenderState = {
   /**
    * Filter the search to item value.
    */
-  refine(value: string): void;
+  refine: (value: string) => void;
   /**
    * True if refinement can be applied.
    */
@@ -97,7 +97,7 @@ export type MenuRenderState = {
   /**
    * Toggles the number of values displayed between `limit` and `showMore.limit`.
    */
-  toggleShowMore(): void;
+  toggleShowMore: () => void;
   /**
    * `true` if the toggleShowMore button can be activated (enough items to display more or
    * already displaying more than `limit` items)

--- a/src/connectors/pagination/connectPagination.ts
+++ b/src/connectors/pagination/connectPagination.ts
@@ -30,7 +30,7 @@ export type PaginationRenderState = {
   createURL: CreateURL<number>;
 
   /** Sets the current page and triggers a search. */
-  refine(page: number): void;
+  refine: (page: number) => void;
 
   /** true if this search returned more than one page */
   canRefine: boolean;

--- a/src/connectors/range/connectRange.ts
+++ b/src/connectors/range/connectRange.ts
@@ -39,7 +39,7 @@ export type RangeRenderState = {
    * previously set bound or to set an infinite bound.
    * @param rangeValue tuple of [min, max] bounds
    */
-  refine(rangeValue: RangeBoundaries): void;
+  refine: (rangeValue: RangeBoundaries) => void;
 
   /**
    * Indicates whether this widget can be refined

--- a/src/connectors/refinement-list/connectRefinementList.ts
+++ b/src/connectors/refinement-list/connectRefinementList.ts
@@ -108,7 +108,7 @@ export type RefinementListRenderState = {
   /**
    * Action to apply selected refinements.
    */
-  refine(value: string): void;
+  refine: (value: string) => void;
   /**
    * Send event to insights middleware
    */
@@ -116,7 +116,7 @@ export type RefinementListRenderState = {
   /**
    * Searches for values inside the list.
    */
-  searchForItems(query: string): void;
+  searchForItems: (query: string) => void;
   /**
    * `true` if the values are from an index search.
    */
@@ -137,7 +137,7 @@ export type RefinementListRenderState = {
   /**
    * Toggles the number of values displayed between `limit` and `showMoreLimit`.
    */
-  toggleShowMore(): void;
+  toggleShowMore: () => void;
 };
 
 export type RefinementListWidgetDescription = {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Currently, the `RenderState` types for connectors inconsistently declare functions as either arrow functions or regular functions:

https://github.com/algolia/instantsearch.js/blob/3faca014aad08145c3b4cc66a5e841da3a0f64b8/src/connectors/search-box/connectSearchBox.ts#L41
https://github.com/algolia/instantsearch.js/blob/74d98f1fcd0d3560c63e4e4dc6dfaa848eb7f5bb/src/connectors/refinement-list/connectRefinementList.ts#L111

In user code, the latter leads to spurious lint errors from the [`@typescript-eslint/no-unbound-method` lint rule](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/unbound-method.md) when trying to assign the property to a standalone variable.

For example, destructuring the return value of the `useRefinementList` hook [as shown in the Algolia docs](https://www.algolia.com/doc/api-reference/widgets/refinement-list/react-hooks/#hook) results in this lint error:

<img width="866" alt="image" src="https://user-images.githubusercontent.com/376616/170845780-4d25df8f-436c-4447-b06f-ce5dcf78f49f.png">

I did a rudimentary regex search of the connector functions to find other affected type declarations, but may have missed some.

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

Lint error goes away after building and `link`ing this branch.