### PR TITLE
fix(answers): mark as deprecated

### DIFF
--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -1,3 +1,5 @@
+import { deprecate } from '../lib/utils';
+
 export { default as connectClearRefinements } from './clear-refinements/connectClearRefinements';
 export { default as connectCurrentRefinements } from './current-refinements/connectCurrentRefinements';
 export { default as connectHierarchicalMenu } from './hierarchical-menu/connectHierarchicalMenu';
@@ -24,12 +26,19 @@ export { default as EXPERIMENTAL_connectConfigureRelatedItems } from './configur
 export { default as connectAutocomplete } from './autocomplete/connectAutocomplete';
 export { default as connectQueryRules } from './query-rules/connectQueryRules';
 export { default as connectVoiceSearch } from './voice-search/connectVoiceSearch';
-export { default as EXPERIMENTAL_connectAnswers } from './answers/connectAnswers';
+import connectAnswers from './answers/connectAnswers';
+
+/** @deprecated answers is no longer supported */
+export const EXPERIMENTAL_connectAnswers = deprecate(
+  connectAnswers,
+  'answers is no longer supported'
+);
+
 export { default as connectRelevantSort } from './relevant-sort/connectRelevantSort';
 
 import connectDynamicWidgets from './dynamic-widgets/connectDynamicWidgets';
 export { connectDynamicWidgets };
-import { deprecate } from '../lib/utils';
+
 /** @deprecated use connectDynamicWidgets */
 export const EXPERIMENTAL_connectDynamicWidgets = deprecate(
   connectDynamicWidgets,

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -1,14 +1,22 @@
+import { deprecate } from '../lib/utils';
+
 export { default as analytics } from './analytics/analytics';
 export { default as breadcrumb } from './breadcrumb/breadcrumb';
 export { default as clearRefinements } from './clear-refinements/clear-refinements';
 export { default as configure } from './configure/configure';
 export { default as currentRefinements } from './current-refinements/current-refinements';
-export { default as EXPERIMENTAL_answers } from './answers/answers';
+
+import answers from './answers/answers';
+/** @deprecated answers is no longer supported */
+export const EXPERIMENTAL_answers = deprecate(
+  answers,
+  'answers is no longer supported'
+);
+
 export { default as EXPERIMENTAL_configureRelatedItems } from './configure-related-items/configure-related-items';
 
 import dynamicWidgets from './dynamic-widgets/dynamic-widgets';
 export { dynamicWidgets };
-import { deprecate } from '../lib/utils';
 /** @deprecated use dynamicWidgets */
 export const EXPERIMENTAL_dynamicWidgets = deprecate(
   dynamicWidgets,


### PR DESCRIPTION
While the answers feature still works, it no longer has any difference from a regular search, and therefore no longer needs its own specialised widget.

Even though it's marked as experimental, I still don't think it's a good idea to delete without major version, as it's used in the downstream packages