### PR TITLE
feat(nextjs): allow passing headers

### DIFF
--- a/packages/react-instantsearch-nextjs/src/InstantSearchNext.tsx
+++ b/packages/react-instantsearch-nextjs/src/InstantSearchNext.tsx
@@ -47,6 +47,7 @@ export type InstantSearchNextProps<
   routing?: InstantSearchNextRouting<TUiState, TRouteState> | boolean;
   instance?: InstantSearchNextInstance;
   ignoreMultipleHooksWarning?: boolean;
+  headers?: Headers;
 };
 
 export function InstantSearchNext<
@@ -57,6 +58,7 @@ export function InstantSearchNext<
   routing: passedRouting,
   instance,
   ignoreMultipleHooksWarning = false,
+  headers: passedHeaders,
   ...instantSearchProps
 }: InstantSearchNextProps<TUiState, TRouteState>) {
   const isMounting = useRef(true);
@@ -66,7 +68,9 @@ export function InstantSearchNext<
     isMounting.current = false;
   }, []);
 
-  const headers = useNextHeaders();
+  // We're not using hooks that are subject to these rules
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const headers = passedHeaders ? new Headers(passedHeaders) : useNextHeaders();
 
   const nonce = safelyRunOnBrowser(() => undefined, {
     fallback: () => headers?.get('x-nonce') || undefined,
@@ -74,7 +78,11 @@ export function InstantSearchNext<
 
   useDynamicRouteWarning({ isServer, isMounting, instance });
 
-  const routing = useInstantSearchRouting(passedRouting, isMounting);
+  const routing = useInstantSearchRouting({
+    routing: passedRouting,
+    isMounting,
+    headers,
+  });
 
   warn(
     false,

--- a/packages/react-instantsearch-nextjs/src/useInstantSearchRouting.ts
+++ b/packages/react-instantsearch-nextjs/src/useInstantSearchRouting.ts
@@ -2,8 +2,6 @@ import historyRouter from 'instantsearch.js/es/lib/routers/history';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { useRef, useEffect } from 'react';
 
-import { useNextHeaders } from './useNextHeaders';
-
 import type { InstantSearchNextProps } from './InstantSearchNext';
 import type { UiState } from 'instantsearch.js';
 import type { BrowserHistoryArgs } from 'instantsearch.js/es/lib/routers/history';
@@ -12,10 +10,15 @@ import type { InstantSearchProps } from 'react-instantsearch-core';
 export function useInstantSearchRouting<
   TUiState extends UiState = UiState,
   TRouteState = TUiState
->(
-  passedRouting: InstantSearchNextProps<TUiState, TRouteState>['routing'],
-  isMounting: React.RefObject<boolean>
-) {
+>({
+  routing,
+  isMounting,
+  headers,
+}: {
+  routing: InstantSearchNextProps<TUiState, TRouteState>['routing'];
+  isMounting: React.RefObject<boolean>;
+  headers?: Headers;
+}) {
   const isServer = typeof window === 'undefined';
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -37,9 +40,7 @@ export function useInstantSearchRouting<
     };
   });
 
-  const headers = useNextHeaders();
-
-  if (passedRouting && !routingRef.current) {
+  if (routing && !routingRef.current) {
     let browserHistoryOptions: Partial<BrowserHistoryArgs<TRouteState>> = {};
 
     browserHistoryOptions.getLocation = () => {
@@ -73,12 +74,12 @@ export function useInstantSearchRouting<
     };
 
     routingRef.current = {};
-    if (typeof passedRouting === 'object') {
+    if (typeof routing === 'object') {
       browserHistoryOptions = {
         ...browserHistoryOptions,
-        ...passedRouting.router,
+        ...routing.router,
       };
-      routingRef.current.stateMapping = passedRouting.stateMapping;
+      routingRef.current.stateMapping = routing.stateMapping;
     }
     routingRef.current.router = historyRouter(browserHistoryOptions);
   }


### PR DESCRIPTION
**Summary**

Allow passing headers for users that can't call `headers` in a client component


