### PR TITLE
test(refinementList): fix type error in options test

### DIFF
--- a/tests/common/widgets/refinement-list/options.ts
+++ b/tests/common/widgets/refinement-list/options.ts
@@ -1878,10 +1878,11 @@ function textRepresentation() {
   return Array.from(document.querySelectorAll('.ais-RefinementList-item'))
     .map(
       (item) =>
-        `${item.querySelector('.ais-RefinementList-labelText')!.textContent} ${item.querySelector<HTMLInputElement>('.ais-RefinementList-checkbox')!
-          .checked
-          ? '☒'
-          : '☐'
+        `${item.querySelector('.ais-RefinementList-labelText')!.textContent} ${
+          item.querySelector<HTMLInputElement>('.ais-RefinementList-checkbox')!
+            .checked
+            ? '☒'
+            : '☐'
         }`
     )
     .join('\n');


### PR DESCRIPTION
**Summary**
This PR fixes the type error in the refinmentList options test.
