### PR TITLE
ci(circle): fix configuration of autorelease task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,10 +197,9 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - run: *install_yarn_version
-      - restore_cache: *restore_yarn_cache
-      - run: *run_yarn_install
-      - save_cache: *save_yarn_cache
+      - *install_yarn_version
+      - *restore_yarn_cache
+      - *run_yarn_install
       - run:
           name: Prepare a pull request for next release
           command: |


### PR DESCRIPTION
When refactoring this in #5162 this part wasn't run, so it didn't error on CI

FX-2087