### PR TITLE
chore(specs-website): update string used when widget has no translations

### DIFF
--- a/specs/src/components/WidgetContent.astro
+++ b/specs/src/components/WidgetContent.astro
@@ -214,7 +214,7 @@ const title = frontmatter.title;
     ) : (
       <p>
         <small>
-          <strong>Note:</strong> there are no CSS classes for this widget
+          <strong>Note:</strong> there are no translations for this widget
         </small>
       </p>
     )


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR changes the wording used on the InstantSearch.css website to better reflect when a widget doesn't have any translations.

**Result**

Before, on a widget's page that has no translations:

> Note: there are no CSS classes for this widget

After:

> Note: there are no translations for this widget
