### PR TITLE
docs(examples): override undefined constants in examples

### DIFF
--- a/examples/js/calendar-widget/env.js
+++ b/examples/js/calendar-widget/env.js
@@ -1,0 +1,6 @@
+// Parcel picks the `source` field of the monorepo packages and thus doesn't
+// apply the Babel config. We therefore need to manually override the constants
+// in the app.
+// See https://twitter.com/devongovett/status/1134231234605830144
+global.__DEV__ = process.env.NODE_ENV !== 'production';
+global.__TEST__ = false;

--- a/examples/js/calendar-widget/index.html
+++ b/examples/js/calendar-widget/index.html
@@ -41,6 +41,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.20.1/moment.min.js"></script>
   <script src="https://unpkg.com/BaremetricsCalendar@1.0.11/public/js/Calendar.js"></script>
+  <script type="module" src="env.js"></script>
   <script type="module" src="app.js"></script>
 </body>
 

--- a/examples/js/e-commerce/index.html
+++ b/examples/js/e-commerce/index.html
@@ -120,6 +120,7 @@
       </button>
     </aside>
 
+    <script type="module" src="./src/env.js"></script>
     <script type="module" src="./src/app.ts"></script>
   </body>
 </html>

--- a/examples/js/e-commerce/src/env.js
+++ b/examples/js/e-commerce/src/env.js
@@ -1,0 +1,6 @@
+// Parcel picks the `source` field of the monorepo packages and thus doesn't
+// apply the Babel config. We therefore need to manually override the constants
+// in the app.
+// See https://twitter.com/devongovett/status/1134231234605830144
+global.__DEV__ = process.env.NODE_ENV !== 'production';
+global.__TEST__ = false;

--- a/examples/js/media/index.html
+++ b/examples/js/media/index.html
@@ -221,6 +221,7 @@
       </div>
     </footer>
 
+    <script type="module" src="./src/env.ts"></script>
     <script type="module" src="./src/app.ts"></script>
   </body>
 </html>

--- a/examples/js/media/src/env.ts
+++ b/examples/js/media/src/env.ts
@@ -1,0 +1,6 @@
+// Parcel picks the `source` field of the monorepo packages and thus doesn't
+// apply the Babel config. We therefore need to manually override the constants
+// in the app.
+// See https://twitter.com/devongovett/status/1134231234605830144
+(global as any).__DEV__ = process.env.NODE_ENV !== 'production';
+(global as any).__TEST__ = false;

--- a/examples/js/tourism/env.js
+++ b/examples/js/tourism/env.js
@@ -1,0 +1,6 @@
+// Parcel picks the `source` field of the monorepo packages and thus doesn't
+// apply the Babel config. We therefore need to manually override the constants
+// in the app.
+// See https://twitter.com/devongovett/status/1134231234605830144
+global.__DEV__ = process.env.NODE_ENV !== 'production';
+global.__TEST__ = false;

--- a/examples/js/tourism/index.html
+++ b/examples/js/tourism/index.html
@@ -82,6 +82,7 @@
     </div>
 
     <script src="https://maps.googleapis.com/maps/api/js?v=weekly&key=AIzaSyBawL8VbstJDdU5397SUX7pEt9DslAwWgQ"></script>
+    <script type="module" src="env.js"></script>
     <script type="module" src="search.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

Examples no longer worked in dev mode after the move to the monorepo because of how Parcel works in such configurations. This is a problem we fixed in the [Autocomplete monorepo](https://github.com/algolia/autocomplete) with `env.{js,ts}` files that override constants otherwise undefined (see [example](https://github.com/algolia/autocomplete/blob/next/examples/github-notification-filters/env.ts)).