### PR TITLE
fix(autocomplete): left and right arrow keys do not navigate items

### DIFF
--- a/packages/instantsearch-ui-components/src/components/autocomplete/createAutocompletePropGetters.ts
+++ b/packages/instantsearch-ui-components/src/components/autocomplete/createAutocompletePropGetters.ts
@@ -147,12 +147,10 @@ export function createAutocompletePropGetters({
 
     const getNextActiveDescendant = (key: string): string | undefined => {
       switch (key) {
-        case 'ArrowLeft':
         case 'ArrowUp': {
           const prevIndex = itemsIds.indexOf(activeDescendant || '') - 1;
           return itemsIds[prevIndex] || itemsIds[itemsIds.length - 1];
         }
-        case 'ArrowRight':
         case 'ArrowDown': {
           const nextIndex = itemsIds.indexOf(activeDescendant || '') + 1;
           return itemsIds[nextIndex] || itemsIds[0];
@@ -221,9 +219,7 @@ export function createAutocompletePropGetters({
               }
               break;
             }
-            case 'ArrowLeft':
             case 'ArrowUp':
-            case 'ArrowRight':
             case 'ArrowDown': {
               setIsOpen(true);
 

--- a/tests/common/widgets/autocomplete/options.tsx
+++ b/tests/common/widgets/autocomplete/options.tsx
@@ -607,6 +607,22 @@ export function createOptionsTests(
         selectedItem!.id
       );
 
+      // ArrowRight should not navigate items
+      await act(async () => {
+        userEvent.keyboard('{ArrowRight}');
+        await wait(0);
+      });
+
+      expect(selectedItem!.textContent).toBe('Item 1');
+
+      // ArrowLeft should not navigate items
+      await act(async () => {
+        userEvent.keyboard('{ArrowLeft}');
+        await wait(0);
+      });
+
+      expect(selectedItem!.textContent).toBe('Item 1');
+
       await act(async () => {
         userEvent.keyboard('{ArrowUp}');
         await wait(0);


### PR DESCRIPTION
[FX-3708]

Now allows the left and right arrow keys to move the caret/cursor in the autocomplete searchbox

https://github.com/user-attachments/assets/22608e16-9a81-4ee0-a02e-4ddeeaddc323



[FX-3708]: https://algolia.atlassian.net/browse/FX-3708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ