### PR TITLE
fix(events): prevent warning on low number of listeners

### DIFF
--- a/src/lib/InstantSearch.ts
+++ b/src/lib/InstantSearch.ts
@@ -202,6 +202,9 @@ Use \`InstantSearch.status === "stalled"\` instead.`
   public constructor(options: InstantSearchOptions<TUiState, TRouteState>) {
     super();
 
+    // prevent `render` event listening from causing a warning
+    this.setMaxListeners(100);
+
     const {
       indexName = null,
       numberLocale,

--- a/src/lib/__tests__/InstantSearch-test.tsx
+++ b/src/lib/__tests__/InstantSearch-test.tsx
@@ -2825,3 +2825,25 @@ If you're using custom widgets that do set these query parameters, we recommend 
 See https://www.algolia.com/doc/guides/building-search-ui/widgets/customize-an-existing-widget/js/#customize-the-complete-ui-of-the-widgets`);
   });
 });
+
+describe('events', () => {
+  test('can attach many `render` listeners', () => {
+    const spy = jest.spyOn(console, 'error');
+    spy.mockImplementation(() => {});
+    const search = new InstantSearch({
+      indexName: 'indexName',
+      searchClient: createSearchClient(),
+    });
+
+    Array.from({ length: 100 }).forEach(() => {
+      search.on('render', () => {});
+    });
+
+    expect(spy).toHaveBeenCalledTimes(0);
+
+    search.on('render', () => {});
+
+    // once for the warning, once for the trace
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/__tests__/status.test.ts
+++ b/src/lib/__tests__/status.test.ts
@@ -198,10 +198,9 @@ describe('status', () => {
     // prevent rethrow of error
     search.on('error', () => {});
 
-    const renderer = jest.fn<
-      void,
-      [{ status: InstantSearch['status']; error?: Error }]
-    >();
+    const renderer = jest.fn(
+      (_: { status: InstantSearch['status']; error?: Error }) => undefined
+    );
     search.on('render', () =>
       renderer({ status: search.status, error: search.error })
     );


### PR DESCRIPTION
The default number of listeners before it's warned of an infinite loop is 10, however you can easily have that many render listeners using useInstantSearch. I've increased the number to 100 in this PR

FX-1626