### PR TITLE
fix(chat): show warning in console when using js widget

### DIFF
--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -7,6 +7,7 @@ import {
   createSendEventForHits,
   getAppIdAndApiKey,
   noop,
+  warning,
 } from '../../lib/utils';
 
 import type {
@@ -114,6 +115,8 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
   return <TUiMessage extends UIMessage = UIMessage>(
     widgetParams: TWidgetParams & ChatConnectorParams<TUiMessage>
   ) => {
+    warning(false, 'Chat is not yet stable and will change in the future.');
+
     const { resume = false, tools = {}, ...options } = widgetParams || {};
 
     let _chatInstance: Chat<TUiMessage>;


### PR DESCRIPTION
**Summary**

This PR adds for `chat()` the same usage warning that is shown with `<Chat />` in React.
