### PR TITLE
feat(react-instantsearch-core): provide facet metadata to DynamicWidgets fallback

### DIFF
--- a/packages/react-instantsearch-core/src/components/DynamicWidgets.tsx
+++ b/packages/react-instantsearch-core/src/components/DynamicWidgets.tsx
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react';
 
 import { useDynamicWidgets } from '../connectors/useDynamicWidgets';
+import { useInstantSearch } from '../hooks/useInstantSearch';
 import { invariant } from '../lib/invariant';
 import { warn } from '../lib/warn';
 
@@ -22,7 +23,11 @@ export type DynamicWidgetsProps = Omit<
 > &
   AtLeastOne<{
     children: ReactNode;
-    fallbackComponent: ComponentType<{ attribute: string }>;
+    fallbackComponent: ComponentType<{
+      attribute: string;
+      canRefine: boolean;
+      facetValues: Record<string, number>;
+    }>;
   }>;
 
 export function DynamicWidgets({
@@ -40,6 +45,9 @@ export function DynamicWidgets({
   const { attributesToRender } = useDynamicWidgets(props, {
     $$widgetType: 'ais.dynamicWidgets',
   });
+  const { results } = useInstantSearch();
+  const rawFacets = results?._rawResults?.[0]?.facets || {};
+  const facets = Object.keys(rawFacets).length > 0 ? rawFacets : results?.facets;
   const widgets: Map<string, ReactNode> = new Map();
 
   React.Children.forEach(children, (child) => {
@@ -58,7 +66,11 @@ export function DynamicWidgets({
       {attributesToRender.map((attribute) => (
         <Fragment key={attribute}>
           {widgets.get(attribute) || (
-            <FallbackComponent.current attribute={attribute} />
+            <FallbackComponent.current
+              attribute={attribute}
+              canRefine={Object.keys(facets?.[attribute] || {}).length > 0}
+              facetValues={facets?.[attribute] || {}}
+            />
           )}
         </Fragment>
       ))}

--- a/packages/react-instantsearch-core/src/components/__tests__/DynamicWidgets.test.tsx
+++ b/packages/react-instantsearch-core/src/components/__tests__/DynamicWidgets.test.tsx
@@ -360,6 +360,68 @@ describe('DynamicWidgets', () => {
     `);
   });
 
+  test('passes facet metadata to fallbackComponent', async () => {
+    const search = jest.fn((requests) =>
+      Promise.resolve({
+        results: requests.map(() => ({
+          facets: {
+            categories: { Phones: 12 },
+          },
+          renderingContent: {
+            facetOrdering: {
+              facets: {
+                order: ['categories', 'brand'],
+              },
+            },
+          },
+        })),
+      })
+    );
+
+    const searchClient = createSearchClient({
+      search,
+    });
+
+    const fallbackComponent = jest.fn(
+      ({
+        attribute,
+        canRefine,
+      }: {
+        attribute: string;
+        canRefine: boolean;
+        facetValues: Record<string, number>;
+      }) => `${attribute}:${canRefine}` as unknown as JSX.Element
+    );
+
+    const { container } = render(
+      <InstantSearch indexName="indexName" searchClient={searchClient}>
+        <DynamicWidgets fallbackComponent={fallbackComponent}>
+          <RefinementList attribute="brand" />
+        </DynamicWidgets>
+      </InstantSearch>
+    );
+
+    await waitFor(() => {
+      expect(searchClient.search).toHaveBeenCalledTimes(1);
+    });
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        categories:true
+        RefinementList(brand)
+      </div>
+    `);
+
+    expect(fallbackComponent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attribute: 'categories',
+        canRefine: true,
+        facetValues: { Phones: 12 },
+      }),
+      undefined
+    );
+  });
+
   test('renders attributes without widget with fallbackComponent (function form)', async () => {
     const searchClient = createSearchClient({});
 


### PR DESCRIPTION
## Summary

This change enriches `DynamicWidgets` fallback rendering with facet metadata from the current results, so fallback components can make visibility decisions without mounting additional facet connectors.

### What changed

- `DynamicWidgets` now passes extra props to `fallbackComponent`:
  - `canRefine: boolean`
  - `facetValues: Record<string, number>`
- The original `attribute` prop remains unchanged.
- Facet metadata is sourced from `_rawResults[0].facets` when available, with fallback to `results.facets`.

## Why

When many dynamic facets are rendered through `fallbackComponent`, apps often mount `useRefinementList()` / `useHierarchicalMenu()` just to know whether a facet has values. This creates duplicate connector registrations and can significantly increase initial rendering cost for high facet counts.

By passing facet metadata directly from `DynamicWidgets`, fallback components can skip those extra connectors and stay mostly presentational.

## Tests

Added test coverage in:

- `packages/react-instantsearch-core/src/components/__tests__/DynamicWidgets.test.tsx`

New test validates that `fallbackComponent` receives:

- `attribute`
- `canRefine`
- `facetValues`

## Validation run

- `yarn jest packages/react-instantsearch-core/src/components/__tests__/DynamicWidgets.test.tsx --runInBand`
- `yarn jest packages/react-instantsearch-core/src/connectors/__tests__/useDynamicWidgets.test.tsx --runInBand`

## Notes

This is an incremental, backwards-compatible step toward reducing `DynamicWidgets` overhead in high-facet scenarios, without removing or changing singular connectors.
