### PR TITLE
tests(unit): delay "wait" for more stability

### DIFF
--- a/packages/instantsearch.js/src/connectors/answers/__tests__/connectAnswers-test.ts
+++ b/packages/instantsearch.js/src/connectors/answers/__tests__/connectAnswers-test.ts
@@ -11,6 +11,8 @@ import connectAnswers from '../connectAnswers';
 
 const defaultRenderDebounceTime = 10;
 const defaultSearchDebounceTime = 10;
+const waitForDebounceTime =
+  defaultRenderDebounceTime + defaultSearchDebounceTime + 80;
 
 describe('connectAnswers', () => {
   describe('Usage', () => {
@@ -236,7 +238,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/answers/js/
       false
     );
 
-    await wait(30); // 10(render debounce) + 10(search debounce) + 10(just to make sure)
+    await wait(waitForDebounceTime);
 
     // render with hits
     const expectedHits = [{ title: '', objectID: 'a', __position: 1 }];
@@ -299,8 +301,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/answers/js/
     // no debounce for rendering loader
     expect(renderFn).toHaveBeenCalledTimes(3);
 
-    // wait for debounce
-    await wait(30);
+    await wait(waitForDebounceTime);
+
     const expectedHits = [{ title: '', objectID: 'a', __position: 1 }];
     expect(renderFn).toHaveBeenCalledTimes(4);
     expect(renderFn).toHaveBeenNthCalledWith(
@@ -312,8 +314,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/answers/js/
       false
     );
 
-    // wait
-    await wait(30);
+    await wait(waitForDebounceTime);
+
     // but no more rendering
     expect(renderFn).toHaveBeenCalledTimes(4);
   });
@@ -421,7 +423,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/answers/js/
         },
       });
 
-      await wait(30);
+      await wait(waitForDebounceTime);
+
       const expectedHits = [{ title: '', objectID: 'a', __position: 1 }];
       expect(
         widget.getWidgetRenderState(

--- a/packages/instantsearch.js/src/lib/__tests__/routing/correct-urls.test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/routing/correct-urls.test.ts
@@ -13,8 +13,10 @@ beforeEach(() => {
   window.history.pushState({}, '', '/');
 });
 
+const writeDelay = 10;
+const writeWait = 10 * writeDelay;
+
 test('correct URL for widgets', async () => {
-  const writeDelay = 10;
   const router = historyRouter({ writeDelay });
 
   const indexName = 'indexName';
@@ -40,7 +42,7 @@ test('correct URL for widgets', async () => {
   // on main index
   search.renderState[indexName].pagination!.refine(39);
 
-  await wait(20);
+  await wait(writeWait);
 
   expect(window.location.search).toBe(
     `?${encodeURI('indexName[page]=40&indexName[query]=test')}`
@@ -48,7 +50,6 @@ test('correct URL for widgets', async () => {
 });
 
 test('correct URL for widgets in indices with repeated indexId', async () => {
-  const writeDelay = 10;
   const router = historyRouter({ writeDelay });
 
   const indexName = 'indexName';
@@ -74,7 +75,7 @@ test('correct URL for widgets in indices with repeated indexId', async () => {
   // on main index
   search.renderState[indexName].pagination!.refine(39);
 
-  await wait(20);
+  await wait(writeWait);
 
   expect(window.location.search).toBe(
     `?${encodeURI('indexName[page]=40&indexName[query]=test')}`

--- a/packages/instantsearch.js/src/lib/__tests__/routing/dispose-start-test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/routing/dispose-start-test.ts
@@ -12,7 +12,7 @@ import type InstantSearch from '../../InstantSearch';
 /* eslint no-lone-blocks: "off" */
 
 const writeDelay = 10;
-const writeWait = 1.5 * writeDelay;
+const writeWait = 10 * writeDelay;
 
 const addWidgetsAndStart = (search: InstantSearch) => {
   search.addWidgets([connectSearchBox(() => {})({})]);

--- a/packages/instantsearch.js/src/lib/__tests__/routing/duplicate-url-test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/routing/duplicate-url-test.ts
@@ -11,7 +11,7 @@ import { connectPagination, connectSearchBox } from '../../../connectors';
 /* eslint no-lone-blocks: "off" */
 
 const writeDelay = 10;
-const writeWait = 1.5 * writeDelay;
+const writeWait = 10 * writeDelay;
 
 test('does not write the same URL twice', async () => {
   // -- Flow

--- a/packages/instantsearch.js/src/lib/__tests__/routing/external-influence-test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/routing/external-influence-test.ts
@@ -11,7 +11,7 @@ import { connectSearchBox } from '../../../connectors';
 /* eslint no-lone-blocks: "off" */
 
 const writeDelay = 10;
-const writeWait = 1.5 * writeDelay;
+const writeWait = 10 * writeDelay;
 
 describe('routing with external influence', () => {
   test('keeps on working when the URL is updated by another program', async () => {

--- a/packages/instantsearch.js/src/lib/__tests__/routing/modal-test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/routing/modal-test.ts
@@ -11,7 +11,7 @@ import { connectSearchBox } from '../../../connectors';
 /* eslint no-lone-blocks: "off" */
 
 const writeDelay = 10;
-const writeWait = 1.5 * writeDelay;
+const writeWait = 10 * writeDelay;
 
 describe('routing with no navigation', () => {
   test('cleans the URL when InstantSearch is disposed within the same page', async () => {

--- a/packages/instantsearch.js/src/lib/__tests__/routing/spa-debounced-test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/routing/spa-debounced-test.ts
@@ -11,7 +11,7 @@ import { connectSearchBox } from '../../../connectors';
 /* eslint no-lone-blocks: "off" */
 
 const writeDelay = 10;
-const writeWait = 1.5 * writeDelay;
+const writeWait = 10 * writeDelay;
 
 describe('routing with debounced third-party client-side router', () => {
   test('does not clean the URL after navigating', async () => {

--- a/packages/instantsearch.js/src/lib/__tests__/routing/spa-replace-state-test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/routing/spa-replace-state-test.ts
@@ -11,7 +11,7 @@ import { connectSearchBox } from '../../../connectors';
 /* eslint no-lone-blocks: "off" */
 
 const writeDelay = 10;
-const writeWait = 1.5 * writeDelay;
+const writeWait = 10 * writeDelay;
 
 describe('routing using `replaceState`', () => {
   // We can't assert whether another router did update the URL

--- a/packages/instantsearch.js/src/lib/__tests__/routing/spa-test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/routing/spa-test.ts
@@ -11,7 +11,7 @@ import { connectSearchBox } from '../../../connectors';
 /* eslint no-lone-blocks: "off" */
 
 const writeDelay = 10;
-const writeWait = 1.5 * writeDelay;
+const writeWait = 10 * writeDelay;
 
 describe('routing with third-party client-side router', () => {
   test('does not clean the URL after navigating', async () => {

--- a/packages/instantsearch.js/src/widgets/answers/__tests__/answers-test.ts
+++ b/packages/instantsearch.js/src/widgets/answers/__tests__/answers-test.ts
@@ -151,7 +151,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/answers/js/
       );
       expect(answersContainer.querySelector('.root')).toHaveClass('empty');
 
-      await wait(30);
+      await wait(100);
 
       // debounced render
       expect(answersContainer.querySelector('.root')).not.toHaveClass('empty');


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

It seems that in some cases the unit tests which wait for a timeout to "definitely have happened" don't wait long enough. AFAICT this is because setTimeout doesn't have an implicit ordering, if the timer in the code is delayed (setTimeout argument is a minimum), it's possible that the timer in the test already has expired, and thus trying to assert too fast.

I could not find other patterns to replace these type of tests with, so added a decent chunk of extra timeout, hoping that these tests from now on no longer are flaky!

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.

  You will be able to test out these changes on the deploy
  preview (address will be commented by a bot):

  1. the documentation site (/)
  2. a widget playground (/stories)
-->

unit tests should no longer be flaky after this PR. I've ran the CI a couple times to confirm. Results:

- Run 1: [passed](https://app.circleci.com/pipelines/github/algolia/instantsearch.js/7763/workflows/bdd9918c-35d4-4019-ae5d-64bee11f0cfc/jobs/37049)
- Run 2: [passed](https://app.circleci.com/pipelines/github/algolia/instantsearch.js/7763/workflows/5081246c-9655-434a-9796-8ebbe6ee49ce/jobs/37052)
- Run 3: [passed](https://app.circleci.com/pipelines/github/algolia/instantsearch.js/7763/workflows/5081246c-9655-434a-9796-8ebbe6ee49ce/jobs/37054)
- Run 4: [passed](https://app.circleci.com/pipelines/github/algolia/instantsearch.js/7763/workflows/caafec12-f6e7-40c3-a909-da68ad6015a7/jobs/37055)
- Run 5: [passed](https://app.circleci.com/pipelines/github/algolia/instantsearch.js/7763/workflows/1d0ca865-2adc-4302-895b-91d3a7972040/jobs/37058)