### PR TITLE
fix(es): update path for InfiniteHits cache in depreciation message

### DIFF
--- a/src/index.es.ts
+++ b/src/index.es.ts
@@ -20,7 +20,7 @@ type InstantSearchModule = {
   version: string;
 
   // @major remove these in favour of the exports
-  /** @deprecated import { createInfiniteHitsSessionStorageCache } from 'instantsearch.js/es/helpers' */
+  /** @deprecated import { createInfiniteHitsSessionStorageCache } from 'instantsearch.js/es/lib/infiniteHitsCache' */
   createInfiniteHitsSessionStorageCache: typeof createInfiniteHitsSessionStorageCache;
   /** @deprecated import { highlight } from 'instantsearch.js/es/helpers' */
   highlight: typeof highlight;
@@ -64,7 +64,7 @@ instantsearch.version = version;
 
 instantsearch.createInfiniteHitsSessionStorageCache = deprecate(
   createInfiniteHitsSessionStorageCache,
-  "import { createInfiniteHitsSessionStorageCache } from 'instantsearch.js/es/helpers'"
+  "import { createInfiniteHitsSessionStorageCache } from 'instantsearch.js/es/lib/infiniteHitsCache'"
 );
 instantsearch.highlight = deprecate(
   highlight,


### PR DESCRIPTION
## Description

Our depreciation message advised to import `createInfiniteHitsSessionStorageCache()` from `instantsearch.js/es/helpers` but it's exported from `instantsearch.js/es/lib/infiniteHitsCache`.

## Related

- [CR-1389](https://algolia.atlassian.net/browse/CR-1389?atlOrigin=eyJpIjoiOWNlMzAzZjE4NDJjNDZlMTk0NTA4MjIwZTQxY2NhOWQiLCJwIjoiaiJ9)