### PR TITLE
fix(chat): `ChatPrompt` should auto focus on InstantSearch.js

### DIFF
--- a/packages/instantsearch.js/src/widgets/chat/chat.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/chat.tsx
@@ -290,6 +290,8 @@ const createRenderer = <THit extends RecordWithObjectID = RecordWithObjectID>({
   tools: UserClientSideToolsWithTemplate;
 }): Renderer<ChatRenderState, Partial<ChatWidgetParams>> => {
   const state = createLocalState();
+  const promptRef = { current: null as HTMLTextAreaElement | null };
+
   return (props, isFirstRendering) => {
     const {
       indexUiState,
@@ -602,6 +604,7 @@ const createRenderer = <THit extends RecordWithObjectID = RecordWithObjectID>({
             translations: messagesTranslations,
           }}
           promptProps={{
+            promptRef,
             status,
             value: input,
             onInput: (event) => {


### PR DESCRIPTION
**Summary**

This PR fixes the auto focus of the `ChatPrompt` on InstantSearch.js when the chat is open.
