### PR TITLE
fix(hierarchicalMenu): show full hierarchical parent values

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,12 +53,12 @@
     "scripts/transforms"
   ],
   "dependencies": {
+    "@algolia/events": "^4.0.1",
     "@types/google.maps": "^3.45.3",
     "@types/hogan.js": "^3.0.0",
     "@types/qs": "^6.5.3",
-    "algoliasearch-helper": "^3.8.2",
+    "algoliasearch-helper": "^3.8.3",
     "classnames": "^2.2.5",
-    "@algolia/events": "^4.0.1",
     "hogan.js": "^3.0.2",
     "preact": "^10.6.0",
     "qs": "^6.5.1 < 6.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3156,10 +3156,10 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@~6.12.6:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-algoliasearch-helper@^3.8.2:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.8.2.tgz#35726dc6d211f49dbab0bf6d37b4658165539523"
-  integrity sha512-AXxiF0zT9oYwl8ZBgU/eRXvfYhz7cBA5YrLPlw9inZHdaYF0QEya/f1Zp1mPYMXc1v6VkHwBq4pk6/vayBLICg==
+algoliasearch-helper@^3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.8.3.tgz#74066a6aa56a6dfa7af1f3ab8c6a545d707d5d5e"
+  integrity sha512-J0H08fQoyhZ2qLi7Uy8EvUeN/NJ4Trtt7NWB8mF1CGLuYpdXPyjZu9+Uoya2eayxQ20RP+QGF9Om/LddPv49vw==
   dependencies:
     "@algolia/events" "^4.0.1"
 


### PR DESCRIPTION
**Summary**

This PR updates **algoliasearch-helper** which now allows the `hierarchicalMenu` widget to retrieve and display the full list of a refined item's parents values.

**Result**

Fixes #5053 