### PR TITLE
fix(ratingMenu): don't warn if results are artificial

### DIFF
--- a/src/connectors/rating-menu/connectRatingMenu.ts
+++ b/src/connectors/rating-menu/connectRatingMenu.ts
@@ -352,7 +352,7 @@ const connectRatingMenu: RatingMenuConnector = function connectRatingMenu(
           const maxFacets = Math.pow(10, maxDecimalPlaces) * max;
 
           warning(
-            maxFacets <= maxValuesPerFacet,
+            maxFacets <= maxValuesPerFacet || Boolean(results.__isArtificial),
             getFacetValuesWarningMessage({
               maxDecimalPlaces,
               maxFacets,


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

If the results are artificial (react instantsearch hooks), `maxValuesPerFacet` can evaluate to 0, as it's not necessarily set by another widget, thus isn't in the result.

Before this fix there's a useless warning if you use useConnector(connectRatingMenu)

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

using useRatingMenu in React InstantSearch Hooks doesn't warn on first use