### PR TITLE
chore: temporarily remove autocomplete export

### DIFF
--- a/packages/react-instantsearch/src/components/index.ts
+++ b/packages/react-instantsearch/src/components/index.ts
@@ -1,2 +1,1 @@
 export * from './Carousel';
-export * from './Autocomplete';


### PR DESCRIPTION
To be merged before the next release.