### PR TITLE
fix(examples): match showcase dark mode background to docs color

### DIFF
--- a/examples/js/showcase/src/style.css
+++ b/examples/js/showcase/src/style.css
@@ -13,12 +13,12 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   color: theme(--color-neutral-900);
-  background-color: theme(--color-white);
+  background-color: theme(--color-white); /* docs light bg */
 }
 
 [data-theme="dark"] body {
   color: theme(--color-neutral-100);
-  background-color: #0a0b11;
+  background-color: #0a0b11; /* docs dark bg */
 }
 
 /* RangeSlider (noUiSlider) */

--- a/examples/js/showcase/src/style.css
+++ b/examples/js/showcase/src/style.css
@@ -18,7 +18,7 @@ body {
 
 [data-theme="dark"] body {
   color: theme(--color-neutral-100);
-  background-color: theme(--color-neutral-950);
+  background-color: #0a0b11;
 }
 
 /* RangeSlider (noUiSlider) */


### PR DESCRIPTION
**Summary**

Update the widget showcase example's dark mode background color from `neutral-950` to `#0a0b11` to match the documentation site's background color.

https://github.com/algolia/docs-new/pull/722

**Result**

The dark mode body background in `examples/js/showcase/src/style.css` now uses `#0a0b11` instead of Tailwind's `neutral-950`, ensuring visual consistency with the docs.