### PR TITLE
test(common): add "only" feature to common test suite

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -180,6 +180,14 @@ const config = {
           'off',
           { additionalTestBlockFunctions: ['skippableTest'] },
         ],
+        'no-restricted-syntax': [
+          'error',
+          {
+            selector:
+              'CallExpression[callee.name="runTestSuites"][arguments.0] Property[key.name="only"]',
+            message: 'Do not commit a restricted test',
+          },
+        ],
       },
     },
     {

--- a/tests/common/common.ts
+++ b/tests/common/common.ts
@@ -72,10 +72,12 @@ export function runTestSuites<
   testSuites,
   testSetups,
   testOptions,
+  only,
 }: {
   testSuites: TTestSuites;
   testSetups: TestSetupsMap<TTestSuites>;
   testOptions: TestOptionsMap<TTestSuites>;
+  only?: Array<keyof TTestSuites>;
 }) {
   test('has all the tests', () => {
     expect(Object.keys(testSetups).sort()).toEqual(
@@ -83,10 +85,10 @@ export function runTestSuites<
     );
   });
 
-  (Object.keys(testSuites) as Array<keyof TTestSuites>).forEach(
-    <T extends keyof TTestSuites>(key: T) => {
+  (Object.keys(testSuites) as Array<keyof TTestSuites>)
+    .filter((name) => !only || only.includes(name))
+    .forEach(<T extends keyof TTestSuites>(key: T) => {
       const suite: TestSuite<TTestSuites, T> = testSuites[key];
       suite(testSetups[key], testOptions[key]);
-    }
-  );
+    });
 }


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

You can pass `only: ['createAutocompleteWidgetTests']` to `runTestSuites`, and will be able to have faster running tests and more easy to read assertions. Eslint will prevent you from comitting this.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

`runTestSuites({ ...args, only: ['specific test suite']})` to scope to just a set of tests temporarily.

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
