### PR TITLE
fix(types): use correct case for `_geoloc` property

### DIFF
--- a/src/connectors/geo-search/connectGeoSearch.ts
+++ b/src/connectors/geo-search/connectGeoSearch.ts
@@ -39,7 +39,7 @@ function setBoundingBoxAsString(state: SearchParameters, value: string) {
   );
 }
 
-export type GeoHit = Hit & Required<Pick<Hit, '_geoLoc'>>;
+export type GeoHit = Hit & Required<Pick<Hit, '_geoloc'>>;
 
 type Bounds = {
   /**

--- a/src/types/results.ts
+++ b/src/types/results.ts
@@ -59,7 +59,7 @@ export type AlgoliaHit<THit extends BaseHit = Record<string, any>> = {
     };
   };
   _distinctSeqID?: number;
-  _geoLoc?: GeoLoc;
+  _geoloc?: GeoLoc;
 } & THit;
 
 export type BaseHit = Record<string, unknown>;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

I noticed Intellisense completing `_geoLoc` instead of `_geoloc` when working on my code sample for Geo search in RISH. This PR correctly writes the property.

**Result**

The property is correctly written and correspond to the actual type of a `GeoHit`.