### PR TITLE
fix(deps): latest markdown-to-jsx

### DIFF
--- a/packages/instantsearch-ui-components/package.json
+++ b/packages/instantsearch-ui-components/package.json
@@ -51,6 +51,6 @@
     "ai": "^5.0.18",
     "zod": "^3.25.76 || ^4",
     "zod-to-json-schema": "3.24.6",
-    "markdown-to-jsx": "^7.1.13"
+    "markdown-to-jsx": "^7.7.15"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -20931,10 +20931,10 @@ markdown-to-jsx@^6.9.1, markdown-to-jsx@^6.9.3:
     prop-types "^15.6.2"
     unquote "^1.1.0"
 
-markdown-to-jsx@^7.1.13:
-  version "7.7.13"
-  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-7.7.13.tgz#8144d89e396cdf3264bec7c97a21bc47cfc0773b"
-  integrity sha512-DiueEq2bttFcSxUs85GJcQVrOr0+VVsPfj9AEUPqmExJ3f8P/iQNvZHltV4tm1XVhu1kl0vWBZWT3l99izRMaA==
+markdown-to-jsx@^7.7.15:
+  version "7.7.15"
+  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-7.7.15.tgz#7dad08e2b2cf35460a1c157f5d3e7bc875bcb511"
+  integrity sha512-U5dw5oRajrPTE2oJQWAbLK8RgbCDJ264AjW3fGABq+/rZjQ0E/WGVCLKAHvpKHQFUwoWoK8ZZWVPNLR/biYMhg==
 
 marked@^0.7.0:
   version "0.7.0"


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

update markdown-to-jsx to avoid needing a peer dependency on react for vanilla


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

This no longer has a peer dependency on React (https://github.com/quantizor/markdown-to-jsx/pull/711) so it becomes easily usable by plain JS without npm warning.


<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
