### PR TITLE
fix(searchable): include parent index state

### DIFF
--- a/packages/instantsearch.js/src/widgets/index/index.ts
+++ b/packages/instantsearch.js/src/widgets/index/index.ts
@@ -723,7 +723,10 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
         maxFacetHits,
         userState
       ) => {
-        const state = helper!.state.setQueryParameters(userState!);
+        const state = mergeSearchParameters(
+          mainHelper.state,
+          ...resolveSearchParameters(this)
+        ).setQueryParameters(userState!);
 
         return mainHelper.searchForFacetValues(
           facetName,


### PR DESCRIPTION



<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Make the searchable refinement lists include the state (like query) of the parent indices.

This edge case had not been discovered yet, as it's pretty subtle to know that a search for facet values did not include the parent search query.

**Result**

search for facet values includes the state of parent indices.

To reproduce:

```js
import { liteClient as algoliasearch } from 'algoliasearch/lite';
import instantsearch from 'instantsearch.js';
import {
  refinementList,
  searchBox,
  index,
} from 'instantsearch.js/es/widgets';

const searchClient = algoliasearch(
  'latency',
  '6be0576ff61c053d5f9a3225e2a90f76'
);

const search = instantsearch({
  indexName: 'instant_search',
  searchClient,
});

search.addWidgets([
  searchBox({
    container: '#searchbox',
  }),
  index({ indexName: 'instant_search_price_asc' }).addWidgets([
    refinementList({
      container: '#brand-list',
      attribute: 'brand',
      showMore: true,
      searchable: true,
    }),
  ])
]).start();
```

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
