### PR TITLE
fix(errors): rethrow error as error if it's an object

### DIFF
--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -493,10 +493,10 @@ See ${createDocumentationLink({
       if (!(error instanceof Error)) {
         // typescript lies here, error is in some cases { name: string, message: string }
         const err = error as Record<string, any>;
-        error = new Error(err.message);
-        Object.keys(err).forEach((key) => {
-          (error as any)[key] = err[key];
-        });
+        error = Object.keys(err).reduce((acc, key) => {
+          (acc as any)[key] = err[key];
+          return acc;
+        }, new Error(err.message));
       }
       // If an error is emitted, it is re-thrown by events. In previous versions
       // we emitted {error}, which is thrown as:

--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -490,6 +490,14 @@ See ${createDocumentationLink({
     // Only the "main" Helper emits the `error` event vs the one for `search`
     // and `results` that are also emitted on the derived one.
     mainHelper.on('error', ({ error }) => {
+      if (!(error instanceof Error)) {
+        // typescript lies here, error is in some cases { name: string, message: string }
+        const err = error as Record<string, any>;
+        error = new Error(err.message);
+        Object.keys(err).forEach((key) => {
+          (error as any)[key] = err[key];
+        });
+      }
       // If an error is emitted, it is re-thrown by events. In previous versions
       // we emitted {error}, which is thrown as:
       // "Uncaught, unspecified \"error\" event. ([object Object])"


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

If you're using the v4 client, the errors (unfortunately) are fake errors, see https://github.com/algolia/algoliasearch-client-javascript/blob/3aec216a9704f818b4faaa8b97d988ec2794f9da/packages/transporter/src/errors/createRetryError.ts for example. When those errors get thrown, you get `"Uncaught, unspecified \"error\" event. ([object Object])"` still.

cfr errors like https://github.com/algolia/react-instantsearch/issues/3534 which have more clear errors (usually wrong api keys, network issues)


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

no more "object Object" errors for search client errors
