### PR TITLE
fix(routing): warn if initialUiState is used

### DIFF
--- a/packages/instantsearch.js/src/middlewares/__tests__/createRouterMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/__tests__/createRouterMiddleware.ts
@@ -139,4 +139,74 @@ describe('router', () => {
     expect(router.onUpdate).toHaveBeenCalledTimes(1);
     expect(setUiStateSpy).not.toHaveBeenCalled();
   });
+
+  it('warns if initialUiState and routing are used together', () => {
+    const state = {
+      'my-index': {
+        query: 'iPhone',
+      },
+    };
+
+    const searchClient = createSearchClient();
+    const router: Router = {
+      onUpdate: jest.fn((callback) => {
+        callback(state);
+      }),
+      read: () => state,
+      write: () => {},
+      createURL: () => '',
+      dispose: () => {},
+    };
+
+    const search = instantsearch({
+      indexName: 'my-index',
+      searchClient,
+      initialUiState: {
+        'my-index': {
+          query: 'MacBook',
+        },
+      },
+      routing: {
+        router,
+      },
+    });
+
+    expect(() => {
+      search.start();
+    }).toWarnDev(
+      '[InstantSearch.js]: Using `initialUiState` together with routing is not recommended. The `initialUiState` will be overwritten by the URL parameters.'
+    );
+  });
+
+  it("does not warn if initialUiState isn't used", () => {
+    const state = {
+      'my-index': {
+        query: 'iPhone',
+      },
+    };
+
+    const searchClient = createSearchClient();
+    const router: Router = {
+      onUpdate: jest.fn((callback) => {
+        callback(state);
+      }),
+      read: () => state,
+      write: () => {},
+      createURL: () => '',
+      dispose: () => {},
+    };
+
+    const search = instantsearch({
+      indexName: 'my-index',
+      searchClient,
+      initialUiState: {},
+      routing: {
+        router,
+      },
+    });
+
+    expect(() => {
+      search.start();
+    }).not.toWarnDev();
+  });
 });

--- a/packages/instantsearch.js/src/middlewares/createRouterMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/createRouterMiddleware.ts
@@ -1,6 +1,6 @@
 import historyRouter from '../lib/routers/history';
 import simpleStateMapping from '../lib/stateMappings/simple';
-import { isEqual } from '../lib/utils';
+import { isEqual, warning } from '../lib/utils';
 
 import type {
   Router,
@@ -97,6 +97,11 @@ export const createRouterMiddleware = <
       },
 
       subscribe() {
+        warning(
+          Object.keys(initialUiState).length === 0,
+          'Using `initialUiState` together with routing is not recommended. The `initialUiState` will be overwritten by the URL parameters.'
+        );
+
         instantSearchInstance._initialUiState = {
           ...initialUiState,
           ...stateMapping.routeToState(router.read()),


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

If you use initialUiState, as well as routing, you can get some confusing situations where the state is overridden, only if routing actually has some state. This can be very sporadic depending on your setup, and thus confusing.

**Result**

[CR-6027] is somewhat handled, documentation still needed.

If you have any state set in `intialUiState` (not an empty object), you will receive a warning upon initialisation of InstantSearch with routing.

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->


[CR-6027]: https://algolia.atlassian.net/browse/CR-6027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ