### PR TITLE
fix(chat): format hits count with locale-specific separators

### DIFF
--- a/packages/instantsearch.js/src/widgets/chat/chat.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/chat.tsx
@@ -189,7 +189,7 @@ function createCarouselTool<
         <div className="ais-ChatToolSearchIndexCarouselHeaderResults">
           {nbHits && (
             <div className="ais-ChatToolSearchIndexCarouselHeaderCount">
-              {hitsPerPage ?? 0} of {nbHits} result
+              {hitsPerPage ?? 0} of {nbHits.toLocaleString()} result
               {nbHits > 1 ? 's' : ''}
             </div>
           )}

--- a/packages/react-instantsearch/src/widgets/chat/tools/SearchIndexTool.tsx
+++ b/packages/react-instantsearch/src/widgets/chat/tools/SearchIndexTool.tsx
@@ -130,7 +130,7 @@ function createCarouselTool<TObject extends RecordWithObjectID>(
         <div className="ais-ChatToolSearchIndexCarouselHeaderResults">
           {nbHits && (
             <div className="ais-ChatToolSearchIndexCarouselHeaderCount">
-              {hitsPerPage ?? 0} of {nbHits} result
+              {hitsPerPage ?? 0} of {nbHits.toLocaleString()} result
               {nbHits > 1 ? 's' : ''}
             </div>
           )}


### PR DESCRIPTION
**Summary**

This PR fixes the display of large hit counts in the chat carousel by formatting numbers with locale-specific thousand separators (e.g., "10,000" instead of "10000").