### PR TITLE
fix(autocomplete): forward the root ref

### DIFF
--- a/packages/instantsearch-ui-components/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/instantsearch-ui-components/src/components/autocomplete/Autocomplete.tsx
@@ -2,11 +2,17 @@
 
 import { cx } from '../../lib/cx';
 
-import type { ComponentChildren, ComponentProps, Renderer } from '../../types';
+import type {
+  ComponentChildren,
+  ComponentProps,
+  MutableRef,
+  Renderer,
+} from '../../types';
 
 export type AutocompleteProps = Omit<ComponentProps<'div'>, 'children'> & {
   children?: ComponentChildren;
   classNames?: Partial<AutocompleteClassNames>;
+  rootRef?: MutableRef<HTMLDivElement | null>;
 };
 
 export type AutocompleteClassNames = {
@@ -54,10 +60,14 @@ export type AutocompleteClassNames = {
 
 export function createAutocompleteComponent({ createElement }: Renderer) {
   return function Autocomplete(userProps: AutocompleteProps) {
-    const { children, classNames = {}, ...props } = userProps;
+    const { children, classNames = {}, rootRef, ...props } = userProps;
 
     return (
-      <div className={cx('ais-Autocomplete', classNames.root)} {...props}>
+      <div
+        className={cx('ais-Autocomplete', classNames.root)}
+        ref={rootRef}
+        {...props}
+      >
         {children}
       </div>
     );

--- a/packages/instantsearch.js/src/widgets/autocomplete/autocomplete.tsx
+++ b/packages/instantsearch.js/src/widgets/autocomplete/autocomplete.tsx
@@ -842,10 +842,11 @@ function AutocompleteWrapper<TItem extends BaseHit>({
         ),
       }
     : cssClasses;
+  const { ref: rootRef, ...rootProps } = getRootProps();
 
   if (isDetached) {
     return (
-      <Autocomplete {...getRootProps()} classNames={cssClasses}>
+      <Autocomplete {...rootProps} rootRef={rootRef} classNames={cssClasses}>
         <AutocompleteDetachedSearchButton
           query={localQuery}
           placeholder={placeholder}
@@ -890,7 +891,7 @@ function AutocompleteWrapper<TItem extends BaseHit>({
 
   // Normal (non-detached) rendering
   return (
-    <Autocomplete {...getRootProps()} classNames={cssClasses}>
+    <Autocomplete {...rootProps} rootRef={rootRef} classNames={cssClasses}>
       {searchBoxContent}
       {panelContent}
     </Autocomplete>

--- a/packages/react-instantsearch/src/widgets/Autocomplete.tsx
+++ b/packages/react-instantsearch/src/widgets/Autocomplete.tsx
@@ -898,10 +898,16 @@ function InnerAutocomplete<TItem extends BaseHit = BaseHit>({
         ),
       }
     : classNames;
+  const { ref: rootRef, ...rootProps } = getRootProps();
 
   if (isDetached) {
     return (
-      <Autocomplete {...props} {...getRootProps()} classNames={classNames}>
+      <Autocomplete
+        {...props}
+        {...rootProps}
+        rootRef={rootRef}
+        classNames={classNames}
+      >
         <AutocompleteDetachedSearchButton
           query={currentRefinement || indexUiState.query || ''}
           placeholder={placeholder}
@@ -947,7 +953,12 @@ function InnerAutocomplete<TItem extends BaseHit = BaseHit>({
 
   // Normal (non-detached) rendering
   return (
-    <Autocomplete {...props} {...getRootProps()} classNames={classNames}>
+    <Autocomplete
+      {...props}
+      {...rootProps}
+      rootRef={rootRef}
+      classNames={classNames}
+    >
       {searchBoxContent}
       {panelContent}
     </Autocomplete>


### PR DESCRIPTION
**Summary**

On the dashboard, React shows a warning when rendering `InnerAutocomplete` that function components cannot be given refs. Because the autocomplete root ref is not attached to the DOM node, focusing the autocomplete input opens the panel briefly and closes it right after. This change fixes the root ref wiring while keeping the existing `getRootProps()` API intact.

**Result**

- Click the autocomplete input and confirm the panel stays open on first focus.
- Confirm the React warning about passing refs to function components no longer appears.