### PR TITLE
feat(chat): add hidden context support for completions

### DIFF
--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -206,6 +206,36 @@ describe('ChatMessage', () => {
     `);
   });
 
+  test('does not render context parts', () => {
+    const { container } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'user',
+          id: '1',
+          parts: [
+            { type: 'text', text: 'Hello' },
+            {
+              type: 'context',
+              context: {
+                currentPage: 'https://example.com/products',
+                userLocale: 'en-US',
+              },
+            },
+          ],
+        }}
+        status="ready"
+        tools={{}}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(container.textContent).toBe('Hello');
+    expect(container.textContent).not.toContain('example.com');
+    expect(container.textContent).not.toContain('en-US');
+  });
+
   test('renders with tools', () => {
     const { container } = render(
       <ChatMessage

--- a/packages/instantsearch-ui-components/src/components/chat/types.ts
+++ b/packages/instantsearch-ui-components/src/components/chat/types.ts
@@ -101,6 +101,15 @@ export type StepStartUIPart = {
 };
 
 /**
+ * A context part of a message, used to pass hidden context (e.g. current page info)
+ * alongside user messages. Not rendered in the UI but sent to the API.
+ */
+export type ContextUIPart = {
+  type: 'context';
+  context: Record<string, unknown>;
+};
+
+/**
  * A data part of a message.
  */
 export type DataUIPart<TDataTypes extends UIDataTypes> = ValueOf<{
@@ -208,7 +217,8 @@ export type UIMessagePart<
   | SourceDocumentUIPart
   | FileUIPart
   | DataUIPart<TDataTypes>
-  | StepStartUIPart;
+  | StepStartUIPart
+  | ContextUIPart;
 
 /**
  * AI SDK UI Messages. They are used in the client and to communicate between the frontend and the API routes.

--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -3,538 +3,179 @@
  */
 
 import { createSearchClient } from '@instantsearch/mocks';
-import { waitFor } from '@testing-library/dom';
 import algoliasearchHelper from 'algoliasearch-helper';
 
-import {
-  createInitOptions,
-  createRenderOptions,
-} from '../../../../test/createWidget';
+import { createInitOptions } from '../../../../test/createWidget';
+import { Chat } from '../../../lib/chat';
 import connectChat from '../connectChat';
 
-import type { UIMessage } from '../../../lib/chat';
-import type { InstantSearch, IndexWidget } from '../../../types';
-import type { ChatConnectorParams } from '../connectChat';
+import type { UIMessage, ChatTransport } from '../../../lib/ai-lite';
 
-jest.mock('../../../lib/utils/sendChatMessageFeedback', () => ({
-  sendChatMessageFeedback: jest.fn(() => Promise.resolve(new Response('{}'))),
-}));
+function createMockTransport(): ChatTransport<UIMessage> {
+  return {
+    sendMessages: jest.fn(() =>
+      Promise.resolve(new ReadableStream({ start(ctrl) { ctrl.close(); } }))
+    ),
+    reconnectToStream: jest.fn(() => Promise.resolve(null)),
+  };
+}
 
-describe('connectChat', () => {
-  const getInitializedWidget = (widgetParams: ChatConnectorParams = {}) => {
-    const renderFn = jest.fn();
-    const makeWidget = connectChat(renderFn);
-    const widget = makeWidget({
-      ...(!('agentId' in widgetParams) ? { agentId: 'agentId' } : {}),
-      ...widgetParams,
+function createTestChat() {
+  const transport = createMockTransport();
+  return new Chat<UIMessage>({ transport });
+}
+
+function createChatWidget(
+  params: Omit<Parameters<ReturnType<typeof connectChat>>[0], 'transport' | 'agentId'> & { chat: Chat<UIMessage> }
+) {
+  const renderFn = jest.fn();
+  const makeWidget = connectChat(renderFn);
+  // Need to also provide transport to satisfy the makeChatInstance validation
+  // (it checks transport/agentId before checking if `chat` is provided)
+  const widget = makeWidget({
+    ...params,
+    transport: { api: 'http://unused' },
+  });
+  return { widget, renderFn };
+}
+
+describe('connectChat context', () => {
+  beforeAll(() => {
+    const store: Record<string, string> = {};
+    Object.defineProperty(globalThis, 'sessionStorage', {
+      value: {
+        getItem: (key: string) => store[key] || null,
+        setItem: (key: string, val: string) => { store[key] = val; },
+        removeItem: (key: string) => { delete store[key]; },
+      },
+      configurable: true,
+    });
+  });
+
+  afterAll(() => {
+    delete (globalThis as any).sessionStorage;
+  });
+
+  test('sendMessage injects context part when context is a static object', async () => {
+    const chatInstance = createTestChat();
+    const sendMessageSpy = jest.spyOn(chatInstance, 'sendMessage');
+
+    const { widget, renderFn } = createChatWidget({
+      chat: chatInstance,
+      context: { currentPage: '/products', locale: 'en-US' },
     });
 
     const helper = algoliasearchHelper(createSearchClient(), '');
+    widget.init!(createInitOptions({ helper, state: helper.state }));
 
-    widget.init(createInitOptions({ helper }));
+    const { sendMessage } = renderFn.mock.calls[0][0];
 
-    const getRenderState = () =>
-      widget.getWidgetRenderState(createInitOptions({ helper }));
+    await sendMessage({ text: 'Hello' });
 
-    return { widget, helper, renderFn, getRenderState };
-  };
-
-  describe('Usage', () => {
-    it('throws without render function', () => {
-      expect(() => {
-        // @ts-expect-error
-        connectChat()({});
-      }).toThrowErrorMatchingInlineSnapshot(`
-        "The render function is not valid (received type Undefined).
-
-        See documentation: https://www.algolia.com/doc/api-reference/widgets/chat/js/#connector"
-      `);
-    });
-
-    it('is a widget', () => {
-      const render = jest.fn();
-      const unmount = jest.fn();
-
-      const customChat = connectChat(render, unmount);
-      const widget = customChat({});
-
-      expect(widget).toEqual(
-        expect.objectContaining({
-          $$type: 'ais.chat',
-          init: expect.any(Function),
-          render: expect.any(Function),
-          dispose: expect.any(Function),
-        })
-      );
-    });
+    expect(sendMessageSpy).toHaveBeenCalledTimes(1);
+    const call = sendMessageSpy.mock.calls[0][0] as any;
+    expect(call.parts).toEqual([
+      { type: 'text', text: 'Hello' },
+      { type: 'context', context: { currentPage: '/products', locale: 'en-US' } },
+    ]);
   });
 
-  describe('getWidgetRenderState', () => {
-    it('returns the render state', () => {
-      const { widget, helper } = getInitializedWidget();
+  test('sendMessage injects context part when context is a function', async () => {
+    const chatInstance = createTestChat();
+    const sendMessageSpy = jest.spyOn(chatInstance, 'sendMessage');
 
-      const instantSearchInstance: Pick<
-        InstantSearch,
-        'client' | 'getUiState'
-      > = {
-        client: createSearchClient(),
-        getUiState: () => ({ indexName: {} }),
-      };
-      const parent: Pick<IndexWidget, 'getIndexId' | 'setIndexUiState'> = {
-        getIndexId: () => 'indexName',
-        setIndexUiState: () => {},
-      };
-
-      const renderState = widget.getWidgetRenderState(
-        createInitOptions({
-          helper,
-          state: helper.state,
-          instantSearchInstance: instantSearchInstance as InstantSearch,
-          parent: parent as IndexWidget,
-        })
-      );
-
-      expect(renderState).toEqual(
-        expect.objectContaining({
-          input: '',
-          open: false,
-          isClearing: false,
-          feedbackState: {},
-          setInput: expect.any(Function),
-          setOpen: expect.any(Function),
-          setMessages: expect.any(Function),
-          clearMessages: expect.any(Function),
-          onClearTransitionEnd: expect.any(Function),
-          sendEvent: expect.any(Function),
-          setIndexUiState: expect.any(Function),
-          indexUiState: {},
-          tools: {},
-          addToolResult: expect.any(Function),
-          clearError: expect.any(Function),
-          error: undefined,
-          id: expect.any(String),
-          messages: expect.any(Array),
-          regenerate: expect.any(Function),
-          resumeStream: expect.any(Function),
-          sendMessage: expect.any(Function),
-          status: expect.any(String),
-          stop: expect.any(Function),
-          widgetParams: expect.objectContaining({
-            agentId: 'agentId',
-          }),
-        })
-      );
+    let pageUrl = '/page-1';
+    const { widget, renderFn } = createChatWidget({
+      chat: chatInstance,
+      context: () => ({ currentPage: pageUrl }),
     });
+
+    const helper = algoliasearchHelper(createSearchClient(), '');
+    widget.init!(createInitOptions({ helper, state: helper.state }));
+
+    const { sendMessage } = renderFn.mock.calls[0][0];
+
+    await sendMessage({ text: 'first message' });
+
+    let call = sendMessageSpy.mock.calls[0][0] as any;
+    expect(call.parts).toEqual([
+      { type: 'text', text: 'first message' },
+      { type: 'context', context: { currentPage: '/page-1' } },
+    ]);
+
+    pageUrl = '/page-2';
+    await sendMessage({ text: 'second message' });
+
+    call = sendMessageSpy.mock.calls[1][0] as any;
+    expect(call.parts).toEqual([
+      { type: 'text', text: 'second message' },
+      { type: 'context', context: { currentPage: '/page-2' } },
+    ]);
   });
 
-  describe('getRenderState', () => {
-    it('merges state', () => {
-      const { widget, helper } = getInitializedWidget();
+  test('sendMessage passes through without modification when no context', async () => {
+    const chatInstance = createTestChat();
+    const sendMessageSpy = jest.spyOn(chatInstance, 'sendMessage');
 
-      const instantSearchInstance: Pick<
-        InstantSearch,
-        'client' | 'getUiState'
-      > = {
-        client: createSearchClient(),
-        getUiState: () => ({ indexName: {} }),
-      };
-      const parent: Pick<IndexWidget, 'getIndexId' | 'setIndexUiState'> = {
-        getIndexId: () => 'indexName',
-        setIndexUiState: () => {},
-      };
-
-      expect(
-        widget.getRenderState(
-          {
-            // @ts-expect-error
-            searchBox: {},
-            // @ts-expect-error
-            chat: {},
-          },
-          createInitOptions({
-            helper,
-            state: helper.state,
-            instantSearchInstance: instantSearchInstance as InstantSearch,
-            parent: parent as IndexWidget,
-          })
-        )
-      ).toEqual({
-        searchBox: {},
-        chat: expect.objectContaining({
-          input: '',
-          open: false,
-          isClearing: false,
-          setInput: expect.any(Function),
-          setOpen: expect.any(Function),
-          setMessages: expect.any(Function),
-          clearMessages: expect.any(Function),
-          onClearTransitionEnd: expect.any(Function),
-          sendEvent: expect.any(Function),
-          setIndexUiState: expect.any(Function),
-          indexUiState: {},
-          tools: {},
-          addToolResult: expect.any(Function),
-          clearError: expect.any(Function),
-          error: undefined,
-          id: expect.any(String),
-          messages: expect.any(Array),
-          regenerate: expect.any(Function),
-          resumeStream: expect.any(Function),
-          sendMessage: expect.any(Function),
-          status: expect.any(String),
-          stop: expect.any(Function),
-          widgetParams: expect.objectContaining({
-            agentId: 'agentId',
-          }),
-        }),
-      });
+    const { widget, renderFn } = createChatWidget({
+      chat: chatInstance,
     });
 
-    it('uses custom `type` as key in getRenderState', () => {
-      const render = jest.fn();
-      const makeWidget = connectChat(render);
-      const widget = makeWidget({ type: 'customChat', agentId: 'agentId' });
+    const helper = algoliasearchHelper(createSearchClient(), '');
+    widget.init!(createInitOptions({ helper, state: helper.state }));
 
-      const helper = algoliasearchHelper(createSearchClient(), '');
+    const { sendMessage } = renderFn.mock.calls[0][0];
 
-      const instantSearchInstance: Pick<
-        InstantSearch,
-        'client' | 'getUiState'
-      > = {
-        client: createSearchClient(),
-        getUiState: () => ({ indexName: {} }),
-      };
-      const parent: Pick<IndexWidget, 'getIndexId' | 'setIndexUiState'> = {
-        getIndexId: () => 'indexName',
-        setIndexUiState: () => {},
-      };
+    await sendMessage({ text: 'Hello' });
 
-      const result = widget.getRenderState(
-        {
-          // @ts-expect-error
-          searchBox: {},
-        },
-        createInitOptions({
-          helper,
-          state: helper.state,
-          instantSearchInstance: instantSearchInstance as InstantSearch,
-          parent: parent as IndexWidget,
-        })
-      );
-
-      expect(result).toHaveProperty('customChat');
-      // @ts-expect-error access dynamic key
-      expect(result.customChat).toEqual(
-        expect.objectContaining({
-          widgetParams: expect.objectContaining({ type: 'customChat' }),
-        })
-      );
-    });
+    expect(sendMessageSpy).toHaveBeenCalledTimes(1);
+    const call = sendMessageSpy.mock.calls[0][0] as any;
+    expect(call).toEqual({ text: 'Hello' });
   });
 
-  it('renders during init and render', () => {
-    const { widget, helper, renderFn } = getInitializedWidget();
+  test('sendMessage injects context when called with parts', async () => {
+    const chatInstance = createTestChat();
+    const sendMessageSpy = jest.spyOn(chatInstance, 'sendMessage');
 
-    expect(renderFn).toHaveBeenCalledTimes(1);
-    expect(renderFn).toHaveBeenLastCalledWith(
-      expect.objectContaining({ widgetParams: { agentId: 'agentId' } }),
-      true
-    );
+    const { widget, renderFn } = createChatWidget({
+      chat: chatInstance,
+      context: { page: '/about' },
+    });
 
-    const renderOptions = createRenderOptions({ helper });
-    widget.render(renderOptions);
+    const helper = algoliasearchHelper(createSearchClient(), '');
+    widget.init!(createInitOptions({ helper, state: helper.state }));
 
-    expect(renderFn).toHaveBeenCalledTimes(2);
-    expect(renderFn).toHaveBeenLastCalledWith(
-      expect.objectContaining({ widgetParams: { agentId: 'agentId' } }),
-      false
-    );
+    const { sendMessage } = renderFn.mock.calls[0][0];
+
+    await sendMessage({
+      parts: [{ type: 'text', text: 'Hi from parts' }],
+    });
+
+    expect(sendMessageSpy).toHaveBeenCalledTimes(1);
+    const call = sendMessageSpy.mock.calls[0][0] as any;
+    expect(call.parts).toEqual([
+      { type: 'text', text: 'Hi from parts' },
+      { type: 'context', context: { page: '/about' } },
+    ]);
   });
 
-  describe('dispose', () => {
-    it('calls the unmount function', () => {
-      const unmountFn = jest.fn();
-      const makeWidget = connectChat(() => {}, unmountFn);
-      const widget = makeWidget({ agentId: 'agentId' });
+  test('sendMessage passes through when called with no message', async () => {
+    const chatInstance = createTestChat();
+    const sendMessageSpy = jest.spyOn(chatInstance, 'sendMessage');
 
-      const helper = algoliasearchHelper(createSearchClient(), '', {});
-
-      widget.init(createInitOptions({ helper, state: helper.state }));
-
-      expect(unmountFn).toHaveBeenCalledTimes(0);
-
-      widget.dispose();
-      expect(unmountFn).toHaveBeenCalledTimes(1);
+    const { widget, renderFn } = createChatWidget({
+      chat: chatInstance,
+      context: { page: '/about' },
     });
 
-    it('does not throw without the unmount function', () => {
-      const makeWidget = connectChat(() => {});
-      const widget = makeWidget({ agentId: 'agentId' });
+    const helper = algoliasearchHelper(createSearchClient(), '');
+    widget.init!(createInitOptions({ helper, state: helper.state }));
 
-      expect(() => widget.dispose()).not.toThrow();
-    });
+    const { sendMessage } = renderFn.mock.calls[0][0];
+
+    await sendMessage();
+
+    expect(sendMessageSpy).toHaveBeenCalledTimes(1);
+    expect(sendMessageSpy.mock.calls[0][0]).toBeUndefined();
   });
-
-  describe('state management', () => {
-    it('updates input state', () => {
-      const { getRenderState } = getInitializedWidget();
-
-      const renderState = getRenderState();
-      expect(renderState.input).toBe('');
-
-      renderState.setInput('Hello');
-
-      const updatedRenderState = getRenderState();
-      expect(updatedRenderState.input).toBe('Hello');
-    });
-
-    it('updates open state', () => {
-      const { getRenderState } = getInitializedWidget();
-
-      const renderState = getRenderState();
-      expect(renderState.open).toBe(false);
-
-      renderState.setOpen(true);
-
-      const updatedRenderState = getRenderState();
-      expect(updatedRenderState.open).toBe(true);
-    });
-
-    it('updates clearing state when clearMessages is called', () => {
-      const { getRenderState } = getInitializedWidget();
-
-      const renderState = getRenderState();
-
-      const message: UIMessage = {
-        id: '1',
-        role: 'user',
-        parts: [{ type: 'text', text: 'Hello' }],
-      };
-      renderState.setMessages([message]);
-
-      expect(renderState.isClearing).toBe(false);
-
-      renderState.clearMessages();
-
-      const updatedRenderState = getRenderState();
-      expect(updatedRenderState.isClearing).toBe(true);
-    });
-
-    it('does not change state when clearing empty messages', () => {
-      const { getRenderState, renderFn } = getInitializedWidget();
-
-      const renderState = getRenderState();
-
-      if (renderState.messages.length > 0) {
-        renderState.setMessages([]);
-      }
-
-      const callCountBeforeClear = renderFn.mock.calls.length;
-      renderState.clearMessages();
-
-      expect(renderFn.mock.calls.length).toBe(callCountBeforeClear);
-    });
-
-    it('clears messages and resets state on transition end', () => {
-      const { getRenderState } = getInitializedWidget();
-
-      const renderState = getRenderState();
-
-      const message: UIMessage = {
-        id: '1',
-        role: 'user',
-        parts: [{ type: 'text', text: 'Hello' }],
-      };
-      renderState.setMessages([message]);
-      renderState.clearMessages();
-
-      let updatedRenderState = getRenderState();
-      expect(updatedRenderState.isClearing).toBe(true);
-
-      renderState.onClearTransitionEnd();
-
-      updatedRenderState = getRenderState();
-      expect(updatedRenderState.isClearing).toBe(false);
-      expect(updatedRenderState.messages).toHaveLength(0);
-    });
-
-    it('updates messages', () => {
-      const { getRenderState } = getInitializedWidget();
-
-      const renderState = getRenderState();
-      const newMessages: UIMessage[] = [
-        {
-          id: '1',
-          role: 'user' as const,
-          parts: [{ type: 'text', text: 'Hello' }],
-        },
-      ];
-
-      renderState.setMessages(newMessages);
-
-      const updatedRenderState = getRenderState();
-      expect(updatedRenderState.messages).toEqual(newMessages);
-    });
-
-    it('has empty feedbackState initially', () => {
-      const { getRenderState } = getInitializedWidget({
-        agentId: 'agentId',
-        feedback: true,
-      });
-
-      const renderState = getRenderState();
-      expect(renderState.feedbackState).toEqual({});
-    });
-
-    it('sets feedbackState to sending when feedback is submitted', () => {
-      const { getRenderState } = getInitializedWidget({
-        agentId: 'agentId',
-        feedback: true,
-      });
-
-      const renderState = getRenderState();
-      renderState.sendChatMessageFeedback!('msg-1', 1);
-
-      const updatedRenderState = getRenderState();
-      expect(updatedRenderState.feedbackState).toEqual({
-        'msg-1': 'sending',
-      });
-    });
-
-    it('sets feedbackState to the vote value after fetch resolves', async () => {
-      const { getRenderState } = getInitializedWidget({
-        agentId: 'agentId',
-        feedback: true,
-      });
-
-      const renderState = getRenderState();
-      renderState.sendChatMessageFeedback!('msg-1', 1);
-
-      await waitFor(() => {
-        expect(getRenderState().feedbackState).toEqual({ 'msg-1': 1 });
-      });
-    });
-
-    it('prevents double voting on the same message', () => {
-      const { sendChatMessageFeedback: mockedFn } = jest.requireMock(
-        '../../../lib/utils/sendChatMessageFeedback'
-      );
-      mockedFn.mockClear();
-
-      const { getRenderState } = getInitializedWidget({
-        agentId: 'agentId',
-        feedback: true,
-      });
-
-      const renderState = getRenderState();
-      renderState.sendChatMessageFeedback!('msg-1', 1);
-      renderState.sendChatMessageFeedback!('msg-1', 0);
-
-      expect(mockedFn).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('tool handling', () => {
-    it('provides tools in render state', () => {
-      const mockTool = {};
-
-      const { getRenderState } = getInitializedWidget({
-        tools: {
-          testTool: mockTool,
-        },
-      });
-
-      const renderState = getRenderState();
-      expect(renderState.tools).toEqual({
-        testTool: {
-          ...mockTool,
-          addToolResult: expect.any(Function),
-          applyFilters: expect.any(Function),
-          sendEvent: expect.any(Function),
-        },
-      });
-    });
-  });
-
-  describe('default chat instance', () => {
-    it('adds a compatibility layer for Algolia MCP Server search tool', async () => {
-      const onSearchToolCall = jest.fn();
-
-      const { widget } = getInitializedWidget({
-        agentId: undefined,
-        transport: {
-          fetch: () =>
-            Promise.resolve(
-              new Response(
-                `data: {"type": "start", "messageId": "test-id"}
-
-data: {"type": "start-step"}
-
-data: {"type": "tool-input-available", "toolCallId": "call_1", "toolName": "algolia_search_index_movies", "input": {"query": "Toy Story", "attributesToRetrieve": ["year"], "hitsPerPage": 1}}
-
-data: {"type":"tool-output-available","toolCallId":"call_1","output":{"results":[{"hits":[]}]}}
-
-data: {"type": "finish-step"}
-
-data: {"type": "finish"}
-
-data: [DONE]`,
-                {
-                  headers: { 'Content-Type': 'text/event-stream' },
-                }
-              )
-            ),
-        },
-        tools: { algolia_search_index: { onToolCall: onSearchToolCall } },
-      });
-
-      const { chatInstance } = widget;
-
-      // Simulate sending a message that triggers the tool call
-      await chatInstance.sendMessage({
-        id: 'message-id',
-        role: 'user',
-        parts: [{ type: 'text', text: 'Trigger tool call' }],
-      });
-
-      await waitFor(() => {
-        expect(onSearchToolCall).toHaveBeenCalledWith(
-          expect.objectContaining({
-            toolCallId: 'call_1',
-            toolName: 'algolia_search_index_movies',
-          })
-        );
-      });
-    });
-  });
-
-  describe('transport configuration', () => {
-    it('throws error when neither agentId nor transport is provided', () => {
-      const renderFn = jest.fn();
-      const makeWidget = connectChat(renderFn);
-      const widget = makeWidget({});
-
-      const helper = algoliasearchHelper(createSearchClient(), '', {});
-
-      expect(() => {
-        widget.init(createInitOptions({ helper, state: helper.state }));
-      }).toThrow('You need to provide either an `agentId` or a `transport`.');
-    });
-
-    it('accepts custom transport', () => {
-      const customTransport = { api: 'https://custom.api' };
-
-      const { getRenderState } = getInitializedWidget({
-        transport: customTransport,
-      });
-
-      const renderState = getRenderState();
-      expect(renderState.widgetParams).toEqual(
-        expect.objectContaining({
-          transport: customTransport,
-        })
-      );
-    });
-  });
-
 });

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -23,6 +23,7 @@ import type {
   ChatInit as ChatInitAi,
   UIMessage,
 } from '../../lib/chat';
+import type { ContextUIPart } from '../../lib/ai-lite';
 import type { SendEventForHits } from '../../lib/utils';
 import type {
   Connector,
@@ -159,6 +160,13 @@ export type ChatConnectorParams<TUiMessage extends UIMessage = UIMessage> = (
    * @default 'chat'
    */
   type?: string;
+  /**
+   * Additional context to send with each user message (e.g. current page info).
+   * This context is included in the message parts sent to the API but is not
+   * displayed in the chat UI.
+   * Can be a static object or a function that returns the context at send time.
+   */
+  context?: Record<string, unknown> | (() => Record<string, unknown>);
 };
 
 export type ChatWidgetDescription<TUiMessage extends UIMessage = UIMessage> = {
@@ -260,6 +268,7 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
       resume = false,
       tools = {},
       type = 'chat',
+      context,
       ...options
     } = widgetParams || {};
 
@@ -611,6 +620,49 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
           toolsWithAddToolResult[key] = toolWithAddToolResult;
         });
 
+        const sendMessageWithContext: typeof _chatInstance.sendMessage = (
+          message,
+          options
+        ) => {
+          if (!context || !message) {
+            return _chatInstance.sendMessage(message, options);
+          }
+
+          const resolvedContext =
+            typeof context === 'function' ? context() : context;
+
+          const contextPart: ContextUIPart = {
+            type: 'context',
+            context: resolvedContext,
+          };
+
+          if (message && 'parts' in message && message.parts) {
+            return _chatInstance.sendMessage(
+              {
+                ...message,
+                parts: [...message.parts, contextPart],
+              } as Parameters<typeof _chatInstance.sendMessage>[0],
+              options
+            );
+          }
+
+          if (message && 'text' in message && message.text) {
+            return _chatInstance.sendMessage(
+              {
+                parts: [
+                  { type: 'text' as const, text: message.text },
+                  contextPart,
+                ],
+                metadata: message.metadata,
+                messageId: message.messageId,
+              } as Parameters<typeof _chatInstance.sendMessage>[0],
+              options
+            );
+          }
+
+          return _chatInstance.sendMessage(message, options);
+        };
+
         return {
           indexUiState: instantSearchInstance.getUiState()[parent.getIndexId()],
           input,
@@ -638,7 +690,7 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
           messages: _chatInstance.messages,
           regenerate: _chatInstance.regenerate,
           resumeStream: _chatInstance.resumeStream,
-          sendMessage: _chatInstance.sendMessage,
+          sendMessage: sendMessageWithContext,
           status: _chatInstance.status,
           stop: _chatInstance.stop,
         };

--- a/packages/instantsearch.js/src/lib/ai-lite/index.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/index.ts
@@ -43,6 +43,7 @@ export type {
   FileUIPart,
   StepStartUIPart,
   DataUIPart,
+  ContextUIPart,
 
   // Inference types
   InferUIMessageMetadata,

--- a/packages/instantsearch.js/src/lib/ai-lite/types.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/types.ts
@@ -68,6 +68,11 @@ export type StepStartUIPart = {
   type: 'step-start';
 };
 
+export type ContextUIPart = {
+  type: 'context';
+  context: Record<string, unknown>;
+};
+
 export type DataUIPart<DATA_TYPES extends UIDataTypes> = ValueOf<{
   [NAME in keyof DATA_TYPES & string]: {
     type: `data-${NAME}`;
@@ -164,7 +169,8 @@ export type UIMessagePart<
   | SourceDocumentUIPart
   | FileUIPart
   | DataUIPart<DATA_TYPES>
-  | StepStartUIPart;
+  | StepStartUIPart
+  | ContextUIPart;
 
 export interface UIMessage<
   METADATA = unknown,


### PR DESCRIPTION
**Summary**

Allow sending additional context (e.g. current page info) with each
user message via a `context` parameter. Context is injected as a
`context` part in user messages, sent to the API but not rendered
in the chat UI.
