### PR TITLE
fix(types): make all usages of UiState in InstantSearch generic

### DIFF
--- a/src/lib/__tests__/InstantSearch-test.tsx
+++ b/src/lib/__tests__/InstantSearch-test.tsx
@@ -21,7 +21,7 @@ import {
 } from '../../../test/mock/createWidget';
 import { castToJestMock } from '../../../test/utils/castToJestMock';
 import type { IndexWidget } from '../../widgets/index/index';
-import type { Widget } from '../../types';
+import type { UiState, Widget } from '../../types';
 import type {
   PaginationConnectorParams,
   PaginationWidgetDescription,
@@ -2038,7 +2038,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
 
   test('with function form sets indices state', async () => {
     const searchClient = createSearchClient();
-    const search = new InstantSearch({
+    const search = new InstantSearch<UiState>({
       indexName: 'indexName',
       searchClient,
       initialUiState: {


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

This allows someone with custom widgets to still use setUiState etc. without type errors


**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

all places `UiState` is used in the InstantSearch instance are now generic and use TUiState.

There are still places left in individual widgets, middleware which aren't generic, but that can be solved in a different PR

A sandbox showing the fixed problem: https://codesandbox.io/s/instantsearch-js-forked-m8nm7s?file=/src/app.ts:1152-1262
