### PR TITLE
fix(types): ensure TWidgetParams reference is kept

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -251,6 +251,12 @@ const config = {
             message:
               '`with` is disallowed in strict mode because it makes code impossible to predict and optimize.',
           },
+          {
+            selector:
+              ":matches(TSSatisfiesExpression, TSAsExpression) ObjectExpression Property[method=true][key.name='getRenderState'] > FunctionExpression:not([returnType]) :matches(MemberExpression[object.name='renderState'], SpreadElement > Identifier[name='renderState'])",
+            message:
+              'Connectors using `satisfies` that use `renderState` must explicitly annotate the return type of `getRenderState`.',
+          },
         ],
       },
     },

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -29,6 +29,7 @@ import type {
   IndexUiState,
   IndexWidget,
   WidgetRenderState,
+  IndexRenderState,
 } from '../../types';
 import type {
   AddToolResultWithOutput,
@@ -312,7 +313,11 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
         );
       },
 
-      getRenderState(renderState, renderOptions) {
+      getRenderState(
+        renderState,
+        renderOptions
+        // Type is explicitly redefined, to avoid having the TWidgetParams type in the definition
+      ): IndexRenderState & ChatWidgetDescription['indexRenderState'] {
         return {
           ...renderState,
           chat: this.getWidgetRenderState(renderOptions),


### PR DESCRIPTION
This is an old issue (https://github.com/microsoft/rushstack/issues/4740) in extractor we solved in https://github.com/algolia/instantsearch/commit/0cde49ee54dd844343e10ba6060b0225492fe0ec#diff-eaddc72b53ce12906d949a84f825b02ed1457775c7bacbf9b478652d0cb2975c

Now with a lint rule failing if you don't explicitly type that return value