### PR TITLE
feat(core): don't schedule search without widgets

### DIFF
--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -515,7 +515,16 @@ See ${createDocumentationLink({
       defer(() => {
         this.scheduleSearch = originalScheduleSearch;
       })();
-    } else {
+    }
+    // We only schedule a search when widgets have been added before `start()`
+    // because there are listeners that can use these results.
+    // This is especially useful in framework-based flavors that wait for
+    // dynamically-added widgets to trigger a network request. It avoids
+    // having to batch this initial network request with the one coming from
+    // `addWidgets()`.
+    // Later, we could also skip `index()` widgets and widgets that don't read
+    // the results, but this is an optimization that has a very low impact for now.
+    else if (this.mainIndex.getWidgets().length > 0) {
       this.scheduleSearch();
     }
 

--- a/src/lib/__tests__/InstantSearch-integration-test.ts
+++ b/src/lib/__tests__/InstantSearch-integration-test.ts
@@ -5,7 +5,7 @@
 import { getByText, fireEvent } from '@testing-library/dom';
 import instantsearch from '../../index.es';
 import { configure, searchBox } from '../../widgets';
-import { connectConfigure } from '../../connectors';
+import { connectConfigure, connectSearchBox } from '../../connectors';
 import { createSearchClient } from '../../../test/mock/createSearchClient';
 import type { MiddlewareDefinition } from '../../types';
 import { wait } from '../../../test/utils/wait';
@@ -121,6 +121,8 @@ describe('middleware', () => {
 });
 
 describe('errors', () => {
+  const virtualSearchBox = connectSearchBox(() => {});
+
   it('client errors can be handled', () => {
     const search = instantsearch({
       searchClient: createSearchClient({
@@ -130,6 +132,8 @@ describe('errors', () => {
       }),
       indexName: '123',
     });
+
+    search.addWidgets([virtualSearchBox({})]);
 
     expect.assertions(4);
 

--- a/src/lib/__tests__/InstantSearch-test.tsx
+++ b/src/lib/__tests__/InstantSearch-test.tsx
@@ -68,6 +68,8 @@ jest.mock('algoliasearch-helper', () => {
   return mock;
 });
 
+const virtualSearchBox = connectSearchBox(() => {});
+
 beforeEach(() => {
   algoliasearchHelper.mockClear();
 });
@@ -414,6 +416,8 @@ See https://www.algolia.com/doc/api-reference/widgets/configure/js/`);
       searchClient,
     });
 
+    search.addWidgets([virtualSearchBox({})]);
+
     expect(search.helper).toBe(null);
 
     search.start();
@@ -674,6 +678,35 @@ describe('start', () => {
     expect(algoliasearchHelper).toHaveBeenCalledWith(searchClient, indexName);
   });
 
+  it('schedules a search with widgets', async () => {
+    const searchClient = createSearchClient();
+    const search = new InstantSearch({
+      indexName: 'indexName',
+      searchClient,
+    });
+
+    search.addWidgets([virtualSearchBox({})]);
+    search.start();
+
+    await wait(0);
+
+    expect(searchClient.search).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not schedule a search without widgets', async () => {
+    const searchClient = createSearchClient();
+    const search = new InstantSearch({
+      indexName: 'indexName',
+      searchClient,
+    });
+
+    search.start();
+
+    await wait(0);
+
+    expect(searchClient.search).toHaveBeenCalledTimes(0);
+  });
+
   it('replaces the regular `search` with `searchOnlyWithDerivedHelpers`', async () => {
     const searchClient = createSearchClient();
     const search = new InstantSearch({
@@ -681,6 +714,7 @@ describe('start', () => {
       searchClient,
     });
 
+    search.addWidgets([virtualSearchBox({})]);
     search.start();
 
     await wait(0);
@@ -700,6 +734,8 @@ describe('start', () => {
       searchFunction,
       searchClient,
     });
+
+    search.addWidgets([virtualSearchBox({})]);
 
     expect(searchFunction).toHaveBeenCalledTimes(0);
     expect(searchClient.search).toHaveBeenCalledTimes(0);
@@ -726,6 +762,8 @@ describe('start', () => {
         helper.setState(nextState).search();
       },
     });
+
+    search.addWidgets([virtualSearchBox({})]);
 
     expect(() => {
       search.start();
@@ -817,6 +855,7 @@ describe('start', () => {
 
     expect(searchClient.search).toHaveBeenCalledTimes(0);
 
+    search.addWidgets([virtualSearchBox({})]);
     search.start();
 
     await wait(0);
@@ -833,6 +872,7 @@ describe('start', () => {
 
     expect(searchClient.search).toHaveBeenCalledTimes(0);
 
+    search.addWidgets([virtualSearchBox({})]);
     search.start();
 
     await wait(0);
@@ -854,6 +894,7 @@ describe('start', () => {
 
     expect(searchClient.search).toHaveBeenCalledTimes(0);
 
+    search.addWidgets([virtualSearchBox({})]);
     search.start();
 
     search.on('error', (event) => {
@@ -1097,6 +1138,7 @@ describe('dispose', () => {
 
     search.on('render', onRender);
 
+    search.addWidgets([virtualSearchBox({})]);
     search.start();
 
     await wait(0);
@@ -1109,6 +1151,7 @@ describe('dispose', () => {
 
     search.on('render', onRender);
 
+    search.addWidgets([virtualSearchBox({})]);
     search.start();
 
     await wait(0);
@@ -1549,6 +1592,7 @@ describe('refresh', () => {
       searchClient,
     });
 
+    search.addWidgets([virtualSearchBox({})]);
     search.start();
 
     await wait(0);
@@ -1813,6 +1857,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
       searchClient,
     });
 
+    search.addWidgets([virtualSearchBox({})]);
     search.start();
     await wait(0);
     expect(searchClient.search).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
> **Note**
> This is in the PR series that brings support for React 18 in React InstantSearch Hooks.

## Description

This updates the behavior of the `start()` method to only schedule a search when there are widgets statically added beforehand. Scheduling a search without widget is a unnecessary operation because there are no listeners at this point to use the search results.

This behavior is required for React InstantSearch Hooks with React 18 to support new concurrent features. We don't have any certainty about the order of execution of our effects anymore in `<InstantSearch>` and `useConnector()`, so we would sometimes end up triggering a single network request, or sometimes two (from `start()`, and then from `addWidgets()`).

This eliminates the problem altogether because our framework-based flavors never rely on the search coming from `start()`, but on the search coming from `addWidgets()`.

## Impact

- This change shouldn't break any current implementations.
- This is also the opportunity to simplify our Vue integration [to not rely on the next tick to start the instance](https://github.com/algolia/vue-instantsearch/blob/71c25d460e1b077b62ca41a59a5c4df7b713ec56/src/util/createInstantSearchComponent.js#L61-L70).

## Related

- algolia/react-instantsearch#3489