### PR TITLE
chore(instantsearch.css): remove unused class

### DIFF
--- a/examples/js/e-commerce/src/app.css
+++ b/examples/js/e-commerce/src/app.css
@@ -318,10 +318,6 @@ mark {
   content: 'Yes';
 }
 
-.ais-ToggleRefinement-count {
-  display: none;
-}
-
 /* RatingMenu */
 
 .ais-RatingMenu-item:not(.ais-RatingMenu-item--selected) {

--- a/examples/js/e-commerce/src/theme.css
+++ b/examples/js/e-commerce/src/theme.css
@@ -292,7 +292,6 @@ a[class^='ais-'] {
 .ais-HierarchicalMenu-count,
 .ais-Menu-count,
 .ais-RefinementList-count,
-.ais-ToggleRefinement-count,
 .ais-RatingMenu-count {
   align-items: center;
   background-color: rgba(65, 66, 71, 0.08);

--- a/examples/js/media/src/theme.css
+++ b/examples/js/media/src/theme.css
@@ -330,7 +330,6 @@ a[class^='ais-'] {
 .ais-HierarchicalMenu-count,
 .ais-Menu-count,
 .ais-RefinementList-count,
-.ais-ToggleRefinement-count,
 .ais-RatingMenu-count {
   align-items: center;
   background-color: #e6ebf7;

--- a/packages/instantsearch.css/src/themes/algolia.scss
+++ b/packages/instantsearch.css/src/themes/algolia.scss
@@ -256,8 +256,7 @@ a[class^='ais-'] {
 
 .ais-HierarchicalMenu-count,
 .ais-Menu-count,
-.ais-RefinementList-count,
-.ais-ToggleRefinement-count {
+.ais-RefinementList-count {
   padding: 0.1rem 0.4rem;
   font-size: 0.8rem;
   color: $port-gore;

--- a/packages/instantsearch.css/src/themes/satellite.scss
+++ b/packages/instantsearch.css/src/themes/satellite.scss
@@ -276,7 +276,6 @@ $break-medium: 767px;
  * Count
  */
 
-.ais-ToggleRefinement-count,
 .ais-HierarchicalMenu-count,
 .ais-Menu-count,
 .ais-RatingMenu-count,

--- a/specs/src/pages/widgets/toggle-refinement.md
+++ b/specs/src/pages/widgets/toggle-refinement.md
@@ -18,8 +18,6 @@ classes:
     description: the checkbox input of the toggle
   - name: .ais-ToggleRefinement-labelText
     description: the label text of the toggle
-  - name: .ais-ToggleRefinement-count
-    description: the count of items of the toggle
 options:
   - name: attribute
     description: Attribute to apply the filter to


### PR DESCRIPTION
## Summary

This removes the `.ais-ToggleRefinement-count` CSS class from our themes and examples. This class was removed a while ago from the `toggleRefinement` markup but somehow wasn't removed from the specs and themes.

This is technically a breaking change to remove those from the themes because users could have manually added an element with `class="ais-ToggleRefinement-count"` and rely on the styles. However, since `instantsearch.css` already received a breaking change and hasn't been released, this should be fine to embark this change with it.

Related: https://github.com/algolia/instantsearch-specs/issues/93