### PR TITLE
test(jest): avoid flaky modules test

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "type-check": "tsc && lerna run type-check",
     "type-check:v3": "tsc --project tsconfig.v3.json",
     "test": "jest && lerna run test",
-    "test:ci": "jest --maxWorkers=4 && lerna run test --concurrency=1",
+    "test:ci": "jest --runInBand && lerna run test --concurrency=1",
     "test:size": "bundlesize",
     "test:exports": "lerna run test:exports",
     "test:versions": "./tests/versions/index.js",


### PR DESCRIPTION
The modules-* test about dependency detection of react-dom in react-instantsearch-hooks is flaky with regular jest workers, as I believe sometimes the jest mock of a module becomes global and still relevant for the next test.

Ideally we wouldn't need to do such tests when react-dom is exclusively user-provided, but for now hopefully running the tests in band will avoid that test being flaky.

test plan: run the unit tests a couple of times on CI and see it pass consistently