### PR TITLE
fix: shouldWrite return false if isDisposed

### DIFF
--- a/src/lib/routers/history.ts
+++ b/src/lib/routers/history.ts
@@ -238,8 +238,12 @@ class BrowserHistory<TRouteState> implements Router<TRouteState> {
 
 export default function historyRouter<TRouteState = UiState>({
   createURL = ({ qsModule, routeState, location }) => {
-    const { protocol, hostname, port = '', pathname, hash } = location;
-    const queryString = qsModule.stringify(routeState);
+    const { protocol, hostname, port = '', pathname, hash, search } = location;
+    const existingSearchParameters = qsModule.parse(search.slice(1));
+    const queryString = qsModule.stringify({
+      ...existingSearchParameters,
+      ...routeState,
+    });
     const portWithPrefix = port === '' ? '' : `:${port}`;
 
     // IE <= 11 has no proper `location.origin` so we cannot rely on it.


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

Updates the "router"'s `createURL` method to take into account any existing search params. This way `shouldWrite` check can be valid and not potentially write a new history push in SPAs where another router has pushed new history changes with search params.

A quick demo of the problem and how this PRs change fixes the issue:
https://www.loom.com/share/09539f87f691407cb7692ba21fa17537

**Result**

By taking into account the existing search params of the URL when creating it to be used in `shouldWrite`, allows `shouldWrite` to return correct expected boolean when another history event has pushed to new url with search params.
