### PR TITLE
fix(ui-components): hide submit button during stalled search and optimize loading SVG

### DIFF
--- a/packages/instantsearch-ui-components/src/components/autocomplete/AutocompleteSearch.tsx
+++ b/packages/instantsearch-ui-components/src/components/autocomplete/AutocompleteSearch.tsx
@@ -14,6 +14,7 @@ export function createAutocompleteSearchComponent({ createElement }: Renderer) {
   return function AutocompleteSearch(userProps: AutocompleteSearchProps) {
     const { inputProps, onClear, query, isSearchStalled } = userProps;
     const inputRef = inputProps.ref as { current: HTMLInputElement | null };
+
     return (
       <form
         className="ais-AutocompleteForm"
@@ -34,6 +35,7 @@ export function createAutocompleteSearchComponent({ createElement }: Renderer) {
               className="ais-AutocompleteSubmitButton"
               type="submit"
               title="Submit"
+              hidden={isSearchStalled}
             >
               <SubmitIcon createElement={createElement} />
             </button>
@@ -42,7 +44,10 @@ export function createAutocompleteSearchComponent({ createElement }: Renderer) {
             className="ais-AutocompleteLoadingIndicator"
             hidden={!isSearchStalled}
           >
-            <LoadingIcon createElement={createElement} />
+            <LoadingIcon
+              createElement={createElement}
+              isSearchStalled={isSearchStalled}
+            />
           </div>
         </div>
         <div className="ais-AutocompleteInputWrapper">

--- a/packages/instantsearch-ui-components/src/components/autocomplete/icons.tsx
+++ b/packages/instantsearch-ui-components/src/components/autocomplete/icons.tsx
@@ -3,6 +3,32 @@ import type { Renderer } from '../../types';
 
 type IconProps = Pick<Renderer, 'createElement'>;
 
+type LoadingIconProps = IconProps & {
+  isSearchStalled: boolean;
+};
+
+// WebKit can keep this SVG spinner animating while the loading slot is hidden (`hidden` / not stalled),
+// which wastes work. We pause SMIL when idle and unpause when `isSearchStalled`.
+// Same approach as autocomplete-js.
+// https://github.com/algolia/autocomplete/issues/1322
+function syncLoadingSvgAnimation(
+  element: SVGSVGElement | null,
+  isSearchStalled: boolean
+) {
+  if (
+    !element ||
+    typeof element.pauseAnimations !== 'function' ||
+    typeof element.unpauseAnimations !== 'function'
+  ) {
+    return;
+  }
+  if (isSearchStalled) {
+    element.unpauseAnimations();
+  } else {
+    element.pauseAnimations();
+  }
+}
+
 export function SubmitIcon({ createElement }: IconProps) {
   return (
     <svg
@@ -15,9 +41,16 @@ export function SubmitIcon({ createElement }: IconProps) {
   );
 }
 
-export function LoadingIcon({ createElement }: IconProps) {
+export function LoadingIcon({
+  createElement,
+  isSearchStalled,
+}: LoadingIconProps) {
   return (
-    <svg className="ais-AutocompleteLoadingIcon" viewBox="0 0 100 100">
+    <svg
+      className="ais-AutocompleteLoadingIcon"
+      viewBox="0 0 100 100"
+      ref={(element) => syncLoadingSvgAnimation(element, isSearchStalled)}
+    >
       <circle
         cx="50"
         cy="50"
@@ -34,7 +67,7 @@ export function LoadingIcon({ createElement }: IconProps) {
           dur="1s"
           values="0 50 50;90 50 50;180 50 50;360 50 50"
           keyTimes="0;0.40;0.65;1"
-        ></animateTransform>
+        />
       </circle>
     </svg>
   );


### PR DESCRIPTION
**Summary**

When the autocomplete search is stalled, the submit button now hides and the loading indicator takes its place. Additionally, the loading SVG SMIL animation is paused when not visible to avoid unnecessary work in WebKit browsers (same approach as [autocomplete-js](https://github.com/algolia/autocomplete/issues/1322)).

[FX-3760](https://algolia.atlassian.net/browse/FX-3760)

**Result**

- Submit button is hidden via `hidden` attribute when `isSearchStalled` is true
- Loading spinner pauses/unpauses its SMIL animation based on stalled state

**Before**

https://github.com/user-attachments/assets/a2a7ee0a-9cb8-4a96-b850-aef565df1682

**After**

https://github.com/user-attachments/assets/0d60cf10-9c78-4924-9a8e-eb807c3b2fb1

[FX-3760]: https://algolia.atlassian.net/browse/FX-3760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ