### PR TITLE
feat(chat): handle show all for other pages than search

### DIFF
--- a/packages/react-instantsearch/src/widgets/Chat.tsx
+++ b/packages/react-instantsearch/src/widgets/Chat.tsx
@@ -21,6 +21,7 @@ import type {
   AddToolResultWithOutput,
   UserClientSideTool,
 } from 'instantsearch-ui-components/src/components/chat/types';
+import type { IndexUiState } from 'instantsearch.js';
 import type { UIMessage } from 'instantsearch.js/es/lib/chat';
 import type { UseChatOptions } from 'react-instantsearch-core';
 
@@ -30,9 +31,10 @@ const ChatUiComponent = createChatComponent({
 });
 
 export function createDefaultTools<TObject extends RecordWithObjectID>(
-  itemComponent?: ItemComponent<TObject>
+  itemComponent?: ItemComponent<TObject>,
+  getSearchPageURL?: (nextUiState: IndexUiState) => string
 ): UserClientSideTool[] {
-  return [createSearchIndexTool(itemComponent)];
+  return [createSearchIndexTool(itemComponent, getSearchPageURL)];
 }
 
 type ItemComponent<TObject> = RecommendComponentProps<TObject>['itemComponent'];
@@ -73,6 +75,7 @@ export type ChatProps<TObject, TUiMessage extends UIMessage = UIMessage> = Omit<
   itemComponent?: ItemComponent<TObject>;
   tools?: UserClientSideTool[];
   defaultOpen?: boolean;
+  getSearchPageURL?: (nextUiState: IndexUiState) => string;
 } & UseChatOptions<TUiMessage> & {
     toggleButtonProps?: UserToggleButtonProps;
     headerProps?: UserHeaderProps;
@@ -93,6 +96,7 @@ export function Chat<
   promptProps,
   classNames,
   title,
+  getSearchPageURL,
   ...props
 }: ChatProps<TObject, TUiMessage>) {
   const { indexUiState, setIndexUiState } = useInstantSearch();
@@ -109,7 +113,7 @@ export function Chat<
     });
 
   const tools = React.useMemo(() => {
-    const defaults = createDefaultTools(itemComponent);
+    const defaults = createDefaultTools(itemComponent, getSearchPageURL);
 
     if (!userTools) {
       return defaults;
@@ -126,7 +130,7 @@ export function Chat<
     );
 
     return [...merged, ...extraUserTools];
-  }, [itemComponent, userTools]);
+  }, [getSearchPageURL, itemComponent, userTools]);
 
   const {
     messages,

--- a/packages/react-instantsearch/src/widgets/chat/tools/SearchIndexTool.tsx
+++ b/packages/react-instantsearch/src/widgets/chat/tools/SearchIndexTool.tsx
@@ -14,6 +14,7 @@ import type {
   ChatToolMessage,
   UserClientSideTool,
 } from 'instantsearch-ui-components';
+import type { IndexUiState } from 'instantsearch.js';
 
 export const SearchIndexToolType: ChatToolMessage['type'] =
   'tool-algolia_search_index';
@@ -21,7 +22,8 @@ export const SearchIndexToolType: ChatToolMessage['type'] =
 type ItemComponent<TObject> = RecommendComponentProps<TObject>['itemComponent'];
 
 export function createSearchIndexTool<TObject extends RecordWithObjectID>(
-  itemComponent?: ItemComponent<TObject>
+  itemComponent?: ItemComponent<TObject>,
+  getSearchPageURL?: (nextUiState: IndexUiState) => string
 ): UserClientSideTool {
   return {
     type: SearchIndexToolType,
@@ -69,12 +71,32 @@ export function createSearchIndexTool<TObject extends RecordWithObjectID>(
                   <button
                     type="button"
                     onClick={() => {
-                      if (input?.query) {
+                      if (!input?.query) {
+                        return;
+                      }
+
+                      if (!getSearchPageURL) {
                         setIndexUiState({
                           ...indexUiState,
                           query: input.query,
                         });
+                        return;
                       }
+
+                      const url = getSearchPageURL({
+                        query: input.query,
+                      });
+
+                      if (new URL(url).pathname === window.location.pathname) {
+                        // same page, just update the state
+                        setIndexUiState({
+                          ...indexUiState,
+                          query: input.query,
+                        });
+                        return;
+                      }
+
+                      window.location.href = url;
                     }}
                     className="ais-ChatToolSearchIndexCarouselHeaderViewAll"
                   >


### PR DESCRIPTION
**Summary**

[FX-3509](https://algolia.atlassian.net/browse/FX-3509)

**Result**

Added a prop at the `chat` level for users to provide a function that maps to their search page url. If pathname doesn't match current one, we do a hard refresh for now.
Later, we could make them override the link component to use React router or Next.js `Link` components


[FX-3509]: https://algolia.atlassian.net/browse/FX-3509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ