### PR TITLE
fix(website): redirect examples/:flavor

### DIFF
--- a/website/_redirects
+++ b/website/_redirects
@@ -1,6 +1,6 @@
 /           https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/js/
 /examples   https://www.algolia.com/doc/guides/building-search-ui/resources/demos/js/
-/examples/js   https://www.algolia.com/doc/guides/building-search-ui/resources/demos/js/
+/examples/:flavor https://www.algolia.com/doc/guides/building-search-ui/resources/demos/:flavor
 
 /examples/:flavor/:name/search/*   /examples/:flavor/:name/index.html   200
 /examples/:name/*   /examples/js/:name/:splat   301


### PR DESCRIPTION
There was an infinite loop on these before, because the last redirect also was valid for /examples/react-hooks/ for example and caused infinite redirects before