### PR TITLE
chore(bundling): don't require "version" env variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "rollup-plugin-node-resolve": "5.2.0",
     "rollup-plugin-replace": "2.2.0",
     "rollup-plugin-uglify": "6.0.4",
-    "semver": "6.3.0",
     "shelljs": "0.8.5",
     "shipjs": "0.25.0",
     "typescript": "4.3.5"

--- a/packages/instantsearch.js/scripts/rollup/rollup.config.js
+++ b/packages/instantsearch.js/scripts/rollup/rollup.config.js
@@ -4,21 +4,12 @@ import babel from 'rollup-plugin-babel';
 import replace from 'rollup-plugin-replace';
 import { uglify } from 'rollup-plugin-uglify';
 import filesize from 'rollup-plugin-filesize';
-import semver from 'semver';
-
-if (
-  process.env.NODE_ENV === 'production' &&
-  !semver.valid(process.env.VERSION)
-) {
-  throw new Error(
-    `You need to specify a valid semver environment variable 'VERSION' to run the build process (received: ${JSON.stringify(
-      process.env.VERSION
-    )}).`
-  );
-}
+import packageJson from '../../package.json';
 
 const version =
-  process.env.VERSION || `UNRELEASED (${new Date().toUTCString()})`;
+  process.env.NODE_ENV === 'production'
+    ? packageJson.version
+    : `UNRELEASED (${new Date().toUTCString()})`;
 const algolia = '© Algolia, Inc. and contributors; MIT License';
 const link = 'https://github.com/algolia/instantsearch.js';
 const license = `/*! InstantSearch.js ${version} | ${algolia} | ${link} */`;


### PR DESCRIPTION
Fixes the build script in prod mode for InstantSearch.js