### PR TITLE
fix(memory): cache key includes agent id

### DIFF
--- a/packages/instantsearch.js/src/lib/chat/__tests__/chat.test.ts
+++ b/packages/instantsearch.js/src/lib/chat/__tests__/chat.test.ts
@@ -37,57 +37,66 @@ describe('ChatState', () => {
   });
 
   it('should save messages to sessionStorage when status changes to ready', () => {
-    const chatState = new ChatState<any>();
+    const agentId = 'agentID1';
+    const chatState = new ChatState<any>(agentId);
     const message = { role: 'user', content: 'Hello' };
     chatState.status = 'submitted';
     chatState.messages = [message];
-    expect(sessionStorage.getItem(CACHE_KEY)).toBe(null);
+    expect(sessionStorage.getItem(CACHE_KEY + agentId)).toBe(null);
 
     chatState.status = 'streaming';
-    expect(sessionStorage.getItem(CACHE_KEY)).toBe(null);
+    expect(sessionStorage.getItem(CACHE_KEY + agentId)).toBe(null);
 
     chatState.status = 'ready';
-    expect(sessionStorage.getItem(CACHE_KEY)).toBe(JSON.stringify([message]));
+    expect(sessionStorage.getItem(CACHE_KEY + agentId)).toBe(
+      JSON.stringify([message])
+    );
   });
 
   it('should load initial messages from sessionStorage', () => {
+    const agentId = 'agentID2';
     const initialMessages = [
       { role: 'user', content: 'Hello' },
       { role: 'bot', content: 'Hi there!' },
     ];
-    sessionStorage.setItem(CACHE_KEY, JSON.stringify(initialMessages));
+    sessionStorage.setItem(
+      CACHE_KEY + agentId,
+      JSON.stringify(initialMessages)
+    );
 
-    const chatState = new ChatState();
+    const chatState = new ChatState(agentId);
     expect(chatState.messages).toEqual(initialMessages);
   });
 
   it('should not save messages to sessionStorage when status is not ready', () => {
-    const chatState = new ChatState<any>();
+    const agentId = 'agentID3';
+    const chatState = new ChatState<any>(agentId);
     const message = { role: 'user', content: 'Hello' };
     chatState.status = 'submitted';
     chatState.messages = [message];
-    expect(sessionStorage.getItem(CACHE_KEY)).toBe(null);
+    expect(sessionStorage.getItem(CACHE_KEY + agentId)).toBe(null);
 
     chatState.status = 'streaming';
-    expect(sessionStorage.getItem(CACHE_KEY)).toBe(null);
+    expect(sessionStorage.getItem(CACHE_KEY + agentId)).toBe(null);
     chatState.status = 'error';
-    expect(sessionStorage.getItem(CACHE_KEY)).toBe(null);
+    expect(sessionStorage.getItem(CACHE_KEY + agentId)).toBe(null);
   });
 
   it('should handle sessionStorage being unavailable', () => {
+    const agentId = 'agentID4';
     // eslint-disable-next-line jest/unbound-method
     const originalSetItem = sessionStorage.setItem;
     sessionStorage.setItem = () => {
       throw new Error('sessionStorage is full');
     };
 
-    const chatState = new ChatState<any>();
+    const chatState = new ChatState<any>(agentId);
     const message = { role: 'user', content: 'Hello' };
     chatState.status = 'submitted';
     chatState.messages = [message];
-    expect(sessionStorage.getItem(CACHE_KEY)).toBe(null);
+    expect(sessionStorage.getItem(CACHE_KEY + agentId)).toBe(null);
     chatState.status = 'ready';
-    expect(sessionStorage.getItem(CACHE_KEY)).toBe(null);
+    expect(sessionStorage.getItem(CACHE_KEY + agentId)).toBe(null);
 
     sessionStorage.setItem = originalSetItem;
   });

--- a/packages/instantsearch.js/src/lib/chat/chat.ts
+++ b/packages/instantsearch.js/src/lib/chat/chat.ts
@@ -11,12 +11,12 @@ export type { UIMessage };
 export { AbstractChat };
 export { ChatInit };
 
-export const CACHE_KEY = 'instantsearch-chat-initial-messages';
+export const CACHE_KEY = 'instantsearch-chat-initial-messages-';
 
-function getDefaultInitialMessages<
-  TUIMessage extends UIMessage
->(): TUIMessage[] {
-  const initialMessages = sessionStorage.getItem(CACHE_KEY);
+function getDefaultInitialMessages<TUIMessage extends UIMessage>(
+  id?: string
+): TUIMessage[] {
+  const initialMessages = sessionStorage.getItem(CACHE_KEY + id);
   return initialMessages ? JSON.parse(initialMessages) : [];
 }
 
@@ -32,13 +32,14 @@ export class ChatState<TUiMessage extends UIMessage>
   _errorCallbacks = new Set<() => void>();
 
   constructor(
-    initialMessages: TUiMessage[] = getDefaultInitialMessages<TUiMessage>()
+    id: string | undefined = undefined,
+    initialMessages: TUiMessage[] = getDefaultInitialMessages<TUiMessage>(id)
   ) {
     this._messages = initialMessages;
     const saveMessagesInLocalStorage = () => {
       if (this.status === 'ready') {
         try {
-          sessionStorage.setItem(CACHE_KEY, JSON.stringify(this.messages));
+          sessionStorage.setItem(CACHE_KEY + id, JSON.stringify(this.messages));
         } catch (e) {
           // Do nothing if sessionStorage is not available or full
         }
@@ -139,8 +140,12 @@ export class Chat<
 > extends AbstractChat<TUiMessage> {
   _state: ChatState<TUiMessage>;
 
-  constructor({ messages, ...init }: ChatInit<TUiMessage>) {
-    const state = new ChatState(messages);
+  constructor({
+    messages,
+    agentId,
+    ...init
+  }: ChatInit<TUiMessage> & { agentId?: string }) {
+    const state = new ChatState(agentId, messages);
     super({ ...init, state });
     this._state = state;
   }


### PR DESCRIPTION
**Summary**

This PR reverts #6755 (which reverts #6737), using the parameter `agentId` instead of `id`.