### PR TITLE
fix(useWidget): correct warning condition for multiple InstantSearch hooks

### DIFF
--- a/packages/react-instantsearch-core/src/lib/useWidget.ts
+++ b/packages/react-instantsearch-core/src/lib/useWidget.ts
@@ -110,8 +110,8 @@ export function useWidget<TWidget extends Widget | IndexWidget, TProps>({
   if (waitForResultsRef?.current?.status === 'fulfilled') {
     countRef.current += 1;
     warn(
-      countRef.current > parentIndex.getWidgets().length &&
-        !ignoreMultipleHooksWarning,
+      ignoreMultipleHooksWarning ||
+        countRef.current <= parentIndex.getWidgets().length,
       `We detected you may have a component with multiple InstantSearch hooks.
 
 With Next.js, you need to set \`skipSuspense\` to \`true\` for all but the last hook in the component, otherwise, only the first hook will be rendered on the server.


### PR DESCRIPTION
**Summary**

Correct `skipSuspense` warning based in the comment from the maintainer @aymeric-giraudet  https://github.com/algolia/instantsearch/pull/6647#discussion_r2564446509

**Result**

I spent a day trying to create proper test with `@jest-environment @instantsearch/testutils/jest-environment-jsdom.ts` and `@testing-library/react`. But for me it was very hard to follow the logic. In the end I tried to launch existing tests and found out that they don't pass the new condition. For example 

https://github.com/algolia/instantsearch/blob/master/packages/react-instantsearch-nextjs/src/__tests__/InitializePromise.test.tsx#L99-L115

And new condition triggers warning in this case. Probably it's related to `waitForResultsRef` handling. If you could support me with an example I could provide tests in an update
