### PR TITLE
fix(insightsMiddleware): infer type of insightsClient for onEvent

### DIFF
--- a/src/middlewares/createInsightsMiddleware.ts
+++ b/src/middlewares/createInsightsMiddleware.ts
@@ -20,25 +20,24 @@ export type InsightsEvent = {
   attribute?: string;
 };
 
-export type InsightsProps = {
-  insightsClient: null | InsightsClient;
+export type InsightsProps<
+  TInsightsClient extends null | InsightsClient = InsightsClient | null
+> = {
+  insightsClient: TInsightsClient;
   insightsInitParams?: {
     userHasOptedOut?: boolean;
     useCookie?: boolean;
     cookieDuration?: number;
     region?: 'de' | 'us';
   };
-  onEvent?: (
-    event: InsightsEvent,
-    insightsClient: null | InsightsClient
-  ) => void;
+  onEvent?: (event: InsightsEvent, insightsClient: TInsightsClient) => void;
 };
 
-export type CreateInsightsMiddleware = (
-  props: InsightsProps
-) => InternalMiddleware;
+export type CreateInsightsMiddleware = typeof createInsightsMiddleware;
 
-export const createInsightsMiddleware: CreateInsightsMiddleware = (props) => {
+export function createInsightsMiddleware<
+  TInsightsClient extends null | InsightsClient
+>(props: InsightsProps<TInsightsClient>): InternalMiddleware {
   const {
     insightsClient: _insightsClient,
     insightsInitParams,
@@ -57,8 +56,8 @@ export const createInsightsMiddleware: CreateInsightsMiddleware = (props) => {
   }
 
   const hasInsightsClient = Boolean(_insightsClient);
-  const insightsClient =
-    _insightsClient === null ? (noop as InsightsClient) : _insightsClient;
+  const insightsClient: InsightsClient =
+    _insightsClient === null ? noop : _insightsClient;
 
   return ({ instantSearchInstance }) => {
     const [appId, apiKey] = getAppIdAndApiKey(instantSearchInstance.client);
@@ -192,4 +191,4 @@ See documentation: https://www.algolia.com/doc/guides/building-search-ui/going-f
       },
     };
   };
-};
+}


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

infer `insightsClient` as `null` or `InsightsClient` inside the `onEvent` callback

If the insightsClient is given in the arguments, we also know that it's no longer optional in `onEvent`

this came to my attention through #5129

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

no need to assert `aa!` in `onEvent` as when you're using it, it's already set

