### PR TITLE
fix(types): avoid inferring UiState type from initialUiState

### DIFF
--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -41,6 +41,11 @@ function defaultCreateURL() {
   return '#';
 }
 
+// this purposely breaks typescript's type inference to ensure it's not used
+// as it's used for a default parameter for example
+// source: https://github.com/Microsoft/TypeScript/issues/14829#issuecomment-504042546
+type NoInfer<T> = [T][T extends any ? 0 : never];
+
 /**
  * Global options for an InstantSearch instance.
  */
@@ -114,7 +119,7 @@ export type InstantSearchOptions<
    * for the first search. To unconditionally pass additional parameters to the
    * Algolia API, take a look at the `configure` widget.
    */
-  initialUiState?: TUiState;
+  initialUiState?: NoInfer<TUiState>;
 
   /**
    * Time before a search is considered stalled. The default is 200ms

--- a/src/lib/__tests__/InstantSearch-test.tsx
+++ b/src/lib/__tests__/InstantSearch-test.tsx
@@ -2038,7 +2038,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
 
   test('with function form sets indices state', async () => {
     const searchClient = createSearchClient();
-    const search = new InstantSearch<UiState>({
+    const search = new InstantSearch({
       indexName: 'indexName',
       searchClient,
       initialUiState: {
@@ -2681,7 +2681,9 @@ describe('onStateChange', () => {
 describe('initialUiState', () => {
   it('warns if UI state contains unmounted widgets in development mode', async () => {
     const searchClient = createSearchClient();
-    const search = new InstantSearch({
+    const search = new InstantSearch<
+      UiState & { [indexName: string]: { customWidget?: { query: string } } }
+    >({
       indexName: 'indexName',
       searchClient,
       initialUiState: {


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

if you pass initialUiState, that should be asserted by the generic UiState, not automatically accepted. Otherwise you get use cases like the "with function form sets indices state" test where setUiState thinks query is required, just because it has the default given

The way this works is by using `NoInfer` from https://github.com/Microsoft/TypeScript/issues/14829#issuecomment-504042546 which seems to be quite relied upon

This is a follow-up on #5060

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->


ui state is not inferred from initialUiState, but rather enforced by it. This means however that custom widgets are no longer "automatically detected from initialUiState", which I don't think is a breaking change, as it's only a type change
