### PR TITLE
fix(autocomplete): clear panel query in instantsearch.js

### DIFF
--- a/packages/instantsearch.js/src/widgets/autocomplete/autocomplete.tsx
+++ b/packages/instantsearch.js/src/widgets/autocomplete/autocomplete.tsx
@@ -190,7 +190,7 @@ function AutocompleteWrapper<TItem extends BaseHit>({
   indices,
   getSearchPageURL,
   onSelect: userOnSelect,
-  refine,
+  refine: refineAutocomplete,
   cssClasses,
   renderState,
   instantSearchInstance,
@@ -223,6 +223,7 @@ function AutocompleteWrapper<TItem extends BaseHit>({
       ) ?? false;
 
   const onRefine = (query: string) => {
+    refineAutocomplete(query);
     instantSearchInstance.setUiState((uiState) => ({
       ...uiState,
       [targetIndex!.getIndexId()]: {
@@ -388,9 +389,11 @@ function AutocompleteWrapper<TItem extends BaseHit>({
           ...getInputProps(),
           // @ts-ignore - This clashes with some ambient React JSX declarations.
           onInput: (evt: JSXPreact.TargetedEvent<HTMLInputElement>) =>
-            refine(evt.currentTarget.value),
+            refineAutocomplete(evt.currentTarget.value),
         }}
-        onClear={() => onRefine('')}
+        onClear={() => {
+          onRefine('');
+        }}
         isSearchStalled={instantSearchInstance.status === 'stalled'}
       />
       <AutocompletePanel {...getPanelProps()}>


### PR DESCRIPTION
**Summary**

[FX-3588](https://algolia.atlassian.net/browse/FX-3588)

**Result**

It only did so on `instantsearch.js`, because it only cleared the root query, not the internal autocomplete one.


[FX-3588]: https://algolia.atlassian.net/browse/FX-3588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ