### PR TITLE
fix(react-instantsearch): index added twice with Next.js app router

### DIFF
--- a/packages/react-instantsearch-core/src/lib/useWidget.ts
+++ b/packages/react-instantsearch-core/src/lib/useWidget.ts
@@ -47,7 +47,7 @@ export function useWidget<TWidget extends Widget | IndexWidget, TProps>({
 
     // Scenario 1: the widget is added for the first time.
     if (!cleanupTimerRef.current) {
-      if (!shouldAddWidgetEarly) {
+      if (!shouldSsr) {
         parentIndex.addWidgets([widget]);
       }
     }
@@ -85,7 +85,7 @@ export function useWidget<TWidget extends Widget | IndexWidget, TProps>({
         });
       });
     };
-  }, [parentIndex, widget, shouldAddWidgetEarly, search, props]);
+  }, [parentIndex, widget, shouldSsr, search, props]);
 
   if (
     shouldAddWidgetEarly ||


### PR DESCRIPTION
**Summary**

This should fix what @MikeIbberson talks about here : https://github.com/algolia/instantsearch/issues/6073#issuecomment-1979230739

The problem was index widgets would get added twice client-side in a Next.js App Router application.
This is due to how `useLayoutEffect` behaves on either React canary or an RSC context (not sure), before what we had was : 
- index gets added on render because `shouldSsr` is `true` and the parent index doesn't contain it yet, making `shouldAddWidgetEarly` be `true`
- `useLayoutEffect` is called, `shouldAddWidgetEarly` is true so we don't add it again
- `useLayoutEffect` dispose function would be called and set the cleanupTimer
- `shouldAddWidgetEarly` is now `false` because `parentIndex` contains the child index
- `useLayoutEffect` called again, with `shouldAddWidgetEarly` being false this time, but it still skips adding the widget again because the cleanup timer is defined

In React 19 canary / Next.js, the cleanup function does not get called (maybe no strict mode or a different one), which means the last point fails.

**Result**

We were just using the wrong dependency in `useEffect`, we should never add the widget in an effect if `shouldSsr` is `true`, and that way the effect will run less often. 
Only an index widget can have `shouldSsr` be `true` client-side
