### PR TITLE
refactor(tools): make search tool the same

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -14,7 +14,7 @@
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.development.js",
-      "maxSize": "184 kB"
+      "maxSize": "184.50 kB"
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
@@ -123,13 +123,13 @@ export type ChatMessageProps = ComponentProps<'article'> & {
    */
   setIndexUiState: (state: object) => void;
   /**
+   * Close the chat
+   */
+  onClose: () => void;
+  /**
    * Array of tools available for the assistant (for tool messages)
    */
-  tools?: ClientSideTools;
-  /**
-   * Optional handler to refine the search query (for tool actions)
-   */
-  handleRefine?: (value: string) => void;
+  tools: ClientSideTools;
   /**
    * Optional class names
    */
@@ -151,13 +151,13 @@ export function createChatMessageComponent({ createElement }: Renderer) {
       variant = 'subtle',
       actions = [],
       autoHideActions = false,
-      handleRefine,
       leadingComponent: LeadingComponent,
       actionsComponent: ActionsComponent,
       footerComponent: FooterComponent,
       tools = {},
       indexUiState,
       setIndexUiState,
+      onClose,
       translations: userTranslations,
       ...props
     } = userProps;
@@ -225,6 +225,7 @@ export function createChatMessageComponent({ createElement }: Renderer) {
                 indexUiState={indexUiState}
                 setIndexUiState={setIndexUiState}
                 addToolResult={boundAddToolResult}
+                onClose={onClose}
               />
             </div>
           );

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
@@ -95,7 +95,7 @@ export type ChatMessagesProps<
   /**
    * Tools available for the assistant
    */
-  tools?: ClientSideTools;
+  tools: ClientSideTools;
   /**
    * Current chat status
    */
@@ -107,7 +107,11 @@ export type ChatMessagesProps<
   /**
    * Callback for reload action
    */
-  onReload?: (messageId?: string) => void;
+  onReload: (messageId?: string) => void;
+  /**
+   * Function to close the chat
+   */
+  onClose: () => void;
   /**
    * Optional class names
    */
@@ -169,6 +173,7 @@ function createDefaultMessageComponent<
     indexUiState,
     setIndexUiState,
     onReload,
+    onClose,
     translations,
     actionsComponent,
   }: {
@@ -178,8 +183,9 @@ function createDefaultMessageComponent<
     assistantMessageProps?: Partial<ChatMessageProps>;
     indexUiState: object;
     setIndexUiState: (state: object) => void;
-    tools?: ClientSideTools;
-    onReload?: (messageId?: string) => void;
+    tools: ClientSideTools;
+    onReload: (messageId?: string) => void;
+    onClose: () => void;
     translations: ChatMessagesTranslations;
     actionsComponent?: ChatMessageProps['actionsComponent'];
   }) {
@@ -196,7 +202,7 @@ function createDefaultMessageComponent<
       {
         title: translations.regenerateLabel,
         icon: () => <ReloadIconComponent createElement={createElement} />,
-        onClick: (m) => onReload?.(m.id),
+        onClick: (m) => onReload(m.id),
       },
     ];
 
@@ -213,6 +219,7 @@ function createDefaultMessageComponent<
         tools={tools}
         indexUiState={indexUiState}
         setIndexUiState={setIndexUiState}
+        onClose={onClose}
         actions={defaultActions}
         actionsComponent={actionsComponent}
         data-role={message.role}
@@ -262,6 +269,7 @@ export function createChatMessagesComponent({
       status = 'ready',
       hideScrollToBottom = false,
       onReload,
+      onClose,
       translations: userTranslations,
       userMessageProps,
       assistantMessageProps,
@@ -337,6 +345,7 @@ export function createChatMessagesComponent({
                 setIndexUiState={setIndexUiState}
                 onReload={onReload}
                 actionsComponent={ActionsComponent}
+                onClose={onClose}
                 translations={translations}
               />
             ))}

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/Chat.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/Chat.test.tsx
@@ -22,6 +22,9 @@ describe('Chat', () => {
           messages: [],
           indexUiState: {},
           setIndexUiState: jest.fn(),
+          tools: {},
+          onReload: jest.fn(),
+          onClose: jest.fn(),
         }}
         promptProps={{}}
         toggleButtonProps={{ open: true, onClick: jest.fn() }}

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -19,6 +19,8 @@ describe('ChatMessage', () => {
         indexUiState={{}}
         setIndexUiState={jest.fn()}
         message={{ role: 'user', id: '1', parts: [] }}
+        tools={{}}
+        onClose={jest.fn()}
       />
     );
     expect(container).toMatchInlineSnapshot(`
@@ -61,6 +63,8 @@ describe('ChatMessage', () => {
           message: 'message',
           actions: 'actions',
         }}
+        tools={{}}
+        onClose={jest.fn()}
       />
     );
     expect(container).toMatchInlineSnapshot(`
@@ -96,6 +100,8 @@ describe('ChatMessage', () => {
             id: '1',
             parts: [{ type: 'text', text: 'User content' }],
           }}
+          tools={{}}
+          onClose={jest.fn()}
         />
         <ChatMessage
           indexUiState={{}}
@@ -105,6 +111,8 @@ describe('ChatMessage', () => {
             id: '2',
             parts: [{ type: 'text', text: 'Assistant content' }],
           }}
+          tools={{}}
+          onClose={jest.fn()}
         />
         <ChatMessage
           indexUiState={{}}
@@ -114,6 +122,8 @@ describe('ChatMessage', () => {
             id: '3',
             parts: [{ type: 'text', text: 'System content' }],
           }}
+          tools={{}}
+          onClose={jest.fn()}
         />
       </div>
     );
@@ -218,6 +228,7 @@ describe('ChatMessage', () => {
             onToolCall: jest.fn(),
           },
         }}
+        onClose={jest.fn()}
       />
     );
     expect(container).toMatchInlineSnapshot(`

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
@@ -19,6 +19,9 @@ describe('ChatMessages', () => {
         messages={[]}
         indexUiState={{}}
         setIndexUiState={jest.fn()}
+        tools={{}}
+        onReload={jest.fn()}
+        onClose={jest.fn()}
       />
     );
 
@@ -79,6 +82,9 @@ describe('ChatMessages', () => {
         indexUiState={{}}
         setIndexUiState={jest.fn()}
         messageComponent={Messages}
+        tools={{}}
+        onReload={jest.fn()}
+        onClose={jest.fn()}
       />
     );
 
@@ -151,6 +157,9 @@ describe('ChatMessages', () => {
         }}
         indexUiState={{}}
         setIndexUiState={jest.fn()}
+        tools={{}}
+        onReload={jest.fn()}
+        onClose={jest.fn()}
       />
     );
 

--- a/packages/instantsearch-ui-components/src/components/chat/types.ts
+++ b/packages/instantsearch-ui-components/src/components/chat/types.ts
@@ -22,6 +22,7 @@ export type ClientSideToolComponentProps = {
   message: ChatToolMessage;
   indexUiState: object;
   setIndexUiState: (state: object) => void;
+  onClose: () => void;
   addToolResult: AddToolResultWithOutput;
 };
 

--- a/packages/instantsearch.js/src/lib/chat/index.ts
+++ b/packages/instantsearch.js/src/lib/chat/index.ts
@@ -3,4 +3,5 @@ export type { ChatInit } from './chat';
 export { AbstractChat } from './chat';
 export { ChatState } from './chat';
 export { Chat } from './chat';
-export * from './tools';
+
+export const SearchIndexToolType = 'algolia_search_index';

--- a/packages/instantsearch.js/src/lib/chat/tools.ts
+++ b/packages/instantsearch.js/src/lib/chat/tools.ts
@@ -1,5 +1,0 @@
-import type { ChatToolType } from 'instantsearch-ui-components';
-
-export const SearchIndexToolType: ChatToolType = 'tool-algolia_search_index';
-
-export const defaultTools: ChatToolType[] = [SearchIndexToolType];

--- a/packages/instantsearch.js/src/templates/carousel/carousel.tsx
+++ b/packages/instantsearch.js/src/templates/carousel/carousel.tsx
@@ -33,7 +33,7 @@ function CarouselWithRefs<TObject extends Record<string, unknown>>(
   >
 ) {
   const [canScrollLeft, setCanScrollLeft] = useState(false);
-  const [canScrollRight, setCanScrollRight] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(true);
 
   const carouselRefs: Pick<
     CarouselUiProps<TObject>,
@@ -59,14 +59,26 @@ function CarouselWithRefs<TObject extends Record<string, unknown>>(
   return <Carousel {...carouselRefs} {...props} />;
 }
 
-type Template = (params: { html: typeof html }) => VNode | VNode[] | null;
+type Template<TData = Record<string, unknown>> = (
+  params: { html: typeof html } & TData
+) => VNode | VNode[] | null;
 
 type CreateCarouselTemplateProps<TObject extends Record<string, unknown>> = {
   templates?: Partial<{
     previous: Exclude<Template, string>;
     next: Exclude<Template, string>;
+    header: Exclude<
+      Template<{
+        canScrollLeft: boolean;
+        canScrollRight: boolean;
+        scrollLeft: () => void;
+        scrollRight: () => void;
+      }>,
+      string
+    >;
   }>;
   cssClasses?: Partial<CarouselUiProps<TObject>['classNames']>;
+  showNavigation?: boolean;
 };
 
 type CarouselTemplateProps<TObject extends Record<string, unknown>> = Pick<
@@ -84,6 +96,7 @@ type CarouselTemplateProps<TObject extends Record<string, unknown>> = Pick<
 export function carousel<TObject extends Record<string, unknown>>({
   cssClasses,
   templates = {},
+  showNavigation = true,
 }: CreateCarouselTemplateProps<TObject> = {}) {
   return function CarouselTemplate({
     items,
@@ -91,13 +104,18 @@ export function carousel<TObject extends Record<string, unknown>>({
     cssClasses: widgetCssClasses = {},
     sendEvent = () => {},
   }: CarouselTemplateProps<TObject>) {
-    const { previous, next } = templates;
+    const { previous, next, header } = templates;
 
     return (
       <CarouselWithRefs
         items={items}
         sendEvent={sendEvent}
         itemComponent={widgetTemplates.item}
+        headerComponent={
+          (header
+            ? (props) => header({ html, ...props })
+            : undefined) as CarouselUiProps<TObject>['headerComponent']
+        }
         previousIconComponent={
           (previous
             ? () => previous({ html })
@@ -115,6 +133,7 @@ export function carousel<TObject extends Record<string, unknown>>({
             item: cx(cssClasses?.item, widgetCssClasses?.item),
           },
         }}
+        showNavigation={showNavigation}
       />
     );
   };

--- a/packages/react-instantsearch/src/widgets/Chat.tsx
+++ b/packages/react-instantsearch/src/widgets/Chat.tsx
@@ -4,7 +4,7 @@ import { useInstantSearch, useChat } from 'react-instantsearch-core';
 
 import { createSearchIndexTool } from './chat/tools/SearchIndexTool';
 
-export { SearchIndexToolType } from './chat/tools/SearchIndexTool';
+export { SearchIndexToolType } from 'instantsearch.js/es/lib/chat';
 
 import type {
   Pragma,
@@ -148,10 +148,6 @@ export function Chat<
   const tools = React.useMemo(() => {
     const defaults = createDefaultTools(itemComponent, getSearchPageURL);
 
-    if (!userTools) {
-      return defaults;
-    }
-
     return { ...defaults, ...userTools };
   }, [getSearchPageURL, itemComponent, userTools]);
 
@@ -166,7 +162,7 @@ export function Chat<
     clearError,
   } = useChat({
     ...props,
-    onToolCall: ({ toolCall }) => {
+    onToolCall({ toolCall }) {
       const tool = tools[toolCall.toolName];
 
       if (tool && tool.onToolCall) {
@@ -234,6 +230,7 @@ export function Chat<
       messagesProps={{
         status,
         onReload: (messageId) => regenerate({ messageId }),
+        onClose: () => setOpen(false),
         messages,
         tools: toolsForUi,
         indexUiState,

--- a/packages/react-instantsearch/src/widgets/chat/tools/SearchIndexTool.tsx
+++ b/packages/react-instantsearch/src/widgets/chat/tools/SearchIndexTool.tsx
@@ -4,19 +4,20 @@ import {
   ArrowRightIconComponent,
   createButtonComponent,
 } from 'instantsearch-ui-components';
+import { SearchIndexToolType } from 'instantsearch.js/es/lib/chat';
 import React, { createElement } from 'react';
 
 import { Carousel } from '../../../components';
 
 import type {
+  ClientSideToolComponentProps,
   Pragma,
   RecommendComponentProps,
   RecordWithObjectID,
   UserClientSideTools,
 } from 'instantsearch-ui-components';
-import type { IndexUiState } from 'instantsearch.js';
-
-export const SearchIndexToolType: string = 'algolia_search_index';
+import type { IndexUiState, IndexWidget } from 'instantsearch.js';
+import type { ComponentProps } from 'react';
 
 type ItemComponent<TObject> = RecommendComponentProps<TObject>['itemComponent'];
 
@@ -28,144 +29,176 @@ export function createSearchIndexTool<TObject extends RecordWithObjectID>(
     createElement: createElement as Pragma,
   });
 
+  function SearchLayoutComponent({
+    message,
+    indexUiState,
+    setIndexUiState,
+    onClose,
+  }: ClientSideToolComponentProps) {
+    const input = message?.input as
+      | {
+          query: string;
+          number_of_results?: number;
+        }
+      | undefined;
+
+    const output = message?.output as
+      | {
+          hits?: Array<RecordWithObjectID<TObject>>;
+          nbHits?: number;
+        }
+      | undefined;
+
+    const items = output?.hits || [];
+
+    const MemoedHeaderComponent = React.useMemo(() => {
+      return (
+        props: Omit<
+          ComponentProps<typeof HeaderComponent>,
+          | 'nbHits'
+          | 'query'
+          | 'hitsPerPage'
+          | 'setIndexUiState'
+          | 'indexUiState'
+          | 'getSearchPageURL'
+          | 'onClose'
+        >
+      ) => (
+        <HeaderComponent
+          nbHits={output?.nbHits}
+          query={input?.query}
+          hitsPerPage={input?.number_of_results}
+          setIndexUiState={setIndexUiState}
+          indexUiState={indexUiState}
+          getSearchPageURL={getSearchPageURL}
+          onClose={onClose}
+          {...props}
+        />
+      );
+    }, [
+      input?.number_of_results,
+      input?.query,
+      output?.nbHits,
+      setIndexUiState,
+      onClose,
+      indexUiState,
+    ]);
+
+    return (
+      <Carousel
+        items={items}
+        itemComponent={itemComponent}
+        sendEvent={() => {}}
+        showNavigation={false}
+        headerComponent={MemoedHeaderComponent}
+      />
+    );
+  }
+
+  function HeaderComponent({
+    canScrollLeft,
+    canScrollRight,
+    scrollLeft,
+    scrollRight,
+    nbHits,
+    query,
+    hitsPerPage,
+    setIndexUiState,
+    indexUiState,
+    // eslint-disable-next-line no-shadow
+    getSearchPageURL,
+    onClose,
+  }: {
+    canScrollLeft: boolean;
+    canScrollRight: boolean;
+    scrollLeft: () => void;
+    scrollRight: () => void;
+    nbHits?: number;
+    query?: string;
+    hitsPerPage?: number;
+    setIndexUiState: IndexWidget['setIndexUiState'];
+    indexUiState: IndexUiState;
+    getSearchPageURL?: (nextUiState: IndexUiState) => string;
+    onClose: () => void;
+  }) {
+    if ((hitsPerPage ?? 0) < 1) {
+      return null;
+    }
+
+    return (
+      <div className="ais-ChatToolSearchIndexCarouselHeader">
+        <div className="ais-ChatToolSearchIndexCarouselHeaderResults">
+          {nbHits && (
+            <div className="ais-ChatToolSearchIndexCarouselHeaderCount">
+              {hitsPerPage ?? 0} of {nbHits} result
+              {nbHits > 1 ? 's' : ''}
+            </div>
+          )}
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              if (!query) return;
+
+              const nextUiState = { ...indexUiState, query };
+
+              // If no main search page URL or we are on the search page, just update the state
+              if (
+                !getSearchPageURL ||
+                (getSearchPageURL &&
+                  new URL(getSearchPageURL(nextUiState)).pathname ===
+                    window.location.pathname)
+              ) {
+                setIndexUiState(nextUiState);
+                onClose();
+                return;
+              }
+
+              // Navigate to different page
+              window.location.href = getSearchPageURL(nextUiState);
+            }}
+            className="ais-ChatToolSearchIndexCarouselHeaderViewAll"
+          >
+            View all
+            <ArrowRightIconComponent createElement={createElement as Pragma} />
+          </Button>
+        </div>
+
+        {(hitsPerPage ?? 0) > 2 && (
+          <div className="ais-ChatToolSearchIndexCarouselHeaderScrollButtons">
+            <Button
+              variant="outline"
+              size="sm"
+              iconOnly
+              onClick={scrollLeft}
+              disabled={!canScrollLeft}
+              className="ais-ChatToolSearchIndexCarouselHeaderScrollButton"
+            >
+              <ChevronLeftIconComponent
+                createElement={createElement as Pragma}
+              />
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              iconOnly
+              onClick={scrollRight}
+              disabled={!canScrollRight}
+              className="ais-ChatToolSearchIndexCarouselHeaderScrollButton"
+            >
+              <ChevronRightIconComponent
+                createElement={createElement as Pragma}
+              />
+            </Button>
+          </div>
+        )}
+      </div>
+    );
+  }
+
   return {
     [SearchIndexToolType]: {
-      layoutComponent: ({ message, indexUiState, setIndexUiState }) => {
-        const input = message?.input as
-          | {
-              query: string;
-              number_of_results?: number;
-            }
-          | undefined;
-
-        const output = message?.output as
-          | {
-              hits?: Array<RecordWithObjectID<TObject>>;
-              nbHits?: number;
-            }
-          | undefined;
-
-        const items = output?.hits || [];
-
-        // Safe: this is called within ChatMessage component's render cycle
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        const HeaderComponent = React.useMemo(
-          () =>
-            ({
-              canScrollLeft,
-              canScrollRight,
-              scrollLeft,
-              scrollRight,
-            }: {
-              canScrollLeft: boolean;
-              canScrollRight: boolean;
-              scrollLeft: () => void;
-              scrollRight: () => void;
-            }) => {
-              return (
-                <div className="ais-ChatToolSearchIndexCarouselHeader">
-                  <div className="ais-ChatToolSearchIndexCarouselHeaderResults">
-                    {output?.nbHits && (
-                      <div className="ais-ChatToolSearchIndexCarouselHeaderCount">
-                        {input?.number_of_results ?? 0} of {output?.nbHits}{' '}
-                        result
-                        {output?.nbHits > 1 ? 's' : ''}
-                      </div>
-                    )}
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => {
-                        if (!input?.query) {
-                          return;
-                        }
-
-                        if (!getSearchPageURL) {
-                          setIndexUiState({
-                            ...indexUiState,
-                            query: input.query,
-                          });
-                          return;
-                        }
-
-                        const url = getSearchPageURL({
-                          query: input.query,
-                        });
-
-                        if (
-                          new URL(url).pathname === window.location.pathname
-                        ) {
-                          // same page, just update the state
-                          setIndexUiState({
-                            ...indexUiState,
-                            query: input.query,
-                          });
-                          return;
-                        }
-
-                        window.location.href = url;
-                      }}
-                      className="ais-ChatToolSearchIndexCarouselHeaderViewAll"
-                    >
-                      View all
-                      <ArrowRightIconComponent
-                        createElement={createElement as Pragma}
-                      />
-                    </Button>
-                  </div>
-
-                  {(input?.number_of_results ?? 0) > 2 && (
-                    <div className="ais-ChatToolSearchIndexCarouselHeaderScrollButtons">
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        iconOnly
-                        onClick={scrollLeft}
-                        disabled={!canScrollLeft}
-                        className="ais-ChatToolSearchIndexCarouselHeaderScrollButton"
-                      >
-                        <ChevronLeftIconComponent
-                          createElement={createElement as Pragma}
-                        />
-                      </Button>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        iconOnly
-                        onClick={scrollRight}
-                        disabled={!canScrollRight}
-                        className="ais-ChatToolSearchIndexCarouselHeaderScrollButton"
-                      >
-                        <ChevronRightIconComponent
-                          createElement={createElement as Pragma}
-                        />
-                      </Button>
-                    </div>
-                  )}
-                </div>
-              );
-            },
-          [
-            input?.number_of_results,
-            input?.query,
-            output?.nbHits,
-            setIndexUiState,
-            indexUiState,
-          ]
-        );
-
-        return (
-          <Carousel
-            items={items}
-            itemComponent={itemComponent}
-            sendEvent={() => {}}
-            showNavigation={false}
-            headerComponent={
-              (input?.number_of_results ?? 0) > 1 ? HeaderComponent : undefined
-            }
-          />
-        );
-      },
+      layoutComponent: SearchLayoutComponent,
     },
   };
 }

--- a/tests/common/widgets/chat/options.ts
+++ b/tests/common/widgets/chat/options.ts
@@ -129,7 +129,7 @@ export function createOptionsTests(
           chat: chat as any,
           tools: {
             hello: {
-              template: {
+              templates: {
                 layout: (_, { html }) =>
                   html`<div id="tool-content">The message said hello!</div>`,
               },
@@ -185,7 +185,7 @@ export function createOptionsTests(
           chat: chat as any,
           tools: {
             [SearchIndexToolType]: {
-              template: {
+              templates: {
                 layout: (_, { html }) =>
                   html`<div id="tool-content">The message said hello!</div>`,
               },


### PR DESCRIPTION
- same between js and react
- close chat on "view all"
- remove "tool-" prefix in js (not needed since we moved to object form)
- refactor search index tool in react
- carousel assumes it can scroll right on initial mount in js
- header template for carousel in js