### PR TITLE
fix(ratingMenu): fix `undefined` facet values error when `disjunctiveFacets` is empty

### DIFF
--- a/src/connectors/rating-menu/__tests__/connectRatingMenu-test.ts
+++ b/src/connectors/rating-menu/__tests__/connectRatingMenu-test.ts
@@ -699,8 +699,48 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
       });
     });
 
+    it('returns the widget render state with no items without throwing an error', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const createRatingMenu = connectRatingMenu(renderFn, unmountFn);
+      const ratingMenuWidget = createRatingMenu({
+        attribute: 'grade',
+      });
+      const helper = jsHelper(createSearchClient(), 'indexName', {
+        disjunctiveFacets: [],
+      });
+
+      const initOptions = createInitOptions({ state: helper.state, helper });
+      const renderState1 = ratingMenuWidget.getWidgetRenderState(initOptions);
+
+      const results = new SearchResults(helper.state, [
+        createSingleSearchResponse({
+          facets: { grade: { 0: 5, 1: 10, 2: 20, 3: 50, 4: 900, 5: 100 } },
+        }),
+      ]);
+
+      const renderOptions = createRenderOptions({
+        helper,
+        state: helper.state,
+        results,
+      });
+      const renderState2 = ratingMenuWidget.getWidgetRenderState(renderOptions);
+
+      expect(renderState2).toEqual({
+        items: [],
+        createURL: expect.any(Function),
+        canRefine: false,
+        refine: expect.any(Function),
+        sendEvent: renderState1.sendEvent,
+        hasNoResults: true,
+        widgetParams: {
+          attribute: 'grade',
+        },
+      });
+    });
+
     describe('canRefine', () => {
-      it('returns `true`  if there are no results but a refinement is applied and total facet count is higher than 0', () => {
+      it('returns `true` if there are no results but a refinement is applied and total facet count is higher than 0', () => {
         const renderFn = jest.fn();
         const unmountFn = jest.fn();
         const createRatingMenu = connectRatingMenu(renderFn, unmountFn);

--- a/src/connectors/rating-menu/connectRatingMenu.ts
+++ b/src/connectors/rating-menu/connectRatingMenu.ts
@@ -346,13 +346,12 @@ const connectRatingMenu: RatingMenuConnector = function connectRatingMenu(
         let refinementIsApplied = false;
         let totalCount = 0;
 
-        if (results) {
-          const facetResults = results.getFacetValues(
-            attribute,
-            {}
-          ) as SearchResults.FacetValue[];
-          const maxValuesPerFacet = facetResults.length;
+        const facetResults = results?.getFacetValues(attribute, {}) as
+          | SearchResults.FacetValue[]
+          | undefined;
 
+        if (results && facetResults) {
+          const maxValuesPerFacet = facetResults.length;
           const maxDecimalPlaces = getFacetsMaxDecimalPlaces(facetResults);
           const maxFacets = Math.pow(10, maxDecimalPlaces) * max;
 


### PR DESCRIPTION
**Summary**

On RISH, if you create a custom RatingMenu widget (based on [this example](https://www.algolia.com/doc/api-reference/widgets/rating-menu/react-hooks/) on the doc) using `useConnector` and `connectRatingMenu` from IS.js and use it with the `useDynamicWidgets` hook, it throws an error as you can see on [this sandbox](https://codesandbox.io/s/fx-1706-ratingmenu-connector-issue-j99rth?file=/src/Refinements.tsx:390-495).

![image](https://user-images.githubusercontent.com/662153/188467581-0aeaf840-bf31-429c-be33-5b98331ed8aa.png)

This PR fixes the error in IS.js by making sure the facet values are not `undefined` before reading their length.

[FX-1706](https://algolia.atlassian.net/browse/FX-1706)

**Result**

The rating menu connector doesn't throw any error when used with RISH.