### PR TITLE
feat(connectors): deprecate `hasNoResults` in favor of `canRefine`

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
   "bundlesize": [
     {
       "path": "./dist/instantsearch.production.min.js",
-      "maxSize": "70.25 kB"
+      "maxSize": "70.75 kB"
     },
     {
       "path": "./dist/instantsearch.development.js",

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     },
     {
       "path": "./dist/instantsearch.development.js",
-      "maxSize": "151.50 kB"
+      "maxSize": "152.00 kB"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
   "bundlesize": [
     {
       "path": "./dist/instantsearch.production.min.js",
-      "maxSize": "70.75 kB"
+      "maxSize": "70.50 kB"
     },
     {
       "path": "./dist/instantsearch.development.js",

--- a/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.ts
+++ b/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.ts
@@ -733,6 +733,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
             createURL: expect.any(Function),
             refine: expect.any(Function),
             hasNoResults: false,
+            canRefine: true,
             widgetParams: {
               items: [
                 {
@@ -767,6 +768,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
         ],
         createURL: expect.any(Function),
         hasNoResults: true,
+        canRefine: false,
         refine: expect.any(Function),
         widgetParams: {
           items: [
@@ -803,6 +805,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
             createURL: () => '',
             refine: () => {},
             hasNoResults: true,
+            canRefine: false,
             widgetParams: {
               items: [
                 {
@@ -850,6 +853,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
         ],
         createURL: expect.any(Function),
         hasNoResults: true,
+        canRefine: false,
         refine: expect.any(Function),
         widgetParams: {
           items: [
@@ -904,6 +908,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
         refine: expect.any(Function),
         createURL: expect.any(Function),
         hasNoResults: true,
+        canRefine: false,
         widgetParams: {
           items: [
             {
@@ -954,6 +959,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits-per-pa
         ],
         createURL: expect.any(Function),
         hasNoResults: true,
+        canRefine: false,
         refine: expect.any(Function),
         widgetParams: {
           items: [

--- a/src/connectors/hits-per-page/connectHitsPerPage.ts
+++ b/src/connectors/hits-per-page/connectHitsPerPage.ts
@@ -91,8 +91,14 @@ export type HitsPerPageRenderState = {
 
   /**
    * Indicates whether or not the search has results.
+   * @deprecated Use `canRefine` instead.
    */
   hasNoResults: boolean;
+
+  /**
+   * Indicates if search state can be refined.
+   */
+  canRefine: boolean;
 };
 
 export type HitsPerPageWidgetDescription = {
@@ -259,11 +265,14 @@ You may want to add another entry to the \`items\` option with this value.`
       },
 
       getWidgetRenderState({ state, results, createURL, helper }) {
+        const hasNoResults = results ? results.nbHits === 0 : true;
+
         return {
           items: transformItems(normalizeItems(state), { results }),
           refine: connectorState.getRefine(helper),
           createURL: connectorState.createURLFactory({ state, createURL }),
-          hasNoResults: results ? results.nbHits === 0 : true,
+          hasNoResults,
+          canRefine: !hasNoResults,
           widgetParams,
         };
       },

--- a/src/connectors/hits-per-page/connectHitsPerPage.ts
+++ b/src/connectors/hits-per-page/connectHitsPerPage.ts
@@ -265,14 +265,14 @@ You may want to add another entry to the \`items\` option with this value.`
       },
 
       getWidgetRenderState({ state, results, createURL, helper }) {
-        const hasNoResults = results ? results.nbHits === 0 : true;
+        const canRefine = results ? results.nbHits > 0 : false;
 
         return {
           items: transformItems(normalizeItems(state), { results }),
           refine: connectorState.getRefine(helper),
           createURL: connectorState.createURLFactory({ state, createURL }),
-          hasNoResults,
-          canRefine: !hasNoResults,
+          hasNoResults: !canRefine,
+          canRefine,
           widgetParams,
         };
       },

--- a/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.ts
+++ b/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.ts
@@ -1200,6 +1200,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
         numerics: {
           createURL: expect.any(Function),
           hasNoResults: true,
+          canRefine: false,
           items: [
             {
               isRefined: false,
@@ -1259,6 +1260,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
           refine: renderState1.numericMenu.numerics.refine,
           sendEvent: renderState1.numericMenu.numerics.sendEvent,
           hasNoResults: true,
+          canRefine: false,
           items: [
             {
               isRefined: false,
@@ -1340,6 +1342,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
         refine: expect.any(Function),
         sendEvent: expect.any(Function),
         hasNoResults: true,
+        canRefine: false,
         widgetParams: {
           attribute: 'numerics',
           items: [
@@ -1390,6 +1393,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
         refine: expect.any(Function),
         sendEvent: expect.any(Function),
         hasNoResults: true,
+        canRefine: false,
         widgetParams: {
           attribute: 'numerics',
           items: [
@@ -1425,6 +1429,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
       expect(renderState2).toEqual({
         createURL: expect.any(Function),
         hasNoResults: true,
+        canRefine: false,
         items: [
           {
             isRefined: false,
@@ -1462,6 +1467,28 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
             },
           ],
         },
+      });
+    });
+
+    describe('canRefine', () => {
+      it('should be true if there are no results but a refinement is being applied', () => {
+        const [widget, helper] = getInitializedWidget();
+        helper.setQueryParameter('numericRefinements', {
+          numerics: { '>=': [20] },
+        });
+        const renderState = widget.getWidgetRenderState(
+          createInitOptions({ state: helper.state, helper })
+        );
+        expect(renderState.canRefine).toBe(true);
+      });
+
+      it('should be false if there are no results and no refinement is being applied', () => {
+        const [widget, helper] = getInitializedWidget();
+
+        const renderState = widget.getWidgetRenderState(
+          createInitOptions({ state: helper.state, helper })
+        );
+        expect(renderState.canRefine).toBe(false);
       });
     });
   });

--- a/src/connectors/numeric-menu/connectNumericMenu.ts
+++ b/src/connectors/numeric-menu/connectNumericMenu.ts
@@ -91,8 +91,17 @@ export type NumericMenuRenderState = {
 
   /**
    * `true` if the last search contains no result
+   * @deprecated Use `canRefine` instead.
    */
   hasNoResults: boolean;
+
+  /**
+   * Indicates if search state can be refined.
+   *
+   * This is `true` if the last search contains no result and
+   * "All" range is selected
+   */
+  canRefine: boolean;
 
   /**
    * Sets the selected value and trigger a new search
@@ -355,10 +364,21 @@ const connectNumericMenu: NumericMenuConnector = function connectNumericMenu(
           });
         }
 
+        const hasNoResults = results ? results.nbHits === 0 : true;
+        const preparedItems = prepareItems(state);
+        let allIsSelected = true;
+        for (const item of preparedItems) {
+          if (item.isRefined && decodeURI(item.value) !== '{}') {
+            allIsSelected = false;
+            break;
+          }
+        }
+
         return {
           createURL: connectorState.createURL(state),
-          items: transformItems(prepareItems(state), { results }),
-          hasNoResults: results ? results.nbHits === 0 : true,
+          items: transformItems(preparedItems, { results }),
+          hasNoResults,
+          canRefine: !(hasNoResults && allIsSelected),
           refine: connectorState.refine,
           sendEvent: connectorState.sendEvent,
           widgetParams,

--- a/src/connectors/rating-menu/__tests__/connectRatingMenu-test.ts
+++ b/src/connectors/rating-menu/__tests__/connectRatingMenu-test.ts
@@ -699,76 +699,103 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
       });
     });
 
-    it('should return canRefine false if there are no results and no refinement is applied', () => {
-      const renderFn = jest.fn();
-      const unmountFn = jest.fn();
-      const createRatingMenu = connectRatingMenu(renderFn, unmountFn);
-      const ratingMenuWidget = createRatingMenu({
-        attribute: 'grade',
-      });
-      const helper = jsHelper(createSearchClient(), 'indexName', {
-        disjunctiveFacets: ['grade'],
-      });
-
-      const results = new SearchResults(helper.state, [
-        createSingleSearchResponse({
-          facets: {
-            grade: { 0: 5, 1: 10, 2: 20, 3: 50, 4: 900, 5: 100 },
-          },
-        }),
-      ]);
-
-      const renderOptions = createRenderOptions({
-        helper,
-        state: helper.state,
-        results,
-      });
-
-      const renderState = ratingMenuWidget.getWidgetRenderState(renderOptions);
-
-      expect(renderState).toEqual({
-        items: [
-          {
-            count: 1000,
-            isRefined: false,
-            label: '4',
-            name: '4',
-            stars: [true, true, true, true, false],
-            value: '4',
-          },
-          {
-            count: 1050,
-            isRefined: false,
-            label: '3',
-            name: '3',
-            stars: [true, true, true, false, false],
-            value: '3',
-          },
-          {
-            count: 1070,
-            isRefined: false,
-            label: '2',
-            name: '2',
-            stars: [true, true, false, false, false],
-            value: '2',
-          },
-          {
-            count: 1080,
-            isRefined: false,
-            label: '1',
-            name: '1',
-            stars: [true, false, false, false, false],
-            value: '1',
-          },
-        ],
-        createURL: expect.any(Function),
-        canRefine: false,
-        refine: expect.any(Function),
-        sendEvent: expect.any(Function),
-        hasNoResults: true,
-        widgetParams: {
+    describe('canRefine', () => {
+      it('returns `true`  if there are no results but a refinement is applied and total facet count is higher than 0', () => {
+        const renderFn = jest.fn();
+        const unmountFn = jest.fn();
+        const createRatingMenu = connectRatingMenu(renderFn, unmountFn);
+        const ratingMenuWidget = createRatingMenu({
           attribute: 'grade',
-        },
+        });
+        const helper = jsHelper(createSearchClient(), 'indexName', {
+          disjunctiveFacets: ['grade'],
+          numericRefinements: {
+            grade: {
+              '>=': [2],
+            },
+          },
+        });
+
+        const results = new SearchResults(helper.state, [
+          createSingleSearchResponse({
+            facets: {
+              grade: { 0: 5, 1: 10, 2: 20, 3: 50, 4: 900, 5: 100 },
+            },
+          }),
+        ]);
+
+        const renderOptions = createRenderOptions({
+          helper,
+          state: helper.state,
+          results,
+        });
+
+        const renderState =
+          ratingMenuWidget.getWidgetRenderState(renderOptions);
+
+        expect(renderState.canRefine).toBe(true);
+      });
+
+      it('returns `false`  if there are no results and no refinement is applied', () => {
+        const renderFn = jest.fn();
+        const unmountFn = jest.fn();
+        const createRatingMenu = connectRatingMenu(renderFn, unmountFn);
+        const ratingMenuWidget = createRatingMenu({
+          attribute: 'grade',
+        });
+        const helper = jsHelper(createSearchClient(), 'indexName', {
+          disjunctiveFacets: ['grade'],
+        });
+
+        const results = new SearchResults(helper.state, [
+          createSingleSearchResponse({
+            facets: {
+              grade: { 0: 5, 1: 10, 2: 20, 3: 50, 4: 900, 5: 100 },
+            },
+          }),
+        ]);
+
+        const renderOptions = createRenderOptions({
+          helper,
+          state: helper.state,
+          results,
+        });
+
+        const renderState =
+          ratingMenuWidget.getWidgetRenderState(renderOptions);
+
+        expect(renderState.canRefine).toBe(false);
+      });
+
+      it('returns `false` if there are no results and a refinement is applied but total facet count is 0', () => {
+        const renderFn = jest.fn();
+        const unmountFn = jest.fn();
+        const createRatingMenu = connectRatingMenu(renderFn, unmountFn);
+        const ratingMenuWidget = createRatingMenu({
+          attribute: 'grade',
+        });
+        const helper = jsHelper(createSearchClient(), 'indexName', {
+          disjunctiveFacets: ['grade'],
+        });
+
+        const results = new SearchResults(helper.state, [
+          createSingleSearchResponse({
+            facets: {
+              grade: { 0: 0, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 },
+            },
+          }),
+        ]);
+
+        const renderOptions = createRenderOptions({
+          helper,
+          state: helper.state,
+          results,
+        });
+
+        const renderState =
+          ratingMenuWidget.getWidgetRenderState(renderOptions);
+
+        expect(renderState.canRefine).toBe(false);
       });
     });
   });

--- a/src/connectors/rating-menu/__tests__/connectRatingMenu-test.ts
+++ b/src/connectors/rating-menu/__tests__/connectRatingMenu-test.ts
@@ -698,6 +698,79 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
         },
       });
     });
+
+    it('should return canRefine false if there are no results and no refinement is applied', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const createRatingMenu = connectRatingMenu(renderFn, unmountFn);
+      const ratingMenuWidget = createRatingMenu({
+        attribute: 'grade',
+      });
+      const helper = jsHelper(createSearchClient(), 'indexName', {
+        disjunctiveFacets: ['grade'],
+      });
+
+      const results = new SearchResults(helper.state, [
+        createSingleSearchResponse({
+          facets: {
+            grade: { 0: 5, 1: 10, 2: 20, 3: 50, 4: 900, 5: 100 },
+          },
+        }),
+      ]);
+
+      const renderOptions = createRenderOptions({
+        helper,
+        state: helper.state,
+        results,
+      });
+
+      const renderState = ratingMenuWidget.getWidgetRenderState(renderOptions);
+
+      expect(renderState).toEqual({
+        items: [
+          {
+            count: 1000,
+            isRefined: false,
+            label: '4',
+            name: '4',
+            stars: [true, true, true, true, false],
+            value: '4',
+          },
+          {
+            count: 1050,
+            isRefined: false,
+            label: '3',
+            name: '3',
+            stars: [true, true, true, false, false],
+            value: '3',
+          },
+          {
+            count: 1070,
+            isRefined: false,
+            label: '2',
+            name: '2',
+            stars: [true, true, false, false, false],
+            value: '2',
+          },
+          {
+            count: 1080,
+            isRefined: false,
+            label: '1',
+            name: '1',
+            stars: [true, false, false, false, false],
+            value: '1',
+          },
+        ],
+        createURL: expect.any(Function),
+        canRefine: false,
+        refine: expect.any(Function),
+        sendEvent: expect.any(Function),
+        hasNoResults: true,
+        widgetParams: {
+          attribute: 'grade',
+        },
+      });
+    });
   });
 
   describe('getWidgetSearchParameters', () => {

--- a/src/connectors/rating-menu/connectRatingMenu.ts
+++ b/src/connectors/rating-menu/connectRatingMenu.ts
@@ -344,6 +344,7 @@ const connectRatingMenu: RatingMenuConnector = function connectRatingMenu(
         }
 
         let refinementIsApplied = false;
+        let totalCount = 0;
 
         if (results) {
           const facetResults = results.getFacetValues(
@@ -374,6 +375,7 @@ const connectRatingMenu: RatingMenuConnector = function connectRatingMenu(
               .filter((f) => Number(f.name) >= star && Number(f.name) <= max)
               .map((f) => f.count)
               .reduce((sum, current) => sum + current, 0);
+            totalCount += count;
 
             if (refinedStar && !isRefined && count === 0) {
               // skip count==0 when at least 1 refinement is enabled
@@ -402,7 +404,7 @@ const connectRatingMenu: RatingMenuConnector = function connectRatingMenu(
         return {
           items: facetValues,
           hasNoResults,
-          canRefine: !hasNoResults || refinementIsApplied,
+          canRefine: (!hasNoResults || refinementIsApplied) && totalCount > 0,
           refine: connectorState.toggleRefinementFactory(helper),
           sendEvent,
           createURL: connectorState.createURLFactory({ state, createURL }),

--- a/src/connectors/rating-menu/connectRatingMenu.ts
+++ b/src/connectors/rating-menu/connectRatingMenu.ts
@@ -126,6 +126,8 @@ export type RatingMenuRenderState = {
 
   /**
    * `true` if the last search contains no result.
+   *
+   * @deprecated Use `canRefine` instead.
    */
   hasNoResults: boolean;
 
@@ -341,6 +343,8 @@ const connectRatingMenu: RatingMenuConnector = function connectRatingMenu(
           });
         }
 
+        let refinementIsApplied = false;
+
         if (results) {
           const facetResults = results.getFacetValues(
             attribute,
@@ -364,6 +368,7 @@ const connectRatingMenu: RatingMenuConnector = function connectRatingMenu(
 
           for (let star = STEP; star < max; star += STEP) {
             const isRefined = refinedStar === star;
+            refinementIsApplied = refinementIsApplied || isRefined;
 
             const count = facetResults
               .filter((f) => Number(f.name) >= star && Number(f.name) <= max)
@@ -392,10 +397,12 @@ const connectRatingMenu: RatingMenuConnector = function connectRatingMenu(
         }
         facetValues = facetValues.reverse();
 
+        const hasNoResults = results ? results.nbHits === 0 : true;
+
         return {
           items: facetValues,
-          hasNoResults: results ? results.nbHits === 0 : true,
-          canRefine: facetValues.length > 0,
+          hasNoResults,
+          canRefine: !hasNoResults || refinementIsApplied,
           refine: connectorState.toggleRefinementFactory(helper),
           sendEvent,
           createURL: connectorState.createURLFactory({ state, createURL }),

--- a/src/connectors/sort-by/__tests__/connectSortBy-test.ts
+++ b/src/connectors/sort-by/__tests__/connectSortBy-test.ts
@@ -328,6 +328,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
         currentRefinement: 'index_default',
         refine: expect.any(Function),
         hasNoResults: true,
+        canRefine: false,
         options: [
           { label: 'default', value: 'index_default' },
           { label: 'asc', value: 'index_asc' },
@@ -369,6 +370,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
         currentRefinement: 'index_desc',
         refine: expect.any(Function),
         hasNoResults: false,
+        canRefine: true,
         options: [
           { label: 'default', value: 'index_default' },
           { label: 'asc', value: 'index_asc' },
@@ -409,6 +411,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
         currentRefinement: 'index_desc',
         refine: expect.any(Function),
         hasNoResults: true,
+        canRefine: false,
         options: [
           { label: 'default', value: 'index_default' },
           { label: 'asc', value: 'index_asc' },
@@ -448,6 +451,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
         currentRefinement: 'index_default',
         refine: expect.any(Function),
         hasNoResults: false,
+        canRefine: true,
         options: [
           { label: 'default', value: 'index_default' },
           { label: 'asc', value: 'index_asc' },
@@ -461,6 +465,36 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
           ],
         },
       });
+    });
+
+    test('canRefine is false if there are results but no item to chose from', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const createSortBy = connectSortBy(renderFn, unmountFn);
+      const sortBy = createSortBy({
+        items: [],
+      });
+      const helper = algoliasearchHelper(createSearchClient(), 'index_desc', {
+        index: 'index_desc',
+      });
+
+      const renderState = sortBy.getWidgetRenderState(
+        createRenderOptions({
+          helper,
+          state: helper.state,
+          results: new SearchResults(helper.state, [
+            createSingleSearchResponse({
+              hits: [
+                { brand: 'samsung', objectID: '1' },
+                { brand: 'apple', objectID: '2' },
+              ],
+              hitsPerPage: 20,
+            }),
+          ]),
+        })
+      );
+
+      expect(renderState.canRefine).toBe(false);
     });
   });
 

--- a/src/connectors/sort-by/connectSortBy.ts
+++ b/src/connectors/sort-by/connectSortBy.ts
@@ -59,8 +59,13 @@ export type SortByRenderState = {
   refine: (value: string) => void;
   /**
    * `true` if the last search contains no result.
+   * @deprecated Use `canRefine` instead.
    */
   hasNoResults: boolean;
+  /**
+   * `true` if we can refine.
+   */
+  canRefine: boolean;
 };
 
 export type SortByWidgetDescription = {
@@ -169,11 +174,14 @@ const connectSortBy: SortByConnector = function connectSortBy(
           };
         }
 
+        const hasNoResults = results ? results.nbHits === 0 : true;
+
         return {
           currentRefinement: state.index,
           options: transformItems(items, { results }),
           refine: connectorState.setIndex,
-          hasNoResults: results ? results.nbHits === 0 : true,
+          hasNoResults,
+          canRefine: !hasNoResults && items.length > 0,
           widgetParams,
         };
       },


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

[FX-740](https://algolia.atlassian.net/browse/FX-740)

We want to encourage users to use `canRefine` instead of `hasNoResults`, and to provide them with more meaningful and easier ways to show users if a widget should be interacted with.

**Result**

- *hits-per-page*: `canRefine` is `true` when `hasNoResults` is `false` and vice-versa, no need to check if `items > 0` as it's done beforehand
- *numeric-menu*: `canRefine` can be true even if `hasNoResults` is true, in the case where a refinement has been applied since we can refine to "All"
- *rating-menu*: `canRefine` can be true even if `hasNoResults` is true when a rating is selected
- *sort-by*: `canRefine` is `true` when there are results and at least 1 item

