### PR TITLE
fix(insights): check before usage of `document`

### DIFF
--- a/src/helpers/get-insights-anonymous-user-token.ts
+++ b/src/helpers/get-insights-anonymous-user-token.ts
@@ -3,7 +3,9 @@ import { warning } from '../lib/utils';
 export const ANONYMOUS_TOKEN_COOKIE_KEY = '_ALGOLIA';
 
 function getCookie(name: string): string | undefined {
-  if (!document || !document.cookie) return undefined;
+  if (typeof document !== 'object' || typeof document.cookie !== 'string') {
+    return undefined;
+  }
 
   const prefix = `${name}=`;
   const cookies = document.cookie.split(';');

--- a/src/helpers/get-insights-anonymous-user-token.ts
+++ b/src/helpers/get-insights-anonymous-user-token.ts
@@ -3,6 +3,8 @@ import { warning } from '../lib/utils';
 export const ANONYMOUS_TOKEN_COOKIE_KEY = '_ALGOLIA';
 
 function getCookie(name: string): string | undefined {
+  if (!document || !document.cookie) return undefined;
+
   const prefix = `${name}=`;
   const cookies = document.cookie.split(';');
   for (let i = 0; i < cookies.length; i++) {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

search-insights is compatible with react-native or other environments without document, but the insights plugin wasn't. This PR fixes that.

I've searched and outside of widgets there's no other occurrences of `document`, but didn't yet find a way to make sure it's a failing test if document is used. We can do that after InstantSearch would be split probably.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

fixes #5148

FX-1926

createInsightsMiddleware supports environments without `document` or `document.cookie`

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

